### PR TITLE
Add STP Phase 2 schema and validator

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "tsx test/validate-stp2.test.ts"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,3 @@
-﻿console.log('sbr service');
+export { default as stp2Schema } from './schema/index.js';
+export type { Stp2ValidationError } from './validate-stp2.js';
+export { validateStp2 } from './validate-stp2.js';

--- a/apgms/services/sbr/src/schema/index.ts
+++ b/apgms/services/sbr/src/schema/index.ts
@@ -1,0 +1,3 @@
+import schema from './stp2.schema.json';
+
+export default schema;

--- a/apgms/services/sbr/src/schema/stp2.schema.json
+++ b/apgms/services/sbr/src/schema/stp2.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.apgms.dev/ato/stp2/payroll-event.json",
+  "title": "ATO STP Phase 2 payroll event",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["payer", "payee", "payrollEvent"],
+  "properties": {
+    "payer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["abn", "name"],
+      "properties": {
+        "abn": {
+          "type": "string",
+          "pattern": "^\\d{11}$",
+          "description": "Australian Business Number must contain exactly 11 digits.",
+          "x-ruleId": "STP2.PAYER.100"
+        },
+        "branch": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9999,
+          "description": "Branch number must be in the range 0001-9999 when supplied.",
+          "x-ruleId": "STP2.PAYER.101"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Payer name is mandatory and must contain at least one character.",
+          "x-ruleId": "STP2.PAYER.001"
+        }
+      },
+      "x-ruleId": "STP2.PAYER.000"
+    },
+    "payee": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["familyName", "givenName", "tfn", "employmentBasis", "incomeStreamType"],
+      "properties": {
+        "familyName": {
+          "type": "string",
+          "minLength": 1,
+          "x-ruleId": "STP2.PAYEE.001"
+        },
+        "givenName": {
+          "type": "string",
+          "minLength": 1,
+          "x-ruleId": "STP2.PAYEE.002"
+        },
+        "otherGivenNames": {
+          "type": "string"
+        },
+        "dateOfBirth": {
+          "type": "string",
+          "format": "date",
+          "description": "Date of birth must be provided in ISO-8601 date format (YYYY-MM-DD).",
+          "x-ruleId": "STP2.PAYEE.101"
+        },
+        "tfn": {
+          "type": "string",
+          "pattern": "^(?:\\d{8}|\\d{9}|000000000|111111111|333333333|444444444|555555555)$",
+          "description": "Tax File Number must be 8 or 9 digits or an accepted special value.",
+          "x-ruleId": "STP2.PAYEE.100"
+        },
+        "employmentBasis": {
+          "type": "string",
+          "enum": [
+            "fullTime",
+            "partTime",
+            "casual",
+            "labourHire",
+            "seasonal",
+            "nonOngoing",
+            "voluntaryAgreement",
+            "other"
+          ],
+          "x-ruleId": "STP2.PAYEE.120"
+        },
+        "incomeStreamType": {
+          "type": "string",
+          "enum": [
+            "salaryAndWages",
+            "workingHoliday",
+            "closelyHeld",
+            "inboundAssignee",
+            "nonResident",
+            "seasonalWorker"
+          ],
+          "x-ruleId": "STP2.PAYEE.121"
+        },
+        "residencyStatus": {
+          "type": "string",
+          "enum": ["australianResident", "foreignResident", "workingHolidayMaker"]
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "line1": { "type": "string" },
+            "line2": { "type": "string" },
+            "suburb": { "type": "string" },
+            "state": {
+              "type": "string",
+              "enum": ["NSW", "QLD", "VIC", "TAS", "SA", "WA", "ACT", "NT"]
+            },
+            "postcode": {
+              "type": "string",
+              "pattern": "^\\d{4}$"
+            }
+          }
+        }
+      },
+      "x-ruleId": "STP2.PAYEE.000"
+    },
+    "payrollEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "payrollPeriod",
+        "paymentDate",
+        "grossAmount",
+        "paygwAmount",
+        "superGuarantee"
+      ],
+      "properties": {
+        "payrollPeriod": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["startDate", "endDate"],
+          "properties": {
+            "startDate": {
+              "type": "string",
+              "format": "date",
+              "x-ruleId": "STP2.EVENT.100"
+            },
+            "endDate": {
+              "type": "string",
+              "format": "date",
+              "x-ruleId": "STP2.EVENT.101"
+            }
+          },
+          "x-ruleId": "STP2.EVENT.099"
+        },
+        "paymentDate": {
+          "type": "string",
+          "format": "date",
+          "x-ruleId": "STP2.EVENT.102"
+        },
+        "payrollEventNumber": {
+          "type": "string",
+          "pattern": "^[0-9A-Za-z-]{1,20}$",
+          "x-ruleId": "STP2.EVENT.050"
+        },
+        "grossAmount": {
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01,
+          "x-ruleId": "STP2.EVENT.200"
+        },
+        "paygwAmount": {
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01,
+          "x-ruleId": "STP2.EVENT.201"
+        },
+        "superGuarantee": {
+          "type": "number",
+          "minimum": 0,
+          "multipleOf": 0.01,
+          "x-ruleId": "STP2.EVENT.202"
+        },
+        "yearToDate": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "grossAmount": {
+              "type": "number",
+              "minimum": 0,
+              "multipleOf": 0.01,
+              "x-ruleId": "STP2.EVENT.210"
+            },
+            "paygwAmount": {
+              "type": "number",
+              "minimum": 0,
+              "multipleOf": 0.01,
+              "x-ruleId": "STP2.EVENT.211"
+            },
+            "superGuarantee": {
+              "type": "number",
+              "minimum": 0,
+              "multipleOf": 0.01,
+              "x-ruleId": "STP2.EVENT.212"
+            }
+          }
+        }
+      },
+      "x-ruleId": "STP2.EVENT.000"
+    }
+  }
+}

