### PR TITLE
Add worker package

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "pino": "^9.3.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "tsx": "^4.20.0"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,8 @@
+import pino from 'pino';
+import { prisma } from '@apgms/shared';
+const log = pino({ level: 'info' });
+async function tick() {
+  const count = await prisma.user.count();
+  log.info({ count }, 'tick');
+}
+setInterval(tick, 2000);

--- a/worker/tsconfig.json
+++ b/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@apgms/shared/*": ["../shared/src/*"],
+      "@apgms/shared": ["../shared/src/index"]
+    }
+  },
+  "include": ["src", "../shared/src"]
+}


### PR DESCRIPTION
## Summary
- add a new worker package configured with TypeScript build and dev scripts
- implement a worker entrypoint that logs Prisma user counts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eaa49ea3fc8327a8d63f744cb65f5d