### PR TITLE
Add BAS compiler with label mapping rules and rounding tests

### DIFF
--- a/apgms/services/tax-engine/app/bas/__init__.py
+++ b/apgms/services/tax-engine/app/bas/__init__.py
@@ -1,0 +1,5 @@
+"""Business Activity Statement compilation helpers."""
+
+from .compiler import compileBas
+
+__all__ = ["compileBas"]

--- a/apgms/services/tax-engine/app/bas/compiler.py
+++ b/apgms/services/tax-engine/app/bas/compiler.py
@@ -1,0 +1,96 @@
+"""Compile Business Activity Statement (BAS) label totals."""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from functools import lru_cache
+from importlib import resources
+from typing import Any, Mapping, TypeAlias
+
+LabelTotals: TypeAlias = dict[str, int]
+
+
+@lru_cache
+def _load_label_rules() -> dict[str, Any]:
+    """Load the label mapping rules from the packaged JSON file."""
+    with resources.files("app.rules.bas").joinpath("labels_v1.json").open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _to_decimal(value: Any) -> Decimal:
+    """Convert a value to :class:`~decimal.Decimal`, returning zero for unsupported types."""
+    if value is None:
+        return Decimal("0")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, str)):
+        return Decimal(str(value))
+    if isinstance(value, float):
+        # Avoid floating point surprises by converting via ``repr``.
+        return Decimal(repr(value))
+    raise TypeError(f"Unsupported numeric value type: {type(value)!r}")
+
+
+def _resolve_path(source: Mapping[str, Any], path: str) -> Decimal:
+    """Resolve a dotted path within ``source`` and return a :class:`Decimal` value."""
+    current: Any = source
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return Decimal("0")
+    if isinstance(current, (list, tuple)):
+        total = Decimal("0")
+        for item in current:
+            total += _to_decimal(item)
+        return total
+    return _to_decimal(current)
+
+
+def _round_half_up(value: Decimal) -> int:
+    """Round to the nearest whole dollar using ATO half-up rounding rules."""
+    return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def compileBas(period: str, gstResult: Mapping[str, Any], paygwResult: Mapping[str, Any]) -> dict[str, Any]:
+    """Compile BAS label totals for the given ``period``.
+
+    Parameters
+    ----------
+    period:
+        Identifier for the BAS period, e.g. ``"2024-05"``.
+    gstResult:
+        Aggregated GST calculation results.
+    paygwResult:
+        Aggregated PAYGW calculation results.
+
+    Returns
+    -------
+    dict[str, Any]
+        A structure containing the ``period``, ``labels`` and the ``rulesVersion`` used.
+    """
+
+    rules = _load_label_rules()
+    labels_config = rules["labels"]
+    sources = {"gst": gstResult, "paygw": paygwResult}
+
+    compiled: LabelTotals = {}
+
+    for label, config in labels_config.items():
+        total = Decimal("0")
+        for source in config["sources"]:
+            source_key = source["source"]
+            if source_key not in sources:
+                raise KeyError(f"Unknown source '{source_key}' for label {label}")
+            total += _resolve_path(sources[source_key], source["path"])
+        compiled[label] = _round_half_up(total)
+
+    return {
+        "period": period,
+        "labels": compiled,
+        "rulesVersion": rules.get("version", "unknown"),
+    }
+
+
+__all__ = ["compileBas"]

--- a/apgms/services/tax-engine/app/rules/__init__.py
+++ b/apgms/services/tax-engine/app/rules/__init__.py
@@ -1,0 +1,1 @@
+"""Rule definitions packaged with the tax engine."""

--- a/apgms/services/tax-engine/app/rules/bas/__init__.py
+++ b/apgms/services/tax-engine/app/rules/bas/__init__.py
@@ -1,0 +1,1 @@
+"""BAS label mapping rules."""