--- a/apgms/services/sbr/src/validate-stp2.ts
+++ b/apgms/services/sbr/src/validate-stp2.ts
@@ -1,0 +1,203 @@
+import schemaJson from './schema/stp2.schema.json';
+
+export interface Stp2ValidationError {
+  /** A dot separated path that points to the offending value. */
+  path: string;
+  /** Keyword that identifies which JSON Schema rule failed. */
+  keyword: string;
+  /** Human readable validation message. */
+  message: string;
+  /** Identifier that maps to an ATO STP Phase 2 validation rule. */
+  ruleId: string;
+}
+
+type JsonSchema = {
+  type?: 'object' | 'string' | 'number' | 'integer';
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  pattern?: string;
+  minLength?: number;
+  enum?: string[];
+  format?: 'date';
+  minimum?: number;
+  maximum?: number;
+  multipleOf?: number;
+  description?: string;
+  'x-ruleId'?: string;
+};
+
+const ROOT_SCHEMA = schemaJson as JsonSchema;
+
+export function validateStp2(payload: unknown): Stp2ValidationError[] {
+  const errors: Stp2ValidationError[] = [];
+  validateAgainstSchema(ROOT_SCHEMA, payload, [], ROOT_SCHEMA['x-ruleId'] ?? 'STP2.UNKNOWN', errors);
+  return errors;
+}
+
+function validateAgainstSchema(
+  schema: JsonSchema,
+  value: unknown,
+  path: string[],
+  inheritedRuleId: string,
+  errors: Stp2ValidationError[]
+): void {
+  const ruleId = schema['x-ruleId'] ?? inheritedRuleId;
+
+  switch (schema.type) {
+    case 'object':
+      validateObject(schema, value, path, ruleId, errors);
+      break;
+    case 'string':
+      validateString(schema, value, path, ruleId, errors);
+      break;
+    case 'number':
+      validateNumber(schema, value, path, ruleId, errors, false);
+      break;
+    case 'integer':
+      validateNumber(schema, value, path, ruleId, errors, true);
+      break;
+    default:
+      // schema without explicit type is treated as permissive but will still walk child properties
+      if (schema.properties && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        validateObject(schema, value, path, ruleId, errors);
+      }
+  }
+}
+
+function validateObject(
+  schema: JsonSchema,
+  value: unknown,
+  path: string[],
+  ruleId: string,
+  errors: Stp2ValidationError[]
+): void {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    errors.push(createError(path, 'type', 'must be an object', ruleId));
+    return;
+  }
+
+  const typedValue = value as Record<string, unknown>;
+  const required = schema.required ?? [];
+  const props = schema.properties ?? {};
+
+  for (const property of required) {
+    if (!(property in typedValue)) {
+      const propertySchema = props[property];
+      const propertyRule = propertySchema?.['x-ruleId'] ?? ruleId;
+      errors.push(
+        createError([...path, property], 'required', `${property} is required`, propertyRule)
+      );
+    }
+  }
+
+  const allowedKeys = new Set(Object.keys(props));
+  for (const [key, val] of Object.entries(typedValue)) {
+    if (props[key]) {
+      validateAgainstSchema(props[key], val, [...path, key], props[key]['x-ruleId'] ?? ruleId, errors);
+    } else if (schema.additionalProperties === false) {
+      errors.push(createError([...path, key], 'additionalProperties', `${key} is not permitted`, ruleId));
+    }
+  }
+}
+
+function validateString(
+  schema: JsonSchema,
+  value: unknown,
+  path: string[],
+  ruleId: string,
+  errors: Stp2ValidationError[]
+): void {
+  if (typeof value !== 'string') {
+    errors.push(createError(path, 'type', 'must be a string', ruleId));
+    return;
+  }
+
+  if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+    errors.push(
+      createError(path, 'minLength', `must contain at least ${schema.minLength} characters`, ruleId)
+    );
+  }
+
+  if (schema.pattern) {
+    const regex = new RegExp(schema.pattern);
+    if (!regex.test(value)) {
+      const message = schema.description ?? `must match pattern ${schema.pattern}`;
+      errors.push(createError(path, 'pattern', message, ruleId));
+    }
+  }
+
+  if (schema.enum && !schema.enum.includes(value)) {
+    errors.push(
+      createError(path, 'enum', `must be one of: ${schema.enum.join(', ')}`, ruleId)
+    );
+  }
+
+  if (schema.format === 'date' && !isValidIsoDate(value)) {
+    errors.push(
+      createError(path, 'format', 'must be a valid ISO-8601 date (YYYY-MM-DD)', ruleId)
+    );
+  }
+}
+
+function validateNumber(
+  schema: JsonSchema,
+  value: unknown,
+  path: string[],
+  ruleId: string,
+  errors: Stp2ValidationError[],
+  mustBeInteger: boolean
+): void {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    errors.push(createError(path, 'type', 'must be a number', ruleId));
+    return;
+  }
+
+  if (mustBeInteger && !Number.isInteger(value)) {
+    errors.push(createError(path, 'type', 'must be an integer', ruleId));
+    return;
+  }
+
+  if (typeof schema.minimum === 'number' && value < schema.minimum) {
+    errors.push(
+      createError(path, 'minimum', `must be greater than or equal to ${schema.minimum}`, ruleId)
+    );
+  }
+
+  if (typeof schema.maximum === 'number' && value > schema.maximum) {
+    errors.push(
+      createError(path, 'maximum', `must be less than or equal to ${schema.maximum}`, ruleId)
+    );
+  }
+
+  if (typeof schema.multipleOf === 'number' && !isMultipleOf(value, schema.multipleOf)) {
+    errors.push(
+      createError(path, 'multipleOf', `must be a multiple of ${schema.multipleOf}`, ruleId)
+    );
+  }
+}
+
+function createError(path: string[], keyword: string, message: string, ruleId: string): Stp2ValidationError {
+  const joinedPath = path.length === 0 ? 'payload' : path.join('.');
+  return { path: joinedPath, keyword, message, ruleId };
+}
+
+function isValidIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return false;
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month && date.getUTCDate() === day;
+}
+
+function isMultipleOf(value: number, divisor: number): boolean {
+  const quotient = value / divisor;
+  const tolerance = 1e-9;
+  return Math.abs(quotient - Math.round(quotient)) <= tolerance;
+}

