### PR TITLE
feat: add tax engine FastAPI service

### DIFF
--- a/services/tax-engine/Makefile
+++ b/services/tax-engine/Makefile
@@ -1,0 +1,13 @@
+.PHONY: lint test serve openapi
+
+lint:
+poetry run ruff check tax_engine tests
+
+test:
+poetry run pytest
+
+serve:
+poetry run uvicorn tax_engine.app:create_app --factory --host 0.0.0.0 --port 8000
+
+openapi:
+poetry run tax-engine-export-openapi openapi.json

--- a/services/tax-engine/pyproject.toml
+++ b/services/tax-engine/pyproject.toml
@@ -1,0 +1,41 @@
+[tool.poetry]
+name = "tax-engine"
+version = "0.1.0"
+description = "APGMS tax engine service with GST, PAYGW, and BAS calculations"
+authors = ["APGMS Automation <automation@example.com>"]
+packages = [{ include = "tax_engine" }]
+include = [
+  { path = "rules/*.json", format = "sdist" }
+]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.111.0"
+uvicorn = { extras = ["standard"], version = "^0.30.0" }
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.1"
+httpx = "^0.27.0"
+ruff = "^0.4.8"
+
+[tool.poetry.scripts]
+tax-engine-serve = "tax_engine.app:main"
+tax-engine-export-openapi = "tax_engine.openapi:export_cli"
+
+[build-system]
+requires = ["poetry-core>=1.8.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = [
+  "E",
+  "F",
+  "B",
+  "I"
+]

--- a/services/tax-engine/rules/bas_v1.json
+++ b/services/tax-engine/rules/bas_v1.json
@@ -1,0 +1,20 @@
+{
+  "version": "2024-07-01",
+  "formulas": {
+    "gst_payable": {
+      "gst_collected": 1.0,
+      "gst_paid": -1.0
+    },
+    "paygw_payable": {
+      "paygw_withheld": 1.0,
+      "paygw_credits": -1.0
+    },
+    "net_payable": {
+      "gst_collected": 1.0,
+      "gst_paid": -1.0,
+      "paygw_withheld": 1.0,
+      "paygw_credits": -1.0,
+      "fuel_tax_credit": -1.0
+    }
+  }
+}

--- a/services/tax-engine/rules/gst_v1.json
+++ b/services/tax-engine/rules/gst_v1.json
@@ -1,0 +1,8 @@
+{
+  "version": "2024-07-01",
+  "rates": {
+    "standard": 0.1,
+    "reduced": 0.05,
+    "zero": 0.0
+  }
+}

--- a/services/tax-engine/rules/paygw_v1.json
+++ b/services/tax-engine/rules/paygw_v1.json
@@ -1,0 +1,9 @@
+{
+  "version": "2024-07-01",
+  "tiers": [
+    { "up_to": 5000, "rate": 0.1 },
+    { "up_to": 10000, "rate": 0.2 },
+    { "up_to": null, "rate": 0.3 }
+  ],
+  "allowance_rate": 0.5
+}

