### PR TITLE
Add offline-friendly dev mocks and servers

### DIFF
--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,5 +1,4 @@
-﻿import { PrismaClient } from "@prisma/client";
-const prisma = new PrismaClient();
+import { prisma } from "../shared/src/db";
 
 async function main() {
   const org = await prisma.org.upsert({
@@ -17,9 +16,9 @@ async function main() {
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
+      { orgId: org.id, date: today, amount: 5000.0, payee: "Birchal", desc: "Investment received" },
     ],
     skipDuplicates: true,
   });
@@ -27,5 +26,11 @@ async function main() {
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,282 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import crypto from "node:crypto";
+import { createRequire } from "node:module";
+
+import type { PrismaClient } from "@prisma/client";
+
+type OrgRecord = {
+  id: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type UserRecord = {
+  email: string;
+  password: string;
+  orgId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type SelectMap<T> = Partial<Record<keyof T, boolean>>;
+
+type OrderDirection = "asc" | "desc" | undefined;
+
+type MockPrismaClient = {
+  org: {
+    upsert(args: {
+      where: { id: string };
+      update: Partial<Omit<OrgRecord, "id">>;
+      create: { id: string; name: string };
+    }): Promise<OrgRecord>;
+  };
+  user: {
+    upsert(args: {
+      where: { email: string };
+      update: Partial<Omit<UserRecord, "email">>;
+      create: { email: string; password: string; orgId: string };
+    }): Promise<UserRecord>;
+    findMany(args?: {
+      select?: SelectMap<UserRecord>;
+      orderBy?: { createdAt?: OrderDirection };
+    }): Promise<Partial<UserRecord>[]>;
+  };
+  bankLine: {
+    findMany(args?: {
+      orderBy?: { date?: OrderDirection };
+      take?: number;
+    }): Promise<BankLineRecord[]>;
+    create(args: {
+      data: {
+        orgId: string;
+        date: Date;
+        amount: number;
+        payee: string;
+        desc: string;
+      };
+    }): Promise<BankLineRecord>;
+    createMany(args: {
+      data: Array<{
+        orgId: string;
+        date: Date;
+        amount: number;
+        payee: string;
+        desc: string;
+      }>;
+      skipDuplicates?: boolean;
+    }): Promise<{ count: number }>;
+  };
+  $disconnect(): Promise<void>;
+};
+
+type PrismaModule = {
+  PrismaClient?: new () => PrismaClient;
+};
+
+const require = createRequire(import.meta.url);
+
+function pick<T extends Record<string, unknown>>(record: T, select?: SelectMap<T>): Partial<T> {
+  if (!select || Object.keys(select).length === 0) {
+    return { ...record };
+  }
+  const result: Partial<T> = {};
+  for (const key of Object.keys(select) as Array<keyof T>) {
+    if (select[key]) {
+      result[key] = record[key];
+    }
+  }
+  return result;
+}
+
+function sortByDate<T extends { date: Date }>(records: T[], direction: OrderDirection = "desc"): T[] {
+  const multiplier = direction === "asc" ? 1 : -1;
+  return [...records].sort((a, b) => (a.date.getTime() - b.date.getTime()) * multiplier);
+}
+
+function sortByCreatedAt<T extends { createdAt: Date }>(records: T[], direction: OrderDirection = "desc"): T[] {
+  const multiplier = direction === "asc" ? 1 : -1;
+  return [...records].sort((a, b) => (a.createdAt.getTime() - b.createdAt.getTime()) * multiplier);
+}
+
+function toDuplicateKey(entry: { orgId: string; date: Date; amount: number; payee: string; desc: string }): string {
+  return [entry.orgId, entry.date.toISOString(), entry.amount, entry.payee, entry.desc].join("|");
+}
+
+function createMockPrisma(): MockPrismaClient {
+  const now = new Date("2024-01-15T00:00:00.000Z");
+  const orgs: OrgRecord[] = [
+    {
+      id: "demo-org",
+      name: "Demo Org",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+
+  const users: UserRecord[] = [
+    {
+      email: "founder@example.com",
+      password: "password123",
+      orgId: "demo-org",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+
+  const bankLines: BankLineRecord[] = [
+    {
+      id: crypto.randomUUID(),
+      orgId: "demo-org",
+      date: new Date("2024-01-13T00:00:00.000Z"),
+      amount: 1250.75,
+      payee: "Acme",
+      desc: "Office fit-out",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      orgId: "demo-org",
+      date: new Date("2024-01-14T00:00:00.000Z"),
+      amount: -299.99,
+      payee: "CloudCo",
+      desc: "Monthly sub",
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: crypto.randomUUID(),
+      orgId: "demo-org",
+      date: new Date("2024-01-15T00:00:00.000Z"),
+      amount: 5000,
+      payee: "Birchal",
+      desc: "Investment received",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ];
+
+  const duplicateKeys = new Set(bankLines.map(toDuplicateKey));
+
+  return {
+    org: {
+      async upsert({ where, update, create }) {
+        const existing = orgs.find((org) => org.id === where.id);
+        if (existing) {
+          Object.assign(existing, update ?? {}, { updatedAt: new Date() });
+          return { ...existing };
+        }
+        const createdAt = new Date();
+        const record: OrgRecord = {
+          id: create.id,
+          name: create.name,
+          createdAt,
+          updatedAt: createdAt,
+        };
+        orgs.push(record);
+        return { ...record };
+      },
+    },
+    user: {
+      async upsert({ where, update, create }) {
+        const existing = users.find((user) => user.email === where.email);
+        if (existing) {
+          Object.assign(existing, update ?? {}, { updatedAt: new Date() });
+          return { ...existing };
+        }
+        const createdAt = new Date();
+        const record: UserRecord = {
+          email: create.email,
+          password: create.password,
+          orgId: create.orgId,
+          createdAt,
+          updatedAt: createdAt,
+        };
+        users.push(record);
+        return { ...record };
+      },
+      async findMany(args) {
+        const direction = args?.orderBy?.createdAt;
+        const sorted = direction ? sortByCreatedAt(users, direction) : [...users];
+        return sorted.map((user) => pick(user, args?.select));
+      },
+    },
+    bankLine: {
+      async findMany(args) {
+        const direction = args?.orderBy?.date;
+        const sorted = sortByDate(bankLines, direction);
+        const take = args?.take;
+        const limited = typeof take === "number" ? sorted.slice(0, Math.max(0, take)) : sorted;
+        return limited.map((line) => ({ ...line }));
+      },
+      async create({ data }) {
+        const createdAt = new Date();
+        const record: BankLineRecord = {
+          id: crypto.randomUUID(),
+          orgId: data.orgId,
+          date: new Date(data.date),
+          amount: data.amount,
+          payee: data.payee,
+          desc: data.desc,
+          createdAt,
+          updatedAt: createdAt,
+        };
+        bankLines.push(record);
+        duplicateKeys.add(toDuplicateKey(record));
+        return { ...record };
+      },
+      async createMany({ data, skipDuplicates }) {
+        let inserted = 0;
+        for (const entry of data) {
+          const key = toDuplicateKey(entry);
+          if (skipDuplicates && duplicateKeys.has(key)) {
+            continue;
+          }
+          const createdAt = new Date();
+          const record: BankLineRecord = {
+            id: crypto.randomUUID(),
+            orgId: entry.orgId,
+            date: new Date(entry.date),
+            amount: entry.amount,
+            payee: entry.payee,
+            desc: entry.desc,
+            createdAt,
+            updatedAt: createdAt,
+          };
+          bankLines.push(record);
+          duplicateKeys.add(key);
+          inserted += 1;
+        }
+        return { count: inserted };
+      },
+    },
+    async $disconnect() {
+      // no-op for the in-memory mock
+    },
+  } satisfies MockPrismaClient;
+}
+
+function instantiatePrisma(): PrismaClient | MockPrismaClient {
+  try {
+    const mod = require("@prisma/client") as PrismaModule;
+    if (mod?.PrismaClient) {
+      return new mod.PrismaClient();
+    }
+  } catch (error) {
+    console.warn("Falling back to mock Prisma client", error);
+  }
+  return createMockPrisma();
+}
+
+export const prisma = instantiatePrisma();

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,10 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "node src/server.mjs",
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  }
+}

--- a/apgms/webapp/src/server.mjs
+++ b/apgms/webapp/src/server.mjs
@@ -1,0 +1,76 @@
+import http from "node:http";
+
+const port = Number(process.env.PORT ?? 5173);
+const host = "0.0.0.0";
+const apiUrl = process.env.VITE_API_URL ?? "http://127.0.0.1:3000";
+
+const indexHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>APGMS Demo Webapp</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root { font-family: system-ui, sans-serif; background: #f8fafc; color: #0f172a; }
+      main { max-width: 720px; margin: 3rem auto; background: white; border-radius: 1rem; padding: 2.5rem; box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.4); }
+      h1 { margin-top: 0; font-size: 2.25rem; }
+      code { background: #0f172a; color: white; padding: 0.25rem 0.5rem; border-radius: 0.5rem; font-size: 0.9rem; }
+      ul { padding-left: 1.25rem; }
+      .status { margin-top: 1.5rem; padding: 1rem; border-radius: 0.75rem; background: #f1f5f9; }
+      .status[data-state="error"] { background: #fee2e2; color: #991b1b; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>APGMS Demo Webapp</h1>
+      <p>This lightweight dev server renders a static page and checks the API health endpoint.</p>
+      <p>Currently configured API URL: <code>${apiUrl}</code></p>
+      <section class="status" id="status" data-state="pending">
+        <strong>API health status:</strong>
+        <span id="health-result">Loading...</span>
+      </section>
+      <section>
+        <h2>Manual smoke tests</h2>
+        <ul>
+          <li><a href="${apiUrl}/health" target="_blank" rel="noreferrer">GET /health</a></li>
+          <li><a href="${apiUrl}/users" target="_blank" rel="noreferrer">GET /users</a></li>
+          <li><a href="${apiUrl}/bank-lines" target="_blank" rel="noreferrer">GET /bank-lines</a></li>
+        </ul>
+      </section>
+    </main>
+    <script>
+      const statusEl = document.getElementById('status');
+      const resultEl = document.getElementById('health-result');
+      fetch('${apiUrl}/health')
+        .then(async (res) => {
+          const text = await res.text();
+          try {
+            const body = JSON.parse(text);
+            resultEl.textContent = body.ok ? 'OK' : text;
+            statusEl.dataset.state = body.ok ? 'ok' : 'error';
+          } catch (error) {
+            resultEl.textContent = text;
+            statusEl.dataset.state = res.ok ? 'ok' : 'error';
+          }
+        })
+        .catch((error) => {
+          statusEl.dataset.state = 'error';
+          resultEl.textContent = error.message;
+        });
+    </script>
+  </body>
+</html>`;
+
+const server = http.createServer((req, res) => {
+  if (req.url && req.url !== "/" && req.url !== "/index.html") {
+    res.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    res.end("Not found");
+    return;
+  }
+  res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  res.end(indexHtml);
+});
+
+server.listen(port, host, () => {
+  console.log(`Webapp listening on http://${host}:${port}`);
+});

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,11 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "node src/index.mjs",
+    "build": "echo build worker",
+    "test": "echo test worker"
+  }
+}

--- a/apgms/worker/src/index.mjs
+++ b/apgms/worker/src/index.mjs
@@ -1,0 +1,5 @@
+setInterval(() => {
+  console.log(`[worker] heartbeat ${new Date().toISOString()}`);
+}, 5000);
+
+console.log("Worker started");

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,0 @@
-﻿console.log('worker');


### PR DESCRIPTION
## Summary
- add a mock Prisma client fallback so the API and seed script can run without downloading engines
- provide lightweight dev servers for the webapp and worker packages so the workspace dev commands succeed

## Testing
- pnpm -F @apgms/api-gateway dev
- pnpm -F @apgms/webapp dev
- pnpm -F @apgms/worker dev
- curl http://127.0.0.1:3000/health
- curl http://127.0.0.1:3000/users
- curl http://127.0.0.1:3000/bank-lines

------
https://chatgpt.com/codex/tasks/task_e_68ea992718288327b457ee92fc40e1f5