### PR TITLE
fix: align api-gateway tsconfig with shared package exports

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -10,7 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { prisma } from "@apgms/shared/db";
 
 const app = Fastify({ logger: true });
 

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- configure the API gateway tsconfig to emit from src into dist while relying on the shared package exports
- update the prisma import to consume the @apgms/shared db module instead of a relative path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea98ce58ec8327bf40b65a3c84cc2e