--- a/services/tax-engine/tax_engine/__init__.py
+++ b/services/tax-engine/tax_engine/__init__.py
@@ -1,0 +1,5 @@
+"""Tax engine service package."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/services/tax-engine/tax_engine/app.py
+++ b/services/tax-engine/tax_engine/app.py
@@ -1,0 +1,75 @@
+"""FastAPI application for tax calculations."""
+
+from __future__ import annotations
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+
+from .calculators import calculate_gst, calculate_paygw, compile_bas
+from .models import (
+    BASCompileRequest,
+    BASCompileResponse,
+    GSTCalcRequest,
+    GSTCalcResponse,
+    PaygwCalcRequest,
+    PaygwCalcResponse,
+)
+from .rules_loader import load_bas_rules, load_gst_rules, load_paygw_rules
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="APGMS Tax Engine",
+        version="0.1.0",
+        description="Deterministic tax calculation engine for GST, PAYGW, and BAS.",
+    )
+
+    @app.post("/gst/calc", response_model=GSTCalcResponse, summary="Calculate GST")
+    def gst_calc(payload: GSTCalcRequest) -> GSTCalcResponse:
+        try:
+            return calculate_gst(payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.post(
+        "/paygw/calc",
+        response_model=PaygwCalcResponse,
+        summary="Calculate PAYGW withholding",
+    )
+    def paygw_calc(payload: PaygwCalcRequest) -> PaygwCalcResponse:
+        try:
+            return calculate_paygw(payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.post(
+        "/bas/compile",
+        response_model=BASCompileResponse,
+        summary="Compile BAS totals",
+    )
+    def bas_compile(payload: BASCompileRequest) -> BASCompileResponse:
+        try:
+            return compile_bas(payload)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @app.get("/rules/versions", summary="Rule versions")
+    def rule_versions() -> dict[str, str]:
+        return {
+            "gst": load_gst_rules()["version"],
+            "paygw": load_paygw_rules()["version"],
+            "bas": load_bas_rules()["version"],
+        }
+
+    return app
+
+
+app = create_app()
+
+
+def main() -> None:
+    uvicorn.run("tax_engine.app:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/tax-engine/tax_engine/calculators.py
+++ b/services/tax-engine/tax_engine/calculators.py
@@ -1,0 +1,97 @@
+"""Deterministic calculation routines for the tax engine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from .models import (
+    BASCompileRequest,
+    BASCompileResponse,
+    GSTCalcRequest,
+    GSTCalcResponse,
+    PaygwCalcRequest,
+    PaygwCalcResponse,
+    quantise,
+)
+from .rules_loader import load_bas_rules, load_gst_rules, load_paygw_rules
+
+
+def calculate_gst(payload: GSTCalcRequest) -> GSTCalcResponse:
+    rules = load_gst_rules()
+    rate_map: Dict[str, float] = rules["rates"]
+    if payload.category not in rate_map:
+        available = ", ".join(sorted(rate_map))
+        raise ValueError(f"Unknown GST category '{payload.category}'. Available: {available}.")
+
+    rate = Decimal(str(rate_map[payload.category]))
+    net_amount = payload.net_amount
+    gst_amount = quantise(net_amount * rate)
+    gross_amount = quantise(net_amount + gst_amount)
+
+    return GSTCalcResponse(
+        rule_version=rules["version"],
+        category=payload.category,
+        rate=rate,
+        net_amount=quantise(net_amount),
+        gst_amount=gst_amount,
+        gross_amount=gross_amount,
+    )
+
+
+def calculate_paygw(payload: PaygwCalcRequest) -> PaygwCalcResponse:
+    rules = load_paygw_rules()
+    tiers = rules["tiers"]
+    taxable_income = payload.taxable_income
+
+    applicable_rate = Decimal("0")
+    for tier in tiers:
+        up_to = tier["up_to"]
+        applicable_rate = Decimal(str(tier["rate"]))
+        if up_to is None or taxable_income <= Decimal(str(up_to)):
+            break
+
+    allowances_reduction = payload.allowances * Decimal(str(rules["allowance_rate"]))
+    withheld = quantise((taxable_income * applicable_rate) - allowances_reduction)
+    if withheld < Decimal("0"):
+        withheld = Decimal("0")
+
+    return PaygwCalcResponse(
+        rule_version=rules["version"],
+        applicable_rate=applicable_rate,
+        taxable_income=quantise(taxable_income),
+        allowances=quantise(payload.allowances),
+        withheld_amount=withheld,
+    )
+
+
+def compile_bas(payload: BASCompileRequest) -> BASCompileResponse:
+    rules = load_bas_rules()
+    formulas: Dict[str, Dict[str, float]] = rules["formulas"]
+
+    totals: Dict[str, Decimal] = {}
+    base_values: Dict[str, Decimal] = {
+        "gst_collected": payload.gst_collected,
+        "gst_paid": payload.gst_paid,
+        "paygw_withheld": payload.paygw_withheld,
+        "paygw_credits": payload.paygw_credits,
+        "fuel_tax_credit": payload.fuel_tax_credit,
+    }
+
+    for name, coefficients in formulas.items():
+        total = Decimal("0")
+        for key, coefficient in coefficients.items():
+            value = base_values.get(key, totals.get(key))
+            if value is None:
+                raise ValueError(f"Unknown component '{key}' in BAS formula '{name}'.")
+            total += Decimal(str(coefficient)) * value
+        totals[name] = quantise(total)
+
+    return BASCompileResponse(rule_version=rules["version"], totals=totals)
+
+
+__all__ = [
+    "calculate_gst",
+    "calculate_paygw",
+    "compile_bas",
+]

