### PR TITLE
feat(worker): add queue processors and health heartbeat

### DIFF
--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,11 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/index.ts",
+    "test": "echo test worker"
+  }
+}

--- a/apgms/worker/src/audit.ts
+++ b/apgms/worker/src/audit.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from 'crypto';
+import { logger } from './logger.js';
+
+export type AuditEvent = {
+  id: string;
+  timestamp: string;
+  queue: string;
+  jobId: string;
+  jobName: string;
+  type: 'queue.job.processed' | 'queue.job.failed';
+  payload: unknown;
+  error?: string;
+};
+
+export async function writeAuditEvent(event: Omit<AuditEvent, 'id' | 'timestamp'>) {
+  const entry: AuditEvent = {
+    ...event,
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+  };
+
+  logger.info({ event: 'audit.recorded', audit: entry }, 'Audit event recorded');
+}

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,149 @@
-﻿console.log('worker');
+import { logger } from './logger.js';
+import { writeAuditEvent } from './audit.js';
+import {
+  QUEUE_NAMES,
+  createQueueSystem,
+  type JobContext,
+  type Processor,
+  type QueueName,
+  type QueueSystem,
+} from './queues.js';
+
+async function main() {
+  const processors = buildProcessors();
+  const queueSystem = await createQueueSystem(processors, logger);
+  const ticker = startHealthTicker();
+
+  await enqueueSampleJobs(queueSystem);
+  setupShutdown(queueSystem, ticker);
+
+  process.on('unhandledRejection', (reason) => {
+    logger.error({ event: 'worker.unhandled-rejection', reason }, 'Unhandled promise rejection');
+  });
+
+  process.on('uncaughtException', (error) => {
+    logger.fatal({ event: 'worker.uncaught-exception', err: error }, 'Uncaught exception');
+  });
+
+  logger.info({ event: 'worker.ready', queues: QUEUE_NAMES }, 'Worker service started');
+}
+
+main().catch((error) => {
+  logger.fatal({ event: 'worker.startup_failed', err: error }, 'Worker failed to start');
+  process.exit(1);
+});
+
+function buildProcessors(): Record<QueueName, Processor> {
+  return Object.fromEntries(
+    QUEUE_NAMES.map((queueName) => [
+      queueName,
+      async (job: JobContext) => {
+        logger.info(
+          {
+            event: 'queue.job.processing',
+            queue: queueName,
+            jobId: job.id,
+            jobName: job.name,
+            attempts: job.attemptsMade,
+          },
+          'Processing job',
+        );
+
+        try {
+          await writeAuditEvent({
+            queue: queueName,
+            jobId: job.id,
+            jobName: job.name,
+            type: 'queue.job.processed',
+            payload: job.data,
+          });
+
+          logger.info(
+            { event: 'queue.job.processed', queue: queueName, jobId: job.id, jobName: job.name },
+            'Job processed successfully',
+          );
+        } catch (error) {
+          logger.error(
+            { event: 'queue.job.audit-failed', queue: queueName, jobId: job.id, err: error },
+            'Failed to write audit event',
+          );
+
+          try {
+            await writeAuditEvent({
+              queue: queueName,
+              jobId: job.id,
+              jobName: job.name,
+              type: 'queue.job.failed',
+              payload: job.data,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          } catch (auditError) {
+            logger.error(
+              {
+                event: 'queue.job.audit-failed-secondary',
+                queue: queueName,
+                jobId: job.id,
+                err: auditError,
+              },
+              'Failed to write failure audit event',
+            );
+          }
+
+          throw error;
+        }
+      },
+    ]),
+  ) as Record<QueueName, Processor>;
+}
+
+function startHealthTicker(): NodeJS.Timeout {
+  const startedAt = Date.now();
+  return setInterval(() => {
+    logger.info({ event: 'worker.tick', uptimeMs: Date.now() - startedAt }, 'Worker heartbeat tick');
+  }, 5000);
+}
+
+async function enqueueSampleJobs(queueSystem: QueueSystem) {
+  const timestamp = new Date().toISOString();
+
+  await Promise.all(
+    QUEUE_NAMES.map((queue) =>
+      queueSystem.enqueue(queue, 'sample-job', {
+        enqueuedAt: timestamp,
+        queue,
+        sample: true,
+      }),
+    ),
+  );
+
+  logger.info({ event: 'worker.sample-jobs.enqueued', timestamp }, 'Sample jobs enqueued');
+}
+
+function setupShutdown(queueSystem: QueueSystem, ticker: NodeJS.Timeout) {
+  let shuttingDown = false;
+
+  const handleSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    logger.info({ event: 'worker.shutdown.start', signal }, 'Received shutdown signal');
+    clearInterval(ticker);
+
+    queueSystem
+      .close()
+      .then(() => {
+        logger.info({ event: 'worker.shutdown.complete' }, 'Worker shutdown complete');
+        process.exit(0);
+      })
+      .catch((error) => {
+        logger.error({ event: 'worker.shutdown.error', err: error }, 'Worker shutdown encountered an error');
+        process.exit(1);
+      });
+  };
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, handleSignal);
+  }
+}

