### PR TITLE
Implement reconciliation parsing and matching service

### DIFF
--- a/services/recon/package.json
+++ b/services/recon/package.json
@@ -1,10 +1,10 @@
-﻿{
+{
   "name": "@apgms/recon",
   "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "echo build recon",
-    "test": "echo test recon"
+    "build": "node -e \"console.log('recon build placeholder')\"",
+    "test": "node --test"
   }
 }

--- a/services/recon/src/audit.js
+++ b/services/recon/src/audit.js
@@ -1,0 +1,11 @@
+export class AuditLogger {
+  constructor() {
+    this.events = [];
+  }
+
+  emit(event) {
+    const enriched = { ...event, timestamp: event?.timestamp ?? new Date().toISOString() };
+    this.events.push(enriched);
+    return enriched;
+  }
+}

--- a/services/recon/src/index.js
+++ b/services/recon/src/index.js
@@ -1,0 +1,5 @@
+export { parseCsvTransactions, parseOfxTransactions, parseQifTransactions } from './parsers.js';
+export { matchTransactions, computeMatchScore } from './matcher.js';
+export { InMemoryQueue } from './queue.js';
+export { AuditLogger } from './audit.js';
+export { ReconciliationService } from './service.js';

--- a/services/recon/src/matcher.js
+++ b/services/recon/src/matcher.js
@@ -1,0 +1,152 @@
+import { parseDate } from './parsers.js';
+
+/**
+ * Computes the Levenshtein distance between two strings.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function levenshtein(a, b) {
+  const s = a ?? '';
+  const t = b ?? '';
+  const rows = s.length + 1;
+  const cols = t.length + 1;
+  const matrix = Array.from({ length: rows }, () => new Array(cols).fill(0));
+
+  for (let i = 0; i < rows; i += 1) {
+    matrix[i][0] = i;
+  }
+  for (let j = 0; j < cols; j += 1) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = s[i - 1] === t[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  return matrix[rows - 1][cols - 1];
+}
+
+/**
+ * Normalises the Levenshtein similarity into a 0..1 score.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function descriptionSimilarity(a, b) {
+  const strA = (a ?? '').toLowerCase();
+  const strB = (b ?? '').toLowerCase();
+  if (!strA && !strB) {
+    return 1;
+  }
+  const distance = levenshtein(strA, strB);
+  const maxLen = Math.max(strA.length, strB.length);
+  return maxLen === 0 ? 1 : 1 - distance / maxLen;
+}
+
+/**
+ * Computes the amount similarity score.
+ * @param {number} amountA
+ * @param {number} amountB
+ * @param {number} tolerance
+ * @returns {number}
+ */
+function amountSimilarity(amountA, amountB, tolerance) {
+  const diff = Math.abs(amountA - amountB);
+  if (diff < 0.005) {
+    return 1;
+  }
+  return Math.max(0, 1 - diff / tolerance);
+}
+
+/**
+ * Computes the date similarity score.
+ * @param {Date} dateA
+ * @param {Date} dateB
+ * @param {number} windowDays
+ * @returns {number}
+ */
+function dateSimilarity(dateA, dateB, windowDays) {
+  const a = dateA instanceof Date ? dateA : parseDate(dateA);
+  const b = dateB instanceof Date ? dateB : parseDate(dateB);
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diff = Math.abs(a.getTime() - b.getTime()) / msPerDay;
+  if (diff === 0) {
+    return 1;
+  }
+  return Math.max(0, 1 - diff / windowDays);
+}
+
+/**
+ * Computes the composite match score between two transactions.
+ * @param {{ amount: number; description: string; date: Date }} bank
+ * @param {{ amount: number; description: string; date: Date }} ledger
+ * @param {{ amountTolerance?: number; dateWindow?: number; weights?: { amount?: number; description?: number; date?: number } }} [options]
+ * @returns {number}
+ */
+export function computeMatchScore(bank, ledger, options = {}) {
+  const {
+    amountTolerance = 5,
+    dateWindow = 10,
+    weights = { amount: 0.7, description: 0.2, date: 0.1 }
+  } = options;
+  const amountScore = amountSimilarity(bank.amount, ledger.amount, amountTolerance);
+  const descriptionScore = descriptionSimilarity(bank.description, ledger.description);
+  const dateScore = dateSimilarity(bank.date, ledger.date, dateWindow);
+
+  return (
+    (amountScore * (weights.amount ?? 0)) +
+    (descriptionScore * (weights.description ?? 0)) +
+    (dateScore * (weights.date ?? 0))
+  );
+}
+
+/**
+ * Matches bank transactions to ledger transactions.
+ * @param {Array<any>} bankTransactions
+ * @param {Array<any>} ledgerTransactions
+ * @param {{ threshold?: number }} [options]
+ * @returns {{ matches: Array<{ bank: any; ledger: any; score: number }>; unmatched: Array<{ bank: any; bestCandidate?: any; score: number }>; remainingLedger: Array<any> }}
+ */
+export function matchTransactions(bankTransactions, ledgerTransactions, options = {}) {
+  const threshold = options.threshold ?? 0.9;
+  const remainingLedger = [...ledgerTransactions];
+  const matches = [];
+  const unmatched = [];
+
+  for (const bankTxn of bankTransactions) {
+    let bestScore = -Infinity;
+    let bestIndex = -1;
+
+    for (let i = 0; i < remainingLedger.length; i += 1) {
+      const ledgerTxn = remainingLedger[i];
+      const score = computeMatchScore(bankTxn, ledgerTxn, options);
+      if (score > bestScore) {
+        bestScore = score;
+        bestIndex = i;
+      }
+    }
+
+    if (bestIndex >= 0 && bestScore + 1e-6 >= threshold) {
+      const [matchedLedger] = remainingLedger.splice(bestIndex, 1);
+      matches.push({ bank: bankTxn, ledger: matchedLedger, score: Number(bestScore.toFixed(3)) });
+    } else {
+      unmatched.push({
+        bank: bankTxn,
+        bestCandidate: bestIndex >= 0 ? remainingLedger[bestIndex] : undefined,
+        score: bestScore === -Infinity ? 0 : Number(bestScore.toFixed(3))
+      });
+    }
+  }
+
+  return { matches, unmatched, remainingLedger };
+}
+
+export { levenshtein, descriptionSimilarity, amountSimilarity, dateSimilarity };

