### PR TITLE
Add Prisma migration and seed scripts

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,32 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "db:migrate": "tsx scripts/db-migrate.ts",
+    "db:seed": "tsx scripts/db-seed.ts"
+  },
+  "prisma": {
+    "seed": "tsx scripts/seed.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/db-migrate.ts
+++ b/apgms/scripts/db-migrate.ts
@@ -1,0 +1,16 @@
+import { runPrismaCommand } from "./db-utils";
+
+async function main() {
+  console.log("Applying Prisma migrations...");
+  await runPrismaCommand("migrate", "deploy");
+
+  console.log("Generating Prisma client...");
+  await runPrismaCommand("generate");
+
+  console.log("Database migrations completed.");
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apgms/scripts/db-seed.ts
+++ b/apgms/scripts/db-seed.ts
@@ -1,0 +1,19 @@
+import { runPrismaCommand, ensureDatabaseEnv } from "./db-utils";
+
+async function main() {
+  console.log("Ensuring database environment...");
+  ensureDatabaseEnv();
+
+  console.log("Generating Prisma client...");
+  await runPrismaCommand("generate");
+
+  console.log("Running Prisma seed script...");
+  await runPrismaCommand("db", "seed", "--skip-generate");
+
+  console.log("Database seed completed.");
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apgms/scripts/db-utils.ts
+++ b/apgms/scripts/db-utils.ts
@@ -1,0 +1,61 @@
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+const DEFAULT_DATABASE_URL = "postgresql://apgms:apgms@127.0.0.1:5432/apgms";
+const DEFAULT_SHADOW_SCHEMA = "shadow";
+const PRISMA_SCHEMA_PATH = "shared/prisma/schema.prisma";
+const PNPM_COMMAND = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+export function ensureDatabaseEnv() {
+  const isDatabaseUrlProvided = Boolean(process.env.DATABASE_URL);
+  const databaseUrl = process.env.DATABASE_URL ?? DEFAULT_DATABASE_URL;
+  process.env.DATABASE_URL = databaseUrl;
+
+  if (!isDatabaseUrlProvided) {
+    console.log(`DATABASE_URL not set, defaulting to ${DEFAULT_DATABASE_URL}`);
+  }
+
+  if (!process.env.SHADOW_DATABASE_URL) {
+    process.env.SHADOW_DATABASE_URL = buildShadowDatabaseUrl(databaseUrl);
+    console.log(`Using shadow database URL ${process.env.SHADOW_DATABASE_URL}`);
+  }
+}
+
+export async function runPrismaCommand(...args: string[]) {
+  ensureDatabaseEnv();
+  await runCommand(PNPM_COMMAND, ["exec", "prisma", ...args, "--schema", PRISMA_SCHEMA_PATH]);
+}
+
+function buildShadowDatabaseUrl(databaseUrl: string) {
+  try {
+    const url = new URL(databaseUrl);
+    if (!url.searchParams.has("schema")) {
+      url.searchParams.set("schema", DEFAULT_SHADOW_SCHEMA);
+    } else {
+      url.searchParams.set("schema", `${url.searchParams.get("schema")}_shadow`);
+    }
+    return url.toString();
+  } catch (error) {
+    console.warn("Failed to parse DATABASE_URL for shadow db, reusing main URL", error);
+    return databaseUrl;
+  }
+}
+
+function runCommand(command: string, args: string[]) {
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    child.on("error", reject);
+
+    child.on("exit", code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Command failed: ${command} ${args.join(" ")}`));
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add root-level scripts to run Prisma migrations and seeding through pnpm
- default database environment variables to the local Postgres container and share execution helpers
- configure the Prisma seed command to use the existing TypeScript seed script

## Testing
- not run (requires Postgres container from step 5)


------
https://chatgpt.com/codex/tasks/task_e_68ea9914208083279805b567b26010b5