### PR TITLE
Build shared package and update configs

### DIFF
--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "baseUrl": "../../",
-    "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
-    }
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": "."
   },
   "include": ["src"]
 }

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -3,9 +3,22 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./db": "./dist/db.js",
+    "./*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "*": ["dist/*"]
+    }
+  },
   "scripts": {
-    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "tsc -p tsconfig.json",
+    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,3 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 export const prisma = new PrismaClient();

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,1 @@
-﻿// shared
+// shared

--- a/apgms/shared/tsconfig.json
+++ b/apgms/shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};


### PR DESCRIPTION
## Summary
- configure @apgms/shared to compile TypeScript into dist/ and expose the built entry points
- point the API gateway TypeScript project at the compiled package instead of shared/src
- add a JS-based PostCSS config for the webapp to avoid JSON parsing errors

## Testing
- pnpm -F @apgms/shared build *(fails: Prisma engines download blocked in the environment, so PrismaClient types are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ea873a1c4083279de10057dc3ed3a0