### PR TITLE
Add audit log chaining and RPT lifecycle endpoints

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/rpt.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/audit-log.ts
+++ b/apgms/services/api-gateway/src/audit-log.ts
@@ -1,0 +1,143 @@
+import { createHash } from "node:crypto";
+import type { PrismaClient } from "@prisma/client";
+
+export interface AuditEventInput {
+  actor: string;
+  action: string;
+  entityType?: string;
+  entityId?: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface AuditEventRecord {
+  id: string;
+  digestAfter: string;
+  digestBefore: string | null;
+}
+
+export interface AuditEventRepository {
+  findLatest(): Promise<AuditEventRecord | null>;
+  create(input: AuditEventPersisted): Promise<AuditEventRecord>;
+}
+
+export interface AuditEventPersisted extends AuditEventInput {
+  occurredAt: Date;
+  digestBefore: string | null;
+  digestAfter: string;
+}
+
+export class PrismaAuditEventRepository implements AuditEventRepository {
+  constructor(private readonly prisma: Pick<PrismaClient, "$queryRaw">) {}
+
+  async findLatest(): Promise<AuditEventRecord | null> {
+    const rows = await this.prisma.$queryRaw<
+      { id: string; digestAfter: string; digestBefore: string | null }[]
+    >`
+      SELECT "id", "digestAfter", "digestBefore"
+      FROM "AuditEvent"
+      ORDER BY "occurredAt" DESC
+      LIMIT 1
+    `;
+    if (rows.length === 0) {
+      return null;
+    }
+    const [{ id, digestAfter, digestBefore }] = rows;
+    return { id, digestAfter, digestBefore };
+  }
+
+  async create(input: AuditEventPersisted): Promise<AuditEventRecord> {
+    const metadataJson =
+      input.metadata === undefined || input.metadata === null
+        ? null
+        : JSON.stringify(input.metadata);
+    const rows = await this.prisma.$queryRaw<
+      { id: string; digestAfter: string; digestBefore: string | null }[]
+    >`
+      INSERT INTO "AuditEvent" (
+        "actor",
+        "action",
+        "entityType",
+        "entityId",
+        "occurredAt",
+        "metadata",
+        "digestBefore",
+        "digestAfter"
+      )
+      VALUES (
+        ${input.actor},
+        ${input.action},
+        ${input.entityType ?? null},
+        ${input.entityId ?? null},
+        ${input.occurredAt},
+        ${metadataJson},
+        ${input.digestBefore},
+        ${input.digestAfter}
+      )
+      RETURNING "id", "digestAfter", "digestBefore"
+    `;
+    const [{ id, digestAfter, digestBefore }] = rows;
+    return { id, digestAfter, digestBefore };
+  }
+}
+
+export class AuditLogWriter {
+  constructor(
+    private readonly repository: AuditEventRepository,
+    private readonly clock: () => Date = () => new Date(),
+  ) {}
+
+  async append(event: AuditEventInput): Promise<AuditEventRecord> {
+    const latest = await this.repository.findLatest();
+    const digestBefore = latest?.digestAfter ?? null;
+    const occurredAt = this.clock();
+    const digestAfter = computeDigest({
+      digestBefore,
+      occurredAt,
+      event,
+    });
+
+    return this.repository.create({
+      ...event,
+      occurredAt,
+      digestBefore,
+      digestAfter,
+    });
+  }
+}
+
+export function computeDigest({
+  digestBefore,
+  occurredAt,
+  event,
+}: {
+  digestBefore: string | null;
+  occurredAt: Date;
+  event: AuditEventInput;
+}): string {
+  const payload = canonicalStringify({
+    digestBefore,
+    occurredAt: occurredAt.toISOString(),
+    actor: event.actor,
+    action: event.action,
+    entityType: event.entityType ?? null,
+    entityId: event.entityId ?? null,
+    metadata: event.metadata ?? null,
+  });
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+export function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalStringify(item)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .map(([key, val]) => [key, val] as const)
+    .sort(([keyA], [keyB]) => (keyA < keyB ? -1 : keyA > keyB ? 1 : 0));
+  const inner = entries
+    .map(([key, val]) => `${JSON.stringify(key)}:${canonicalStringify(val)}`)
+    .join(",");
+  return `{${inner}}`;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,7 +9,11 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import { z, ZodError } from "zod";
 import { prisma } from "../../../shared/src/db";
+import { AuditLogWriter, PrismaAuditEventRepository } from "./audit-log";
+import { ManifestChain, PrismaManifestRepository } from "./manifest-chain";
+import { PrismaRptRepository, RptService } from "./rpt-service";
 
 const app = Fastify({ logger: true });
 
@@ -17,6 +21,16 @@ await app.register(cors, { origin: true });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+const auditLogWriter = new AuditLogWriter(
+  new PrismaAuditEventRepository(prisma),
+);
+const manifestChain = new ManifestChain(new PrismaManifestRepository(prisma));
+const rptService = new RptService({
+  manifestChain,
+  auditLog: auditLogWriter,
+  repository: new PrismaRptRepository(prisma),
+});
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -62,6 +76,152 @@ app.post("/bank-lines", async (req, rep) => {
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+const mintSchema = z.object({
+  orgId: z.string().min(1),
+  period: z.string().min(1),
+  actor: z.string().min(1),
+  manifest: z
+    .object({})
+    .catchall(z.unknown())
+    .default({}),
+});
+
+app.post("/rpt/mint", async (req, rep) => {
+  try {
+    const body = mintSchema.parse(req.body ?? {});
+    const result = await rptService.mint({
+      orgId: body.orgId,
+      period: body.period,
+      actor: body.actor,
+      payload: body.manifest as Record<string, unknown>,
+    });
+    return rep.code(201).send({
+      token: result.token,
+      manifest: {
+        id: result.manifest.id,
+        orgId: result.manifest.orgId,
+        period: result.manifest.period,
+        sequence: result.manifest.sequence,
+        digest: result.manifest.digest,
+        prevDigest: result.manifest.prevDigest,
+        createdAt: result.manifest.createdAt.toISOString(),
+        payload: result.manifest.payload,
+      },
+    });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return rep.status(400).send({
+        error: "validation_error",
+        issues: err.format(),
+      });
+    }
+    req.log.error(err);
+    return rep.status(500).send({ error: "internal_error" });
+  }
+});
+
+const verifySchema = z.object({ token: z.string().min(1) });
+
+app.post("/rpt/verify", async (req, rep) => {
+  try {
+    const body = verifySchema.parse(req.body ?? {});
+    const result = await rptService.verify({ token: body.token });
+    if (!result.valid) {
+      return rep.status(200).send({
+        valid: false,
+        reason: result.reason,
+        revokedAt: result.revokedAt?.toISOString(),
+        revokedReason: result.revokedReason ?? undefined,
+      });
+    }
+    return rep.status(200).send({
+      valid: true,
+      orgId: result.orgId,
+      period: result.period,
+      manifestDigest: result.manifestDigest,
+      mintedAt: result.mintedAt.toISOString(),
+    });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return rep.status(400).send({
+        error: "validation_error",
+        issues: err.format(),
+      });
+    }
+    req.log.error(err);
+    return rep.status(500).send({ error: "internal_error" });
+  }
+});
+
+const revokeSchema = z.object({
+  token: z.string().min(1),
+  actor: z.string().min(1),
+  reason: z.string().max(512).optional(),
+});
+
+app.post("/rpt/revoke", async (req, rep) => {
+  try {
+    const body = revokeSchema.parse(req.body ?? {});
+    const result = await rptService.revoke({
+      token: body.token,
+      actor: body.actor,
+      reason: body.reason,
+    });
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return rep.status(404).send({ error: "not_found" });
+      }
+      return rep.status(409).send({
+        error: "already_revoked",
+        revokedAt: result.revokedAt?.toISOString(),
+      });
+    }
+    return rep.status(200).send({
+      ok: true,
+      revokedAt: result.revokedAt.toISOString(),
+    });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return rep.status(400).send({
+        error: "validation_error",
+        issues: err.format(),
+      });
+    }
+    req.log.error(err);
+    return rep.status(500).send({ error: "internal_error" });
+  }
+});
+
+app.get("/manifests/:orgId/:period", async (req, rep) => {
+  try {
+    const paramsSchema = z.object({
+      orgId: z.string().min(1),
+      period: z.string().min(1),
+    });
+    const params = paramsSchema.parse(req.params ?? {});
+    const chain = await manifestChain.getChain(params.orgId, params.period);
+    return rep.status(200).send({
+      chain: chain.map((entry) => ({
+        id: entry.id,
+        sequence: entry.sequence,
+        digest: entry.digest,
+        prevDigest: entry.prevDigest,
+        createdAt: entry.createdAt.toISOString(),
+        payload: entry.payload,
+      })),
+    });
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return rep.status(400).send({
+        error: "validation_error",
+        issues: err.format(),
+      });
+    }
+    req.log.error(err);
+    return rep.status(500).send({ error: "internal_error" });
   }
 });
 