--- a/apgms/worker/src/logger.ts
+++ b/apgms/worker/src/logger.ts
@@ -1,0 +1,45 @@
+export type LogPayload = Record<string, unknown>;
+
+export type LogLevel = 'info' | 'warn' | 'error' | 'fatal';
+
+function log(level: LogLevel, payload: LogPayload, message: string) {
+  const entry = {
+    level,
+    message,
+    time: new Date().toISOString(),
+    service: 'worker',
+    ...payload,
+  };
+
+  const serialized = JSON.stringify(entry);
+
+  switch (level) {
+    case 'warn':
+      console.warn(serialized);
+      break;
+    case 'error':
+    case 'fatal':
+      console.error(serialized);
+      break;
+    default:
+      console.log(serialized);
+      break;
+  }
+}
+
+export const logger = {
+  info(payload: LogPayload, message: string) {
+    log('info', payload, message);
+  },
+  warn(payload: LogPayload, message: string) {
+    log('warn', payload, message);
+  },
+  error(payload: LogPayload, message: string) {
+    log('error', payload, message);
+  },
+  fatal(payload: LogPayload, message: string) {
+    log('fatal', payload, message);
+  },
+};
+
+export type Logger = typeof logger;

--- a/apgms/worker/src/queues.ts
+++ b/apgms/worker/src/queues.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from 'crypto';
+import type { Logger } from './logger.js';
+
+export const QUEUE_NAMES = ['ingestion', 'recon', 'billing', 'exports', 'key-rotate'] as const;
+
+export type QueueName = (typeof QUEUE_NAMES)[number];
+
+export interface JobContext<T = unknown> {
+  id: string;
+  name: string;
+  data: T;
+  attemptsMade: number;
+  queue: QueueName;
+}
+
+export type Processor<T = unknown> = (job: JobContext<T>) => Promise<void> | void;
+
+export interface QueueSystem {
+  enqueue(queue: QueueName, jobName: string, data: unknown): Promise<void>;
+  close(): Promise<void>;
+}
+
+export async function createQueueSystem(
+  processors: Record<QueueName, Processor>,
+  logger: Logger,
+): Promise<QueueSystem> {
+  const redisUrl = process.env.REDIS_URL;
+
+  if (redisUrl) {
+    const bullmq = await loadBullMq(logger);
+
+    if (bullmq) {
+      logger.info({ event: 'queue.driver', driver: 'bullmq', redisUrl }, 'Starting BullMQ queue system');
+      return new BullMqQueueSystem(bullmq, processors, logger, redisUrl);
+    }
+
+    logger.warn(
+      { event: 'queue.driver.fallback', driver: 'in-memory', reason: 'bullmq-unavailable' },
+      'BullMQ module unavailable, falling back to in-memory queues',
+    );
+  }
+
+  logger.info({ event: 'queue.driver', driver: 'in-memory' }, 'Starting in-memory queue system');
+  return new InMemoryQueueSystem(processors, logger);
+}
+
+class InMemoryQueueSystem implements QueueSystem {
+  private readonly queues = new Map<QueueName, InMemoryQueue>();
+
+  constructor(processors: Record<QueueName, Processor>, private readonly logger: Logger) {
+    for (const [name, processor] of Object.entries(processors) as [QueueName, Processor][]) {
+      this.queues.set(name, new InMemoryQueue(name, processor, this.logger));
+    }
+  }
+
+  async enqueue(queue: QueueName, jobName: string, data: unknown): Promise<void> {
+    const target = this.queues.get(queue);
+    if (!target) {
+      throw new Error(`Queue ${queue} is not registered`);
+    }
+
+    const job = await target.add(jobName, data);
+    this.logger.info({ event: 'queue.job.enqueued', queue, jobId: job.id, jobName }, 'Job enqueued');
+  }
+
+  async close(): Promise<void> {
+    await Promise.all(Array.from(this.queues.values()).map((queue) => queue.close()));
+  }
+}
+
+class InMemoryQueue {
+  private readonly pending: JobContext[] = [];
+  private processing = false;
+  private closed = false;
+
+  constructor(
+    private readonly queue: QueueName,
+    private readonly processor: Processor,
+    private readonly logger: Logger,
+  ) {}
+
+  async add(jobName: string, data: unknown): Promise<JobContext> {
+    if (this.closed) {
+      throw new Error(`Queue ${this.queue} has been closed`);
+    }
+
+    const job: JobContext = {
+      id: randomUUID(),
+      name: jobName,
+      data,
+      attemptsMade: 0,
+      queue: this.queue,
+    };
+
+    this.pending.push(job);
+    this.schedule();
+
+    return job;
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    this.pending.length = 0;
+  }
+
+  private schedule() {
+    if (this.processing) {
+      return;
+    }
+
+    this.processing = true;
+    setImmediate(() => {
+      void this.processNext();
+    });
+  }
+
+  private async processNext(): Promise<void> {
+    const job = this.pending.shift();
+
+    if (!job) {
+      this.processing = false;
+      return;
+    }
+
+    try {
+      await Promise.resolve(this.processor(job));
+    } catch (error) {
+      this.logger.error(
+        { event: 'queue.job.failed', queue: this.queue, jobId: job.id, err: error },
+        'Job processing failed',
+      );
+    } finally {
+      if (this.pending.length > 0) {
+        setImmediate(() => {
+          void this.processNext();
+        });
+      } else {
+        this.processing = false;
+      }
+    }
+  }
+}
+
+class BullMqQueueSystem implements QueueSystem {
+  private readonly queues = new Map<QueueName, BullQueue>();
+  private readonly workers: BullWorker[] = [];
+
+  constructor(
+    bullmq: BullmqModule,
+    processors: Record<QueueName, Processor>,
+    private readonly logger: Logger,
+    redisUrl: string,
+  ) {
+    const connection = parseRedisConnection(redisUrl);
+
+    for (const [name, processor] of Object.entries(processors) as [QueueName, Processor][]) {
+      const queue = new bullmq.Queue(name, { connection });
+      const worker = new bullmq.Worker(
+        name,
+        async (job) => {
+          const context = mapJob(name, job);
+          this.logger.info(
+            { event: 'queue.job.received', queue: name, jobId: context.id, jobName: context.name },
+            'Job received',
+          );
+
+          try {
+            await Promise.resolve(processor(context));
+          } catch (error) {
+            this.logger.error(
+              { event: 'queue.job.failed', queue: name, jobId: context.id, err: error },
+              'Job processing failed',
+            );
+            throw error;
+          }
+        },
+        { connection },
+      );
+
+      worker.on('error', (error) => {
+        this.logger.error({ event: 'queue.worker.error', queue: name, err: error }, 'Worker error');
+      });
+
+      this.queues.set(name, queue);
+      this.workers.push(worker);
+    }
+  }
+
+  async enqueue(queue: QueueName, jobName: string, data: unknown): Promise<void> {
+    const target = this.queues.get(queue);
+    if (!target) {
+      throw new Error(`Queue ${queue} is not registered`);
+    }
+
+    const job = await target.add(jobName, data);
+    const jobId = job?.id != null ? job.id : null;
+    this.logger.info({ event: 'queue.job.enqueued', queue, jobId, jobName }, 'Job enqueued');
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([
+      ...Array.from(this.queues.values()).map((queue) => queue.close()),
+      ...this.workers.map((worker) => worker.close()),
+    ]);
+  }
+}
+
+type BullmqModule = {
+  Queue: new (name: string, options?: { connection?: RedisConnectionOptions }) => BullQueue;
+  Worker: new (
+    name: string,
+    processor: (job: BullJob) => Promise<void> | void,
+    options?: { connection?: RedisConnectionOptions },
+  ) => BullWorker;
+};
+
+type BullQueue = {
+  add(name: string, data: unknown): Promise<BullJob>;
+  close(): Promise<void>;
+};
+
+type BullWorker = {
+  close(): Promise<void>;
+  on(event: 'error', handler: (error: unknown) => void): void;
+};
+
+type BullJob = {
+  id?: string | number;
+  name?: string;
+  data: unknown;
+  attemptsMade?: number;
+};
+
+type RedisConnectionOptions = Record<string, unknown> & {
+  host: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  db?: number;
+};
+
+async function loadBullMq(logger: Logger): Promise<BullmqModule | undefined> {
+  try {
+    const mod = (await import('bullmq')) as BullmqModule;
+    return mod;
+  } catch (error) {
+    logger.warn({ event: 'queue.bullmq.import_failed', err: error }, 'Failed to load BullMQ module');
+    return undefined;
+  }
+}
+
+function mapJob(queue: QueueName, job: BullJob): JobContext {
+  return {
+    id: job.id != null ? job.id.toString() : randomUUID(),
+    name: job.name ?? 'default',
+    data: job.data,
+    attemptsMade: job.attemptsMade ?? 0,
+    queue,
+  };
+}
+
+function parseRedisConnection(url: string): RedisConnectionOptions {
+  const parsed = new URL(url);
+  const connection: RedisConnectionOptions = {
+    host: parsed.hostname,
+  };
+
+  if (parsed.port) {
+    connection.port = Number(parsed.port);
+  }
+
+  if (parsed.username) {
+    connection.username = parsed.username;
+  }
+
+  if (parsed.password) {
+    connection.password = parsed.password;
+  }
+
+  if (parsed.pathname && parsed.pathname !== '/') {
+    const dbIndex = Number(parsed.pathname.replace('/', ''));
+    if (!Number.isNaN(dbIndex)) {
+      connection.db = dbIndex;
+    }
+  }
+
+  return connection;
+}

