### PR TITLE
Add BAS compilation utility and tests

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/apgms/services/sbr/src/compileBas.js
+++ b/apgms/services/sbr/src/compileBas.js
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const LABELS_FILE = path.resolve(__dirname, '../../../../rules/bas/labels_v1.json');
+
+let cachedDefinitions;
+
+function loadDefinitions() {
+  if (!cachedDefinitions) {
+    const raw = readFileSync(LABELS_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    if (!parsed || !Array.isArray(parsed.labels)) {
+      throw new Error('Invalid BAS label definition file');
+    }
+
+    cachedDefinitions = {
+      version: parsed.version ?? '1.0.0',
+      labels: parsed.labels.map((label) => ({
+        code: label.code,
+        description: label.description ?? '',
+        source: label.source,
+        field: label.field
+      }))
+    };
+  }
+
+  return cachedDefinitions;
+}
+
+function normaliseAmount(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 0;
+  }
+
+  return value;
+}
+
+function roundToWholeDollar(value) {
+  const numeric = normaliseAmount(value);
+  const absolute = Math.abs(numeric);
+  const integer = Math.floor(absolute);
+  const fraction = absolute - integer;
+  const rounded = fraction >= 0.5 ? integer + 1 : integer;
+  return numeric < 0 ? -rounded : rounded;
+}
+
+export function compileBas(period, gstResult = {}, paygwResult = {}) {
+  if (!period) {
+    throw new Error('A BAS period must be provided');
+  }
+
+  const { version, labels } = loadDefinitions();
+  const compiled = {};
+
+  for (const definition of labels) {
+    const sourceData = definition.source === 'gst' ? gstResult : paygwResult;
+    const rawAmount = normaliseAmount(sourceData?.[definition.field]);
+    compiled[definition.code] = {
+      code: definition.code,
+      description: definition.description,
+      rawAmount,
+      amount: roundToWholeDollar(rawAmount)
+    };
+  }
+
+  return {
+    version,
+    period,
+    labels: compiled
+  };
+}
+
+export const __testing = {
+  roundToWholeDollar,
+  loadDefinitions
+};

--- a/apgms/services/sbr/src/index.js
+++ b/apgms/services/sbr/src/index.js
@@ -1,0 +1,1 @@
+export { compileBas } from './compileBas.js';

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,0 @@
-﻿console.log('sbr service');

--- a/apgms/services/sbr/test/compileBas.test.js
+++ b/apgms/services/sbr/test/compileBas.test.js
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { compileBas, __testing } from '../src/compileBas.js';
+
+const period = { start: '2024-07-01', end: '2024-07-31' };
+
+describe('compileBas', () => {
+  it('maps GST and PAYGW results to BAS labels for a synthetic month', () => {
+    const gstResult = {
+      totalSales: 13579.49,
+      gstOnSales: 1250.55,
+      gstOnPurchases: 349.15
+    };
+
+    const paygwResult = {
+      totalWages: 9800.75,
+      taxWithheld: 1450.49
+    };
+
+    const bas = compileBas(period, gstResult, paygwResult);
+
+    assert.deepStrictEqual(bas.period, period);
+    assert.equal(bas.version, '1.0.0');
+    assert.deepStrictEqual(Object.keys(bas.labels).sort(), ['1A', '1B', 'G1', 'W1', 'W2']);
+
+    assert.equal(bas.labels.G1.rawAmount, gstResult.totalSales);
+    assert.equal(bas.labels.G1.amount, 13579);
+    assert.equal(bas.labels['1A'].rawAmount, gstResult.gstOnSales);
+    assert.equal(bas.labels['1A'].amount, 1251);
+    assert.equal(bas.labels['1B'].rawAmount, gstResult.gstOnPurchases);
+    assert.equal(bas.labels['1B'].amount, 349);
+    assert.equal(bas.labels.W1.rawAmount, paygwResult.totalWages);
+    assert.equal(bas.labels.W1.amount, 9801);
+    assert.equal(bas.labels.W2.rawAmount, paygwResult.taxWithheld);
+    assert.equal(bas.labels.W2.amount, 1450);
+  });
+
+  it('rounds amounts to whole dollars following ATO guidance', () => {
+    const gstResult = {
+      totalSales: 100.49,
+      gstOnSales: 100.5,
+      gstOnPurchases: -100.5
+    };
+
+    const paygwResult = {
+      totalWages: -100.49,
+      taxWithheld: -100.5
+    };
+
+    const bas = compileBas('2024-08', gstResult, paygwResult);
+
+    assert.equal(bas.labels.G1.amount, 100, '100.49 rounds down');
+    assert.equal(bas.labels['1A'].amount, 101, '100.5 rounds up');
+    assert.equal(bas.labels['1B'].amount, -101, '-100.5 rounds away from zero');
+    assert.equal(bas.labels.W1.amount, -100, '-100.49 rounds toward zero');
+    assert.equal(bas.labels.W2.amount, -101, '-100.5 rounds away from zero');
+  });
+
+  it('caches label definitions for reuse', () => {
+    const first = __testing.loadDefinitions();
+    const second = __testing.loadDefinitions();
+    assert.strictEqual(first, second);
+  });
+});

--- a/rules/bas/labels_v1.json
+++ b/rules/bas/labels_v1.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0.0",
+  "labels": [
+    {
+      "code": "G1",
+      "description": "Total sales",
+      "source": "gst",
+      "field": "totalSales"
+    },
+    {
+      "code": "1A",
+      "description": "GST on sales",
+      "source": "gst",
+      "field": "gstOnSales"
+    },
+    {
+      "code": "1B",
+      "description": "GST on purchases",
+      "source": "gst",
+      "field": "gstOnPurchases"
+    },
+    {
+      "code": "W1",
+      "description": "Total salary and wages",
+      "source": "paygw",
+      "field": "totalWages"
+    },
+    {
+      "code": "W2",
+      "description": "Amounts withheld from payments",
+      "source": "paygw",
+      "field": "taxWithheld"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add BAS label definition file for BAS reporting labels G1, 1A, 1B, W1, and W2
- implement compileBas helper to map GST and PAYGW results to BAS output using those labels
- add node:test coverage for synthetic month totals, rounding, and definition caching

## Testing
- pnpm --dir apgms/services/sbr test

------
https://chatgpt.com/codex/tasks/task_e_68eb09b875e88327ae94be93cc500d05