### PR TITLE
Add observability metrics, tracing, and Grafana dashboards

### DIFF
--- a/apgms/infra/observability/grafana/dashboards.json
+++ b/apgms/infra/observability/grafana/dashboards.json
@@ -1,1 +1,4 @@
-{}
+{
+  "api-http-latency": "./http-latency.json",
+  "queue-throughput": "./queue-throughput.json"
+}

--- a/apgms/infra/observability/grafana/http-latency.json
+++ b/apgms/infra/observability/grafana/http-latency.json
@@ -1,0 +1,287 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": "8.5.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": "8.5.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "8.5.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{service=\"api-gateway\", route=~\"$route\"}[5m])) by (le, route))",
+          "interval": "",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API Gateway p95 latency",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 2
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "8.5.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_requests_total{service=\"api-gateway\", status_code=~\"5..\", route=~\"$route\"}[5m])) / sum(rate(http_requests_total{service=\"api-gateway\", route=~\"$route\"}[5m])) * 100",
+          "interval": "",
+          "legendFormat": "error %",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error percentage",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 16,
+        "x": 8,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(http_requests_total{service=\"api-gateway\", route=~\"$route\"}[1m])) by (method)",
+          "interval": "",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request throughput by method",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "api",
+    "latency"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Route",
+        "multi": false,
+        "name": "route",
+        "options": [],
+        "query": {
+          "query": "label_values(http_request_duration_seconds_bucket{service=\"api-gateway\"}, route)",
+          "refId": "route"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "API Gateway HTTP Latency",
+  "uid": "api-http-latency",
+  "version": 1,
+  "weekStart": ""
+}

--- a/apgms/infra/observability/grafana/queue-throughput.json
+++ b/apgms/infra/observability/grafana/queue-throughput.json
@@ -1,0 +1,309 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": "8.5.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": "8.5.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "8.5.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 25
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(queue_jobs_processed_total{queue=~\"$queue\", status=~\"$status\"}[5m])) by (queue, status)",
+          "interval": "",
+          "legendFormat": "{{queue}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 14,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(queue_job_duration_seconds_bucket{queue=~\"$queue\", status=~\"$status\"}[5m])) by (le, queue))",
+          "interval": "",
+          "legendFormat": "{{queue}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Job duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 14,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "displayMode": "lcd",
+        "max": 1,
+        "min": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(queue_jobs_processed_total{queue=~\"$queue\", status=\"failed\"}[5m])) / sum(rate(queue_jobs_processed_total{queue=~\"$queue\"}[5m]))",
+          "interval": "",
+          "legendFormat": "failure ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Failure ratio",
+      "type": "bargauge"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "worker",
+    "queue"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Queue",
+        "multi": false,
+        "name": "queue",
+        "options": [],
+        "query": {
+          "query": "label_values(queue_jobs_processed_total, queue)",
+          "refId": "queue"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": ".*"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Status",
+        "multi": false,
+        "name": "status",
+        "options": [],
+        "query": {
+          "query": "label_values(queue_jobs_processed_total, status)",
+          "refId": "status"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Worker Queue Throughput",
+  "uid": "queue-throughput",
+  "version": 1,
+  "weekStart": ""
+}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,6 +8,12 @@
     "build": "echo building shared"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.10.0",
+    "@opentelemetry/core": "^1.23.0",
+    "@opentelemetry/resources": "^1.23.0",
+    "@opentelemetry/sdk-trace-base": "^1.23.0",
+    "@opentelemetry/sdk-trace-node": "^1.23.0",
+    "@opentelemetry/semantic-conventions": "^1.23.0",
     "@prisma/client": "6.17.1"
   },
   "devDependencies": {

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export { prisma } from "./db";
+export { setupTracing, extractContextFromHeaders, injectContextToHeaders } from "./tracing";

--- a/apgms/shared/src/tracing.ts
+++ b/apgms/shared/src/tracing.ts
@@ -1,0 +1,49 @@
+import { diag, DiagConsoleLogger, DiagLogLevel, propagation, context, type Context, type Tracer } from "@opentelemetry/api";
+import { W3CTraceContextPropagator } from "@opentelemetry/core";
+import { Resource } from "@opentelemetry/resources";
+import { SimpleSpanProcessor, ConsoleSpanExporter } from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+
+let provider: NodeTracerProvider | undefined;
+const tracerCache = new Map<string, Tracer>();
+let diagnosticsConfigured = false;
+
+export function setupTracing(serviceName: string): Tracer {
+  if (tracerCache.has(serviceName)) {
+    return tracerCache.get(serviceName)!;
+  }
+
+  if (!diagnosticsConfigured) {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+    diagnosticsConfigured = true;
+  }
+
+  if (!provider) {
+    provider = new NodeTracerProvider({
+      resource: new Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      }),
+    });
+
+    provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+
+    provider.register({
+      propagator: new W3CTraceContextPropagator(),
+    });
+  }
+
+  const tracer = provider.getTracer(serviceName);
+  tracerCache.set(serviceName, tracer);
+  return tracer;
+}
+
+export function extractContextFromHeaders(headers: Record<string, unknown>): Context {
+  return propagation.extract(context.active(), headers);
+}
+
+export function injectContextToHeaders(ctx: Context): Record<string, string> {
+  const carrier: Record<string, string> = {};
+  propagation.inject(ctx, carrier);
+  return carrier;
+}

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,21 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "echo test worker"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.10.0",
+    "@opentelemetry/core": "^1.23.0",
+    "@opentelemetry/resources": "^1.23.0",
+    "@opentelemetry/sdk-trace-base": "^1.23.0",
+    "@opentelemetry/sdk-trace-node": "^1.23.0",
+    "@opentelemetry/semantic-conventions": "^1.23.0",
+    "fastify": "^5.6.1",
+    "pino": "^9.5.0",
+    "prom-client": "^15.1.2"
+  }
+}

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,165 @@
-﻿console.log('worker');
+import Fastify from "fastify";
+import pino from "pino";
+import client from "prom-client";
+import { randomUUID } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  setupTracing,
+  extractContextFromHeaders,
+  injectContextToHeaders,
+} from "../../shared/src";
+
+const serviceName = "queue-worker";
+const tracer = setupTracing(serviceName);
+
+const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  base: { service: serviceName },
+});
+
+const register = new client.Registry();
+register.setDefaultLabels({ service: serviceName });
+client.collectDefaultMetrics({ register });
+
+const jobProcessedCounter = new client.Counter({
+  name: "queue_jobs_processed_total",
+  help: "Total number of queue jobs processed",
+  labelNames: ["queue", "status"],
+  registers: [register],
+});
+
+const jobDurationHistogram = new client.Histogram({
+  name: "queue_job_duration_seconds",
+  help: "Duration of queue job processing in seconds",
+  labelNames: ["queue", "status"],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [register],
+});
+
+const app = Fastify({
+  logger,
+  genReqId(req) {
+    const headerId = req.headers["x-request-id"] ?? req.headers["x-requestid"];
+    if (Array.isArray(headerId)) {
+      return headerId[0];
+    }
+    return typeof headerId === "string" && headerId.length > 0 ? headerId : randomUUID();
+  },
+  requestIdHeader: "x-request-id",
+  requestIdLogLabel: "reqId",
+});
+
+app.addHook("onRequest", (req, reply, done) => {
+  (req as any).metricsStart = process.hrtime.bigint();
+  const parentCtx = extractContextFromHeaders(req.headers as Record<string, unknown>);
+  const span = tracer.startSpan(`${req.method} ${req.url}`, undefined, parentCtx);
+  const otelCtx = trace.setSpan(parentCtx, span);
+  (req as any).otelSpan = span;
+  (req as any).otelCtx = otelCtx;
+  context.bind(req.raw, otelCtx);
+  context.bind(reply.raw, otelCtx);
+  const spanCtx = span.spanContext();
+  const enrichedLogger = req.log.child({ traceId: spanCtx.traceId, spanId: spanCtx.spanId });
+  (req as any).log = enrichedLogger;
+  (reply as any).log = enrichedLogger;
+  done();
+});
+
+app.addHook("preHandler", (req, _reply, done) => {
+  const ctx = (req as any).otelCtx;
+  if (ctx) {
+    context.with(ctx, done);
+    return;
+  }
+  done();
+});
+
+app.addHook("onResponse", (req, reply, done) => {
+  const span = (req as any).otelSpan;
+  const ctx = (req as any).otelCtx ?? context.active();
+  const route = req.routerPath ?? req.routeOptions?.url ?? req.url ?? "unknown";
+
+  const start = (req as any).metricsStart as bigint | undefined;
+  if (start) {
+    const diff = Number(process.hrtime.bigint() - start) / 1e9;
+    span?.setAttribute("http.server.duration", diff);
+  }
+
+  if (span) {
+    span.setAttribute("http.method", req.method);
+    span.setAttribute("http.route", route);
+    span.setAttribute("http.status_code", reply.statusCode);
+    span.setStatus({
+      code: reply.statusCode >= 500 ? SpanStatusCode.ERROR : SpanStatusCode.OK,
+    });
+    span.end();
+  }
+
+  const outboundHeaders = injectContextToHeaders(ctx);
+  for (const [key, value] of Object.entries(outboundHeaders)) {
+    reply.header(key, value);
+  }
+  done();
+});
+
+app.get("/health", async () => ({ ok: true, service: serviceName }));
+
+app.get("/metrics", async (_req, reply) => {
+  reply.header("content-type", register.contentType);
+  return reply.send(await register.metrics());
+});
+
+async function processJob(queue: string): Promise<void> {
+  const jobId = randomUUID();
+  const span = tracer.startSpan(`job ${queue}`);
+  const spanCtx = span.spanContext();
+  const jobLogger = logger.child({ queue, reqId: jobId, traceId: spanCtx.traceId, spanId: spanCtx.spanId });
+  const start = process.hrtime.bigint();
+  try {
+    await context.with(trace.setSpan(context.active(), span), async () => {
+      jobLogger.info({ jobId, queue }, "processing job");
+      await sleep(100);
+    });
+    const duration = Number(process.hrtime.bigint() - start) / 1e9;
+    jobProcessedCounter.inc({ queue, status: "success" });
+    jobDurationHistogram.observe({ queue, status: "success" }, duration);
+    span.setStatus({ code: SpanStatusCode.OK });
+    span.setAttribute("queue.name", queue);
+    span.setAttribute("job.id", jobId);
+    span.setAttribute("job.duration", duration);
+    jobLogger.info({ jobId, queue, duration }, "job completed");
+  } catch (err) {
+    const duration = Number(process.hrtime.bigint() - start) / 1e9;
+    jobProcessedCounter.inc({ queue, status: "failed" });
+    jobDurationHistogram.observe({ queue, status: "failed" }, duration);
+    span.recordException(err as Error);
+    span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error)?.message });
+    jobLogger.error({ err, jobId, queue, duration }, "job failed");
+  } finally {
+    span.end();
+  }
+}
+
+let processing = false;
+const queueName = process.env.WORKER_QUEUE ?? "reconciliation";
+
+setInterval(() => {
+  if (processing) {
+    return;
+  }
+  processing = true;
+  processJob(queueName).finally(() => {
+    processing = false;
+  });
+}, Number(process.env.WORKER_POLL_INTERVAL_MS ?? 15000));
+
+const port = Number(process.env.PORT ?? 4000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).then(() => {
+  logger.info({ port, host }, "worker ready");
+}).catch((err) => {
+  logger.error(err, "failed to start worker");
+  process.exit(1);
+});

