### PR TITLE
Add PowerShell helpers for writing UTF-8 without BOM

### DIFF
--- a/tools/no_bom_helpers.ps1
+++ b/tools/no_bom_helpers.ps1
@@ -1,0 +1,20 @@
+# PowerShell helpers for writing UTF-8 files without a BOM
+function Write-Utf8NoBom {
+  param([Parameter(Mandatory)][string]$Path,[Parameter(Mandatory)][string]$Content)
+  $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+  [System.IO.File]::WriteAllText((Resolve-Path $Path), $Content, $utf8NoBom)
+}
+function Set-JsonNoBom {
+  param([Parameter(Mandatory)][string]$Path,[Parameter(Mandatory)][hashtable]$Obj,[int]$Depth=50)
+  $json = $Obj | ConvertTo-Json -Depth $Depth
+  Write-Utf8NoBom -Path $Path -Content $json
+}
+function Remove-Bom {
+  param([Parameter(Mandatory)][string]$Path)
+  if (-not (Test-Path $Path)) { return }
+  $bytes = [System.IO.File]::ReadAllBytes($Path)
+  if ($bytes.Length -ge 3 -and $bytes[0] -eq 0xEF -and $bytes[1] -eq 0xBB -and $bytes[2] -eq 0xBF) {
+    [System.IO.File]::WriteAllBytes((Resolve-Path $Path), $bytes[3..($bytes.Length-1)])
+    Write-Host "Removed BOM from $Path"
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable PowerShell script that defines helpers to write UTF-8 files without emitting a BOM

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea9796bc0c83279fa373351adbc62a