### PR TITLE
Expand tax schema and add BAS calculation services

### DIFF
--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,31 +1,446 @@
-﻿import { PrismaClient } from "@prisma/client";
+import {
+  AccountingMethod,
+  BasCycle,
+  EvidenceScope,
+  FinanceAccountType,
+  GstTaxCode,
+  MandateStatus,
+  MembershipRole,
+  PaymentEventType,
+  PaymentStatus,
+  PrismaClient,
+  TaxPeriodStatus,
+  TaxRegistrationType,
+} from "@prisma/client";
+
 const prisma = new PrismaClient();
 
-async function main() {
-  const org = await prisma.org.upsert({
-    where: { id: "demo-org" },
-    update: {},
-    create: { id: "demo-org", name: "Demo Org" },
-  });
-
-  await prisma.user.upsert({
-    where: { email: "founder@example.com" },
-    update: {},
-    create: { email: "founder@example.com", password: "password123", orgId: org.id },
-  });
-
-  const today = new Date();
-  await prisma.bankLine.createMany({
-    data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
-    ],
-    skipDuplicates: true,
-  });
-
-  console.log("Seed OK");
+async function reset() {
+  await prisma.auditRpt.deleteMany();
+  await prisma.auditEvent.deleteMany();
+  await prisma.reconException.deleteMany();
+  await prisma.reconMatch.deleteMany();
+  await prisma.bankLine.deleteMany();
+  await prisma.bankImport.deleteMany();
+  await prisma.paymentEvent.deleteMany();
+  await prisma.payment.deleteMany();
+  await prisma.financeMandate.deleteMany();
+  await prisma.financeAccount.deleteMany();
+  await prisma.idempotencyKey.deleteMany();
+  await prisma.paygwWithholdingCalc.deleteMany();
+  await prisma.paygwPayEvent.deleteMany();
+  await prisma.paygwEmployee.deleteMany();
+  await prisma.gstBasCalc.deleteMany();
+  await prisma.gstAdjustment.deleteMany();
+  await prisma.gstPurchase.deleteMany();
+  await prisma.gstSupply.deleteMany();
+  await prisma.taxScheduleMeta.deleteMany();
+  await prisma.adminIngestionJob.deleteMany();
+  await prisma.adminDocument.deleteMany();
+  await prisma.taxPeriod.deleteMany();
+  await prisma.taxRegistration.deleteMany();
+  await prisma.apiKey.deleteMany();
+  await prisma.membership.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.org.deleteMany();
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+function cents(value: number) {
+  return Math.round(value * 100);
+}
+
+async function seedOrg(index: number) {
+  const baseDate = new Date();
+  const startMonth = Math.floor(baseDate.getMonth() / 3) * 3;
+  const currentQuarterStart = new Date(baseDate.getFullYear(), startMonth, 1);
+  const currentQuarterEnd = new Date(currentQuarterStart);
+  currentQuarterEnd.setMonth(currentQuarterEnd.getMonth() + 3);
+  currentQuarterEnd.setDate(currentQuarterEnd.getDate() - 1);
+
+  const org = await prisma.org.create({
+    data: {
+      name: index === 1 ? "Birchal Demo Pty Ltd" : "Acme Services Co",
+      abn: index === 1 ? "12345678901" : "98765432109",
+      accountingMethod: index === 1 ? AccountingMethod.ACCRUAL : AccountingMethod.CASH,
+      basCycle: index === 1 ? BasCycle.QUARTERLY : BasCycle.MONTHLY,
+    },
+  });
+
+  const owner = await prisma.user.create({
+    data: {
+      email: index === 1 ? "founder@birchal.demo" : "ceo@acme.demo",
+      password: "argon2$demo", // placeholder for hashed password
+      name: index === 1 ? "Ava Founder" : "Ben Manager",
+      memberships: {
+        create: {
+          orgId: org.id,
+          role: MembershipRole.OWNER,
+        },
+      },
+    },
+  });
+
+  await prisma.user.create({
+    data: {
+      email: index === 1 ? "accountant@birchal.demo" : "bookkeeper@acme.demo",
+      password: "argon2$demo",
+      name: index === 1 ? "Charlotte Ledger" : "Dylan Numbers",
+      memberships: {
+        create: {
+          orgId: org.id,
+          role: MembershipRole.ACCOUNTANT,
+          invitedBy: owner.id,
+        },
+      },
+    },
+  });
+
+  const revenueAccount = await prisma.financeAccount.create({
+    data: {
+      orgId: org.id,
+      type: FinanceAccountType.OPERATING,
+      displayName: "Operating Account",
+      institution: "Sample Bank",
+      bsb: "123-456",
+      accountNumber: index === 1 ? "12345678" : "98765432",
+      balanceCents: cents(82500.5),
+    },
+  });
+
+  const gstWallet = await prisma.financeAccount.create({
+    data: {
+      orgId: org.id,
+      type: FinanceAccountType.GST_WALLET,
+      displayName: "GST One-Way Wallet",
+      institution: "Sample Bank",
+      bsb: "123-456",
+      accountNumber: index === 1 ? "44556677" : "55667788",
+      oneWay: true,
+      balanceCents: cents(10250.75),
+    },
+  });
+
+  const paygwWallet = await prisma.financeAccount.create({
+    data: {
+      orgId: org.id,
+      type: FinanceAccountType.PAYGW_WALLET,
+      displayName: "PAYGW One-Way Wallet",
+      institution: "Sample Bank",
+      bsb: "123-456",
+      accountNumber: index === 1 ? "88990011" : "11009988",
+      oneWay: true,
+      balanceCents: cents(6400.25),
+    },
+  });
+
+  const mandate = await prisma.financeMandate.create({
+    data: {
+      orgId: org.id,
+      accountId: revenueAccount.id,
+      reference: index === 1 ? "BIRCHAL-PAYTO" : "ACME-PAYTO",
+      status: MandateStatus.ACTIVE,
+      activatedAt: new Date(),
+    },
+  });
+
+  await prisma.taxRegistration.createMany({
+    data: [
+      {
+        orgId: org.id,
+        type: TaxRegistrationType.GST,
+        effectiveFrom: new Date(baseDate.getFullYear() - 1, 6, 1),
+        accountBsb: gstWallet.bsb,
+        accountNumber: gstWallet.accountNumber,
+      },
+      {
+        orgId: org.id,
+        type: TaxRegistrationType.PAYGW,
+        effectiveFrom: new Date(baseDate.getFullYear() - 1, 6, 1),
+        accountBsb: paygwWallet.bsb,
+        accountNumber: paygwWallet.accountNumber,
+      },
+    ],
+  });
+
+  const previousPeriod = await prisma.taxPeriod.create({
+    data: {
+      orgId: org.id,
+      abn: org.abn ?? "00000000000",
+      label: index === 1 ? "2023Q4" : "2024M05",
+      status: TaxPeriodStatus.LODGED,
+      dueDate: new Date(baseDate.getFullYear(), baseDate.getMonth() - 2, 21),
+      lockDate: new Date(baseDate.getFullYear(), baseDate.getMonth() - 3, 30),
+      lodgedAt: new Date(baseDate.getFullYear(), baseDate.getMonth() - 2, 20),
+    },
+  });
+
+  const currentPeriod = await prisma.taxPeriod.create({
+    data: {
+      orgId: org.id,
+      abn: org.abn ?? "00000000000",
+      label: index === 1 ? "2024Q1" : "2024M06",
+      status: TaxPeriodStatus.OPEN,
+      dueDate: new Date(currentQuarterEnd.getFullYear(), currentQuarterEnd.getMonth() + 1, 21),
+    },
+  });
+
+  const supplyData = [
+    {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      description: "Consulting services",
+      supplyDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 12),
+      amountCents: cents(27500),
+      gstCents: cents(27500 * 0.1),
+      taxCode: GstTaxCode.TX,
+    },
+    {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      description: "Export goods",
+      supplyDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth() + 1, 5),
+      amountCents: cents(8200),
+      gstCents: 0,
+      taxCode: GstTaxCode.FRE,
+    },
+  ];
+  await prisma.gstSupply.createMany({ data: supplyData });
+
+  const purchaseData = [
+    {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      description: "Software subscription",
+      purchaseDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 18),
+      amountCents: cents(1200),
+      gstCents: cents(120),
+      taxCode: GstTaxCode.TX,
+    },
+    {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      description: "Entertainment (non-claimable)",
+      purchaseDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 27),
+      amountCents: cents(450),
+      gstCents: 0,
+      taxCode: GstTaxCode.NT,
+    },
+  ];
+  await prisma.gstPurchase.createMany({ data: purchaseData });
+
+  await prisma.gstAdjustment.create({
+    data: {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      description: "Prior period adjustment",
+      amountCents: cents(320),
+      gstCents: cents(32),
+      taxCode: GstTaxCode.ADJ,
+    },
+  });
+
+  const employee = await prisma.paygwEmployee.create({
+    data: {
+      orgId: org.id,
+      firstName: "Jordan",
+      lastName: index === 1 ? "Taylor" : "Nguyen",
+      tfn: "123456789",
+      stsl: index === 1,
+      taxFreeThreshold: true,
+    },
+  });
+
+  await prisma.paygwPayEvent.createMany({
+    data: [
+      {
+        orgId: org.id,
+        employeeId: employee.id,
+        periodId: currentPeriod.id,
+        payDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 15),
+        grossCents: cents(3200),
+        withheldCents: cents(620),
+        stslCents: cents(index === 1 ? 45 : 0),
+      },
+      {
+        orgId: org.id,
+        employeeId: employee.id,
+        periodId: currentPeriod.id,
+        payDate: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth() + 1, 15),
+        grossCents: cents(3300),
+        withheldCents: cents(640),
+        stslCents: cents(index === 1 ? 45 : 0),
+      },
+    ],
+  });
+
+  const bankImport = await prisma.bankImport.create({
+    data: {
+      orgId: org.id,
+      filename: index === 1 ? "birchal-demo.ofx" : "acme-demo.csv",
+      format: index === 1 ? "OFX" : "CSV",
+      fileHash: "demo-hash",
+    },
+  });
+
+  const bankLineOne = await prisma.bankLine.create({
+    data: {
+      orgId: org.id,
+      importId: bankImport.id,
+      date: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 16),
+      amount: 3200.0,
+      payee: "Payroll",
+      desc: "Payroll debit",
+      reference: "PAYGW-DEBIT",
+      status: "matched",
+    },
+  });
+
+  const bankLineTwo = await prisma.bankLine.create({
+    data: {
+      orgId: org.id,
+      importId: bankImport.id,
+      date: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth() + 1, 2),
+      amount: 8250.0,
+      payee: "ATO",
+      desc: "GST remittance",
+      reference: "GST-WALLET",
+      status: "needs_review",
+    },
+  });
+
+  const paymentSettled = await prisma.payment.create({
+    data: {
+      orgId: org.id,
+      accountId: paygwWallet.id,
+      mandateId: mandate.id,
+      periodId: currentPeriod.id,
+      amountCents: cents(1260),
+      status: PaymentStatus.SETTLED,
+      reference: index === 1 ? "PAYGW-MAR" : "PAYGW-JUN",
+      description: "PAYGW withholding",
+      settledAt: new Date(currentQuarterStart.getFullYear(), currentQuarterStart.getMonth(), 16),
+      events: {
+        create: {
+          type: PaymentEventType.CAPTURED,
+          detail: {
+            message: "Payment settled via mock PayTo",
+          },
+        },
+      },
+    },
+  });
+
+  const paymentPending = await prisma.payment.create({
+    data: {
+      orgId: org.id,
+      accountId: gstWallet.id,
+      mandateId: mandate.id,
+      periodId: currentPeriod.id,
+      amountCents: cents(2750),
+      status: PaymentStatus.PENDING_CAPTURE,
+      reference: index === 1 ? "GST-Q1" : "GST-MAY",
+      description: "GST transfer to wallet",
+    },
+  });
+
+  await prisma.reconMatch.create({
+    data: {
+      orgId: org.id,
+      bankLineId: bankLineOne.id,
+      paymentId: paymentSettled.id,
+      confidence: 0.98,
+      status: "reconciled",
+      note: "Auto matched based on reference",
+    },
+  });
+
+  await prisma.auditEvent.createMany({
+    data: [
+      {
+        orgId: org.id,
+        actorId: owner.id,
+        entityType: "mandate",
+        entityId: mandate.id,
+        action: "activated",
+        afterHash: "hash-mandate",
+      },
+      {
+        orgId: org.id,
+        actorId: owner.id,
+        entityType: "anomaly",
+        entityId: `${org.id}-${currentPeriod.id}`,
+        action: "anomaly_flag",
+        afterHash: "gst-swing",
+      },
+    ],
+  });
+
+  await prisma.auditRpt.create({
+    data: {
+      orgId: org.id,
+      periodId: currentPeriod.id,
+      scope: EvidenceScope.BAS,
+      tokenId: `rpt-${org.id}-${currentPeriod.id}`,
+      evidenceDigest: "sha256-demo",
+      createdBy: owner.id,
+      expiresAt: new Date(currentQuarterEnd.getFullYear(), currentQuarterEnd.getMonth() + 2, 1),
+    },
+  });
+
+  const document = await prisma.adminDocument.create({
+    data: {
+      storagePath: index === 1 ? "docs/ato_gst_2024.pdf" : "docs/ato_paygw_2024.pdf",
+      type: "ATO_RULE",
+      source: "ATO",
+      version: "2024.1",
+      metadata: {
+        description: "Imported reference schedule",
+      },
+    },
+  });
+
+  await prisma.taxScheduleMeta.create({
+    data: {
+      registration: TaxRegistrationType.GST,
+      source: "ATO",
+      version: "2024.1",
+      effectiveFrom: new Date(baseDate.getFullYear(), 0, 1),
+      documentId: document.id,
+      metadata: {
+        note: "Standard GST rates",
+      },
+    },
+  });
+
+  await prisma.adminIngestionJob.create({
+    data: {
+      documentId: document.id,
+      status: "complete",
+      completedAt: new Date(),
+    },
+  });
+
+  return { org, currentPeriod };
+}
+
+async function main() {
+  await reset();
+  const results = [];
+  for (const index of [1, 2]) {
+    results.push(await seedOrg(index));
+  }
+  console.log(
+    `Seeded ${results.length} orgs with demo data: ${results
+      .map((r) => `${r.org.name} (${r.currentPeriod.label})`)
+      .join(", ")}`,
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,348 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+type JsonValue = Record<string, unknown> | string | number | boolean | null | JsonValue[];
+
+import Fastify, { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
+import { z } from "zod";
 import { prisma } from "../../../shared/src/db";
+import { PaymentEventType, PaymentStatus } from "@prisma/client";
 
-const app = Fastify({ logger: true });
+const TAX_ENGINE_URL = process.env.TAX_ENGINE_URL ?? "http://localhost:8000";
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+async function callTaxEngine<T>(path: string, body: JsonValue): Promise<T> {
+  const response = await fetch(`${TAX_ENGINE_URL}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
   });
-  return { users };
-});
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`tax-engine error ${response.status}: ${text}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function computeBasDraft(periodId: string) {
+  const period = await prisma.taxPeriod.findUnique({
+    where: { id: periodId },
+    include: {
+      org: true,
+      supplies: true,
+      purchases: true,
+      adjustments: true,
+      payEvents: true,
+    },
   });
-  return { lines };
-});
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
+  if (!period) {
+    throw new Error(`Period ${periodId} not found`);
+  }
+
+  const payload = {
+    period: {
+      id: period.id,
+      label: period.label,
+      abn: period.abn,
+      dueDate: period.dueDate.toISOString(),
+    },
+    gst: {
+      supplies: period.supplies.map((s) => ({
+        date: s.supplyDate.toISOString().slice(0, 10),
+        amount_cents: s.amountCents,
+        gst_cents: s.gstCents,
+        tax_code: s.taxCode,
+      })),
+      purchases: period.purchases.map((p) => ({
+        date: p.purchaseDate.toISOString().slice(0, 10),
+        amount_cents: p.amountCents,
+        gst_cents: p.gstCents,
+        tax_code: p.taxCode,
+      })),
+      adjustments: period.adjustments.map((a) => ({
+        amount_cents: a.amountCents,
+        gst_cents: a.gstCents,
+        tax_code: a.taxCode,
+      })),
+    },
+    paygw: {
+      pay_events: period.payEvents.map((pe) => ({
+        date: pe.payDate.toISOString().slice(0, 10),
+        gross_cents: pe.grossCents,
+        withheld_cents: pe.withheldCents,
+        stsl_cents: pe.stslCents ?? 0,
+      })),
+    },
+  };
+
+  return callTaxEngine<{ gst: any; paygw: any; bas: any }>("/bas/compile", payload);
+}
+
+export async function buildApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/orgs", async () => {
+    const orgs = await prisma.org.findMany({
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        name: true,
+        abn: true,
+        accountingMethod: true,
+        basCycle: true,
+        createdAt: true,
       },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { orgs };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  app.get("/orgs/:orgId/dashboard", async (req, rep) => {
+    const params = z.object({ orgId: z.string() }).parse(req.params);
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+    const org = await prisma.org.findUnique({
+      where: { id: params.orgId },
+      include: {
+        financeAccounts: true,
+      },
+    });
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+    if (!org) {
+      return rep.code(404).send({ error: "org_not_found" });
+    }
 
+    const currentPeriod = await prisma.taxPeriod.findFirst({
+      where: { orgId: org.id },
+      orderBy: [{ status: "asc" }, { dueDate: "asc" }],
+    });
+
+    const reconMatches = await prisma.reconMatch.groupBy({
+      by: ["status"],
+      where: { orgId: org.id },
+      _count: { _all: true },
+    });
+
+    const pendingPayments = await prisma.payment.findMany({
+      where: {
+        orgId: org.id,
+        status: { in: [PaymentStatus.PENDING_CAPTURE, PaymentStatus.CREATED] },
+      },
+      orderBy: { initiatedAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        amountCents: true,
+        reference: true,
+        status: true,
+        initiatedAt: true,
+      },
+    });
+
+    const alerts = await prisma.auditEvent.findMany({
+      where: { orgId: org.id, action: "anomaly_flag" },
+      orderBy: { createdAt: "desc" },
+      take: 5,
+      select: { id: true, entityId: true, createdAt: true, afterHash: true },
+    });
+
+    return {
+      org: {
+        id: org.id,
+        name: org.name,
+        abn: org.abn,
+        accountingMethod: org.accountingMethod,
+        basCycle: org.basCycle,
+      },
+      wallets: org.financeAccounts.map((acct) => ({
+        id: acct.id,
+        displayName: acct.displayName,
+        type: acct.type,
+        balanceCents: acct.balanceCents,
+        oneWay: acct.oneWay,
+      })),
+      currentPeriod,
+      reconciliation: reconMatches.map((entry) => ({
+        status: entry.status,
+        count: entry._count._all,
+      })),
+      pendingPayments,
+      alerts,
+    };
+  });
+
+  app.get("/periods/:periodId/bas", async (req, rep) => {
+    const params = z.object({ periodId: z.string() }).parse(req.params);
+
+    try {
+      const result = await computeBasDraft(params.periodId);
+
+      const period = await prisma.taxPeriod.findUnique({ where: { id: params.periodId } });
+      if (period) {
+        await prisma.$transaction(async (tx) => {
+          await tx.gstBasCalc.upsert({
+            where: { periodId: params.periodId },
+            update: {
+              g1: result.gst.g1,
+              g2: result.gst.g2,
+              g3: result.gst.g3,
+              g10: result.gst.g10,
+              g11: result.gst.g11,
+              label1A: result.gst["1A"],
+              label1B: result.gst["1B"],
+              netPayable: result.bas.net_payable,
+              source: result,
+            },
+            create: {
+              orgId: period.orgId,
+              periodId: params.periodId,
+              g1: result.gst.g1,
+              g2: result.gst.g2,
+              g3: result.gst.g3,
+              g10: result.gst.g10,
+              g11: result.gst.g11,
+              label1A: result.gst["1A"],
+              label1B: result.gst["1B"],
+              netPayable: result.bas.net_payable,
+              source: result,
+            },
+          });
+
+          await tx.paygwWithholdingCalc.upsert({
+            where: { periodId: params.periodId },
+            update: {
+              w1: result.paygw.W1,
+              w2: result.paygw.W2,
+              source: result,
+            },
+            create: {
+              orgId: period.orgId,
+              periodId: params.periodId,
+              w1: result.paygw.W1,
+              w2: result.paygw.W2,
+              source: result,
+            },
+          });
+        });
+      }
+
+      return result;
+    } catch (error) {
+      req.log.error(error);
+      return rep.code(500).send({ error: "bas_generation_failed" });
+    }
+  });
+
+  app.post("/orgs/:orgId/payments/debit", async (req, rep) => {
+    const params = z.object({ orgId: z.string() }).parse(req.params);
+    const idempotencyKey = req.headers["idempotency-key"];
+
+    if (!idempotencyKey || typeof idempotencyKey !== "string") {
+      return rep.code(400).send({ error: "missing_idempotency_key" });
+    }
+
+    const bodySchema = z.object({
+      accountId: z.string(),
+      amountCents: z.number().int().positive(),
+      reference: z.string().min(3),
+      description: z.string().optional(),
+      periodId: z.string().optional(),
+    });
+    const body = bodySchema.parse(req.body);
+
+    const hash = createHash("sha256").update(JSON.stringify(body)).digest("hex");
+
+    const existingKey = await prisma.idempotencyKey.findUnique({ where: { key: idempotencyKey } });
+    if (existingKey) {
+      if (existingKey.requestHash !== hash) {
+        return rep.code(409).send({ error: "idempotency_conflict" });
+      }
+      return rep.send(existingKey.response ?? {});
+    }
+
+    const account = await prisma.financeAccount.findUnique({ where: { id: body.accountId } });
+    if (!account || account.orgId !== params.orgId) {
+      return rep.code(404).send({ error: "account_not_found" });
+    }
+
+    const period = body.periodId
+      ? await prisma.taxPeriod.findUnique({ where: { id: body.periodId } })
+      : null;
+
+    const responsePayload = await prisma.$transaction(async (tx) => {
+      await tx.idempotencyKey.create({
+        data: {
+          key: idempotencyKey,
+          scope: "payments:debit",
+          requestHash: hash,
+          orgId: params.orgId,
+        },
+      });
+
+      const payment = await tx.payment.create({
+        data: {
+          orgId: params.orgId,
+          accountId: account.id,
+          periodId: period?.id,
+          amountCents: body.amountCents,
+          reference: body.reference,
+          description: body.description,
+          status: PaymentStatus.PENDING_CAPTURE,
+        },
+        select: {
+          id: true,
+          orgId: true,
+          accountId: true,
+          periodId: true,
+          amountCents: true,
+          status: true,
+          reference: true,
+          description: true,
+          initiatedAt: true,
+        },
+      });
+
+      await tx.paymentEvent.create({
+        data: {
+          paymentId: payment.id,
+          type: PaymentEventType.STATUS_CHANGED,
+          detail: { status: PaymentStatus.PENDING_CAPTURE },
+        },
+      });
+
+      return payment;
+    });
+
+    await prisma.idempotencyKey.update({
+      where: { key: idempotencyKey },
+      data: { response: responsePayload },
+    });
+
+    return rep.code(201).send(responsePayload);
+  });
+
+  return app;
+}
+
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  buildApp()
+    .then((app) => app.listen({ port, host }))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/apgms/services/tax-engine/app/main.py
+++ b/apgms/services/tax-engine/app/main.py
@@ -1,5 +1,245 @@
-﻿from fastapi import FastAPI
-app = FastAPI()
-@app.get('/health')
-def health():
-    return {'ok': True}
+from __future__ import annotations
+
+from datetime import date
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional
+
+import json
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, validator
+
+app = FastAPI(title="APGMS Tax Engine", version="0.2.0")
+
+RULES_DIR = Path(__file__).resolve().parent / "rules"
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@lru_cache()
+def load_gst_rules() -> List[dict]:
+    rules_file = RULES_DIR / "gst_rates_2024.json"
+    return _load_json(rules_file)["rates"]
+
+
+@lru_cache()
+def load_gst_adjustments() -> List[dict]:
+    return _load_json(RULES_DIR / "gst_adjustments.json")
+
+
+@lru_cache()
+def load_paygw_schedules() -> List[dict]:
+    return _load_json(RULES_DIR / "paygw_schedules_2024.json")
+
+
+def select_rule(effective_date: date, rules: List[dict]) -> dict:
+    applicable = None
+    for rule in rules:
+        start = date.fromisoformat(rule["effective_from"])
+        end_raw = rule.get("effective_to")
+        end = date.fromisoformat(end_raw) if end_raw else None
+        if effective_date >= start and (end is None or effective_date <= end):
+            applicable = rule
+    if applicable is None:
+        raise HTTPException(status_code=400, detail="no_rule_for_date")
+    return applicable
+
+
+def round_cents_to_dollars(value: int) -> int:
+    if value >= 0:
+        return (value + 50) // 100
+    return -((-value + 50) // 100)
+
+
+class GstLine(BaseModel):
+    date: Optional[date] = Field(None, alias="date")
+    amount_cents: int
+    gst_cents: int
+    tax_code: str
+
+    @validator("tax_code")
+    def validate_tax_code(cls, value: str) -> str:
+        allowed = {"TX", "FRE", "NT", "INP", "ADJ"}
+        if value not in allowed:
+            raise ValueError(f"unsupported tax code {value}")
+        return value
+
+
+class GstCalcRequest(BaseModel):
+    period_due_date: Optional[date] = None
+    supplies: List[GstLine] = Field(default_factory=list)
+    purchases: List[GstLine] = Field(default_factory=list)
+    adjustments: List[GstLine] = Field(default_factory=list)
+
+
+class GstCalcResponse(BaseModel):
+    g1: int
+    g2: int
+    g3: int
+    g10: int
+    g11: int
+    label_1A: int = Field(..., alias="1A")
+    label_1B: int = Field(..., alias="1B")
+    net_payable: int
+    metadata: dict
+
+    class Config:
+        allow_population_by_field_name = True
+
+
+class PayEvent(BaseModel):
+    date: Optional[date] = None
+    gross_cents: int
+    withheld_cents: int
+    stsl_cents: int = 0
+
+
+class PaygwCalcRequest(BaseModel):
+    period_due_date: Optional[date] = None
+    pay_events: List[PayEvent] = Field(default_factory=list)
+
+
+class PaygwCalcResponse(BaseModel):
+    W1: int
+    W2: int
+    metadata: dict
+
+
+class BasCompileRequest(BaseModel):
+    period: dict
+    gst: GstCalcRequest
+    paygw: PaygwCalcRequest
+
+
+class BasCompileResponse(BaseModel):
+    period: dict
+    gst: GstCalcResponse
+    paygw: PaygwCalcResponse
+    bas: dict
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"ok": True, "service": "tax-engine"}
+
+
+@app.post("/gst/calc", response_model=GstCalcResponse)
+def gst_calc(payload: GstCalcRequest) -> GstCalcResponse:
+    if not payload.supplies and not payload.purchases and not payload.adjustments:
+        return GstCalcResponse(
+            g1=0,
+            g2=0,
+            g3=0,
+            g10=0,
+            g11=0,
+            **{"1A": 0, "1B": 0},
+            net_payable=0,
+            metadata={"note": "no activity"},
+        )
+
+    effective_date = payload.period_due_date or date.today()
+    rule = select_rule(effective_date, load_gst_rules())
+    adjustments_catalogue = load_gst_adjustments()
+
+    taxable_codes = {"TX", "ADJ"}
+    gst_free_codes = {"FRE"}
+    non_taxable_codes = {"NT"}
+
+    g1_cents = sum(item.amount_cents for item in payload.supplies)
+    g2_cents = sum(item.amount_cents for item in payload.supplies if item.tax_code in gst_free_codes)
+    g3_cents = sum(item.amount_cents for item in payload.supplies if item.tax_code in non_taxable_codes)
+
+    g10_cents = sum(item.amount_cents for item in payload.purchases if item.tax_code in taxable_codes | {"INP"})
+    g11_cents = sum(item.amount_cents for item in payload.purchases)
+
+    adjustments_cents = sum(item.amount_cents for item in payload.adjustments)
+    adjustments_gst_cents = sum(item.gst_cents for item in payload.adjustments)
+
+    one_a_cents = sum(item.gst_cents for item in payload.supplies if item.tax_code in taxable_codes)
+    one_b_cents = sum(item.gst_cents for item in payload.purchases if item.tax_code in taxable_codes | {"INP"})
+
+    one_a_cents += adjustments_gst_cents
+    g1_cents += adjustments_cents
+
+    net_payable_cents = one_a_cents - one_b_cents
+
+    metadata = {
+        "rule_version": rule.get("version"),
+        "adjustment_codes": [entry["code"] for entry in adjustments_catalogue],
+    }
+
+    return GstCalcResponse(
+        g1=round_cents_to_dollars(g1_cents),
+        g2=round_cents_to_dollars(g2_cents),
+        g3=round_cents_to_dollars(g3_cents),
+        g10=round_cents_to_dollars(g10_cents),
+        g11=round_cents_to_dollars(g11_cents),
+        **{"1A": round_cents_to_dollars(one_a_cents), "1B": round_cents_to_dollars(one_b_cents)},
+        net_payable=round_cents_to_dollars(net_payable_cents),
+        metadata=metadata,
+    )
+
+
+@app.post("/paygw/calc", response_model=PaygwCalcResponse)
+def paygw_calc(payload: PaygwCalcRequest) -> PaygwCalcResponse:
+    if not payload.pay_events:
+        return PaygwCalcResponse(W1=0, W2=0, metadata={"note": "no payroll"})
+
+    effective_date = payload.period_due_date or date.today()
+    schedule = select_rule(effective_date, load_paygw_schedules())
+
+    total_gross = sum(event.gross_cents for event in payload.pay_events)
+    total_withheld = sum(event.withheld_cents + event.stsl_cents for event in payload.pay_events)
+
+    metadata = {
+        "schedule_version": schedule.get("version"),
+        "events_count": len(payload.pay_events),
+    }
+
+    return PaygwCalcResponse(
+        W1=round_cents_to_dollars(total_gross),
+        W2=round_cents_to_dollars(total_withheld),
+        metadata=metadata,
+    )
+
+
+@app.post("/bas/compile", response_model=BasCompileResponse)
+def bas_compile(payload: BasCompileRequest) -> BasCompileResponse:
+    gst_result = gst_calc(
+        GstCalcRequest(
+            period_due_date=payload.gst.period_due_date or payload.period.get("dueDate"),
+            supplies=payload.gst.supplies,
+            purchases=payload.gst.purchases,
+            adjustments=payload.gst.adjustments,
+        )
+    )
+    paygw_result = paygw_calc(
+        PaygwCalcRequest(
+            period_due_date=payload.paygw.period_due_date or payload.period.get("dueDate"),
+            pay_events=payload.paygw.pay_events,
+        )
+    )
+
+    net_payable = gst_result.net_payable + paygw_result.W2
+    bas_summary = {
+        "net_payable": net_payable,
+        "labels": {
+            "1A": gst_result.label_1A,
+            "1B": gst_result.label_1B,
+            "W1": paygw_result.W1,
+            "W2": paygw_result.W2,
+        },
+    }
+
+    return BasCompileResponse(
+        period=payload.period,
+        gst=gst_result,
+        paygw=paygw_result,
+        bas=bas_summary,
+    )

--- a/apgms/services/tax-engine/app/rules/gst_adjustments.json
+++ b/apgms/services/tax-engine/app/rules/gst_adjustments.json
@@ -1,0 +1,4 @@
+[
+  { "code": "ADJ", "description": "Standard GST adjustment" },
+  { "code": "FRE", "description": "GST free supplies" }
+]

--- a/apgms/services/tax-engine/app/rules/gst_rates_2024.json
+++ b/apgms/services/tax-engine/app/rules/gst_rates_2024.json
@@ -1,0 +1,11 @@
+{
+  "rates": [
+    {
+      "version": "GST-2024.1",
+      "effective_from": "2024-01-01",
+      "effective_to": null,
+      "standard_rate": 0.1,
+      "reduced_rates": []
+    }
+  ]
+}

--- a/apgms/services/tax-engine/app/rules/paygw_schedules_2024.json
+++ b/apgms/services/tax-engine/app/rules/paygw_schedules_2024.json
@@ -1,0 +1,13 @@
+[
+  {
+    "version": "PAYGW-2024.1",
+    "effective_from": "2024-01-01",
+    "effective_to": null,
+    "thresholds": {
+      "weekly": [
+        { "min": 0, "max": 87000, "rate": 0.19 },
+        { "min": 87000, "max": 180000, "rate": 0.325 }
+      ]
+    }
+  }
+]

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,17 @@
-﻿[tool.poetry]
-name='apgms-tax-engine'
-version='0.1.0'
+[tool.poetry]
+name = "apgms-tax-engine"
+version = "0.2.0"
+description = "Tax calculation service for APGMS"
+
 [tool.poetry.dependencies]
-python='^3.10'
-fastapi='*'
-uvicorn='*'
+python = "^3.10"
+fastapi = "^0.115.0"
+uvicorn = "^0.30.6"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.3"
+httpx = "^0.27.2"
+
+[build-system]
+requires = ["poetry-core>=1.7.0"]
+build-backend = "poetry.core.masonry.api"

--- a/apgms/services/tax-engine/tests/test_tax_engine.py
+++ b/apgms/services/tax-engine/tests/test_tax_engine.py
@@ -1,0 +1,80 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_gst_calc_basic():
+    payload = {
+        "period_due_date": "2024-03-31",
+        "supplies": [
+            {"date": "2024-01-10", "amount_cents": 10000, "gst_cents": 1000, "tax_code": "TX"},
+            {"date": "2024-01-15", "amount_cents": 2000, "gst_cents": 0, "tax_code": "FRE"},
+        ],
+        "purchases": [
+            {"date": "2024-01-20", "amount_cents": 3000, "gst_cents": 300, "tax_code": "TX"},
+            {"date": "2024-01-22", "amount_cents": 1000, "gst_cents": 0, "tax_code": "NT"},
+        ],
+        "adjustments": [
+            {"amount_cents": 500, "gst_cents": 100, "tax_code": "ADJ"}
+        ],
+    }
+    response = client.post("/gst/calc", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["g1"] == 125
+    assert data["g2"] == 20
+    assert data["g10"] == 30
+    assert data["g11"] == 40
+    assert data["1A"] == 11
+    assert data["1B"] == 3
+    assert data["net_payable"] == 8
+
+
+def test_paygw_calc_basic():
+    payload = {
+        "period_due_date": "2024-03-31",
+        "pay_events": [
+            {"date": "2024-01-15", "gross_cents": 20000, "withheld_cents": 4200, "stsl_cents": 300},
+            {"date": "2024-02-15", "gross_cents": 18000, "withheld_cents": 3800, "stsl_cents": 0},
+        ],
+    }
+    response = client.post("/paygw/calc", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["W1"] == 380
+    assert data["W2"] == 83
+    assert data["metadata"]["events_count"] == 2
+
+
+def test_bas_compile_combines_results():
+    payload = {
+        "period": {"id": "period-1", "label": "2024Q1", "dueDate": "2024-03-31"},
+        "gst": {
+            "period_due_date": "2024-03-31",
+            "supplies": [
+                {"date": "2024-01-10", "amount_cents": 10000, "gst_cents": 1000, "tax_code": "TX"}
+            ],
+            "purchases": [
+                {"date": "2024-01-12", "amount_cents": 3000, "gst_cents": 300, "tax_code": "TX"}
+            ],
+            "adjustments": [],
+        },
+        "paygw": {
+            "period_due_date": "2024-03-31",
+            "pay_events": [
+                {"date": "2024-01-15", "gross_cents": 22000, "withheld_cents": 4300, "stsl_cents": 0}
+            ],
+        },
+    }
+
+    response = client.post("/bas/compile", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["gst"]["1A"] == 10
+    assert data["paygw"]["W2"] == 43
+    assert data["bas"]["net_payable"] == 53

--- a/apgms/shared/prisma/migrations/20251010133922_domain_expansion/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010133922_domain_expansion/migration.sql
@@ -1,0 +1,429 @@
+-- Drop legacy tables if they exist
+DROP TABLE IF EXISTS "BankLine" CASCADE;
+DROP TABLE IF EXISTS "User" CASCADE;
+DROP TABLE IF EXISTS "Org" CASCADE;
+
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'MembershipRole') THEN DROP TYPE "MembershipRole"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'TaxRegistrationType') THEN DROP TYPE "TaxRegistrationType"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'TaxPeriodStatus') THEN DROP TYPE "TaxPeriodStatus"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'AccountingMethod') THEN DROP TYPE "AccountingMethod"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'BasCycle') THEN DROP TYPE "BasCycle"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'FinanceAccountType') THEN DROP TYPE "FinanceAccountType"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'MandateStatus') THEN DROP TYPE "MandateStatus"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PaymentStatus') THEN DROP TYPE "PaymentStatus"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'PaymentEventType') THEN DROP TYPE "PaymentEventType"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'GstTaxCode') THEN DROP TYPE "GstTaxCode"; END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'EvidenceScope') THEN DROP TYPE "EvidenceScope"; END IF;
+END $$;
+
+CREATE TYPE "MembershipRole" AS ENUM ('OWNER', 'ADMIN', 'STAFF', 'ACCOUNTANT');
+CREATE TYPE "TaxRegistrationType" AS ENUM ('GST', 'PAYGW');
+CREATE TYPE "TaxPeriodStatus" AS ENUM ('OPEN', 'LOCKED', 'LODGED', 'AMENDED');
+CREATE TYPE "AccountingMethod" AS ENUM ('CASH', 'ACCRUAL');
+CREATE TYPE "BasCycle" AS ENUM ('MONTHLY', 'QUARTERLY', 'ANNUALLY');
+CREATE TYPE "FinanceAccountType" AS ENUM ('OPERATING', 'PAYGW_WALLET', 'GST_WALLET', 'OTHER');
+CREATE TYPE "MandateStatus" AS ENUM ('REQUESTED', 'ACTIVE', 'PAUSED', 'REVOKED');
+CREATE TYPE "PaymentStatus" AS ENUM ('CREATED', 'PENDING_CAPTURE', 'SETTLED', 'FAILED', 'RECONCILED');
+CREATE TYPE "PaymentEventType" AS ENUM ('STATUS_CHANGED', 'CAPTURED', 'REFUNDED', 'NOTE');
+CREATE TYPE "GstTaxCode" AS ENUM ('TX', 'FRE', 'NT', 'INP', 'ADJ');
+CREATE TYPE "EvidenceScope" AS ENUM ('GST', 'PAYGW', 'BAS');
+
+CREATE TABLE "Org" (
+  "id" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "abn" TEXT,
+  "timezone" TEXT NOT NULL DEFAULT 'Australia/Brisbane',
+  "accountingMethod" "AccountingMethod" NOT NULL DEFAULT 'ACCRUAL',
+  "basCycle" "BasCycle" NOT NULL DEFAULT 'QUARTERLY',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Org_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "User" (
+  "id" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "password" TEXT NOT NULL,
+  "name" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+CREATE TABLE "Membership" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "role" "MembershipRole" NOT NULL,
+  "invitedBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Membership_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "Membership_userId_orgId_key" UNIQUE ("userId", "orgId"),
+  CONSTRAINT "Membership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "Membership_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "ApiKey" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "hashedKey" TEXT NOT NULL,
+  "scopes" TEXT[] NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3),
+  "lastUsedAt" TIMESTAMP(3),
+  CONSTRAINT "ApiKey_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ApiKey_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "TaxRegistration" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "type" "TaxRegistrationType" NOT NULL,
+  "effectiveFrom" TIMESTAMP(3) NOT NULL,
+  "effectiveTo" TIMESTAMP(3),
+  "accountBsb" TEXT,
+  "accountNumber" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'active',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TaxRegistration_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TaxRegistration_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "TaxPeriod" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "abn" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "status" "TaxPeriodStatus" NOT NULL DEFAULT 'OPEN',
+  "dueDate" TIMESTAMP(3) NOT NULL,
+  "lockDate" TIMESTAMP(3),
+  "lodgedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TaxPeriod_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "TaxPeriod_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "TaxScheduleMeta" (
+  "id" TEXT NOT NULL,
+  "registration" "TaxRegistrationType" NOT NULL,
+  "source" TEXT NOT NULL,
+  "version" TEXT NOT NULL,
+  "effectiveFrom" TIMESTAMP(3) NOT NULL,
+  "effectiveTo" TIMESTAMP(3),
+  "metadata" JSONB,
+  "documentId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "TaxScheduleMeta_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "FinanceAccount" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "type" "FinanceAccountType" NOT NULL,
+  "displayName" TEXT NOT NULL,
+  "institution" TEXT,
+  "bsb" TEXT,
+  "accountNumber" TEXT,
+  "oneWay" BOOLEAN NOT NULL DEFAULT false,
+  "balanceCents" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "FinanceAccount_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "FinanceAccount_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "FinanceMandate" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "accountId" TEXT NOT NULL,
+  "status" "MandateStatus" NOT NULL DEFAULT 'REQUESTED',
+  "reference" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "activatedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "metadata" JSONB,
+  CONSTRAINT "FinanceMandate_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "FinanceMandate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "FinanceMandate_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "FinanceAccount"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Payment" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "accountId" TEXT,
+  "mandateId" TEXT,
+  "periodId" TEXT,
+  "amountCents" INTEGER NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'AUD',
+  "status" "PaymentStatus" NOT NULL DEFAULT 'CREATED',
+  "reference" TEXT NOT NULL,
+  "description" TEXT,
+  "initiatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "settledAt" TIMESTAMP(3),
+  "failedAt" TIMESTAMP(3),
+  "reconciledAt" TIMESTAMP(3),
+  CONSTRAINT "Payment_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "Payment_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "Payment_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "FinanceAccount"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "Payment_mandateId_fkey" FOREIGN KEY ("mandateId") REFERENCES "FinanceMandate"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "Payment_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "PaymentEvent" (
+  "id" TEXT NOT NULL,
+  "paymentId" TEXT NOT NULL,
+  "type" "PaymentEventType" NOT NULL,
+  "detail" JSONB,
+  "actorId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PaymentEvent_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PaymentEvent_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "IdempotencyKey" (
+  "id" TEXT NOT NULL,
+  "key" TEXT NOT NULL,
+  "scope" TEXT NOT NULL,
+  "requestHash" TEXT NOT NULL,
+  "response" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3),
+  "orgId" TEXT,
+  CONSTRAINT "IdempotencyKey_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "IdempotencyKey_key_key" UNIQUE ("key")
+);
+
+CREATE TABLE "BankImport" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "filename" TEXT NOT NULL,
+  "format" TEXT NOT NULL,
+  "importedBy" TEXT,
+  "importedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "fileHash" TEXT,
+  CONSTRAINT "BankImport_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "BankImport_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "BankLine" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "importId" TEXT,
+  "date" TIMESTAMP(3) NOT NULL,
+  "amount" DECIMAL(65,30) NOT NULL,
+  "payee" TEXT NOT NULL,
+  "desc" TEXT NOT NULL,
+  "reference" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'unmatched',
+  "externalId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "BankLine_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "BankLine_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "BankLine_importId_fkey" FOREIGN KEY ("importId") REFERENCES "BankImport"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "ReconMatch" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "bankLineId" TEXT NOT NULL,
+  "paymentId" TEXT,
+  "confidence" DECIMAL(5,2) NOT NULL DEFAULT 0,
+  "status" TEXT NOT NULL DEFAULT 'needs_review',
+  "note" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "resolvedAt" TIMESTAMP(3),
+  CONSTRAINT "ReconMatch_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ReconMatch_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "ReconMatch_bankLineId_fkey" FOREIGN KEY ("bankLineId") REFERENCES "BankLine"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "ReconMatch_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "Payment"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "ReconException" (
+  "id" TEXT NOT NULL,
+  "matchId" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "detail" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ReconException_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ReconException_matchId_fkey" FOREIGN KEY ("matchId") REFERENCES "ReconMatch"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "GstSupply" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT,
+  "documentRef" TEXT,
+  "description" TEXT,
+  "supplyDate" TIMESTAMP(3) NOT NULL,
+  "amountCents" INTEGER NOT NULL,
+  "gstCents" INTEGER NOT NULL,
+  "taxCode" "GstTaxCode" NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GstSupply_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "GstSupply_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "GstSupply_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "GstPurchase" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT,
+  "documentRef" TEXT,
+  "description" TEXT,
+  "purchaseDate" TIMESTAMP(3) NOT NULL,
+  "amountCents" INTEGER NOT NULL,
+  "gstCents" INTEGER NOT NULL,
+  "taxCode" "GstTaxCode" NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GstPurchase_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "GstPurchase_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "GstPurchase_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "GstAdjustment" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT,
+  "description" TEXT,
+  "amountCents" INTEGER NOT NULL,
+  "gstCents" INTEGER NOT NULL,
+  "taxCode" "GstTaxCode" NOT NULL DEFAULT 'ADJ',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "GstAdjustment_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "GstAdjustment_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "GstAdjustment_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "GstBasCalc" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT NOT NULL,
+  "g1" INTEGER NOT NULL,
+  "g2" INTEGER NOT NULL,
+  "g3" INTEGER NOT NULL,
+  "g10" INTEGER NOT NULL,
+  "g11" INTEGER NOT NULL,
+  "label1A" INTEGER NOT NULL,
+  "label1B" INTEGER NOT NULL,
+  "netPayable" INTEGER NOT NULL,
+  "calculatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "source" JSONB,
+  CONSTRAINT "GstBasCalc_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "GstBasCalc_periodId_key" UNIQUE ("periodId"),
+  CONSTRAINT "GstBasCalc_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "GstBasCalc_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "PaygwEmployee" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "firstName" TEXT NOT NULL,
+  "lastName" TEXT NOT NULL,
+  "tfn" TEXT,
+  "taxFreeThreshold" BOOLEAN NOT NULL DEFAULT true,
+  "stsl" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PaygwEmployee_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PaygwEmployee_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "PaygwPayEvent" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "employeeId" TEXT,
+  "periodId" TEXT,
+  "payDate" TIMESTAMP(3) NOT NULL,
+  "grossCents" INTEGER NOT NULL,
+  "withheldCents" INTEGER NOT NULL,
+  "stslCents" INTEGER NOT NULL DEFAULT 0,
+  "metadata" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "PaygwPayEvent_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PaygwPayEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "PaygwPayEvent_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "PaygwEmployee"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "PaygwPayEvent_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "PaygwWithholdingCalc" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT NOT NULL,
+  "w1" INTEGER NOT NULL,
+  "w2" INTEGER NOT NULL,
+  "calculatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "source" JSONB,
+  CONSTRAINT "PaygwWithholdingCalc_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "PaygwWithholdingCalc_periodId_key" UNIQUE ("periodId"),
+  CONSTRAINT "PaygwWithholdingCalc_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "PaygwWithholdingCalc_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "AuditEvent" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT,
+  "actorId" TEXT,
+  "entityType" TEXT NOT NULL,
+  "entityId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "beforeHash" TEXT,
+  "afterHash" TEXT,
+  "ip" TEXT,
+  "ua" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "AuditEvent_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "AuditEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "AuditEvent_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE TABLE "AuditRpt" (
+  "id" TEXT NOT NULL,
+  "tokenId" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "periodId" TEXT NOT NULL,
+  "scope" "EvidenceScope" NOT NULL,
+  "evidenceDigest" TEXT NOT NULL,
+  "createdBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "expiresAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  CONSTRAINT "AuditRpt_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "AuditRpt_tokenId_key" UNIQUE ("tokenId"),
+  CONSTRAINT "AuditRpt_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "AuditRpt_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "AdminDocument" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT,
+  "periodId" TEXT,
+  "storagePath" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "source" TEXT NOT NULL,
+  "version" TEXT,
+  "uploadedBy" TEXT,
+  "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "hash" TEXT,
+  "metadata" JSONB,
+  CONSTRAINT "AdminDocument_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "AdminDocument_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "AdminDocument_periodId_fkey" FOREIGN KEY ("periodId") REFERENCES "TaxPeriod"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+ALTER TABLE "TaxScheduleMeta" ADD CONSTRAINT "TaxScheduleMeta_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "AdminDocument"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE TABLE "AdminIngestionJob" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT,
+  "documentId" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "completedAt" TIMESTAMP(3),
+  "error" TEXT,
+  CONSTRAINT "AdminIngestionJob_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "AdminIngestionJob_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT "AdminIngestionJob_documentId_fkey" FOREIGN KEY ("documentId") REFERENCES "AdminDocument"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,36 +1,495 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
+enum MembershipRole {
+  OWNER
+  ADMIN
+  STAFF
+  ACCOUNTANT
+}
+
+enum TaxRegistrationType {
+  GST
+  PAYGW
+}
+
+enum TaxPeriodStatus {
+  OPEN
+  LOCKED
+  LODGED
+  AMENDED
+}
+
+enum AccountingMethod {
+  CASH
+  ACCRUAL
+}
+
+enum BasCycle {
+  MONTHLY
+  QUARTERLY
+  ANNUALLY
+}
+
+enum FinanceAccountType {
+  OPERATING
+  PAYGW_WALLET
+  GST_WALLET
+  OTHER
+}
+
+enum MandateStatus {
+  REQUESTED
+  ACTIVE
+  PAUSED
+  REVOKED
+}
+
+enum PaymentStatus {
+  CREATED
+  PENDING_CAPTURE
+  SETTLED
+  FAILED
+  RECONCILED
+}
+
+enum PaymentEventType {
+  STATUS_CHANGED
+  CAPTURED
+  REFUNDED
+  NOTE
+}
+
+enum GstTaxCode {
+  TX
+  FRE
+  NT
+  INP
+  ADJ
+}
+
+enum EvidenceScope {
+  GST
+  PAYGW
+  BAS
+}
+
 model Org {
-  id        String   @id @default(cuid())
-  name      String
-  createdAt DateTime @default(now())
-  users     User[]
-  lines     BankLine[]
+  id               String              @id @default(cuid())
+  name             String
+  abn              String?
+  timezone         String              @default("Australia/Brisbane")
+  accountingMethod AccountingMethod    @default(ACCRUAL)
+  basCycle         BasCycle            @default(QUARTERLY)
+  createdAt        DateTime            @default(now())
+  updatedAt        DateTime            @updatedAt
+  users            User[]
+  memberships      Membership[]
+  apiKeys          ApiKey[]
+  bankLines        BankLine[]
+  taxRegistrations TaxRegistration[]
+  taxPeriods       TaxPeriod[]
+  financeAccounts  FinanceAccount[]
+  mandates         FinanceMandate[]
+  payments         Payment[]
+  bankImports      BankImport[]
+  reconMatches     ReconMatch[]
+  gstSupplies      GstSupply[]
+  gstPurchases     GstPurchase[]
+  gstAdjustments   GstAdjustment[]
+  gstBasCalcs      GstBasCalc[]
+  paygwEmployees   PaygwEmployee[]
+  paygwPayEvents   PaygwPayEvent[]
+  paygwCalcs       PaygwWithholdingCalc[]
+  auditEvents      AuditEvent[]
+  auditRpts        AuditRpt[]
+  adminDocuments   AdminDocument[]
+  ingestionJobs    AdminIngestionJob[]
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  id          String        @id @default(cuid())
+  email       String        @unique
+  password    String
+  name        String?
+  createdAt   DateTime      @default(now())
+  memberships Membership[]
+  auditEvents AuditEvent[]  @relation("UserAuditEvents")
+}
+
+model Membership {
+  id        String         @id @default(cuid())
+  user      User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  org       Org            @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
+  role      MembershipRole
+  invitedBy String?
+  createdAt DateTime       @default(now())
+
+  @@unique([userId, orgId])
+}
+
+model ApiKey {
+  id         String   @id @default(cuid())
+  org        Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  label      String
+  hashedKey  String
+  scopes     String[]
+  createdAt  DateTime @default(now())
+  expiresAt  DateTime?
+  lastUsedAt DateTime?
+}
+
+model TaxRegistration {
+  id            String               @id @default(cuid())
+  org           Org                  @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  type          TaxRegistrationType
+  effectiveFrom DateTime
+  effectiveTo   DateTime?
+  accountBsb    String?
+  accountNumber String?
+  status        String               @default("active")
+  createdAt     DateTime             @default(now())
+}
+
+model TaxPeriod {
+  id         String          @id @default(cuid())
+  org        Org             @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  abn        String
+  label      String
+  status     TaxPeriodStatus @default(OPEN)
+  dueDate    DateTime
+  lockDate   DateTime?
+  lodgedAt   DateTime?
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+  gstCalcs   GstBasCalc?
+  paygwCalcs PaygwWithholdingCalc?
+  payments   Payment[]
+  supplies   GstSupply[]
+  purchases  GstPurchase[]
+  adjustments GstAdjustment[]
+  payEvents  PaygwPayEvent[]
+  auditRpts  AuditRpt[]
+  documents  AdminDocument[]
+}
+
+model TaxScheduleMeta {
+  id            String               @id @default(cuid())
+  registration  TaxRegistrationType
+  source        String
+  version       String
+  effectiveFrom DateTime
+  effectiveTo   DateTime?
+  metadata      Json?
+  document      AdminDocument?       @relation(fields: [documentId], references: [id], onDelete: SetNull)
+  documentId    String?
+  createdAt     DateTime             @default(now())
+}
+
+model FinanceAccount {
+  id             String             @id @default(cuid())
+  org            Org                @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId          String
+  type           FinanceAccountType
+  displayName    String
+  institution    String?
+  bsb            String?
+  accountNumber  String?
+  oneWay         Boolean            @default(false)
+  balanceCents   Int                @default(0)
+  createdAt      DateTime           @default(now())
+  updatedAt      DateTime           @updatedAt
+  mandates       FinanceMandate[]
+  payments       Payment[]
+}
+
+model FinanceMandate {
+  id          String        @id @default(cuid())
+  org         Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  account     FinanceAccount @relation(fields: [accountId], references: [id], onDelete: Cascade)
+  accountId   String
+  status      MandateStatus  @default(REQUESTED)
+  reference   String
+  createdAt   DateTime       @default(now())
+  activatedAt DateTime?
+  revokedAt   DateTime?
+  metadata    Json?
+  payments    Payment[]
+}
+
+model Payment {
+  id            String         @id @default(cuid())
+  org           Org            @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  account       FinanceAccount? @relation(fields: [accountId], references: [id], onDelete: SetNull)
+  accountId     String?
+  mandate       FinanceMandate? @relation(fields: [mandateId], references: [id], onDelete: SetNull)
+  mandateId     String?
+  period        TaxPeriod?     @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId      String?
+  amountCents   Int
+  currency      String         @default("AUD")
+  status        PaymentStatus  @default(CREATED)
+  reference     String
+  description   String?
+  initiatedAt   DateTime       @default(now())
+  settledAt     DateTime?
+  failedAt      DateTime?
+  reconciledAt  DateTime?
+  events        PaymentEvent[]
+  reconMatches  ReconMatch[]
+}
+
+model PaymentEvent {
+  id         String            @id @default(cuid())
+  payment    Payment           @relation(fields: [paymentId], references: [id], onDelete: Cascade)
+  paymentId  String
+  type       PaymentEventType
+  detail     Json?
+  actorId    String?
+  createdAt  DateTime          @default(now())
+}
+
+model IdempotencyKey {
+  id          String   @id @default(cuid())
+  key         String   @unique
+  scope       String
+  requestHash String
+  response    Json?
+  createdAt   DateTime @default(now())
+  expiresAt   DateTime?
+  orgId       String?
+}
+
+model BankImport {
+  id          String    @id @default(cuid())
+  org         Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  filename    String
+  format      String
+  importedBy  String?
+  importedAt  DateTime  @default(now())
+  fileHash    String?
+  bankLines   BankLine[]
 }
 
 model BankLine {
-  id        String   @id @default(cuid())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
-  date      DateTime
-  amount    Decimal
-  payee     String
-  desc      String
-  createdAt DateTime @default(now())
+  id         String      @id @default(cuid())
+  org        Org         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  import     BankImport? @relation(fields: [importId], references: [id], onDelete: SetNull)
+  importId   String?
+  date       DateTime
+  amount     Decimal
+  payee      String
+  desc       String
+  reference  String?
+  status     String      @default("unmatched")
+  externalId String?
+  createdAt  DateTime    @default(now())
+  matches    ReconMatch[]
+}
+
+model ReconMatch {
+  id          String     @id @default(cuid())
+  org         Org        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  bankLine    BankLine   @relation(fields: [bankLineId], references: [id], onDelete: Cascade)
+  bankLineId  String
+  payment     Payment?   @relation(fields: [paymentId], references: [id], onDelete: SetNull)
+  paymentId   String?
+  confidence  Decimal    @default(0)
+  status      String     @default("needs_review")
+  note        String?
+  createdAt   DateTime   @default(now())
+  resolvedAt  DateTime?
+  exceptions  ReconException[]
+}
+
+model ReconException {
+  id         String     @id @default(cuid())
+  match      ReconMatch @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  matchId    String
+  type       String
+  detail     Json?
+  createdAt  DateTime   @default(now())
+}
+
+model GstSupply {
+  id          String      @id @default(cuid())
+  org         Org         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  period      TaxPeriod?  @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId    String?
+  documentRef String?
+  description String?
+  supplyDate  DateTime
+  amountCents Int
+  gstCents    Int
+  taxCode     GstTaxCode
+  createdAt   DateTime    @default(now())
+}
+
+model GstPurchase {
+  id          String      @id @default(cuid())
+  org         Org         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  period      TaxPeriod?  @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId    String?
+  documentRef String?
+  description String?
+  purchaseDate DateTime
+  amountCents Int
+  gstCents    Int
+  taxCode     GstTaxCode
+  createdAt   DateTime    @default(now())
+}
+
+model GstAdjustment {
+  id          String      @id @default(cuid())
+  org         Org         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  period      TaxPeriod?  @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId    String?
+  description String?
+  amountCents Int
+  gstCents    Int
+  taxCode     GstTaxCode  @default(ADJ)
+  createdAt   DateTime    @default(now())
+}
+
+model GstBasCalc {
+  id            String    @id @default(cuid())
+  org           Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  period        TaxPeriod @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  periodId      String
+  g1            Int
+  g2            Int
+  g3            Int
+  g10           Int
+  g11           Int
+  label1A       Int
+  label1B       Int
+  netPayable    Int
+  calculatedAt  DateTime  @default(now())
+  source        Json?
+
+  @@unique([periodId])
+}
+
+model PaygwEmployee {
+  id                 String     @id @default(cuid())
+  org                Org        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId              String
+  firstName          String
+  lastName           String
+  tfn                String?
+  taxFreeThreshold   Boolean    @default(true)
+  stsl               Boolean    @default(false)
+  createdAt          DateTime   @default(now())
+  payEvents          PaygwPayEvent[]
+}
+
+model PaygwPayEvent {
+  id            String     @id @default(cuid())
+  org           Org        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  employee      PaygwEmployee? @relation(fields: [employeeId], references: [id], onDelete: SetNull)
+  employeeId    String?
+  period        TaxPeriod? @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId      String?
+  payDate       DateTime
+  grossCents    Int
+  withheldCents Int
+  stslCents     Int?       @default(0)
+  metadata      Json?
+  createdAt     DateTime   @default(now())
+}
+
+model PaygwWithholdingCalc {
+  id           String     @id @default(cuid())
+  org          Org        @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
+  period       TaxPeriod  @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  periodId     String
+  w1           Int
+  w2           Int
+  calculatedAt DateTime   @default(now())
+  source       Json?
+
+  @@unique([periodId])
+}
+
+model AuditEvent {
+  id         String   @id @default(cuid())
+  org        Org?     @relation(fields: [orgId], references: [id], onDelete: SetNull)
+  orgId      String?
+  actor      User?    @relation("UserAuditEvents", fields: [actorId], references: [id], onDelete: SetNull)
+  actorId    String?
+  entityType String
+  entityId   String
+  action     String
+  beforeHash String?
+  afterHash  String?
+  ip         String?
+  ua         String?
+  createdAt  DateTime @default(now())
+}
+
+model AuditRpt {
+  id             String        @id @default(cuid())
+  tokenId        String        @unique
+  org            Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId          String
+  period         TaxPeriod     @relation(fields: [periodId], references: [id], onDelete: Cascade)
+  periodId       String
+  scope          EvidenceScope
+  evidenceDigest String
+  createdBy      String?
+  createdAt      DateTime      @default(now())
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+}
+
+model AdminDocument {
+  id          String        @id @default(cuid())
+  org         Org?          @relation(fields: [orgId], references: [id], onDelete: SetNull)
+  orgId       String?
+  period      TaxPeriod?     @relation(fields: [periodId], references: [id], onDelete: SetNull)
+  periodId    String?
+  storagePath String
+  type        String
+  source      String
+  version     String?
+  uploadedBy  String?
+  uploadedAt  DateTime       @default(now())
+  hash        String?
+  metadata    Json?
+  schedules   TaxScheduleMeta[]
+}
+
+model AdminIngestionJob {
+  id          String        @id @default(cuid())
+  org         Org?          @relation(fields: [orgId], references: [id], onDelete: SetNull)
+  orgId       String?
+  document    AdminDocument? @relation(fields: [documentId], references: [id], onDelete: SetNull)
+  documentId  String?
+  status      String        @default("pending")
+  createdAt   DateTime      @default(now())
+  completedAt DateTime?
+  error       String?
 }


### PR DESCRIPTION
## Summary
- replace the simplistic Prisma data model with a full APGMS domain schema and accompanying migration
- refresh the seed script with rich demo data that exercises PAYGW, GST, reconciliation and evidence flows
- extend the API gateway with BAS drafting and idempotent debit endpoints backed by the enhanced FastAPI tax engine
- implement GST/PAYGW/BAS calculation endpoints, reference rule datasets and FastAPI tests in the tax engine service

## Testing
- `pnpm --dir shared prisma:generate` *(fails: Prisma engines checksum download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ea91d7681c832796052746fdaaa07d