--- a/apgms/services/sbr/test/fixtures/invalid-abn.json
+++ b/apgms/services/sbr/test/fixtures/invalid-abn.json
@@ -1,0 +1,25 @@
+{
+  "payer": {
+    "abn": "12345",
+    "name": "Acme Payroll Pty Ltd",
+    "branch": 12000
+  },
+  "payee": {
+    "familyName": "Citizen",
+    "givenName": "Alex",
+    "dateOfBirth": "1990-02-18",
+    "tfn": "12AB5678",
+    "employmentBasis": "fullTime",
+    "incomeStreamType": "salaryAndWages"
+  },
+  "payrollEvent": {
+    "payrollPeriod": {
+      "startDate": "2024-06-24",
+      "endDate": "2024-07-07"
+    },
+    "paymentDate": "2024-07-08",
+    "grossAmount": 3850.75,
+    "paygwAmount": 812.35,
+    "superGuarantee": 365.82
+  }
+}

--- a/apgms/services/sbr/test/fixtures/invalid-dates.json
+++ b/apgms/services/sbr/test/fixtures/invalid-dates.json
@@ -1,0 +1,24 @@
+{
+  "payer": {
+    "abn": "53004085616",
+    "name": "Acme Payroll Pty Ltd"
+  },
+  "payee": {
+    "familyName": "Citizen",
+    "givenName": "Alex",
+    "dateOfBirth": "18-02-1990",
+    "tfn": "123456782",
+    "employmentBasis": "contractor",
+    "incomeStreamType": "mysteryIncome"
+  },
+  "payrollEvent": {
+    "payrollPeriod": {
+      "startDate": "2024/06/24",
+      "endDate": "2024-07-07"
+    },
+    "paymentDate": "2024-13-01",
+    "grossAmount": -10,
+    "paygwAmount": 812.333,
+    "superGuarantee": -1
+  }
+}

