### PR TITLE
feat: scaffold webapp shell and screens

### DIFF
--- a/apgms/webapp/env.example
+++ b/apgms/webapp/env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.example.com

--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>APGMS Platform</title>
+  </head>
+  <body class="min-h-screen bg-background font-sans antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,45 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@radix-ui/react-avatar": "^1.0.4",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-scroll-area": "^1.0.5",
+    "@radix-ui/react-slot": "^1.0.3",
+    "@radix-ui/react-tooltip": "^1.0.7",
+    "@tanstack/react-query": "^5.45.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "i18next": "^23.11.5",
+    "lucide-react": "^0.356.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.51.5",
+    "react-i18next": "^14.1.3",
+    "react-router-dom": "^6.23.1",
+    "tailwind-merge": "^2.2.0"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.9.0",
+    "@playwright/test": "^1.44.1",
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.9"
+  }
+}

--- a/apgms/webapp/playwright.config.ts
+++ b/apgms/webapp/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+  webServer: {
+    command: 'pnpm -F @apgms/webapp dev -- --host',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  }
+});

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apgms/webapp/src/App.tsx
+++ b/apgms/webapp/src/App.tsx
@@ -1,0 +1,37 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { AppProviders } from '@/providers/AppProviders';
+import { AppShell } from '@/components/layout/AppShell';
+import { DashboardPage } from '@/pages/DashboardPage';
+import { BasWorkspacePage } from '@/pages/BasWorkspacePage';
+import { ReconCenterPage } from '@/pages/ReconCenterPage';
+import { EvidenceAuditPage } from '@/pages/EvidenceAuditPage';
+import { SettingsPage } from '@/pages/SettingsPage';
+import { OnboardingWizardPage } from '@/pages/OnboardingWizardPage';
+import { DEFAULT_ONBOARDING_STEP } from '@/routes/config';
+
+function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<DashboardPage />} />
+      <Route path="/bas-workspace" element={<BasWorkspacePage />} />
+      <Route path="/recon-center" element={<ReconCenterPage />} />
+      <Route path="/evidence-audit" element={<EvidenceAuditPage />} />
+      <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/onboarding" element={<Navigate to={`/onboarding/${DEFAULT_ONBOARDING_STEP}`} replace />} />
+      <Route path="/onboarding/:stepId" element={<OnboardingWizardPage />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}
+
+export default function App() {
+  return (
+    <AppProviders>
+      <BrowserRouter>
+        <AppShell>
+          <AppRoutes />
+        </AppShell>
+      </BrowserRouter>
+    </AppProviders>
+  );
+}

--- a/apgms/webapp/src/components/layout/AppShell.tsx
+++ b/apgms/webapp/src/components/layout/AppShell.tsx
@@ -1,0 +1,84 @@
+import { useState, type ReactNode } from 'react';
+import { Sidebar } from '@/components/layout/Sidebar';
+import { Topbar } from '@/components/layout/Topbar';
+import { Breadcrumbs } from '@/components/navigation/Breadcrumbs';
+import { NAVIGATION_ROUTES } from '@/routes/config';
+import { NavLink } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const closeMobile = () => setMobileOpen(false);
+
+  return (
+    <div className="flex min-h-screen w-full bg-background">
+      <Sidebar onNavigate={closeMobile} />
+      <MobileSidebar isOpen={mobileOpen} onNavigate={closeMobile} />
+      <div className="flex min-h-screen flex-1 flex-col">
+        <Topbar onToggleSidebar={() => setMobileOpen(!mobileOpen)} />
+        <main className="flex-1 space-y-6 bg-muted/30 px-4 py-6 sm:px-6 lg:px-8">
+          <Breadcrumbs />
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+interface MobileSidebarProps {
+  isOpen: boolean;
+  onNavigate: () => void;
+}
+
+function MobileSidebar({ isOpen, onNavigate }: MobileSidebarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-40 flex transform flex-col bg-background/80 backdrop-blur-sm transition-all duration-200 ease-in-out lg:hidden',
+        isOpen ? 'translate-x-0 opacity-100' : '-translate-x-full opacity-0'
+      )}
+      role="dialog"
+      aria-modal="true"
+      aria-hidden={!isOpen}
+    >
+      <div className="w-72 max-w-[80%] bg-card shadow-xl">
+        <div className="flex h-16 items-center gap-3 border-b border-border px-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary text-primary-foreground font-semibold" aria-hidden>
+            AP
+          </div>
+          <div>
+            <p className="text-sm font-semibold tracking-tight">APGMS Platform</p>
+            <p className="text-xs text-muted-foreground">Compliance made clear</p>
+          </div>
+        </div>
+        <nav aria-label="Mobile" className="flex flex-col gap-1 px-3 py-4">
+          {NAVIGATION_ROUTES.map(route => (
+            <NavLink
+              key={route.path}
+              to={route.path === '/onboarding' ? '/onboarding' : route.path}
+              onClick={onNavigate}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                  isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              <route.icon className="h-4 w-4" aria-hidden />
+              <span>{t(route.translationKey)}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <Button type="button" variant="ghost" className="w-full rounded-none" onClick={onNavigate}>
+          Close
+        </Button>
+      </div>
+      <button className="flex-1" onClick={onNavigate} aria-label="Close navigation" />
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/layout/Sidebar.tsx
+++ b/apgms/webapp/src/components/layout/Sidebar.tsx
@@ -1,0 +1,50 @@
+import { NavLink } from 'react-router-dom';
+import { NAVIGATION_ROUTES } from '@/routes/config';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+
+interface SidebarProps {
+  onNavigate?: () => void;
+}
+
+export function Sidebar({ onNavigate }: SidebarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <aside className="hidden border-r border-border bg-card/40 lg:flex lg:w-64 lg:flex-col lg:justify-between">
+      <div>
+        <div className="flex h-16 items-center gap-2 border-b border-border px-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary text-primary-foreground font-semibold" aria-hidden>
+            AP
+          </div>
+          <div>
+            <p className="text-sm font-semibold tracking-tight">APGMS Platform</p>
+            <p className="text-xs text-muted-foreground">Compliance made clear</p>
+          </div>
+        </div>
+        <nav aria-label="Main" className="flex flex-col gap-1 px-3 py-4">
+          {NAVIGATION_ROUTES.map(route => (
+            <NavLink
+              key={route.path}
+              to={route.path === '/onboarding' ? '/onboarding' : route.path}
+              onClick={onNavigate}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                  isActive ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'
+                )
+              }
+            >
+              <route.icon className="h-4 w-4" aria-hidden />
+              <span>{t(route.translationKey)}</span>
+            </NavLink>
+          ))}
+        </nav>
+      </div>
+      <div className="px-6 py-4 text-xs text-muted-foreground">
+        <p className="font-medium">Need help?</p>
+        <p>Reach out to your APGMS onboarding specialist any time.</p>
+      </div>
+    </aside>
+  );
+}

