### PR TITLE
Add Docker builds for API gateway and webapp

### DIFF
--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -36,12 +36,12 @@ importers:
 
   services/api-gateway:
     dependencies:
-      '@apgms/shared':
-        specifier: workspace:*
-        version: link:../../shared
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
+      '@prisma/client':
+        specifier: 6.17.1
+        version: 6.17.1(prisma@6.17.1(typescript@5.9.3))(typescript@5.9.3)
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -55,6 +55,9 @@ importers:
       '@types/node':
         specifier: ^24.7.1
         version: 24.7.1
+      prisma:
+        specifier: 6.17.1
+        version: 6.17.1(typescript@5.9.3)
       tsx:
         specifier: ^4.20.6
         version: 4.20.6

--- a/apgms/services/api-gateway/.dockerignore
+++ b/apgms/services/api-gateway/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+pnpm-debug.log
+Dockerfile
+Dockerfile.*
+.git
+.gitignore
+dist
+.env

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.6
+FROM node:20-alpine AS base
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml .
+RUN pnpm install --frozen-lockfile
+
+COPY tsconfig.json ./
+COPY prisma ./prisma
+COPY src ./src
+
+RUN pnpm run generate
+RUN pnpm run build
+RUN pnpm prune --prod
+
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml ./
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/dist ./dist
+COPY --from=base /app/prisma ./prisma
+
+EXPOSE 3000
+CMD ["node", "dist/index.js"]

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,17 +4,21 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "build": "pnpm run generate && tsc --project tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "start": "node dist/index.js",
+    "generate": "prisma generate"
   },
   "dependencies": {
-    "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/apgms/services/api-gateway/pnpm-lock.yaml
+++ b/apgms/services/api-gateway/pnpm-lock.yaml
@@ -6,30 +6,36 @@ settings:
 
 importers:
 
-  .:
-    dependencies:
-      '@apgms/shared':
-        specifier: workspace:*
-        version: link:../../shared
-      '@fastify/cors':
-        specifier: ^11.1.0
-        version: 11.1.0
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
-      fastify:
-        specifier: ^5.6.1
-        version: 5.6.1
-    devDependencies:
-      '@types/node':
-        specifier: ^24.7.1
-        version: 24.7.1
-      tsx:
-        specifier: ^4.20.6
-        version: 4.20.6
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+    .:
+      dependencies:
+        '@fastify/cors':
+          specifier: ^11.1.0
+          version: 11.1.0
+        '@prisma/client':
+          specifier: 6.17.1
+          version: 6.17.1(prisma@6.17.1(typescript@5.9.3))(typescript@5.9.3)
+        dotenv:
+          specifier: ^16.6.1
+          version: 16.6.1
+        fastify:
+          specifier: ^5.6.1
+          version: 5.6.1
+        zod:
+          specifier: ^4.1.12
+          version: 4.1.12
+      devDependencies:
+        '@types/node':
+          specifier: ^24.7.1
+          version: 24.7.1
+        prisma:
+          specifier: 6.17.1
+          version: 6.17.1(typescript@5.9.3)
+        tsx:
+          specifier: ^4.20.6
+          version: 4.20.6
+        typescript:
+          specifier: ^5.9.3
+          version: 5.9.3
 
 packages:
 

--- a/apgms/services/api-gateway/prisma/schema.prisma
+++ b/apgms/services/api-gateway/prisma/schema.prisma
@@ -1,0 +1,37 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+}
+
+model Org {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  users     User[]
+  lines     BankLine[]
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  password  String
+  createdAt DateTime @default(now())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+}
+
+model BankLine {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  date      DateTime
+  amount    Decimal
+  payee     String
+  desc      String
+  createdAt DateTime @default(now())
+}

--- a/apgms/services/api-gateway/src/db.ts
+++ b/apgms/services/api-gateway/src/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from "@prisma/client";
+
+export const prisma = new PrismaClient();

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,15 +1,10 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+
+import { prisma } from "./db";
+
+dotenv.config();
 
 const app = Fastify({ logger: true });
 
@@ -31,7 +26,7 @@ app.get("/users", async () => {
 
 // List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+  const take = Number((req.query as Record<string, unknown>).take ?? 20);
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
     take: Math.min(Math.max(take, 1), 200),
@@ -77,4 +72,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -1,16 +1,9 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "types": ["node"],
-    "baseUrl": "../../",
-    "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
-    }
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/apgms/webapp/.dockerignore
+++ b/apgms/webapp/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+pnpm-debug.log
+Dockerfile
+Dockerfile.*
+.git
+.gitignore
+dist
+.env

--- a/apgms/webapp/Dockerfile
+++ b/apgms/webapp/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.6
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml .
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm run build
+
+FROM nginx:1.27-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,9 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "test": "echo test webapp"
+  }
+}

--- a/apgms/webapp/pnpm-lock.yaml
+++ b/apgms/webapp/pnpm-lock.yaml
@@ -1,0 +1,10 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+
+packages: {}

--- a/apgms/webapp/scripts/build.mjs
+++ b/apgms/webapp/scripts/build.mjs
@@ -1,0 +1,12 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const distDir = path.join(projectRoot, "dist");
+
+await rm(distDir, { recursive: true, force: true });
+await mkdir(distDir, { recursive: true });
+
+await cp(path.join(projectRoot, "index.html"), path.join(distDir, "index.html"));
+await cp(path.join(projectRoot, "public"), path.join(distDir, "public"), { recursive: true });


### PR DESCRIPTION
## Summary
- add a production-oriented Dockerfile for the API gateway with Prisma schema generation and runtime assets
- include supporting Prisma schema, build script updates, and Docker ignores so the service can build in isolation
- provide a static build workflow and Docker image for the webapp to produce nginx-served assets

## Testing
- pnpm run build (webapp)
- pnpm -F @apgms/api-gateway build *(fails in offline environment when Prisma engines cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68ea9932ed54832788be143fce04388a