### PR TITLE
Add cross-platform dev helper scripts

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,34 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "dev-up": "docker compose up -d",
+    "db-reset": "pnpm exec prisma migrate reset --force --skip-generate --schema shared/prisma/schema.prisma",
+    "seed": "pnpm exec tsx scripts/seed.ts",
+    "e2e-run": "pnpm -w exec playwright test",
+    "k6-load": "k6 run k6/debit-path.js",
+    "key-rotate": "pnpm exec tsx scripts/key-rotate.ts",
+    "export-dump": "pnpm exec tsx scripts/export-dump.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/db-reset.ps1
+++ b/apgms/scripts/db-reset.ps1
@@ -1,1 +1,31 @@
-﻿# db-reset script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run db-reset -- $args
+} else {
+  pnpm run db-reset
+}

--- a/apgms/scripts/db-reset.sh
+++ b/apgms/scripts/db-reset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run db-reset -- "$@"

--- a/apgms/scripts/dev-up.ps1
+++ b/apgms/scripts/dev-up.ps1
@@ -1,1 +1,31 @@
-﻿# dev-up script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run dev-up -- $args
+} else {
+  pnpm run dev-up
+}

--- a/apgms/scripts/dev-up.sh
+++ b/apgms/scripts/dev-up.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run dev-up -- "$@"

--- a/apgms/scripts/e2e-run.ps1
+++ b/apgms/scripts/e2e-run.ps1
@@ -1,1 +1,31 @@
-﻿# e2e-run script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run e2e-run -- $args
+} else {
+  pnpm run e2e-run
+}

--- a/apgms/scripts/e2e-run.sh
+++ b/apgms/scripts/e2e-run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run e2e-run -- "$@"

--- a/apgms/scripts/export-dump.ps1
+++ b/apgms/scripts/export-dump.ps1
@@ -1,1 +1,31 @@
-﻿# export-dump script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run export-dump -- $args
+} else {
+  pnpm run export-dump
+}

--- a/apgms/scripts/export-dump.sh
+++ b/apgms/scripts/export-dump.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run export-dump -- "$@"

--- a/apgms/scripts/export-dump.ts
+++ b/apgms/scripts/export-dump.ts
@@ -1,0 +1,49 @@
+import { PrismaClient } from "@prisma/client";
+import { promises as fs } from "fs";
+import path from "path";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    throw new Error("DATABASE_URL must be set to export data");
+  }
+
+  const orgs = await prisma.org.findMany({
+    include: {
+      users: true,
+      lines: true,
+    },
+  });
+
+  const payload = orgs.map((org) => ({
+    ...org,
+    createdAt: org.createdAt.toISOString(),
+    users: org.users.map((user) => ({
+      ...user,
+      createdAt: user.createdAt.toISOString(),
+    })),
+    lines: org.lines.map((line) => ({
+      ...line,
+      amount: line.amount.toString(),
+      date: line.date.toISOString(),
+      createdAt: line.createdAt.toISOString(),
+    })),
+  }));
+
+  const exportDir = path.resolve(process.cwd(), "exports");
+  await fs.mkdir(exportDir, { recursive: true });
+  const filePath = path.join(exportDir, `dump-${Date.now()}.json`);
+  await fs.writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
+
+  console.log(`Exported ${payload.length} organisation(s) to ${filePath}`);
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/scripts/k6-load.ps1
+++ b/apgms/scripts/k6-load.ps1
@@ -1,1 +1,31 @@
-﻿# k6-load script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run k6-load -- $args
+} else {
+  pnpm run k6-load
+}

--- a/apgms/scripts/k6-load.sh
+++ b/apgms/scripts/k6-load.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run k6-load -- "$@"

--- a/apgms/scripts/key-rotate.ps1
+++ b/apgms/scripts/key-rotate.ps1
@@ -1,1 +1,31 @@
-﻿# key-rotate script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run key-rotate -- $args
+} else {
+  pnpm run key-rotate
+}

--- a/apgms/scripts/key-rotate.sh
+++ b/apgms/scripts/key-rotate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run key-rotate -- "$@"

--- a/apgms/scripts/key-rotate.ts
+++ b/apgms/scripts/key-rotate.ts
@@ -1,0 +1,52 @@
+import crypto from "crypto";
+import { promises as fs } from "fs";
+import path from "path";
+
+function createSecret(): string {
+  return crypto.randomBytes(32).toString("base64").replace(/=+$/, "");
+}
+
+async function main() {
+  const newSecret = createSecret();
+  const envPath = path.resolve(process.cwd(), ".env");
+
+  let existing = "";
+  try {
+    existing = await fs.readFile(envPath, "utf8");
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const lines = existing.split(/\r?\n/);
+  let updated = false;
+  const nextLines = lines
+    .map((line) => {
+      const trimmed = line.trimStart();
+      if (!trimmed || trimmed.startsWith("#")) {
+        return line;
+      }
+      if (trimmed.startsWith("JWT_SECRET=")) {
+        updated = true;
+        return `JWT_SECRET=${newSecret}`;
+      }
+      return line;
+    })
+    .filter((line, index, arr) => !(line === "" && index === arr.length - 1));
+
+  if (!updated) {
+    if (nextLines.length && nextLines[nextLines.length - 1] !== "") {
+      nextLines.push("");
+    }
+    nextLines.push(`JWT_SECRET=${newSecret}`);
+  }
+
+  await fs.writeFile(envPath, `${nextLines.join("\n")}\n`, "utf8");
+  console.log("Generated new JWT secret and wrote it to .env");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apgms/scripts/seed.ps1
+++ b/apgms/scripts/seed.ps1
@@ -1,1 +1,31 @@
-﻿# seed script
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RootDir = Resolve-Path (Join-Path $ScriptDir "..")
+Set-Location $RootDir
+
+$envFile = Join-Path $RootDir ".env"
+if (Test-Path $envFile) {
+  Get-Content $envFile | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_)) { return }
+    $trimmed = $_.Trim()
+    if ($trimmed.StartsWith("#")) { return }
+    $index = $trimmed.IndexOf("=")
+    if ($index -lt 0) { return }
+    $name = $trimmed.Substring(0, $index).Trim()
+    $value = $trimmed.Substring($index + 1).Trim()
+    if ($value.Length -ge 2 -and (
+        ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+        ($value.StartsWith("'") -and $value.EndsWith("'")))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    Set-Item -Path Env:$name -Value $value
+  }
+}
+
+if ($args.Count -gt 0) {
+  pnpm run seed -- $args
+} else {
+  pnpm run seed
+}

--- a/apgms/scripts/seed.sh
+++ b/apgms/scripts/seed.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [ -f "${ROOT_DIR}/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${ROOT_DIR}/.env"
+  set +a
+fi
+
+cd "${ROOT_DIR}"
+pnpm run seed -- "$@"


### PR DESCRIPTION
## Summary
- add workspace-level pnpm scripts for common dev and data operations
- add PowerShell and Bash wrappers that load .env before invoking the pnpm commands
- implement TypeScript utilities for key rotation and exporting database snapshots

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea9954463c83278572c47c9fa7bede