--- a/services/tax-engine/tax_engine/models.py
+++ b/services/tax-engine/tax_engine/models.py
@@ -1,0 +1,76 @@
+"""Pydantic models for the tax engine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+DecimalLike = Decimal | float | int
+
+
+class MonetaryModel(BaseModel):
+    """Base model that normalises monetary values to decimals."""
+
+    model_config = ConfigDict(json_encoders={Decimal: lambda v: float(round(v, 2))})
+
+    @field_validator("*", mode="before")
+    @classmethod
+    def _coerce_decimal(cls, value: DecimalLike) -> Decimal:
+        if isinstance(value, Decimal):
+            return value
+        return Decimal(str(value))
+
+
+class GSTCalcRequest(MonetaryModel):
+    net_amount: Decimal = Field(gt=Decimal("-0.0001"))
+    category: str = Field(default="standard")
+
+
+class GSTCalcResponse(BaseModel):
+    model_config = ConfigDict(json_encoders={Decimal: lambda v: float(round(v, 2))})
+
+    rule_version: str
+    category: str
+    rate: Decimal
+    net_amount: Decimal
+    gst_amount: Decimal
+    gross_amount: Decimal
+
+
+class PaygwCalcRequest(MonetaryModel):
+    taxable_income: Decimal = Field(gt=Decimal("-0.0001"))
+    allowances: Decimal = Field(default=Decimal("0"), ge=Decimal("0"))
+
+
+class PaygwCalcResponse(BaseModel):
+    model_config = ConfigDict(json_encoders={Decimal: lambda v: float(round(v, 2))})
+
+    rule_version: str
+    applicable_rate: Decimal
+    taxable_income: Decimal
+    allowances: Decimal
+    withheld_amount: Decimal
+
+
+class BASCompileRequest(MonetaryModel):
+    gst_collected: Decimal = Field(default=Decimal("0"))
+    gst_paid: Decimal = Field(default=Decimal("0"))
+    paygw_withheld: Decimal = Field(default=Decimal("0"))
+    paygw_credits: Decimal = Field(default=Decimal("0"))
+    fuel_tax_credit: Decimal = Field(default=Decimal("0"))
+
+
+class BASCompileResponse(BaseModel):
+    model_config = ConfigDict(json_encoders={Decimal: lambda v: float(round(v, 2))})
+
+    rule_version: str
+    totals: Dict[str, Decimal]
+
+
+def quantise(value: Decimal, precision: str = "0.01") -> Decimal:
+    """Quantise to the provided precision using bankers rounding."""
+
+    return value.quantize(Decimal(precision))

--- a/services/tax-engine/tax_engine/openapi.py
+++ b/services/tax-engine/tax_engine/openapi.py
@@ -1,0 +1,24 @@
+"""Utilities for exporting the OpenAPI schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .app import create_app
+
+
+def export_schema(destination: Path) -> Path:
+    app = create_app()
+    schema = app.openapi()
+    destination.write_text(json.dumps(schema, indent=2), encoding="utf-8")
+    return destination
+
+
+def export_cli(path: str = "openapi.json") -> None:
+    destination = Path(path)
+    export_schema(destination)
+    print(f"OpenAPI schema exported to {destination.resolve()}")
+
+
+__all__ = ["export_schema", "export_cli"]