--- a/apgms/services/api-gateway/src/manifest-chain.ts
+++ b/apgms/services/api-gateway/src/manifest-chain.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+import type { PrismaClient } from "@prisma/client";
+import { canonicalStringify } from "./audit-log";
+
+export interface ManifestInput {
+  orgId: string;
+  period: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ManifestRecord {
+  id: string;
+  orgId: string;
+  period: string;
+  sequence: number;
+  digest: string;
+  prevDigest: string | null;
+  createdAt: Date;
+  payload: Record<string, unknown>;
+}
+
+export interface ManifestRepository {
+  findLatest(orgId: string, period: string): Promise<ManifestRecord | null>;
+  create(input: ManifestPersisted): Promise<ManifestRecord>;
+  getChain(orgId: string, period: string): Promise<ManifestRecord[]>;
+}
+
+export interface ManifestPersisted {
+  orgId: string;
+  period: string;
+  sequence: number;
+  digest: string;
+  prevDigest: string | null;
+  createdAt: Date;
+  payload: Record<string, unknown>;
+}
+
+export class PrismaManifestRepository implements ManifestRepository {
+  constructor(private readonly prisma: Pick<PrismaClient, "$queryRaw">) {}
+
+  async findLatest(orgId: string, period: string): Promise<ManifestRecord | null> {
+    const rows = await this.prisma.$queryRaw<
+      ManifestRow[]
+    >`
+      SELECT "id", "orgId", "period", "sequence", "digest", "prevDigest", "createdAt", "payload"
+      FROM "ManifestEntry"
+      WHERE "orgId" = ${orgId} AND "period" = ${period}
+      ORDER BY "sequence" DESC
+      LIMIT 1
+    `;
+    if (rows.length === 0) {
+      return null;
+    }
+    return mapManifestFromPrisma(rows[0]);
+  }
+
+  async create(input: ManifestPersisted): Promise<ManifestRecord> {
+    const payloadJson = JSON.stringify(input.payload);
+    const rows = await this.prisma.$queryRaw<
+      ManifestRow[]
+    >`
+      INSERT INTO "ManifestEntry" (
+        "orgId",
+        "period",
+        "sequence",
+        "digest",
+        "prevDigest",
+        "createdAt",
+        "payload"
+      )
+      VALUES (
+        ${input.orgId},
+        ${input.period},
+        ${input.sequence},
+        ${input.digest},
+        ${input.prevDigest},
+        ${input.createdAt},
+        ${payloadJson}
+      )
+      RETURNING "id", "orgId", "period", "sequence", "digest", "prevDigest", "createdAt", "payload"
+    `;
+    return mapManifestFromPrisma(rows[0]);
+  }
+
+  async getChain(orgId: string, period: string): Promise<ManifestRecord[]> {
+    const rows = await this.prisma.$queryRaw<
+      ManifestRow[]
+    >`
+      SELECT "id", "orgId", "period", "sequence", "digest", "prevDigest", "createdAt", "payload"
+      FROM "ManifestEntry"
+      WHERE "orgId" = ${orgId} AND "period" = ${period}
+      ORDER BY "sequence" ASC
+    `;
+    return rows.map(mapManifestFromPrisma);
+  }
+}
+
+type ManifestRow = {
+  id: string;
+  orgId: string;
+  period: string;
+  sequence: number;
+  digest: string;
+  prevDigest: string | null;
+  createdAt: Date;
+  payload: unknown;
+};
+
+export function mapManifestFromPrisma(entry: ManifestRow): ManifestRecord {
+  let payloadObject: Record<string, unknown> = {};
+  if (entry.payload && typeof entry.payload === "object") {
+    payloadObject = entry.payload as Record<string, unknown>;
+  } else if (typeof entry.payload === "string") {
+    try {
+      const parsed = JSON.parse(entry.payload);
+      if (parsed && typeof parsed === "object") {
+        payloadObject = parsed as Record<string, unknown>;
+      }
+    } catch (err) {
+      // ignore malformed json and fall back to empty object
+    }
+  }
+  return {
+    id: entry.id,
+    orgId: entry.orgId,
+    period: entry.period,
+    sequence: entry.sequence,
+    digest: entry.digest,
+    prevDigest: entry.prevDigest,
+    createdAt: entry.createdAt,
+    payload: payloadObject,
+  };
+}
+
+export class ManifestChain {
+  constructor(
+    private readonly repository: ManifestRepository,
+    private readonly clock: () => Date = () => new Date(),
+  ) {}
+
+  async append(input: ManifestInput): Promise<ManifestRecord> {
+    const latest = await this.repository.findLatest(input.orgId, input.period);
+    const prevDigest = latest?.digest ?? null;
+    const sequence = latest ? latest.sequence + 1 : 1;
+    const createdAt = this.clock();
+    const digest = createHash("sha256")
+      .update(
+        canonicalStringify({
+          orgId: input.orgId,
+          period: input.period,
+          sequence,
+          prevDigest,
+          createdAt: createdAt.toISOString(),
+          payload: input.payload,
+        }),
+      )
+      .digest("hex");
+
+    return this.repository.create({
+      orgId: input.orgId,
+      period: input.period,
+      sequence,
+      prevDigest,
+      createdAt,
+      digest,
+      payload: input.payload,
+    });
+  }
+
+  async getChain(orgId: string, period: string): Promise<ManifestRecord[]> {
+    return this.repository.getChain(orgId, period);
+  }
+}

--- a/apgms/services/api-gateway/src/rpt-service.ts
+++ b/apgms/services/api-gateway/src/rpt-service.ts
@@ -1,0 +1,351 @@
+import { randomBytes } from "node:crypto";
+import type { PrismaClient } from "@prisma/client";
+import type { AuditLogWriter } from "./audit-log";
+import type { ManifestChain, ManifestRecord } from "./manifest-chain";
+import { mapManifestFromPrisma } from "./manifest-chain";
+
+export interface RptRecord {
+  id: string;
+  orgId: string;
+  period: string;
+  status: "ACTIVE" | "REVOKED";
+  token: string;
+  mintedAt: Date;
+  mintedBy: string;
+  revokedAt: Date | null;
+  revokedBy: string | null;
+  revokedReason: string | null;
+  manifest: ManifestRecord;
+}
+
+export interface RptRepository {
+  create(input: RptCreateInput): Promise<RptRecord>;
+  findByToken(token: string): Promise<RptRecord | null>;
+  markRevoked(id: string, update: RptRevokeUpdate): Promise<RptRecord>;
+}
+
+export interface RptCreateInput {
+  orgId: string;
+  period: string;
+  token: string;
+  manifestId: string;
+  mintedAt: Date;
+  mintedBy: string;
+}
+
+export interface RptRevokeUpdate {
+  revokedAt: Date;
+  revokedBy: string;
+  revokedReason?: string;
+}
+
+export class PrismaRptRepository implements RptRepository {
+  constructor(private readonly prisma: Pick<PrismaClient, "$queryRaw">) {}
+
+  async create(input: RptCreateInput): Promise<RptRecord> {
+    const rows = await this.prisma.$queryRaw<RptRow[]>`
+      WITH inserted AS (
+        INSERT INTO "RptToken" (
+          "orgId",
+          "period",
+          "manifestId",
+          "token",
+          "mintedAt",
+          "mintedBy"
+        )
+        VALUES (
+          ${input.orgId},
+          ${input.period},
+          ${input.manifestId},
+          ${input.token},
+          ${input.mintedAt},
+          ${input.mintedBy}
+        )
+        RETURNING *
+      )
+      SELECT
+        inserted."id",
+        inserted."orgId",
+        inserted."period",
+        inserted."token",
+        inserted."status",
+        inserted."mintedAt",
+        inserted."mintedBy",
+        inserted."revokedAt",
+        inserted."revokedBy",
+        inserted."revokedReason",
+        manifest."id"        AS "manifest_id",
+        manifest."orgId"     AS "manifest_orgId",
+        manifest."period"    AS "manifest_period",
+        manifest."sequence"  AS "manifest_sequence",
+        manifest."digest"    AS "manifest_digest",
+        manifest."prevDigest" AS "manifest_prevDigest",
+        manifest."createdAt" AS "manifest_createdAt",
+        manifest."payload"   AS "manifest_payload"
+      FROM inserted
+      JOIN "ManifestEntry" manifest ON manifest."id" = inserted."manifestId"
+    `;
+    return mapRpt(rows[0]);
+  }
+
+  async findByToken(token: string): Promise<RptRecord | null> {
+    const rows = await this.prisma.$queryRaw<RptRow[]>`
+      SELECT
+        rpt."id",
+        rpt."orgId",
+        rpt."period",
+        rpt."token",
+        rpt."status",
+        rpt."mintedAt",
+        rpt."mintedBy",
+        rpt."revokedAt",
+        rpt."revokedBy",
+        rpt."revokedReason",
+        manifest."id"        AS "manifest_id",
+        manifest."orgId"     AS "manifest_orgId",
+        manifest."period"    AS "manifest_period",
+        manifest."sequence"  AS "manifest_sequence",
+        manifest."digest"    AS "manifest_digest",
+        manifest."prevDigest" AS "manifest_prevDigest",
+        manifest."createdAt" AS "manifest_createdAt",
+        manifest."payload"   AS "manifest_payload"
+      FROM "RptToken" rpt
+      JOIN "ManifestEntry" manifest ON manifest."id" = rpt."manifestId"
+      WHERE rpt."token" = ${token}
+    `;
+    if (rows.length === 0) {
+      return null;
+    }
+    return mapRpt(rows[0]);
+  }
+
+  async markRevoked(id: string, update: RptRevokeUpdate): Promise<RptRecord> {
+    const rows = await this.prisma.$queryRaw<RptRow[]>`
+      WITH updated AS (
+        UPDATE "RptToken"
+        SET
+          "status" = 'REVOKED',
+          "revokedAt" = ${update.revokedAt},
+          "revokedBy" = ${update.revokedBy},
+          "revokedReason" = ${update.revokedReason ?? null}
+        WHERE "id" = ${id}
+        RETURNING *
+      )
+      SELECT
+        updated."id",
+        updated."orgId",
+        updated."period",
+        updated."token",
+        updated."status",
+        updated."mintedAt",
+        updated."mintedBy",
+        updated."revokedAt",
+        updated."revokedBy",
+        updated."revokedReason",
+        manifest."id"        AS "manifest_id",
+        manifest."orgId"     AS "manifest_orgId",
+        manifest."period"    AS "manifest_period",
+        manifest."sequence"  AS "manifest_sequence",
+        manifest."digest"    AS "manifest_digest",
+        manifest."prevDigest" AS "manifest_prevDigest",
+        manifest."createdAt" AS "manifest_createdAt",
+        manifest."payload"   AS "manifest_payload"
+      FROM updated
+      JOIN "ManifestEntry" manifest ON manifest."id" = updated."manifestId"
+    `;
+    return mapRpt(rows[0]);
+  }
+}
+
+type RptRow = {
+  id: string;
+  orgId: string;
+  period: string;
+  token: string;
+  status: "ACTIVE" | "REVOKED";
+  mintedAt: Date;
+  mintedBy: string;
+  revokedAt: Date | null;
+  revokedBy: string | null;
+  revokedReason: string | null;
+  manifest_id: string;
+  manifest_orgId: string;
+  manifest_period: string;
+  manifest_sequence: number;
+  manifest_digest: string;
+  manifest_prevDigest: string | null;
+  manifest_createdAt: Date;
+  manifest_payload: unknown;
+};
+
+function mapRpt(row: RptRow): RptRecord {
+  return {
+    id: row.id,
+    orgId: row.orgId,
+    period: row.period,
+    token: row.token,
+    status: row.status,
+    mintedAt: row.mintedAt,
+    mintedBy: row.mintedBy,
+    revokedAt: row.revokedAt,
+    revokedBy: row.revokedBy,
+    revokedReason: row.revokedReason,
+    manifest: mapManifestFromPrisma({
+      id: row.manifest_id,
+      orgId: row.manifest_orgId,
+      period: row.manifest_period,
+      sequence: row.manifest_sequence,
+      digest: row.manifest_digest,
+      prevDigest: row.manifest_prevDigest,
+      createdAt: row.manifest_createdAt,
+      payload: row.manifest_payload,
+    }),
+  };
+}
+
+export interface MintRequest {
+  orgId: string;
+  period: string;
+  payload: Record<string, unknown>;
+  actor: string;
+}
+
+export interface VerifyRequest {
+  token: string;
+}
+
+export interface RevokeRequest {
+  token: string;
+  actor: string;
+  reason?: string;
+}
+
+export class RptService {
+  constructor(
+    private readonly deps: {
+      manifestChain: ManifestChain;
+      auditLog: AuditLogWriter;
+      repository: RptRepository;
+      tokenGenerator?: () => string;
+      clock?: () => Date;
+    },
+  ) {}
+
+  private get clock(): () => Date {
+    return this.deps.clock ?? (() => new Date());
+  }
+
+  private get tokenGenerator(): () => string {
+    return (
+      this.deps.tokenGenerator ?? (() => randomBytes(24).toString("hex"))
+    );
+  }
+
+  async mint(request: MintRequest): Promise<{
+    token: string;
+    manifest: ManifestRecord;
+  }> {
+    const manifest = await this.deps.manifestChain.append({
+      orgId: request.orgId,
+      period: request.period,
+      payload: request.payload,
+    });
+
+    const token = this.tokenGenerator();
+    const mintedAt = this.clock();
+
+    const rpt = await this.deps.repository.create({
+      orgId: request.orgId,
+      period: request.period,
+      token,
+      manifestId: manifest.id,
+      mintedAt,
+      mintedBy: request.actor,
+    });
+
+    await this.deps.auditLog.append({
+      actor: request.actor,
+      action: "rpt.mint",
+      entityType: "RPT",
+      entityId: rpt.id,
+      metadata: {
+        token,
+        orgId: request.orgId,
+        period: request.period,
+        manifestDigest: manifest.digest,
+      },
+    });
+
+    return { token, manifest };
+  }
+
+  async verify(request: VerifyRequest): Promise<
+    | { valid: false; reason: "not_found" | "revoked"; revokedAt?: Date; revokedReason?: string | null }
+    | {
+        valid: true;
+        orgId: string;
+        period: string;
+        manifestDigest: string;
+        mintedAt: Date;
+      }
+  > {
+    const rpt = await this.deps.repository.findByToken(request.token);
+    if (!rpt) {
+      return { valid: false, reason: "not_found" };
+    }
+    if (rpt.status === "REVOKED") {
+      return {
+        valid: false,
+        reason: "revoked",
+        revokedAt: rpt.revokedAt ?? undefined,
+        revokedReason: rpt.revokedReason,
+      };
+    }
+    return {
+      valid: true,
+      orgId: rpt.orgId,
+      period: rpt.period,
+      manifestDigest: rpt.manifest.digest,
+      mintedAt: rpt.mintedAt,
+    };
+  }
+
+  async revoke(request: RevokeRequest): Promise<
+    | { ok: true; revokedAt: Date }
+    | { ok: false; reason: "not_found" | "already_revoked"; revokedAt?: Date }
+  > {
+    const rpt = await this.deps.repository.findByToken(request.token);
+    if (!rpt) {
+      return { ok: false, reason: "not_found" };
+    }
+    if (rpt.status === "REVOKED") {
+      return {
+        ok: false,
+        reason: "already_revoked",
+        revokedAt: rpt.revokedAt ?? undefined,
+      };
+    }
+
+    const revokedAt = this.clock();
+    const updated = await this.deps.repository.markRevoked(rpt.id, {
+      revokedAt,
+      revokedBy: request.actor,
+      revokedReason: request.reason,
+    });
+
+    await this.deps.auditLog.append({
+      actor: request.actor,
+      action: "rpt.revoke",
+      entityType: "RPT",
+      entityId: updated.id,
+      metadata: {
+        token: request.token,
+        reason: request.reason ?? null,
+        orgId: updated.orgId,
+        period: updated.period,
+      },
+    });
+
+    return { ok: true, revokedAt };
+  }
+}

--- a/apgms/services/api-gateway/test/rpt.test.ts
+++ b/apgms/services/api-gateway/test/rpt.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  AuditEventRepository,
+  AuditEventRecord,
+  AuditLogWriter,
+  AuditEventPersisted,
+} from "../src/audit-log";
+import {
+  ManifestChain,
+  ManifestRepository,
+  ManifestRecord,
+  ManifestPersisted,
+} from "../src/manifest-chain";
+import {
+  MintRequest,
+  RptRepository,
+  RptService,
+  RptRecord,
+  RptCreateInput,
+  RptRevokeUpdate,
+} from "../src/rpt-service";
+
+class InMemoryAuditRepository implements AuditEventRepository {
+  private events: (AuditEventRecord & AuditEventPersisted)[] = [];
+
+  async findLatest(): Promise<AuditEventRecord | null> {
+    if (this.events.length === 0) {
+      return null;
+    }
+    const { id, digestAfter, digestBefore } = this.events[this.events.length - 1];
+    return { id, digestAfter, digestBefore };
+  }
+
+  async create(input: AuditEventPersisted): Promise<AuditEventRecord> {
+    const record: AuditEventRecord & AuditEventPersisted = {
+      id: `event-${this.events.length + 1}`,
+      ...input,
+    };
+    this.events.push(record);
+    const { id, digestAfter, digestBefore } = record;
+    return { id, digestAfter, digestBefore };
+  }
+
+  all(): (AuditEventRecord & AuditEventPersisted)[] {
+    return this.events;
+  }
+}
+
+class InMemoryManifestRepository implements ManifestRepository {
+  private store: ManifestRecord[] = [];
+  private counter = 0;
+
+  async findLatest(orgId: string, period: string): Promise<ManifestRecord | null> {
+    const relevant = this.store
+      .filter((entry) => entry.orgId === orgId && entry.period === period)
+      .sort((a, b) => b.sequence - a.sequence);
+    return relevant[0] ?? null;
+  }
+
+  async create(input: ManifestPersisted): Promise<ManifestRecord> {
+    const record: ManifestRecord = {
+      id: `manifest-${++this.counter}`,
+      ...input,
+    };
+    this.store.push(record);
+    return record;
+  }
+
+  async getChain(orgId: string, period: string): Promise<ManifestRecord[]> {
+    return this.store
+      .filter((entry) => entry.orgId === orgId && entry.period === period)
+      .sort((a, b) => a.sequence - b.sequence);
+  }
+
+  getById(id: string): ManifestRecord | undefined {
+    return this.store.find((entry) => entry.id === id);
+  }
+}
+
+class InMemoryRptRepository implements RptRepository {
+  private store: RptRecord[] = [];
+  private counter = 0;
+
+  constructor(private readonly manifestRepo: InMemoryManifestRepository) {}
+
+  async create(input: RptCreateInput): Promise<RptRecord> {
+    const manifest = this.manifestRepo.getById(input.manifestId);
+    if (!manifest) {
+      throw new Error("manifest not found");
+    }
+    const record: RptRecord = {
+      id: `rpt-${++this.counter}`,
+      orgId: input.orgId,
+      period: input.period,
+      status: "ACTIVE",
+      token: input.token,
+      mintedAt: input.mintedAt,
+      mintedBy: input.mintedBy,
+      revokedAt: null,
+      revokedBy: null,
+      revokedReason: null,
+      manifest,
+    };
+    this.store.push(record);
+    return record;
+  }
+
+  async findByToken(token: string): Promise<RptRecord | null> {
+    return this.store.find((record) => record.token === token) ?? null;
+  }
+
+  async markRevoked(id: string, update: RptRevokeUpdate): Promise<RptRecord> {
+    const record = this.store.find((entry) => entry.id === id);
+    if (!record) {
+      throw new Error("rpt not found");
+    }
+    record.status = "REVOKED";
+    record.revokedAt = update.revokedAt;
+    record.revokedBy = update.revokedBy;
+    record.revokedReason = update.revokedReason ?? null;
+    return record;
+  }
+}
+
+test("audit log writer maintains digest continuity", async () => {
+  const auditRepo = new InMemoryAuditRepository();
+  let tick = 0;
+  const writer = new AuditLogWriter(auditRepo, () => {
+    const base = Date.parse("2024-01-01T00:00:00Z");
+    return new Date(base + tick++ * 1000);
+  });
+
+  await writer.append({ actor: "alice", action: "create" });
+  await writer.append({ actor: "bob", action: "update", entityId: "doc-1" });
+  await writer.append({ actor: "carol", action: "delete", metadata: { hard: true } });
+
+  const events = auditRepo.all();
+  assert.equal(events[0].digestBefore, null);
+  assert.equal(events[1].digestBefore, events[0].digestAfter);
+  assert.equal(events[2].digestBefore, events[1].digestAfter);
+  assert.notEqual(events[0].digestAfter, events[1].digestAfter);
+  assert.notEqual(events[1].digestAfter, events[2].digestAfter);
+});
+
+test("rpt service verifies active tokens", async () => {
+  const auditRepo = new InMemoryAuditRepository();
+  const manifestRepo = new InMemoryManifestRepository();
+  let manifestTick = 0;
+  const manifestChain = new ManifestChain(
+    manifestRepo,
+    () => new Date(Date.parse("2024-02-01T00:00:00Z") + manifestTick++ * 1000),
+  );
+  const rptRepo = new InMemoryRptRepository(manifestRepo);
+  const service = new RptService({
+    manifestChain,
+    auditLog: new AuditLogWriter(auditRepo),
+    repository: rptRepo,
+    tokenGenerator: () => "token-1",
+    clock: () => new Date("2024-02-15T12:00:00Z"),
+  });
+
+  const mintRequest: MintRequest = {
+    orgId: "org-1",
+    period: "2024-Q1",
+    payload: { total: 1000 },
+    actor: "issuer",
+  };
+  await service.mint(mintRequest);
+
+  const verify = await service.verify({ token: "token-1" });
+  assert.equal(verify.valid, true);
+  if (verify.valid) {
+    assert.equal(verify.orgId, "org-1");
+    assert.equal(verify.period, "2024-Q1");
+    assert.ok(verify.manifestDigest.length > 0);
+  }
+
+  const missing = await service.verify({ token: "unknown" });
+  assert.deepEqual(missing, { valid: false, reason: "not_found" });
+});
+
+test("rpt service revokes tokens and blocks verification", async () => {
+  const auditRepo = new InMemoryAuditRepository();
+  const manifestRepo = new InMemoryManifestRepository();
+  const manifestChain = new ManifestChain(
+    manifestRepo,
+    () => new Date("2024-03-01T00:00:00Z"),
+  );
+  const rptRepo = new InMemoryRptRepository(manifestRepo);
+  const auditWriter = new AuditLogWriter(auditRepo);
+  const service = new RptService({
+    manifestChain,
+    auditLog: auditWriter,
+    repository: rptRepo,
+    tokenGenerator: () => "token-2",
+    clock: () => new Date("2024-03-10T10:00:00Z"),
+  });
+
+  await service.mint({
+    orgId: "org-9",
+    period: "2024-Q2",
+    payload: { total: 42 },
+    actor: "issuer",
+  });
+
+  const revoke = await service.revoke({
+    token: "token-2",
+    actor: "auditor",
+    reason: "compromised",
+  });
+  assert.equal(revoke.ok, true);
+  if (revoke.ok) {
+    assert.equal(revoke.revokedAt.toISOString(), "2024-03-10T10:00:00.000Z");
+  }
+
+  const verify = await service.verify({ token: "token-2" });
+  assert.equal(verify.valid, false);
+  if (!verify.valid) {
+    assert.equal(verify.reason, "revoked");
+    assert.equal(verify.revokedReason, "compromised");
+  }
+
+  const second = await service.revoke({
+    token: "token-2",
+    actor: "auditor",
+  });
+  assert.deepEqual(second, {
+    ok: false,
+    reason: "already_revoked",
+    revokedAt: new Date("2024-03-10T10:00:00Z"),
+  });
+
+  assert.equal(auditRepo.all().length, 2);
+});