--- a/services/api-gateway/package.json
+++ b/services/api-gateway/package.json
@@ -14,7 +14,15 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.1.0",
+    "@opentelemetry/api": "^1.10.0",
+    "@opentelemetry/core": "^1.23.0",
+    "@opentelemetry/resources": "^1.23.0",
+    "@opentelemetry/sdk-trace-base": "^1.23.0",
+    "@opentelemetry/sdk-trace-node": "^1.23.0",
+    "@opentelemetry/semantic-conventions": "^1.23.0",
     "dotenv": "^17.2.3",
-    "fastify": "^5.6.1"
+    "fastify": "^5.6.1",
+    "pino": "^9.5.0",
+    "prom-client": "^15.1.2"
   }
 }

--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -10,14 +10,132 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import pino from "pino";
+import client from "prom-client";
+import { randomUUID } from "node:crypto";
+import { context, trace, SpanStatusCode } from "@opentelemetry/api";
+import {
+  prisma,
+  setupTracing,
+  extractContextFromHeaders,
+  injectContextToHeaders,
+} from "../../../shared/src";
 
-const app = Fastify({ logger: true });
+const serviceName = "api-gateway";
+const tracer = setupTracing(serviceName);
+
+const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  base: { service: serviceName },
+});
+
+const register = new client.Registry();
+register.setDefaultLabels({ service: serviceName });
+client.collectDefaultMetrics({ register });
+
+const httpRequestCounter = new client.Counter({
+  name: "http_requests_total",
+  help: "Count of HTTP requests",
+  labelNames: ["method", "route", "status_code"],
+  registers: [register],
+});
+
+const httpRequestDuration = new client.Histogram({
+  name: "http_request_duration_seconds",
+  help: "Duration of HTTP requests",
+  labelNames: ["method", "route", "status_code"],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+  registers: [register],
+});
+
+const app = Fastify({
+  logger,
+  genReqId(req) {
+    const headerId = req.headers["x-request-id"] ?? req.headers["x-requestid"];
+    if (Array.isArray(headerId)) {
+      return headerId[0];
+    }
+    return typeof headerId === "string" && headerId.length > 0 ? headerId : randomUUID();
+  },
+  requestIdHeader: "x-request-id",
+  requestIdLogLabel: "reqId",
+});
+
+app.addHook("onRequest", (req, reply, done) => {
+  const start = process.hrtime.bigint();
+  (req as any).metricsStart = start;
+
+  const parentCtx = extractContextFromHeaders(req.headers as Record<string, unknown>);
+  const span = tracer.startSpan(`${req.method} ${req.url}`, undefined, parentCtx);
+  const spanCtx = span.spanContext();
+  const otelCtx = trace.setSpan(parentCtx, span);
+  (req as any).otelSpan = span;
+  (req as any).otelCtx = otelCtx;
+  context.bind(req.raw, otelCtx);
+  context.bind(reply.raw, otelCtx);
+
+  const enrichedLogger = req.log.child({ traceId: spanCtx.traceId, spanId: spanCtx.spanId });
+  (req as any).log = enrichedLogger;
+  (reply as any).log = enrichedLogger;
+
+  done();
+});
+
+app.addHook("preHandler", (req, _reply, done) => {
+  const ctx = (req as any).otelCtx;
+  if (ctx) {
+    context.with(ctx, done);
+    return;
+  }
+  done();
+});
+
+app.addHook("onResponse", (req, reply, done) => {
+  const span = (req as any).otelSpan;
+  const ctx = (req as any).otelCtx ?? context.active();
+  const route = req.routerPath ?? req.routeOptions?.url ?? req.url ?? "unknown";
+  const labels = {
+    method: req.method,
+    route,
+    status_code: String(reply.statusCode),
+  } as const;
+
+  httpRequestCounter.inc(labels);
+
+  const start = (req as any).metricsStart as bigint | undefined;
+  if (start) {
+    const diff = Number(process.hrtime.bigint() - start) / 1e9;
+    httpRequestDuration.observe(labels, diff);
+    span?.setAttribute("http.server.duration", diff);
+  }
+
+  if (span) {
+    span.setAttribute("http.method", req.method);
+    span.setAttribute("http.route", route);
+    span.setAttribute("http.status_code", reply.statusCode);
+    span.setStatus({
+      code: reply.statusCode >= 500 ? SpanStatusCode.ERROR : SpanStatusCode.OK,
+    });
+    span.end();
+  }
+
+  const outboundHeaders = injectContextToHeaders(ctx);
+  for (const [key, value] of Object.entries(outboundHeaders)) {
+    reply.header(key, value);
+  }
+
+  done();
+});
 
 await app.register(cors, { origin: true });
 
 // Quick sanity log so you can verify the DSN being used
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+app.get("/metrics", async (_req, reply) => {
+  reply.header("content-type", register.contentType);
+  return reply.send(await register.metrics());
+});
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 


### PR DESCRIPTION
## Summary
- instrument the API gateway with structured pino logging, Prometheus metrics, and OpenTelemetry span propagation
- build a queue worker service harness with matching logging, metrics, and trace emission helpers
- commit Grafana dashboards-as-code for HTTP latency and queue throughput visualisation

## Testing
- `pnpm install` *(fails: registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaab83cca08327beca71be3f0d9a10