--- a/apgms/services/sbr/test/fixtures/missing-required.json
+++ b/apgms/services/sbr/test/fixtures/missing-required.json
@@ -1,0 +1,6 @@
+{
+  "payer": {
+    "abn": "53004085616",
+    "name": "Missing Payee Holdings"
+  }
+}

--- a/apgms/services/sbr/test/fixtures/valid-stp2.json
+++ b/apgms/services/sbr/test/fixtures/valid-stp2.json
@@ -1,0 +1,39 @@
+{
+  "payer": {
+    "abn": "53004085616",
+    "name": "Acme Payroll Pty Ltd",
+    "branch": 123
+  },
+  "payee": {
+    "familyName": "Citizen",
+    "givenName": "Alex",
+    "otherGivenNames": "Pat",
+    "dateOfBirth": "1990-02-18",
+    "tfn": "123456782",
+    "employmentBasis": "fullTime",
+    "incomeStreamType": "salaryAndWages",
+    "residencyStatus": "australianResident",
+    "address": {
+      "line1": "100 Market Street",
+      "suburb": "Sydney",
+      "state": "NSW",
+      "postcode": "2000"
+    }
+  },
+  "payrollEvent": {
+    "payrollPeriod": {
+      "startDate": "2024-06-24",
+      "endDate": "2024-07-07"
+    },
+    "paymentDate": "2024-07-08",
+    "payrollEventNumber": "PAY-000123",
+    "grossAmount": 3850.75,
+    "paygwAmount": 812.35,
+    "superGuarantee": 365.82,
+    "yearToDate": {
+      "grossAmount": 45210.5,
+      "paygwAmount": 9600.4,
+      "superGuarantee": 4280.12
+    }
+  }
+}