--- a/services/recon/src/parsers.js
+++ b/services/recon/src/parsers.js
@@ -1,0 +1,226 @@
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Normalizes a string and trims BOM/whitespace.
+ * @param {string} input
+ * @returns {string}
+ */
+function cleanInput(input) {
+  if (typeof input !== 'string') {
+    throw new TypeError('Expected input to be a string');
+  }
+  return input.replace(/^\uFEFF/, '').trim();
+}
+
+/**
+ * Parses a date string into a JavaScript Date.
+ * Falls back to new Date parsing and throws if invalid.
+ * @param {string} value
+ * @returns {Date}
+ */
+function parseDate(value) {
+  if (!value) {
+    throw new Error('Missing date value');
+  }
+  const normalised = value.trim();
+  // Handle QIF style dates that use YYYY-MM-DD or YYYY/MM/DD
+  const isoCandidate = normalised
+    .replace(/'(\d{2})$/, '20$1')
+    .replace(/(\d{4})\/(\d{2})\/(\d{2})/, '$1-$2-$3')
+    .replace(/(\d{2})\/(\d{2})\/(\d{4})/, '$3-$1-$2');
+  const date = new Date(isoCandidate);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Unable to parse date value: ${value}`);
+  }
+  return date;
+}
+
+/**
+ * Parses an OFX date value in YYYYMMDD or YYYYMMDDHHmm format.
+ * @param {string} value
+ * @returns {Date}
+ */
+function parseOfxDate(value) {
+  const trimmed = value.trim();
+  const match = trimmed.match(/^(\d{4})(\d{2})(\d{2})/);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(`${year}-${month}-${day}`);
+  }
+  return parseDate(trimmed);
+}
+
+/**
+ * Normalises a parsed transaction object.
+ * @param {{ id?: string; date: Date; amount: number; description: string; source?: string }} txn
+ * @returns {{ id: string; date: Date; amount: number; description: string; source: string }}
+ */
+function normaliseTransaction(txn) {
+  const { id, date, amount, description, source = 'unknown' } = txn;
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    throw new Error('Transaction date is invalid');
+  }
+  if (typeof amount !== 'number' || Number.isNaN(amount)) {
+    throw new Error('Transaction amount is invalid');
+  }
+  return {
+    id: id ?? randomUUID(),
+    date,
+    amount,
+    description: description ?? '',
+    source
+  };
+}
+
+/**
+ * Parses CSV data into transactions.
+ * Supports the headers: date,amount,description,id (case insensitive).
+ * @param {string} csv
+ * @returns {Array<{ id: string; date: Date; amount: number; description: string; source: string }>}
+ */
+export function parseCsvTransactions(csv) {
+  const lines = cleanInput(csv).split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) {
+    return [];
+  }
+  const header = lines[0]
+    .split(',')
+    .map((segment) => segment.trim().toLowerCase());
+  const indexOf = (field) => header.indexOf(field);
+  const dateIdx = indexOf('date');
+  const amountIdx = indexOf('amount');
+  const descriptionIdx = indexOf('description');
+  const idIdx = indexOf('id');
+
+  return lines.slice(1).map((line) => {
+    const parts = line.split(',');
+    const dateValue = parts[dateIdx]?.trim();
+    const amountValue = parts[amountIdx]?.trim();
+    const description = descriptionIdx >= 0 ? parts[descriptionIdx]?.trim() ?? '' : '';
+    const id = idIdx >= 0 ? parts[idIdx]?.trim() : undefined;
+
+    return normaliseTransaction({
+      id,
+      date: parseDate(dateValue),
+      amount: Number.parseFloat(amountValue ?? '0'),
+      description,
+      source: 'csv'
+    });
+  });
+}
+
+/**
+ * Parses QIF formatted data. Only a subset of the spec is supported (D, T, P, M, N fields).
+ * @param {string} qif
+ * @returns {Array<{ id: string; date: Date; amount: number; description: string; source: string }>}
+ */
+export function parseQifTransactions(qif) {
+  const content = cleanInput(qif);
+  if (!content) {
+    return [];
+  }
+  const entries = content
+    .split('^')
+    .map((block) => block.trim())
+    .filter(Boolean);
+  const transactions = [];
+
+  for (const entry of entries) {
+    const lines = entry.split(/\r?\n/);
+    const txn = { source: 'qif' };
+    for (const line of lines) {
+      if (!line) continue;
+      const code = line[0];
+      const value = line.slice(1).trim();
+      switch (code) {
+        case 'D':
+          txn.date = parseDate(value);
+          break;
+        case 'T':
+          txn.amount = Number.parseFloat(value.replace(/,/g, ''));
+          break;
+        case 'P':
+          txn.description = value;
+          break;
+        case 'M':
+          txn.description = txn.description ? `${txn.description} ${value}`.trim() : value;
+          break;
+        case 'N':
+          txn.id = value;
+          break;
+        default:
+          break;
+      }
+    }
+    if (!txn.date || typeof txn.amount !== 'number') {
+      continue;
+    }
+    transactions.push(normaliseTransaction(txn));
+  }
+
+  return transactions;
+}
+
+/**
+ * Parses OFX data into transactions. Supports DTPOSTED, TRNAMT, FITID, NAME and MEMO tags.
+ * @param {string} ofx
+ * @returns {Array<{ id: string; date: Date; amount: number; description: string; source: string }>}
+ */
+export function parseOfxTransactions(ofx) {
+  const input = cleanInput(ofx);
+  if (!input) {
+    return [];
+  }
+  const transactions = [];
+  const stmtRegex = /<STMTTRN>([\s\S]*?)<\/STMTTRN>/gi;
+  let match;
+
+  const extractTag = (block, tag) => {
+    const tagRegex = new RegExp(`<${tag}>([^<\r\n]+)`, 'i');
+    const result = block.match(tagRegex);
+    return result ? result[1].trim() : undefined;
+  };
+
+  while ((match = stmtRegex.exec(input)) !== null) {
+    const block = match[1];
+    const dateRaw = extractTag(block, 'DTPOSTED');
+    const amountRaw = extractTag(block, 'TRNAMT');
+    const id = extractTag(block, 'FITID') ?? extractTag(block, 'REFNUM');
+    const description =
+      extractTag(block, 'NAME') ?? extractTag(block, 'MEMO') ?? extractTag(block, 'PAYEE') ?? '';
+
+    if (!dateRaw || !amountRaw) {
+      continue;
+    }
+
+    const amount = Number.parseFloat(amountRaw.replace(/,/g, ''));
+
+    transactions.push(
+      normaliseTransaction({
+        id,
+        date: parseOfxDate(dateRaw),
+        amount,
+        description,
+        source: 'ofx'
+      })
+    );
+  }
+
+  return transactions;
+}
+
+export function getParserForFormat(format) {
+  const key = format?.toLowerCase();
+  switch (key) {
+    case 'csv':
+      return parseCsvTransactions;
+    case 'ofx':
+      return parseOfxTransactions;
+    case 'qif':
+      return parseQifTransactions;
+    default:
+      throw new Error(`Unsupported format: ${format}`);
+  }
+}
+
+export { parseDate };

--- a/services/recon/src/queue.js
+++ b/services/recon/src/queue.js
@@ -1,0 +1,9 @@
+export class InMemoryQueue {
+  constructor() {
+    this.items = [];
+  }
+
+  enqueue(item) {
+    this.items.push({ item, enqueuedAt: new Date() });
+  }
+}

--- a/services/recon/src/service.js
+++ b/services/recon/src/service.js
@@ -1,0 +1,63 @@
+import { AuditLogger } from './audit.js';
+import { InMemoryQueue } from './queue.js';
+import { getParserForFormat } from './parsers.js';
+import { matchTransactions } from './matcher.js';
+
+export class ReconciliationService {
+  constructor({ queue, auditLogger, threshold } = {}) {
+    this.queue = queue ?? new InMemoryQueue();
+    this.auditLogger = auditLogger ?? new AuditLogger();
+    this.threshold = threshold ?? 0.9;
+  }
+
+  parse(format, payload) {
+    const parser = getParserForFormat(format);
+    return parser(payload);
+  }
+
+  reconcile({
+    bank,
+    ledger,
+    matcherOptions = {}
+  }) {
+    if (!bank || !ledger) {
+      throw new Error('Bank and ledger data are required');
+    }
+
+    const bankTransactions = this.parse(bank.format, bank.data);
+    const ledgerTransactions = this.parse(ledger.format, ledger.data);
+
+    const result = matchTransactions(bankTransactions, ledgerTransactions, {
+      ...matcherOptions,
+      threshold: matcherOptions.threshold ?? this.threshold
+    });
+
+    for (const match of result.matches) {
+      this.auditLogger.emit({
+        type: 'match',
+        bankId: match.bank.id,
+        ledgerId: match.ledger.id,
+        score: match.score
+      });
+    }
+
+    for (const entry of result.unmatched) {
+      this.queue.enqueue({
+        transaction: entry.bank,
+        attemptedScore: entry.score,
+        suggestedLedgerId: entry.bestCandidate?.id
+      });
+      this.auditLogger.emit({
+        type: 'queued',
+        bankId: entry.bank.id,
+        suggestedLedgerId: entry.bestCandidate?.id,
+        score: entry.score
+      });
+    }
+
+    return {
+      matches: result.matches,
+      queued: result.unmatched.map((entry) => entry.bank)
+    };
+  }
+}

--- a/services/recon/test/matcher.test.js
+++ b/services/recon/test/matcher.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { matchTransactions, computeMatchScore } from '../src/matcher.js';
+
+const ledgerTransactions = [
+  { id: 'L1', date: new Date('2024-05-01'), amount: 123.45, description: 'Acme Supplies Pty Ltd' },
+  { id: 'L2', date: new Date('2024-05-02'), amount: -45.67, description: 'Coffee Corner' },
+  { id: 'L3', date: new Date('2024-05-03'), amount: -15.25, description: 'Downtown Parking' }
+];
+
+const bankTransactions = [
+  { id: 'B1', date: new Date('2024-05-01'), amount: 123.45, description: 'ACME SUPPLIES PTY LTD' },
+  { id: 'B2', date: new Date('2024-05-02'), amount: -45.67, description: 'Coffee Corner - Sydney' },
+  { id: 'B3', date: new Date('2024-05-06'), amount: -15.25, description: 'Downtown Parking Garage' },
+  { id: 'B4', date: new Date('2024-05-07'), amount: -22.0, description: 'Unknown Vendor' }
+];
+
+test('computeMatchScore gives higher values for similar transactions', () => {
+  const exact = computeMatchScore(bankTransactions[0], ledgerTransactions[0]);
+  const distant = computeMatchScore(bankTransactions[3], ledgerTransactions[0]);
+  assert.ok(exact > 0.95);
+  assert.ok(distant < exact);
+});
+
+test('matchTransactions auto matches above threshold and leaves difficult ones unmatched', () => {
+  const { matches, unmatched } = matchTransactions(bankTransactions, ledgerTransactions, { threshold: 0.9 });
+  assert.equal(matches.length, 3);
+  assert.equal(unmatched.length, 1);
+  assert.equal(unmatched[0].bank.id, 'B4');
+  assert.equal(unmatched[0].score < 0.5, true);
+});

--- a/services/recon/test/parsers.test.js
+++ b/services/recon/test/parsers.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCsvTransactions, parseQifTransactions, parseOfxTransactions } from '../src/parsers.js';
+
+test('parseCsvTransactions parses simple CSV content', () => {
+  const csv = `date,amount,description,id\n2024-05-01,123.45,Acme Supplies,L1\n2024-05-03,-45.67,Coffee Corner,L2`;
+  const result = parseCsvTransactions(csv);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, 'L1');
+  assert.equal(result[0].amount, 123.45);
+  assert.equal(result[1].description, 'Coffee Corner');
+});
+
+test('parseQifTransactions parses QIF blocks', () => {
+  const qif = `!Type:Bank\nD2024-05-01\nT123.45\nPAcme Supplies\n^\nD2024-05-02\nT-45.67\nPCoffee Corner\nMLatte run\n^`;
+  const result = parseQifTransactions(qif);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].description, 'Acme Supplies');
+  assert.equal(result[1].description, 'Coffee Corner Latte run');
+  assert.equal(result[1].amount, -45.67);
+});
+
+test('parseOfxTransactions parses minimal OFX content', () => {
+  const ofx = `
+  <OFX>
+    <BANKTRANLIST>
+      <STMTTRN>
+        <DTPOSTED>20240501
+        <TRNAMT>123.45
+        <FITID>TXN001
+        <NAME>Acme Supplies</NAME>
+      </STMTTRN>
+      <STMTTRN>
+        <DTPOSTED>20240503
+        <TRNAMT>-45.67
+        <FITID>TXN002
+        <MEMO>Coffee Corner</MEMO>
+      </STMTTRN>
+    </BANKTRANLIST>
+  </OFX>`;
+  const result = parseOfxTransactions(ofx);
+  assert.equal(result.length, 2);
+  assert.equal(result[0].id, 'TXN001');
+  assert.equal(result[1].description, 'Coffee Corner');
+  assert.equal(result[1].amount, -45.67);
+});

--- a/services/recon/test/service.test.js
+++ b/services/recon/test/service.test.js
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ReconciliationService } from '../src/service.js';
+import { InMemoryQueue } from '../src/queue.js';
+import { AuditLogger } from '../src/audit.js';
+
+const bankCsv = `date,amount,description,id\n2024-05-01,120.00,Acme Supplies Pty Ltd,B1\n2024-05-02,-45.67,Coffee Corner,B2\n2024-05-03,-89.10,Metro Transport,B3\n2024-05-04,-25.50,City Parking Station,B4\n2024-05-05,2500.00,Client Payment Invoice 104,B5\n2024-05-06,-19.99,Officeworks Stationery,B6\n2024-05-07,-60.00,Utility Energy Bill,B7\n2024-05-08,-15.75,Lunch Hub Catering,B8\n2024-05-09,-120.00,Team Dinner Catering,B9\n2024-05-10,-30.00,Mystery Transaction,B10`;
+
+const ledgerOfx = `
+<OFX>
+  <BANKTRANLIST>
+    <STMTTRN>
+      <DTPOSTED>20240501
+      <TRNAMT>120.00
+      <FITID>L1
+      <NAME>ACME SUPPLIES PTY</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240502
+      <TRNAMT>-45.67
+      <FITID>L2
+      <NAME>Coffee Corner Cafe</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240503
+      <TRNAMT>-89.10
+      <FITID>L3
+      <NAME>Metro Transport Services</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240504
+      <TRNAMT>-25.50
+      <FITID>L4
+      <NAME>City Parking</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240505
+      <TRNAMT>2500.00
+      <FITID>L5
+      <NAME>Client Payment 104</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240506
+      <TRNAMT>-19.99
+      <FITID>L6
+      <NAME>Officeworks</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240507
+      <TRNAMT>-60.00
+      <FITID>L7
+      <NAME>Utility Energy Pty</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240508
+      <TRNAMT>-15.75
+      <FITID>L8
+      <NAME>Lunch Hub</NAME>
+    </STMTTRN>
+    <STMTTRN>
+      <DTPOSTED>20240509
+      <TRNAMT>-120.00
+      <FITID>L9
+      <NAME>Team Dinner Group</NAME>
+    </STMTTRN>
+  </BANKTRANLIST>
+</OFX>`;
+
+test('ReconciliationService auto matches >=90% and queues the rest', () => {
+  const queue = new InMemoryQueue();
+  const auditLogger = new AuditLogger();
+  const service = new ReconciliationService({ queue, auditLogger, threshold: 0.9 });
+
+  const { matches, queued } = service.reconcile({
+    bank: { format: 'csv', data: bankCsv },
+    ledger: { format: 'ofx', data: ledgerOfx }
+  });
+
+  assert.equal(matches.length, 9);
+  assert.equal(queued.length, 1);
+  assert.equal(queue.items.length, 1);
+  assert.equal(queue.items[0].item.transaction.id, 'B10');
+
+  const matchRate = matches.length / 10;
+  assert.ok(matchRate >= 0.9);
+
+  const matchEvents = auditLogger.events.filter((event) => event.type === 'match');
+  const queuedEvents = auditLogger.events.filter((event) => event.type === 'queued');
+  assert.equal(matchEvents.length, 9);
+  assert.equal(queuedEvents.length, 1);
+});


### PR DESCRIPTION
## Summary
- add CSV, QIF, and OFX parsers for reconciliation inputs with unit coverage
- implement heuristic matcher leveraging Levenshtein scoring and queuing for low confidence results
- expose a reconciliation service that emits audit events while ensuring at least 90% auto-match on fixtures

## Testing
- npm test (services/recon)


------
https://chatgpt.com/codex/tasks/task_e_68eaab2499fc83279655b8b707278cd8