### PR TITLE
feat(shared): configure build output

### DIFF
--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -3,9 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./db": "./dist/db.js",
+    "./*": "./dist/*"
+  },
   "scripts": {
-    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "tsc -p tsconfig.json",
+    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,13 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export type { PrismaClient };

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "@prisma/client";
+export * from "./db.js";

--- a/apgms/shared/tsconfig.json
+++ b/apgms/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated tsconfig so the shared package compiles TypeScript source into dist with declaration files
- update the shared package metadata and exports to surface the compiled entrypoints
- expose a cached Prisma client and re-export Prisma helpers for consumers

## Testing
- pnpm --filter @apgms/shared build *(fails: Module '@prisma/client' has no exported member 'PrismaClient' — Prisma client types are unavailable until `prisma generate` completes)*
- pnpm --filter @apgms/shared prisma:generate *(fails: unable to download Prisma engines in the offline CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea98b3e9648327afc7f6bd0db7ebb7