--- a/apgms/services/tax-engine/app/rules/bas/labels_v1.json
+++ b/apgms/services/tax-engine/app/rules/bas/labels_v1.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0.0",
+  "labels": {
+    "G1": {
+      "description": "Total sales for the period",
+      "sources": [
+        {"source": "gst", "path": "sales.taxable"},
+        {"source": "gst", "path": "sales.export"},
+        {"source": "gst", "path": "sales.other"}
+      ]
+    },
+    "1A": {
+      "description": "GST on sales",
+      "sources": [
+        {"source": "gst", "path": "gst.collected"}
+      ]
+    },
+    "1B": {
+      "description": "GST on purchases",
+      "sources": [
+        {"source": "gst", "path": "gst.credits"}
+      ]
+    },
+    "W1": {
+      "description": "Total salary and wages",
+      "sources": [
+        {"source": "paygw", "path": "wages.gross"}
+      ]
+    },
+    "W2": {
+      "description": "Amounts withheld from payments shown at W1",
+      "sources": [
+        {"source": "paygw", "path": "wages.withheld"}
+      ]
+    }
+  }
+}

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,10 @@
-﻿[tool.poetry]
+[tool.poetry]
 name='apgms-tax-engine'
 version='0.1.0'
 [tool.poetry.dependencies]
 python='^3.10'
 fastapi='*'
 uvicorn='*'
+
+[tool.poetry.group.dev.dependencies]
+pytest='^8.3'

--- a/apgms/services/tax-engine/tests/test_compile_bas.py
+++ b/apgms/services/tax-engine/tests/test_compile_bas.py
@@ -1,0 +1,67 @@
+from decimal import Decimal
+
+import pytest
+
+from app.bas import compileBas
+
+
+@pytest.fixture
+def synthetic_inputs():
+    return {
+        "period": "2024-03",
+        "gst": {
+            "sales": {
+                "taxable": Decimal("18750.45"),
+                "export": 1325.10,
+                "other": 425.25,
+            },
+            "gst": {
+                "collected": 1975.55,
+                "credits": 845.49,
+            },
+        },
+        "paygw": {
+            "wages": {
+                "gross": 9825.51,
+                "withheld": 2210.50,
+            }
+        },
+    }
+
+
+def test_compile_bas_synthetic_month(synthetic_inputs):
+    result = compileBas(
+        synthetic_inputs["period"],
+        synthetic_inputs["gst"],
+        synthetic_inputs["paygw"],
+    )
+
+    assert result["period"] == synthetic_inputs["period"]
+    assert result["labels"] == {
+        "G1": 20501,  # 18750.45 + 1325.10 + 425.25 = 20500.80 -> 20501
+        "1A": 1976,   # 1975.55 -> 1976
+        "1B": 845,    # 845.49 -> 845
+        "W1": 9826,   # 9825.51 -> 9826
+        "W2": 2211,   # 2210.50 -> 2211
+    }
+    assert result["rulesVersion"] == "1.0.0"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, 0),
+        (99.49, 99),
+        (99.50, 100),
+        (Decimal("99.50"), 100),
+        (Decimal("-99.50"), -100),
+        (-99.49, -99),
+    ],
+)
+def test_rounding_matches_ato_guidance(value, expected):
+    gst = {"sales": {"taxable": value, "export": 0, "other": 0}, "gst": {"collected": 0, "credits": 0}}
+    paygw = {"wages": {"gross": 0, "withheld": 0}}
+
+    compiled = compileBas("2024-05", gst, paygw)
+
+    assert compiled["labels"]["G1"] == expected


### PR DESCRIPTION
## Summary
- add a `compileBas` helper that loads BAS label mappings and rounds totals per ATO rules
- package BAS label mapping JSON covering GST and PAYGW labels G1/1A/1B/W1/W2
- cover compilation and rounding behaviour with targeted pytest cases

## Testing
- PYTHONPATH=apgms/services/tax-engine pytest apgms/services/tax-engine/tests -q


------
https://chatgpt.com/codex/tasks/task_e_68eaacc74b6c83279b44bab3df5aa638