--- a/apgms/services/sbr/test/validate-stp2.test.ts
+++ b/apgms/services/sbr/test/validate-stp2.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { validateStp2 } from '../src/validate-stp2.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadFixture<T>(name: string): T {
+  const filePath = resolve(__dirname, 'fixtures', name);
+  const raw = readFileSync(filePath, 'utf-8');
+  return JSON.parse(raw) as T;
+}
+
+test('valid STP 2 payload passes with no validation errors', () => {
+  const payload = loadFixture<Record<string, unknown>>('valid-stp2.json');
+  const result = validateStp2(payload);
+  assert.equal(result.length, 0);
+});
+
+test('missing required structures returns the correct rule identifiers', () => {
+  const payload = loadFixture<Record<string, unknown>>('missing-required.json');
+  const result = validateStp2(payload);
+
+  const ruleIds = new Set(result.map((error) => error.ruleId));
+  assert.ok(ruleIds.has('STP2.PAYEE.000'), 'payee rule id is returned');
+  assert.ok(ruleIds.has('STP2.EVENT.000'), 'payroll event rule id is returned');
+
+  const payeeError = result.find((error) => error.ruleId === 'STP2.PAYEE.000');
+  assert.equal(payeeError?.path, 'payee');
+  assert.equal(payeeError?.keyword, 'required');
+});
+
+test('invalid payer identifiers surface granular rule ids and paths', () => {
+  const payload = loadFixture<Record<string, unknown>>('invalid-abn.json');
+  const result = validateStp2(payload);
+
+  const abnError = result.find((error) => error.path === 'payer.abn');
+  assert.equal(abnError?.ruleId, 'STP2.PAYER.100');
+  assert.match(abnError?.message ?? '', /11 digits/);
+
+  const branchError = result.find((error) => error.path === 'payer.branch');
+  assert.equal(branchError?.ruleId, 'STP2.PAYER.101');
+  assert.equal(branchError?.keyword, 'maximum');
+
+  const tfnError = result.find((error) => error.path === 'payee.tfn');
+  assert.equal(tfnError?.ruleId, 'STP2.PAYEE.100');
+});
+
+test('invalid dates, enumerations and monetary amounts are all reported', () => {
+  const payload = loadFixture<Record<string, unknown>>('invalid-dates.json');
+  const result = validateStp2(payload);
+
+  const dateOfBirthError = result.find((error) => error.path === 'payee.dateOfBirth');
+  assert.equal(dateOfBirthError?.ruleId, 'STP2.PAYEE.101');
+
+  const employmentError = result.find((error) => error.path === 'payee.employmentBasis');
+  assert.equal(employmentError?.ruleId, 'STP2.PAYEE.120');
+  assert.equal(employmentError?.keyword, 'enum');
+
+  const incomeStreamError = result.find((error) => error.path === 'payee.incomeStreamType');
+  assert.equal(incomeStreamError?.ruleId, 'STP2.PAYEE.121');
+
+  const startDateError = result.find((error) => error.path === 'payrollEvent.payrollPeriod.startDate');
+  assert.equal(startDateError?.ruleId, 'STP2.EVENT.100');
+
+  const paymentDateError = result.find((error) => error.path === 'payrollEvent.paymentDate');
+  assert.equal(paymentDateError?.ruleId, 'STP2.EVENT.102');
+
+  const grossAmountError = result.find((error) => error.path === 'payrollEvent.grossAmount');
+  assert.equal(grossAmountError?.ruleId, 'STP2.EVENT.200');
+  assert.equal(grossAmountError?.keyword, 'minimum');
+
+  const paygwAmountError = result.find((error) => error.path === 'payrollEvent.paygwAmount');
+  assert.equal(paygwAmountError?.ruleId, 'STP2.EVENT.201');
+  assert.equal(paygwAmountError?.keyword, 'multipleOf');
+
+  const superError = result.find((error) => error.path === 'payrollEvent.superGuarantee');
+  assert.equal(superError?.ruleId, 'STP2.EVENT.202');
+  assert.equal(superError?.keyword, 'minimum');
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add an STP Phase 2 payroll event JSON Schema to the SBR service
- implement a schema-driven `validateStp2` helper that returns typed rule identifiers and field paths
- add fixtures and node:test coverage for representative rule failures

## Testing
- pnpm exec tsx services/sbr/test/validate-stp2.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eaacda89608327b0084a6f18d7bf4c