--- a/services/tax-engine/tax_engine/rules_loader.py
+++ b/services/tax-engine/tax_engine/rules_loader.py
@@ -1,0 +1,50 @@
+"""Utility functions for reading tax rules."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+
+
+class RuleError(RuntimeError):
+    """Raised when there is a problem with a rule definition."""
+
+
+def _load_rule_file(filename: str) -> Dict[str, Any]:
+    path = RULES_DIR / filename
+    if not path.exists():
+        raise RuleError(f"Rule file {filename} was not found in {RULES_DIR}.")
+
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if "version" not in data:
+        raise RuleError(f"Rule file {filename} is missing the 'version' field.")
+    return data
+
+
+@lru_cache(maxsize=None)
+def load_gst_rules() -> Dict[str, Any]:
+    return _load_rule_file("gst_v1.json")
+
+
+@lru_cache(maxsize=None)
+def load_paygw_rules() -> Dict[str, Any]:
+    return _load_rule_file("paygw_v1.json")
+
+
+@lru_cache(maxsize=None)
+def load_bas_rules() -> Dict[str, Any]:
+    return _load_rule_file("bas_v1.json")
+
+
+__all__ = [
+    "RuleError",
+    "load_gst_rules",
+    "load_paygw_rules",
+    "load_bas_rules",
+]

--- a/services/tax-engine/tests/test_golden_vectors.py
+++ b/services/tax-engine/tests/test_golden_vectors.py
@@ -1,0 +1,62 @@
+"""Golden vector tests for tax engine endpoints."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tax_engine.app import create_app
+from tax_engine.openapi import export_schema
+
+client = TestClient(create_app())
+
+
+def test_gst_standard_category() -> None:
+    response = client.post(
+        "/gst/calc",
+        json={"net_amount": 1000.0, "category": "standard"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["gst_amount"] == 100.0
+    assert payload["gross_amount"] == 1100.0
+    assert payload["rule_version"] == "2024-07-01"
+
+
+def test_paygw_tier_transition() -> None:
+    response = client.post(
+        "/paygw/calc",
+        json={"taxable_income": 7500.0, "allowances": 200.0},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["withheld_amount"] == 1400.0
+    assert payload["applicable_rate"] == 0.2
+    assert payload["rule_version"] == "2024-07-01"
+
+
+def test_bas_net_payable() -> None:
+    response = client.post(
+        "/bas/compile",
+        json={
+            "gst_collected": 1500.0,
+            "gst_paid": 500.0,
+            "paygw_withheld": 2000.0,
+            "paygw_credits": 300.0,
+            "fuel_tax_credit": 100.0,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"]["gst_payable"] == 1000.0
+    assert payload["totals"]["paygw_payable"] == 1700.0
+    assert payload["totals"]["net_payable"] == 2600.0
+    assert payload["rule_version"] == "2024-07-01"
+
+
+def test_openapi_export_lists_endpoints(tmp_path) -> None:
+    schema_path = tmp_path / "openapi.json"
+    export_schema(schema_path)
+    data = schema_path.read_text(encoding="utf-8")
+    assert "/gst/calc" in data
+    assert "/paygw/calc" in data
+    assert "/bas/compile" in data


### PR DESCRIPTION
## Summary
- add a FastAPI-powered tax engine service with GST, PAYGW, and BAS endpoints
- version tax calculation rules through JSON payloads and expose rule metadata
- provide Poetry/Makefile tooling, schema export utility, and golden vector tests

## Testing
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' because dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaab0b4dcc8327b1b25d8271f31559