--- a/apgms/worker/src/types/bullmq.d.ts
+++ b/apgms/worker/src/types/bullmq.d.ts
@@ -1,0 +1,22 @@
+declare module 'bullmq' {
+  export class Queue {
+    constructor(name: string, options?: { connection?: Record<string, unknown> });
+    add(name: string, data: unknown): Promise<{ id?: string | number }>;
+    close(): Promise<void>;
+  }
+
+  export class Worker {
+    constructor(
+      name: string,
+      processor: (job: {
+        id?: string | number;
+        name?: string;
+        data: unknown;
+        attemptsMade?: number;
+      }) => Promise<void> | void,
+      options?: { connection?: Record<string, unknown> },
+    );
+    close(): Promise<void>;
+    on(event: 'error', handler: (error: unknown) => void): void;
+  }
+}

--- a/apgms/worker/tsconfig.json
+++ b/apgms/worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "baseUrl": "../",
+    "paths": {
+      "@apgms/shared/*": ["shared/src/*"]
+    }
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- implement worker bootstrap that registers ingestion, recon, billing, exports, and key-rotate queue processors
- add structured logging, audit event writer, and periodic heartbeat with graceful shutdown hooks
- support BullMQ when available with an in-memory queue fallback and seed sample jobs on startup

## Testing
- pnpm -F @apgms/worker dev

------
https://chatgpt.com/codex/tasks/task_e_68eaaaf17140832781ea5dda272cb83a