### PR TITLE
Add documentation placeholders for governance backlogs

### DIFF
--- a/docs/accessibility/README.md
+++ b/docs/accessibility/README.md
@@ -1,0 +1,8 @@
+# Accessibility Guidelines
+
+> _Placeholder_: Add accessibility audits, inclusive design principles, and compliance reporting from the accessibility backlog.
+
+## TODO
+- [ ] Document WCAG conformance targets and testing cadence.
+- [ ] Provide inclusive content and design checklists.
+- [ ] Capture assistive technology compatibility findings.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,8 @@
+# Architecture Overview
+
+> _Placeholder_: Populate with system context, integration diagrams, and decision records from the architecture backlog.
+
+## TODO
+- [ ] Document current system context and dependencies.
+- [ ] Capture key architectural decision records.
+- [ ] Describe deployment topology and infrastructure components.

--- a/docs/dsp-osf/README.md
+++ b/docs/dsp-osf/README.md
@@ -1,0 +1,8 @@
+# DSP & OSF Alignment
+
+> _Placeholder_: Incorporate delivery, service performance (DSP), and operating service framework (OSF) materials from the backlog.
+
+## TODO
+- [ ] Summarise DSP objectives and key metrics.
+- [ ] Outline OSF governance checkpoints.
+- [ ] Map backlog items to DSP/OSF compliance requirements.

--- a/docs/ops/runbook.md
+++ b/docs/ops/runbook.md
@@ -1,0 +1,12 @@
+# Operations Runbook
+
+> _Placeholder_: Populate with procedures, escalation paths, and on-call schedules from the governance backlog.
+
+## Overview
+- [ ] Document service ownership and contact details.
+- [ ] Add incident response checklist.
+- [ ] Capture deployment and rollback steps.
+
+## Appendices
+- [ ] Link monitoring dashboards.
+- [ ] Reference post-incident review template.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,0 +1,8 @@
+# Security Documentation
+
+> _Placeholder_: Backfill threat models, control mappings, and audit requirements from the security backlog.
+
+## TODO
+- [ ] Document authentication and authorization architecture.
+- [ ] List vulnerability management processes.
+- [ ] Provide third-party risk assessments.


### PR DESCRIPTION
## Summary
- add placeholder accessibility, architecture, dsp-osf, and security documentation readmes
- add placeholder operations runbook with overview and appendices tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea9c8248f08327ba8a1e68437a142b