--- a/apgms/webapp/src/components/layout/Topbar.tsx
+++ b/apgms/webapp/src/components/layout/Topbar.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+import { Menu, Bell, HelpCircle, Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu';
+import { ThemeToggle } from '@/components/theme/ThemeToggle';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { useTranslation } from 'react-i18next';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface TopbarProps {
+  onToggleSidebar: () => void;
+}
+
+const NOTIFICATIONS = [
+  {
+    id: '1',
+    title: 'Submission received',
+    description: 'ATO acknowledged your March BAS lodgement.'
+  },
+  {
+    id: '2',
+    title: 'Evidence approved',
+    description: 'Lease agreement uploaded by Samuels Finance.'
+  }
+];
+
+export function Topbar({ onToggleSidebar }: TopbarProps) {
+  const { t } = useTranslation();
+  const [searchQuery, setSearchQuery] = useState('');
+
+  return (
+    <header className="flex h-16 items-center justify-between gap-4 border-b border-border bg-background px-4 lg:px-6">
+      <div className="flex items-center gap-3">
+        <Button type="button" variant="ghost" size="icon" className="lg:hidden" onClick={onToggleSidebar} aria-label="Toggle navigation">
+          <Menu className="h-5 w-5" aria-hidden />
+        </Button>
+        <OrgSwitcher />
+      </div>
+      <div className="flex flex-1 items-center justify-end gap-2 sm:gap-4">
+        <label className="relative hidden w-full max-w-sm items-center gap-2 rounded-md border border-input px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2 md:flex">
+          <Search className="h-4 w-4 text-muted-foreground" aria-hidden />
+          <span className="sr-only">{t('topbar.search')}</span>
+          <Input
+            className="border-none bg-transparent p-0 shadow-none focus-visible:ring-0"
+            placeholder={t('topbar.search')}
+            value={searchQuery}
+            onChange={event => setSearchQuery(event.target.value)}
+          />
+        </label>
+        <Button type="button" variant="ghost" size="icon" className="md:hidden" aria-label={t('topbar.search')}>
+          <Search className="h-4 w-4" aria-hidden />
+        </Button>
+        <TooltipHelp />
+        <NotificationsMenu />
+        <ThemeToggle />
+        <ProfileMenu />
+      </div>
+    </header>
+  );
+}
+
+function OrgSwitcher() {
+  const { t } = useTranslation();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="outline" className="flex items-center gap-2">
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" aria-hidden />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-600" aria-hidden />
+          </span>
+          <span className="hidden text-sm font-medium sm:inline">{t('orgs.primary')}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56" align="start">
+        <DropdownMenuLabel>Switch organisation</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>{t('orgs.primary')}</DropdownMenuItem>
+        <DropdownMenuItem>{t('orgs.secondary')}</DropdownMenuItem>
+        <DropdownMenuItem>{t('orgs.tertiary')}</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function TooltipHelp() {
+  const { t } = useTranslation();
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" aria-label={t('topbar.help')}>
+          <HelpCircle className="h-4 w-4" aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{t('topbar.help')}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function NotificationsMenu() {
+  const { t } = useTranslation();
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" aria-label={t('topbar.notifications')}>
+          <Bell className="h-4 w-4" aria-hidden />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end">
+        <div className="border-b border-border px-4 py-3">
+          <p className="text-sm font-semibold">{t('topbar.notifications')}</p>
+          <p className="text-xs text-muted-foreground">Stay on top of key compliance activities.</p>
+        </div>
+        <ScrollArea className="max-h-64">
+          <ul className="divide-y divide-border">
+            {NOTIFICATIONS.map(item => (
+              <li key={item.id} className="px-4 py-3 text-sm">
+                <p className="font-medium text-foreground">{item.title}</p>
+                <p className="text-muted-foreground">{item.description}</p>
+              </li>
+            ))}
+          </ul>
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function ProfileMenu() {
+  const { t } = useTranslation();
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button type="button" variant="ghost" className="flex items-center gap-2">
+          <Avatar className="h-8 w-8">
+            <AvatarFallback aria-label={t('topbar.profile')}>JD</AvatarFallback>
+          </Avatar>
+          <span className="hidden text-sm font-medium md:inline">Jordan Diaz</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-48" align="end">
+        <DropdownMenuLabel>{t('topbar.profile')}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>View profile</DropdownMenuItem>
+        <DropdownMenuItem>Account settings</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>Log out</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apgms/webapp/src/components/navigation/Breadcrumbs.tsx
+++ b/apgms/webapp/src/components/navigation/Breadcrumbs.tsx
@@ -1,0 +1,61 @@
+import { Link, useLocation, matchPath } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { NAVIGATION_ROUTES, ONBOARDING_STEPS, type OnboardingStepId } from '@/routes/config';
+
+interface Crumb {
+  label: string;
+  path: string;
+}
+
+export function Breadcrumbs() {
+  const { pathname } = useLocation();
+  const { t } = useTranslation();
+
+  const crumbs: Crumb[] = [];
+
+  if (pathname !== '/') {
+    crumbs.push({ label: t('navigation.dashboard'), path: '/' });
+  }
+
+  const primaryMatch = NAVIGATION_ROUTES.find(route => route.path !== '/' && pathname.startsWith(route.path));
+  if (primaryMatch) {
+    const label = t(primaryMatch.translationKey);
+    crumbs.push({ label, path: primaryMatch.path === '/onboarding' ? '/onboarding' : primaryMatch.path });
+  }
+
+  const onboardingMatch = matchPath('/onboarding/:stepId', pathname);
+  if (onboardingMatch && onboardingMatch.params.stepId) {
+    const stepId = onboardingMatch.params.stepId as OnboardingStepId;
+    if (ONBOARDING_STEPS.includes(stepId)) {
+      crumbs.push({ label: t(`onboarding.steps.${stepId}.name`), path: `/onboarding/${stepId}` });
+    }
+  }
+
+  if (crumbs.length === 0) {
+    crumbs.push({ label: t('navigation.dashboard'), path: '/' });
+  }
+
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-muted-foreground">
+      <ol className="flex flex-wrap items-center gap-2">
+        {crumbs.map((crumb, index) => {
+          const isLast = index === crumbs.length - 1;
+          return (
+            <li key={crumb.path} className="flex items-center gap-2">
+              {isLast ? (
+                <span aria-current="page" className="font-medium text-foreground">
+                  {crumb.label}
+                </span>
+              ) : (
+                <Link className="hover:text-foreground" to={crumb.path}>
+                  {crumb.label}
+                </Link>
+              )}
+              {!isLast && <span aria-hidden>/</span>}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/apgms/webapp/src/components/theme/ThemeToggle.tsx
+++ b/apgms/webapp/src/components/theme/ThemeToggle.tsx
@@ -1,0 +1,28 @@
+import { Moon, Sun } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTheme } from '@/components/theme/theme-provider';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          aria-label={theme === 'light' ? 'Switch to dark theme' : 'Switch to light theme'}
+          onClick={toggleTheme}
+        >
+          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" aria-hidden />
+          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <span>{theme === 'light' ? 'Dark mode' : 'Light mode'}</span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apgms/webapp/src/components/theme/theme-provider.tsx
+++ b/apgms/webapp/src/components/theme/theme-provider.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+export type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: ThemeMode;
+  setTheme: (theme: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
+const THEME_STORAGE_KEY = 'apgms-theme';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = React.useState<ThemeMode>('light');
+
+  React.useEffect(() => {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY) as ThemeMode | null;
+    if (stored === 'light' || stored === 'dark') {
+      setThemeState(stored);
+      document.documentElement.classList.toggle('dark', stored === 'dark');
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const defaultTheme: ThemeMode = prefersDark ? 'dark' : 'light';
+      setThemeState(defaultTheme);
+      document.documentElement.classList.toggle('dark', prefersDark);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme]);
+
+  const setTheme = React.useCallback((next: ThemeMode) => {
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = React.useCallback(() => {
+    setThemeState(prev => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const value = React.useMemo(() => ({ theme, setTheme, toggleTheme }), [theme, setTheme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = React.useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/apgms/webapp/src/components/ui/avatar.tsx
+++ b/apgms/webapp/src/components/ui/avatar.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import { cn } from '@/lib/utils';
+
+const Avatar = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Root>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Root ref={ref} className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)} {...props} />
+  )
+);
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+const AvatarImage = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Image>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Image ref={ref} className={cn('aspect-square h-full w-full', className)} {...props} />
+  )
+);
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+const AvatarFallback = React.forwardRef<React.ElementRef<typeof AvatarPrimitive.Fallback>, React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>>(
+  ({ className, ...props }, ref) => (
+    <AvatarPrimitive.Fallback ref={ref} className={cn('flex h-full w-full items-center justify-center rounded-full bg-muted text-sm font-medium', className)} {...props} />
+  )
+);
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/apgms/webapp/src/components/ui/button.tsx
+++ b/apgms/webapp/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/apgms/webapp/src/components/ui/card.tsx
+++ b/apgms/webapp/src/components/ui/card.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border border-border bg-card text-card-foreground shadow-sm', className)} {...props} />
+));
+Card.displayName = 'Card';
+
+const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h3 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = ({ className, ...props }: React.HTMLAttributes<HTMLParagraphElement>) => (
+  <p className={cn('text-sm text-muted-foreground', className)} {...props} />
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('p-6 pt-0', className)} {...props} />
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex items-center p-6 pt-0', className)} {...props} />
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/apgms/webapp/src/components/ui/dropdown-menu.tsx
+++ b/apgms/webapp/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,175 @@
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { cn } from '@/lib/utils';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[12rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <span className="h-2 w-2 rounded-full bg-primary" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <span className="h-2 w-2 rounded-full bg-primary" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return <span className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)} {...props} />;
+};
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut';
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+  DropdownMenuRadioGroup
+};

--- a/apgms/webapp/src/components/ui/input.tsx
+++ b/apgms/webapp/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = 'text', ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/apgms/webapp/src/components/ui/popover.tsx
+++ b/apgms/webapp/src/components/ui/popover.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn } from '@/lib/utils';
+
+const Popover = PopoverPrimitive.Root;
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-72 rounded-md border border-border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/apgms/webapp/src/components/ui/progress.tsx
+++ b/apgms/webapp/src/components/ui/progress.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+}
+
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(({ className, value = 0, ...props }, ref) => (
+  <div ref={ref} className={cn('relative h-2 w-full overflow-hidden rounded-full bg-muted', className)} {...props}>
+    <div
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - Math.min(100, Math.max(0, value))}%)` }}
+    />
+  </div>
+));
+Progress.displayName = 'Progress';
+
+export { Progress };

--- a/apgms/webapp/src/components/ui/scroll-area.tsx
+++ b/apgms/webapp/src/components/ui/scroll-area.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
+import { cn } from '@/lib/utils';
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">{children}</ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = 'vertical', ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      'flex touch-none select-none transition-colors',
+      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
+      orientation === 'horizontal' && 'h-2.5 border-t border-t-transparent p-[1px]',
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/apgms/webapp/src/components/ui/tooltip.tsx
+++ b/apgms/webapp/src/components/ui/tooltip.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { cn } from '@/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+const Tooltip = TooltipPrimitive.Root;
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95',
+      className
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent };

--- a/apgms/webapp/src/lib/apiClient.ts
+++ b/apgms/webapp/src/lib/apiClient.ts
@@ -1,0 +1,41 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface RequestOptions<TBody = unknown> {
+  method?: HttpMethod;
+  body?: TBody;
+  headers?: HeadersInit;
+}
+
+const DEFAULT_HEADERS: HeadersInit = {
+  'Content-Type': 'application/json'
+};
+
+export class ApiClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string = import.meta.env.VITE_API_URL ?? 'http://localhost:3000') {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+  }
+
+  async request<TResponse>(endpoint: string, options: RequestOptions = {}): Promise<TResponse> {
+    const url = `${this.baseUrl}${endpoint.startsWith('/') ? '' : '/'}${endpoint}`;
+    const response = await fetch(url, {
+      method: options.method ?? 'GET',
+      headers: { ...DEFAULT_HEADERS, ...options.headers },
+      body: options.body ? JSON.stringify(options.body) : undefined
+    });
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || `Request failed with status ${response.status}`);
+    }
+
+    if (response.status === 204) {
+      return undefined as TResponse;
+    }
+
+    return (await response.json()) as TResponse;
+  }
+}
+
+export const apiClient = new ApiClient();

--- a/apgms/webapp/src/lib/i18n.ts
+++ b/apgms/webapp/src/lib/i18n.ts
@@ -1,0 +1,101 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: {
+    translation: {
+      navigation: {
+        dashboard: 'Dashboard',
+        basWorkspace: 'BAS Workspace',
+        reconCenter: 'Recon Center',
+        evidenceAudit: 'Evidence & Audit',
+        settings: 'Settings',
+        onboarding: 'Onboarding Wizard'
+      },
+      topbar: {
+        search: 'Search the platform',
+        help: 'Help center',
+        notifications: 'Notifications',
+        profile: 'Profile'
+      },
+      orgs: {
+        primary: 'Birchal Capital',
+        secondary: 'APGMS Advisory',
+        tertiary: 'Launch Partners'
+      },
+      dashboard: {
+        welcome: 'Welcome back,',
+        subtitle: 'Here is a quick overview of your compliance posture today.',
+        readiness: 'Readiness status',
+        openTasks: 'Open tasks',
+        recentActivity: 'Recent activity'
+      },
+      bas: {
+        title: 'BAS Workspace',
+        subtitle: 'Track and manage your Business Activity Statements with confidence.',
+        summary: 'Submission summary',
+        upcoming: 'Upcoming lodgements'
+      },
+      recon: {
+        title: 'Recon Center',
+        subtitle: 'Monitor reconciliation progress across ledgers and banking.',
+        status: 'Reconciliation status'
+      },
+      evidence: {
+        title: 'Evidence & Audit',
+        subtitle: 'Centralize documentation for fast audit response.',
+        evidenceLog: 'Evidence log'
+      },
+      settings: {
+        title: 'Settings',
+        subtitle: 'Configure organization, preferences, and integrations.'
+      },
+      onboarding: {
+        title: 'Onboarding wizard',
+        subtitle: 'Complete these steps to get APGMS ready for your team.',
+        steps: {
+          welcome: {
+            name: 'Welcome',
+            description: 'Overview of the onboarding process.'
+          },
+          organization: {
+            name: 'Organization details',
+            description: 'Confirm legal entity information.'
+          },
+          compliance: {
+            name: 'Compliance scope',
+            description: 'Select frameworks and obligations.'
+          },
+          team: {
+            name: 'Team access',
+            description: 'Invite collaborators and assign roles.'
+          },
+          integrations: {
+            name: 'Integrations',
+            description: 'Connect accounting and evidence sources.'
+          },
+          review: {
+            name: 'Review & launch',
+            description: 'Validate setup and finish onboarding.'
+          }
+        },
+        actions: {
+          next: 'Next',
+          back: 'Back',
+          finish: 'Finish setup'
+        }
+      }
+    }
+  }
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false
+  }
+});
+
+export default i18n;

--- a/apgms/webapp/src/lib/utils.ts
+++ b/apgms/webapp/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,11 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles/globals.css';
+import './lib/i18n';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/pages/BasWorkspacePage.tsx
+++ b/apgms/webapp/src/pages/BasWorkspacePage.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { CalendarClock, FileSpreadsheet } from 'lucide-react';
+
+export function BasWorkspacePage() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('bas.title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('bas.subtitle')}</p>
+        </div>
+        <Button type="button" className="self-start">
+          Start new BAS
+        </Button>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('bas.summary')}</CardTitle>
+            <CardDescription>ATO lodgements across the financial year.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="flex items-start gap-3">
+              <FileSpreadsheet className="mt-1 h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="font-medium">FY24 Q1</p>
+                <p className="text-muted-foreground">Submitted · Refund of $12,300 processed</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <FileSpreadsheet className="mt-1 h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="font-medium">FY24 Q2</p>
+                <p className="text-muted-foreground">In review · Awaiting approval from CFO</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('bas.upcoming')}</CardTitle>
+            <CardDescription>Keep compliance dates visible for the team.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="flex items-start gap-3">
+              <CalendarClock className="mt-1 h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="font-medium">Prepare FY24 Q3</p>
+                <p className="text-muted-foreground">Working papers due 15 Apr · Evidence owner: Asha Patel</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <CalendarClock className="mt-1 h-4 w-4 text-primary" aria-hidden />
+              <div>
+                <p className="font-medium">Submit IAS</p>
+                <p className="text-muted-foreground">Payment scheduled 21 Apr · Status: Pending</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/apgms/webapp/src/pages/DashboardPage.tsx
+++ b/apgms/webapp/src/pages/DashboardPage.tsx
@@ -1,0 +1,90 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ArrowRight, Shield, CheckCircle, AlertTriangle } from 'lucide-react';
+
+export function DashboardPage() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div>
+          <p className="text-sm text-muted-foreground">{t('dashboard.welcome')} Jordan</p>
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('navigation.dashboard')}</h1>
+          <p className="text-sm text-muted-foreground">{t('dashboard.subtitle')}</p>
+        </div>
+        <Button type="button" className="self-start">
+          Launch workspace
+          <ArrowRight className="ml-2 h-4 w-4" aria-hidden />
+        </Button>
+      </header>
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle>{t('dashboard.readiness')}</CardTitle>
+            <CardDescription>Overview of current control performance.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 sm:grid-cols-2">
+            <div className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/60 p-4">
+              <Shield className="mt-1 h-5 w-5 text-primary" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Critical controls</p>
+                <p className="text-sm text-muted-foreground">92% passing across 14 monitored controls.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/60 p-4">
+              <CheckCircle className="mt-1 h-5 w-5 text-emerald-500" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Tasks completed</p>
+                <p className="text-sm text-muted-foreground">18 actions closed out in the past 7 days.</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('dashboard.openTasks')}</CardTitle>
+            <CardDescription>Upcoming obligations needing attention.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-4">
+              <li>
+                <p className="text-sm font-medium">Prepare Q2 BAS evidence</p>
+                <p className="text-xs text-muted-foreground">Due in 3 days · Assigned to Jordan Diaz</p>
+              </li>
+              <li>
+                <p className="text-sm font-medium">Review payroll reconciliation</p>
+                <p className="text-xs text-muted-foreground">Due in 6 days · Assigned to Sam Chen</p>
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('dashboard.recentActivity')}</CardTitle>
+          <CardDescription>Latest updates across BAS, reconciliation, and evidence.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ul className="divide-y divide-border text-sm">
+            <li className="flex items-start gap-3 py-3">
+              <AlertTriangle className="mt-1 h-4 w-4 text-amber-500" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Variance flagged in payroll clearing account</p>
+                <p className="text-xs text-muted-foreground">Recon Center · Investigate within 24 hours</p>
+              </div>
+            </li>
+            <li className="flex items-start gap-3 py-3">
+              <CheckCircle className="mt-1 h-4 w-4 text-emerald-500" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Evidence item verified: Supplier agreements</p>
+                <p className="text-xs text-muted-foreground">Evidence & Audit · Marked by Leila Rao</p>
+              </div>
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apgms/webapp/src/pages/EvidenceAuditPage.tsx
+++ b/apgms/webapp/src/pages/EvidenceAuditPage.tsx
@@ -1,0 +1,94 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Paperclip, Upload } from 'lucide-react';
+
+const EVIDENCE_ITEMS = [
+  {
+    id: 'ev-1',
+    title: 'Supplier contracts FY24',
+    owner: 'Leila Rao',
+    status: 'Approved'
+  },
+  {
+    id: 'ev-2',
+    title: 'Payroll tax statements',
+    owner: 'Jordan Diaz',
+    status: 'Pending review'
+  },
+  {
+    id: 'ev-3',
+    title: 'Lease agreements',
+    owner: 'Sam Chen',
+    status: 'Updated'
+  }
+];
+
+export function EvidenceAuditPage() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('evidence.title')}</h1>
+          <p className="text-sm text-muted-foreground">{t('evidence.subtitle')}</p>
+        </div>
+        <Button type="button" className="self-start">
+          <Upload className="mr-2 h-4 w-4" aria-hidden />
+          Upload evidence
+        </Button>
+      </header>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('evidence.evidenceLog')}</CardTitle>
+          <CardDescription>Ensure auditors have everything they need.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ScrollArea className="max-h-72">
+            <table className="w-full table-fixed border-separate border-spacing-y-2 text-left text-sm">
+              <thead className="text-xs uppercase tracking-wide text-muted-foreground">
+                <tr>
+                  <th scope="col" className="px-3 py-2">
+                    Evidence name
+                  </th>
+                  <th scope="col" className="px-3 py-2">
+                    Owner
+                  </th>
+                  <th scope="col" className="px-3 py-2">
+                    Status
+                  </th>
+                  <th scope="col" className="px-3 py-2 sr-only">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {EVIDENCE_ITEMS.map(item => (
+                  <tr key={item.id} className="rounded-lg border border-border bg-card/80">
+                    <td className="px-3 py-3">
+                      <div className="flex items-center gap-2">
+                        <Paperclip className="h-4 w-4 text-primary" aria-hidden />
+                        <span className="font-medium text-foreground">{item.title}</span>
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-muted-foreground">{item.owner}</td>
+                    <td className="px-3 py-3">
+                      <span className="rounded-full bg-secondary px-2 py-1 text-xs text-secondary-foreground">{item.status}</span>
+                    </td>
+                    <td className="px-3 py-3 text-right">
+                      <Button type="button" variant="ghost" size="sm">
+                        View details
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </ScrollArea>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apgms/webapp/src/pages/OnboardingWizardPage.tsx
+++ b/apgms/webapp/src/pages/OnboardingWizardPage.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { DEFAULT_ONBOARDING_STEP, ONBOARDING_STEPS, type OnboardingStepId } from '@/routes/config';
+
+const STEP_CONTENT: Record<OnboardingStepId, { heading: string; description: string; checklist: string[] }> = {
+  welcome: {
+    heading: 'Kick off your onboarding',
+    description: 'Learn how APGMS guides your BAS, reconciliation, and audit readiness.',
+    checklist: ['Review onboarding roadmap', 'Meet your implementation partner']
+  },
+  organization: {
+    heading: 'Confirm organisation profile',
+    description: 'We use this information for filings and reporting outputs.',
+    checklist: ['Verify legal entity details', 'Upload trust deed and corporate docs']
+  },
+  compliance: {
+    heading: 'Define compliance scope',
+    description: 'Select frameworks, lodgements, and obligations for automation.',
+    checklist: ['Choose ATO and payroll requirements', 'Add industry-specific obligations']
+  },
+  team: {
+    heading: 'Invite your team',
+    description: 'Ensure stakeholders receive the right notifications and tasks.',
+    checklist: ['Add finance owners and reviewers', 'Assign access levels']
+  },
+  integrations: {
+    heading: 'Connect integrations',
+    description: 'Securely link accounting and evidence systems for data sync.',
+    checklist: ['Connect Xero or MYOB', 'Authorise document storage provider']
+  },
+  review: {
+    heading: 'Review & launch',
+    description: 'Validate that everything looks correct before going live.',
+    checklist: ['Check onboarding progress summary', 'Schedule go-live session']
+  }
+};
+
+export function OnboardingWizardPage() {
+  const { stepId = DEFAULT_ONBOARDING_STEP } = useParams<{ stepId: OnboardingStepId }>();
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+
+  const currentStep = useMemo<OnboardingStepId>(() => {
+    return ONBOARDING_STEPS.includes(stepId) ? stepId : DEFAULT_ONBOARDING_STEP;
+  }, [stepId]);
+
+  const currentIndex = ONBOARDING_STEPS.indexOf(currentStep);
+  const completion = ((currentIndex + 1) / ONBOARDING_STEPS.length) * 100;
+
+  const goToStep = (index: number) => {
+    const nextStep = ONBOARDING_STEPS[index];
+    if (nextStep) {
+      navigate(`/onboarding/${nextStep}`);
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('onboarding.title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('onboarding.subtitle')}</p>
+      </header>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t(`onboarding.steps.${currentStep}.name`)}</CardTitle>
+          <CardDescription>{t(`onboarding.steps.${currentStep}.description`)}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-muted-foreground">Step {currentIndex + 1} of {ONBOARDING_STEPS.length}</p>
+            <Progress value={completion} aria-label={`Onboarding progress ${Math.round(completion)} percent`} />
+          </div>
+          <section aria-labelledby="onboarding-checklist" className="space-y-3">
+            <h2 id="onboarding-checklist" className="text-sm font-semibold text-foreground">
+              {STEP_CONTENT[currentStep].heading}
+            </h2>
+            <p className="text-sm text-muted-foreground">{STEP_CONTENT[currentStep].description}</p>
+            <ul className="space-y-2 text-sm">
+              {STEP_CONTENT[currentStep].checklist.map(item => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 inline-block h-2 w-2 rounded-full bg-primary" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+          <div className="flex flex-wrap justify-between gap-3">
+            <Button type="button" variant="outline" disabled={currentIndex === 0} onClick={() => goToStep(currentIndex - 1)}>
+              {t('onboarding.actions.back')}
+            </Button>
+            {currentIndex === ONBOARDING_STEPS.length - 1 ? (
+              <Button type="button">{t('onboarding.actions.finish')}</Button>
+            ) : (
+              <Button type="button" onClick={() => goToStep(currentIndex + 1)}>
+                {t('onboarding.actions.next')}
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apgms/webapp/src/pages/ReconCenterPage.tsx
+++ b/apgms/webapp/src/pages/ReconCenterPage.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { AlertCircle, CheckCircle } from 'lucide-react';
+
+export function ReconCenterPage() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('recon.title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('recon.subtitle')}</p>
+      </header>
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('recon.status')}</CardTitle>
+          <CardDescription>Ledger connections and variance monitoring.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <span>Bank feed reconciliation</span>
+              <span className="font-medium text-emerald-500">98% matched</span>
+            </div>
+            <Progress value={98} aria-label="Bank feed reconciliation 98 percent matched" />
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-sm">
+              <span>Payroll clearing account</span>
+              <span className="font-medium text-amber-500">Variance $1,240</span>
+            </div>
+            <Progress value={62} aria-label="Payroll clearing account reconciliation 62 percent complete" />
+          </div>
+          <ul className="space-y-4 text-sm">
+            <li className="flex items-start gap-3">
+              <AlertCircle className="mt-1 h-4 w-4 text-amber-500" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Variance detected in clearing account</p>
+                <p className="text-muted-foreground">Assigning to Recon Analyst queue</p>
+              </div>
+            </li>
+            <li className="flex items-start gap-3">
+              <CheckCircle className="mt-1 h-4 w-4 text-emerald-500" aria-hidden />
+              <div>
+                <p className="font-medium text-foreground">Stripe settlement matched</p>
+                <p className="text-muted-foreground">Confirmed by Automation rules 23 mins ago</p>
+              </div>
+            </li>
+          </ul>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apgms/webapp/src/pages/SettingsPage.tsx
+++ b/apgms/webapp/src/pages/SettingsPage.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export function SettingsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">{t('settings.title')}</h1>
+        <p className="text-sm text-muted-foreground">{t('settings.subtitle')}</p>
+      </header>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Organisation profile</CardTitle>
+            <CardDescription>Control legal entity and contact details.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="org-name">
+                Legal name
+              </label>
+              <Input id="org-name" name="org-name" defaultValue="Birchal Capital Pty Ltd" autoComplete="organization" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground" htmlFor="org-abn">
+                ABN
+              </label>
+              <Input id="org-abn" name="org-abn" defaultValue="23 456 789 123" autoComplete="off" />
+            </div>
+            <Button type="button">Save changes</Button>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Notification preferences</CardTitle>
+            <CardDescription>Choose how your team receives updates.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <label className="flex items-center justify-between gap-4">
+              <span>Email summaries</span>
+              <input type="checkbox" defaultChecked aria-label="Enable email summaries" className="h-4 w-4" />
+            </label>
+            <label className="flex items-center justify-between gap-4">
+              <span>Slack notifications</span>
+              <input type="checkbox" aria-label="Enable Slack notifications" className="h-4 w-4" />
+            </label>
+            <label className="flex items-center justify-between gap-4">
+              <span>Escalation SMS</span>
+              <input type="checkbox" aria-label="Enable escalation SMS" className="h-4 w-4" />
+            </label>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/apgms/webapp/src/providers/AppProviders.tsx
+++ b/apgms/webapp/src/providers/AppProviders.tsx
@@ -1,0 +1,18 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+import { ThemeProvider } from '@/components/theme/theme-provider';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const queryClient = new QueryClient();
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <React.Suspense fallback={null}>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </React.Suspense>
+  );
+}

--- a/apgms/webapp/src/routes/config.tsx
+++ b/apgms/webapp/src/routes/config.tsx
@@ -1,0 +1,30 @@
+import { LayoutDashboard, Settings, Briefcase, Radar, FileCheck, Rocket } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+export interface NavigationRoute {
+  path: string;
+  translationKey: string;
+  icon: LucideIcon;
+}
+
+export const NAVIGATION_ROUTES: NavigationRoute[] = [
+  { path: '/', translationKey: 'navigation.dashboard', icon: LayoutDashboard },
+  { path: '/bas-workspace', translationKey: 'navigation.basWorkspace', icon: Briefcase },
+  { path: '/recon-center', translationKey: 'navigation.reconCenter', icon: Radar },
+  { path: '/evidence-audit', translationKey: 'navigation.evidenceAudit', icon: FileCheck },
+  { path: '/settings', translationKey: 'navigation.settings', icon: Settings },
+  { path: '/onboarding', translationKey: 'navigation.onboarding', icon: Rocket }
+];
+
+export const ONBOARDING_STEPS = [
+  'welcome',
+  'organization',
+  'compliance',
+  'team',
+  'integrations',
+  'review'
+] as const;
+
+export type OnboardingStepId = (typeof ONBOARDING_STEPS)[number];
+
+export const DEFAULT_ONBOARDING_STEP: OnboardingStepId = 'welcome';

--- a/apgms/webapp/src/styles/globals.css
+++ b/apgms/webapp/src/styles/globals.css
@@ -1,0 +1,61 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 221.2 83.2% 53.3%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 221.2 83.2% 53.3%;
+  --radius: 0.75rem;
+}
+
+.dark {
+  --background: 224 71% 4%;
+  --foreground: 213 31% 91%;
+  --card: 224 71% 4%;
+  --card-foreground: 213 31% 91%;
+  --popover: 224 71% 4%;
+  --popover-foreground: 213 31% 91%;
+  --primary: 217 91% 60%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 224.3 76.3% 48%;
+}
+
+body {
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
+}
+
+* {
+  @apply border-border;
+}
+
+html {
+  scroll-behavior: smooth;
+}

--- a/apgms/webapp/tailwind.config.ts
+++ b/apgms/webapp/tailwind.config.ts
@@ -1,0 +1,68 @@
+import type { Config } from 'tailwindcss';
+import animatePlugin from 'tailwindcss-animate';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' }
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' }
+        }
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out'
+      }
+    }
+  },
+  plugins: [animatePlugin]
+};
+
+export default config;

--- a/apgms/webapp/tests/accessibility.spec.ts
+++ b/apgms/webapp/tests/accessibility.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+const routes = [
+  { path: '/', title: 'Dashboard' },
+  { path: '/bas-workspace', title: 'BAS Workspace' },
+  { path: '/recon-center', title: 'Recon Center' },
+  { path: '/evidence-audit', title: 'Evidence & Audit' },
+  { path: '/settings', title: 'Settings' },
+  { path: '/onboarding', title: 'Onboarding Wizard' }
+];
+
+test.describe('core route accessibility', () => {
+  for (const route of routes) {
+    test(`no critical accessibility issues on ${route.title}`, async ({ page }) => {
+      await page.goto(route.path);
+      const results = await new AxeBuilder({ page }).analyze();
+      const criticalViolations = results.violations.filter(violation => violation.impact === 'critical');
+      expect(criticalViolations).toEqual([]);
+    });
+  }
+});

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": [
+    "src",
+    "tests",
+    "vite.config.ts",
+    "playwright.config.ts",
+    "tailwind.config.ts"
+  ]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind webapp with shadcn-inspired components, routing, theming, and i18n providers
- implement sidebar/topbar shell with dashboard, BAS workspace, recon center, evidence & audit, settings, and onboarding wizard screens
- add API client with VITE_API_URL support plus Playwright axe accessibility checks for core routes

## Testing
- pnpm install --filter @apgms/webapp... *(fails: ERR_PNPM_FETCH_403 when fetching @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68eaab6f725c8327b50a6ec1f96aa9c9