### PR TITLE
Add Vite React webapp scaffold

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>APGMS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "typescript": "^5.9.3",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "tailwindcss": "^3.4.13",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47"
+  }
+}

--- a/webapp/postcss.config.cjs
+++ b/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import './styles.css';
+
+function App() {
+  return <div className="p-6">APGMS Webapp</div>;
+}
+
+createRoot(document.getElementById('root')!).render(<App />);

--- a/webapp/src/styles.css
+++ b/webapp/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/webapp/tailwind.config.cjs
+++ b/webapp/tailwind.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: { extend: {} },
+  plugins: []
+};

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+export default defineConfig({
+  server: { port: 5173 },
+  resolve: { alias: { '@': path.resolve(__dirname, 'src') } }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-based React webapp with Tailwind CSS setup
- configure TypeScript, PostCSS, and Tailwind settings for the new webapp package
- add a basic entry point rendering a placeholder application

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaa48b55bc832792e573153019f786