### PR TITLE
Add GST calculator with rule-based rounding

### DIFF
--- a/apgms/services/tax-engine/package.json
+++ b/apgms/services/tax-engine/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@apgms/tax-engine",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/apgms/services/tax-engine/src/calcGst.js
+++ b/apgms/services/tax-engine/src/calcGst.js
@@ -1,0 +1,188 @@
+const DEFAULT_PRECISION = 2;
+const DEFAULT_RATE = 0.1;
+
+function roundHalfAway(value, decimals = DEFAULT_PRECISION) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  if (decimals < 0) {
+    throw new RangeError('decimals must be non-negative');
+  }
+  if (value < 0) {
+    return -roundHalfAway(-value, decimals);
+  }
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  const epsilon = 1e-8;
+  const rounded = Math.floor(scaled + 0.5 + epsilon);
+  return rounded / factor;
+}
+
+function roundHalfEven(value, decimals = DEFAULT_PRECISION) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  if (decimals < 0) {
+    throw new RangeError('decimals must be non-negative');
+  }
+  if (value < 0) {
+    return -roundHalfEven(-value, decimals);
+  }
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  const epsilon = 1e-8;
+  const floored = Math.floor(scaled + epsilon);
+  const fraction = scaled - floored;
+  if (Math.abs(fraction - 0.5) <= epsilon) {
+    const even = floored % 2 === 0 ? floored : floored + 1;
+    return even / factor;
+  }
+  return Math.round(scaled) / factor;
+}
+
+function applyRounding(value, mode = 'tax', decimals = DEFAULT_PRECISION) {
+  if (typeof mode === 'function') {
+    return mode(value, decimals);
+  }
+  switch (mode) {
+    case 'none':
+      return value;
+    case 'bankers':
+      return roundHalfEven(value, decimals);
+    case 'tax':
+    default:
+      return roundHalfAway(value, decimals);
+  }
+}
+
+function normaliseNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function matchesAdjustmentRule(adjustment, rule) {
+  if (adjustment.rule && adjustment.rule === rule.id) {
+    return true;
+  }
+  if (!rule.appliesTo) {
+    return false;
+  }
+  const applies = Array.isArray(rule.appliesTo) ? rule.appliesTo : [rule.appliesTo];
+  return applies.some((item) => item === adjustment.type || item === adjustment.mode);
+}
+
+export function calcGst(inputs = {}, rules = []) {
+  if (!Array.isArray(rules)) {
+    throw new TypeError('rules must be an array');
+  }
+
+  const baselineRule = rules.find((rule) => rule && rule.id === 'gst.act.9-70');
+  if (!baselineRule) {
+    throw new Error('Missing baseline GST rule gst.act.9-70');
+  }
+
+  const baselineRate = typeof baselineRule.rate === 'number' ? baselineRule.rate : DEFAULT_RATE;
+  const baselinePrecision = baselineRule.precision ?? DEFAULT_PRECISION;
+  const baselineRounding = baselineRule.rounding || 'tax';
+
+  const supplies = Array.isArray(inputs.supplies) ? inputs.supplies : [];
+  const adjustments = (Array.isArray(inputs.adjustments) ? inputs.adjustments : []).map((item) => ({
+    ...item,
+    _consumed: false,
+  }));
+
+  const breakdown = [];
+  let gstCollected = 0;
+  let gstPayable = 0;
+
+  for (const supply of supplies) {
+    const baseAmount = normaliseNumber(supply?.amount);
+    const taxable = supply?.taxable !== false;
+    const supplyPrecision = supply?.precision ?? baselinePrecision;
+    const supplyRounding = supply?.rounding || baselineRounding;
+
+    if (!taxable) {
+      breakdown.push({
+        type: 'supply',
+        rule: baselineRule.id,
+        supply_id: supply?.id,
+        taxable: false,
+        base_amount: baseAmount,
+        gst_rate: baselineRate,
+        gst_amount: 0,
+        rounding: supplyRounding,
+        note: 'Non-taxable supply',
+      });
+      continue;
+    }
+
+    const gstRaw = baseAmount * baselineRate;
+    const gstRounded = applyRounding(gstRaw, supplyRounding, supplyPrecision);
+
+    gstCollected += gstRounded;
+    gstPayable += gstRounded;
+
+    breakdown.push({
+      type: 'supply',
+      rule: baselineRule.id,
+      supply_id: supply?.id,
+      taxable: true,
+      base_amount: applyRounding(baseAmount, 'tax', supplyPrecision),
+      gst_rate: baselineRate,
+      gst_amount: gstRounded,
+      rounding: supplyRounding,
+    });
+  }
+
+  for (const rule of rules) {
+    if (!rule || rule.type !== 'adjustment') {
+      continue;
+    }
+    const rulePrecision = rule.precision ?? baselinePrecision;
+    const ruleRounding = rule.rounding || baselineRounding;
+    const affectsCollected = Boolean(rule.affectsCollected);
+
+    for (const adjustment of adjustments) {
+      if (adjustment._consumed) {
+        continue;
+      }
+      if (!matchesAdjustmentRule(adjustment, rule)) {
+        continue;
+      }
+
+      adjustment._consumed = true;
+
+      const amount = normaliseNumber(adjustment.amount);
+      const mode = rule.mode || adjustment.mode || adjustment.type || 'credit';
+      const sign = mode === 'credit' || mode === 'refund' ? -1 : 1;
+      const rounded = applyRounding(amount, ruleRounding, rulePrecision);
+
+      if (affectsCollected) {
+        gstCollected += sign * rounded;
+      }
+      gstPayable += sign * rounded;
+
+      breakdown.push({
+        type: 'adjustment',
+        rule: rule.id,
+        adjustment_id: adjustment.id,
+        amount: sign * rounded,
+        original_amount: amount,
+        mode,
+        rounding: ruleRounding,
+        affects_collected: affectsCollected,
+      });
+    }
+  }
+
+  const totalPrecision = baselineRule.totalPrecision ?? baselinePrecision;
+  const totalRounding = baselineRule.totalRounding || baselineRounding;
+
+  return {
+    gst_collected: applyRounding(gstCollected, totalRounding, totalPrecision),
+    gst_payable: applyRounding(gstPayable, totalRounding, totalPrecision),
+    breakdown,
+  };
+}
+
+export const rounding = { roundHalfAway, roundHalfEven, applyRounding };

