### PR TITLE
Add shared Prisma package and seed scripts

### DIFF
--- a/scripts/rehash.ts
+++ b/scripts/rehash.ts
@@ -1,0 +1,1 @@
+console.log('rehash placeholder');

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+async function main() {
+  const org = await prisma.org.upsert({
+    where: { id: 'seed-org-1' },
+    update: {},
+    create: { id: 'seed-org-1', name: 'Seed Org' }
+  });
+  await prisma.user.upsert({
+    where: { email: 'demo@apgms.local' },
+    update: {},
+    create: { email: 'demo@apgms.local', orgId: org.id }
+  });
+  console.log('Seed complete');
+}
+main().finally(() => prisma.$disconnect());

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@apgms/shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./*": "./dist/*",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": { "*": ["dist/*"] }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma"
+  },
+  "dependencies": {
+    "@prisma/client": "6.17.1"
+  },
+  "devDependencies": {
+    "prisma": "6.17.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/shared/prisma/schema.prisma
+++ b/shared/prisma/schema.prisma
@@ -1,0 +1,23 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Org {
+  id        String   @id @default(cuid())
+  name      String
+  createdAt DateTime @default(now())
+  users     User[]
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  orgId     String
+  org       Org      @relation(fields: [orgId], references: [id])
+  createdAt DateTime @default(now())
+}

--- a/shared/src/db.ts
+++ b/shared/src/db.ts
@@ -1,0 +1,2 @@
+import { PrismaClient } from '@prisma/client';
+export const prisma = new PrismaClient();

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './db';

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add shared package configuration for Prisma client generation
- expose a Prisma client helper and schema within the shared package
- add seed and rehash scripts for database seeding and placeholder task

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaa45a238083279da584775f83182e