### PR TITLE
Add Dockerfiles for API gateway and webapp

### DIFF
--- a/apgms/webapp/Dockerfile
+++ b/apgms/webapp/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN corepack enable && pnpm i
+COPY . .
+RUN pnpm build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* ./
+RUN corepack enable && pnpm i --prod
+COPY src ./src
+COPY tsconfig.json ./
+CMD ["node", "--loader", "tsx", "src/index.ts"]


### PR DESCRIPTION
## Summary
- add Dockerfile for the API gateway service that runs the TypeScript entrypoint via tsx
- add Dockerfile for the webapp that builds with Vite and serves with nginx

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaa4e8c2b08327af6a70d09d8db11c