### PR TITLE
Add CI, e2e, and security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-test:
+    name: Install, test, and build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: apgms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apgms/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Format check
+        run: |
+          pnpm --if-present run fmt:check
+          pnpm -r --if-present run fmt:check
+
+      - name: Lint
+        run: |
+          pnpm --if-present run lint
+          pnpm -r --if-present run lint
+
+      - name: Typecheck
+        run: |
+          pnpm --if-present run typecheck
+          pnpm -r --if-present run typecheck
+
+      - name: Unit tests
+        run: |
+          pnpm --if-present run test
+          pnpm -r --if-present run test
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: apgms
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-spdx
+          path: sbom.spdx.json
+
+      - name: Docker build
+        run: docker build -t apgms-ci .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,76 @@
+name: E2E
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+      - 'release/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  playwright:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: apgms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apgms/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm dlx @playwright/test@latest install --with-deps
+
+      - name: Start application stack
+        run: docker compose up -d
+
+      - name: Wait for services
+        run: |
+          for i in {1..10}; do
+            if docker compose ps | grep -q "Up"; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker compose ps
+          exit 1
+
+      - name: Run Playwright tests
+        env:
+          CI: 'true'
+        run: pnpm dlx @playwright/test@latest test --reporter=line --config=playwright.config.ts
+
+      - name: Upload Playwright traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: |
+            apgms/playwright-report
+            apgms/test-results
+          if-no-files-found: ignore
+
+      - name: Tear down environment
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,87 @@
+name: Security
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  security-scans:
+    name: Security gates
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: apgms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apgms/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build container image
+        run: docker build -t apgms-security .
+
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0
+        with:
+          scan-type: fs
+          path: apgms
+          format: table
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@v0
+        with:
+          scan-type: image
+          image-ref: apgms-security
+          format: table
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      - name: pnpm audit
+        run: pnpm audit --recursive
+
+      - name: Secret scan
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source=. --no-git
+
+      - name: Verify SBOM
+        run: |
+          pnpm dlx @cyclonedx/cdxgen --fail-on-error --spec-version 1.5 --output sbom.cdx.json
+          test -s sbom.cdx.json
+
+      - name: Upload SBOM verification report
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: apgms/sbom.cdx.json
+
+      - name: License audit
+        run: pnpm dlx license-checker --summary --production

--- a/apgms/.dockerignore
+++ b/apgms/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+**/node_modules
+.git
+.gitignore
+playwright-report
+test-results
+sbom*.json

--- a/apgms/Dockerfile
+++ b/apgms/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+FROM node:20-bookworm-slim AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY services ./services
+COPY shared ./shared
+COPY webapp ./webapp
+COPY worker ./worker
+RUN corepack enable \
+    && pnpm install --frozen-lockfile
+
+FROM deps AS build
+COPY . .
+RUN pnpm run build
+
+FROM node:20-bookworm-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app .
+CMD ["node", "--version"]


### PR DESCRIPTION
## Summary
- add a CI workflow that installs dependencies, runs format/lint/type-check/unit/build stages, emits an SBOM artifact, and exercises the Docker build
- add an end-to-end workflow that boots the docker-compose stack, runs headless Playwright tests, and captures traces as artifacts
- add a security workflow for Trivy filesystem and image scans, pnpm audit, secret detection, SBOM verification, and license auditing, plus supporting Docker build assets

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68eaabb1c1bc8327a786160510ec3d3d