--- a/apgms/shared/prisma/migrations/20251011120000_audit_rpt/migration.sql
+++ b/apgms/shared/prisma/migrations/20251011120000_audit_rpt/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+CREATE TYPE "RptStatus" AS ENUM ('ACTIVE', 'REVOKED');
+
+-- CreateTable
+CREATE TABLE "AuditEvent" (
+    "id" TEXT NOT NULL,
+    "actor" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "entityType" TEXT,
+    "entityId" TEXT,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "metadata" JSONB,
+    "digestBefore" TEXT,
+    "digestAfter" TEXT NOT NULL,
+
+    CONSTRAINT "AuditEvent_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "AuditEvent_digestAfter_key" UNIQUE ("digestAfter")
+);
+
+-- CreateTable
+CREATE TABLE "ManifestEntry" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "payload" JSONB NOT NULL,
+    "prevDigest" TEXT,
+    "digest" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ManifestEntry_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "ManifestEntry_digest_key" UNIQUE ("digest"),
+    CONSTRAINT "ManifestEntry_orgId_period_sequence_key" UNIQUE ("orgId", "period", "sequence")
+);
+
+-- CreateTable
+CREATE TABLE "RptToken" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "manifestId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "status" "RptStatus" NOT NULL DEFAULT 'ACTIVE',
+    "mintedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "mintedBy" TEXT NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "revokedBy" TEXT,
+    "revokedReason" TEXT,
+
+    CONSTRAINT "RptToken_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "RptToken_token_key" UNIQUE ("token")
+);
+
+-- CreateIndex
+CREATE INDEX "RptToken_orgId_period_idx" ON "RptToken"("orgId", "period");
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_manifestId_fkey" FOREIGN KEY ("manifestId") REFERENCES "ManifestEntry"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -34,3 +34,51 @@ model BankLine {
   desc      String
   createdAt DateTime @default(now())
 }