--- a/apgms/services/tax-engine/test/calcGst.test.js
+++ b/apgms/services/tax-engine/test/calcGst.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { calcGst } from '../src/calcGst.js';
+
+test('calcGst applies gst.act.9-70 baseline and adjustments', () => {
+  const inputs = {
+    supplies: [
+      { id: 'invoice-1', amount: 100 },
+      { id: 'invoice-2', amount: 55, taxable: false },
+      { id: 'invoice-3', amount: 14.25 },
+    ],
+    adjustments: [
+      { id: 'credit-1', rule: 'credit-note', amount: 1.5, type: 'credit' },
+      { id: 'refund-1', rule: 'refund-rule', amount: 2.0, type: 'refund' },
+    ],
+  };
+
+  const rules = [
+    { id: 'gst.act.9-70', type: 'baseline', rate: 0.1, rounding: 'bankers' },
+    { id: 'credit-note', type: 'adjustment', mode: 'credit', rounding: 'tax' },
+    { id: 'refund-rule', type: 'adjustment', mode: 'refund', rounding: 'tax' },
+  ];
+
+  const result = calcGst(inputs, rules);
+
+  assert.strictEqual(result.gst_collected, 11.42);
+  assert.strictEqual(result.gst_payable, 7.92);
+  assert.strictEqual(result.breakdown.length, 5);
+
+  const taxableEntries = result.breakdown.filter((entry) => entry.type === 'supply' && entry.taxable);
+  assert.ok(taxableEntries.every((entry) => entry.rule === 'gst.act.9-70'));
+  assert.strictEqual(taxableEntries[0].gst_amount, 10);
+  assert.strictEqual(taxableEntries[1].gst_amount, 1.42);
+
+  const nonTaxable = result.breakdown.find((entry) => entry.supply_id === 'invoice-2');
+  assert.strictEqual(nonTaxable.gst_amount, 0);
+  assert.strictEqual(nonTaxable.rule, 'gst.act.9-70');
+
+  const creditAdjustment = result.breakdown.find((entry) => entry.rule === 'credit-note');
+  assert.strictEqual(creditAdjustment.amount, -1.5);
+  const refundAdjustment = result.breakdown.find((entry) => entry.rule === 'refund-rule');
+  assert.strictEqual(refundAdjustment.amount, -2);
+});
+
+test('gst.act.9-70 rounding differs between bankers and tax rules', () => {
+  const tieInputs = {
+    supplies: [{ id: 'tie', amount: 14.25 }],
+  };
+
+  const bankers = calcGst(tieInputs, [
+    { id: 'gst.act.9-70', type: 'baseline', rate: 0.1, rounding: 'bankers' },
+  ]);
+  const tax = calcGst(tieInputs, [
+    { id: 'gst.act.9-70', type: 'baseline', rate: 0.1, rounding: 'tax' },
+  ]);
+
+  assert.strictEqual(bankers.breakdown[0].rule, 'gst.act.9-70');
+  assert.strictEqual(bankers.breakdown[0].gst_amount, 1.42);
+  assert.strictEqual(tax.breakdown[0].gst_amount, 1.43);
+});
+
+test('throws when gst.act.9-70 rule is missing', () => {
+  assert.throws(() => calcGst({ supplies: [{ amount: 10 }] }, []), /gst\.act\.9-70/);
+});


### PR DESCRIPTION
## Summary
- implement `calcGst` that enforces the gst.act.9-70 baseline, supports rounding modes, and produces a detailed breakdown
- add utilities for banker and tax rounding plus rule-driven adjustments for credits and refunds
- cover baseline, adjustment, and rounding scenarios with node:test cases referencing gst.act.9-70

## Testing
- pnpm --filter @apgms/tax-engine test

------
https://chatgpt.com/codex/tasks/task_e_68eb099cde9c8327966e151eac890e99