### PR TITLE
Add smoke checklist to ops runbook

### DIFF
--- a/apgms/docs/ops/runbook.md
+++ b/apgms/docs/ops/runbook.md
@@ -1,1 +1,17 @@
-﻿# Ops runbook
+# Ops runbook
+
+## Smoke checklist
+
+- [ ] `pnpm fmt:check`
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm -r test`
+- [ ] `docker compose up -d (db, redis)`
+- [ ] `pnpm run db:migrate && pnpm run db:seed`
+- [ ] API `GET /health` returns 200
+- [ ] API `GET /users` returns 200
+- [ ] API `GET /bank-lines` returns 200
+- [ ] Web at http://localhost:5173/
+- [ ] `/metrics` reachable
+- [ ] Playwright e2e
+- [ ] k6 thresholds


### PR DESCRIPTION
## Summary
- add a smoke checklist to the ops runbook covering key verification steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaabff22a8832792ff706f8afbc194