+
+model AuditEvent {
+  id           String   @id @default(cuid())
+  actor        String
+  action       String
+  entityType   String?
+  entityId     String?
+  occurredAt   DateTime @default(now())
+  metadata     Json?
+  digestBefore String?
+  digestAfter  String   @unique
+}
+
+model ManifestEntry {
+  id         String   @id @default(cuid())
+  orgId      String
+  period     String
+  sequence   Int
+  payload    Json
+  prevDigest String?
+  digest     String   @unique
+  createdAt  DateTime @default(now())
+  rptTokens  RptToken[]
+
+  @@unique([orgId, period, sequence])
+}
+
+model RptToken {
+  id            String    @id @default(cuid())
+  orgId         String
+  period        String
+  manifest      ManifestEntry @relation(fields: [manifestId], references: [id], onDelete: Restrict)
+  manifestId    String
+  token         String    @unique
+  status        RptStatus @default(ACTIVE)
+  mintedAt      DateTime  @default(now())
+  mintedBy      String
+  revokedAt     DateTime?
+  revokedBy     String?
+  revokedReason String?
+
+  @@index([orgId, period])
+}
+
+enum RptStatus {
+  ACTIVE
+  REVOKED
+}


### PR DESCRIPTION
## Summary
- add Prisma-backed audit log writer that maintains SHA-256 digest chaining for append-only records
- implement manifest chain storage plus RPT mint/verify/revoke orchestration and expose the corresponding Fastify endpoints
- extend the Prisma schema with audit/manifests/RPT tables and add unit tests covering digest continuity and RPT lifecycle behaviours

## Testing
- pnpm -C apgms/services/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68eaab58118c8327bac821faf1f6615a