### PR TITLE
feat: add rules package for rule pack loading

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker",
+    "rules"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - rules
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/rules/package.json
+++ b/apgms/rules/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@apgms/rules",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "tsx --test test/loadRulePack.test.ts"
+  },
+  "dependencies": {
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/rules/rules/gst/2023-default.json
+++ b/apgms/rules/rules/gst/2023-default.json
@@ -1,0 +1,13 @@
+{
+  "meta": {
+    "domain": "gst",
+    "effective_from": "2023-07-01",
+    "effective_to": "2024-06-30",
+    "source": "ATO GST reference 2023",
+    "schema_version": "1.0.0"
+  },
+  "rules": {
+    "rate": 0.1,
+    "low_value_threshold": 75000
+  }
+}

--- a/apgms/rules/rules/gst/2024-default.json
+++ b/apgms/rules/rules/gst/2024-default.json
@@ -1,0 +1,12 @@
+{
+  "meta": {
+    "domain": "gst",
+    "effective_from": "2024-07-01",
+    "source": "ATO GST reference 2024",
+    "schema_version": "1.0.0"
+  },
+  "rules": {
+    "rate": 0.1,
+    "low_value_threshold": 82000
+  }
+}

--- a/apgms/rules/rules/gst/2024-reduced.json
+++ b/apgms/rules/rules/gst/2024-reduced.json
@@ -1,0 +1,13 @@
+{
+  "meta": {
+    "domain": "gst",
+    "variant": "reduced",
+    "effective_from": "2024-07-01",
+    "source": "ATO GST reduced rate 2024",
+    "schema_version": "1.0.0"
+  },
+  "rules": {
+    "rate": 0.05,
+    "low_value_threshold": 60000
+  }
+}

--- a/apgms/rules/rules/paygw/2024-default.json
+++ b/apgms/rules/rules/paygw/2024-default.json
@@ -1,0 +1,18 @@
+{
+  "meta": {
+    "domain": "paygw",
+    "effective_from": "2024-01-01",
+    "effective_to": "2024-12-31",
+    "source": "PAYGW schedule 2024",
+    "schema_version": "1.0.0"
+  },
+  "rules": {
+    "tax_free_threshold": 18200,
+    "marginal_rates": [
+      { "up_to": 45000, "rate": 0.19 },
+      { "up_to": 120000, "rate": 0.325 },
+      { "up_to": 180000, "rate": 0.37 },
+      { "rate": 0.45 }
+    ]
+  }
+}

--- a/apgms/rules/src/index.ts
+++ b/apgms/rules/src/index.ts
@@ -1,0 +1,234 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+export const RULE_DOMAINS = [
+  'gst',
+  'paygw',
+  'bas',
+  'stp2',
+  'ftc',
+] as const;
+
+export type RuleDomain = (typeof RULE_DOMAINS)[number];
+
+export interface RulePackMeta {
+  domain: RuleDomain;
+  variant?: string;
+  effective_from: string;
+  effective_to?: string;
+  source: string;
+  schema_version: string;
+}
+
+export interface RulePack<TData> {
+  meta: RulePackMeta;
+  rules: TData;
+}
+
+type RawRulePack = RulePack<unknown>;
+
+type DateTuple = [number, number, number];
+
+const metaSchema = z.object({
+  domain: z.enum(RULE_DOMAINS),
+  variant: z
+    .string()
+    .min(1)
+    .optional(),
+  effective_from: z
+    .string()
+    .refine(isValidDateString, {
+      message: 'must be an ISO-8601 date string',
+    }),
+  effective_to: z
+    .string()
+    .refine(isValidDateString, {
+      message: 'must be an ISO-8601 date string',
+    })
+    .optional(),
+  source: z.string().min(1, 'source cannot be empty'),
+  schema_version: z.string().min(1, 'schema_version cannot be empty'),
+});
+
+const rulePackSchema = z.object({
+  meta: metaSchema,
+  rules: z.unknown(),
+});
+
+const DEFAULT_RULES_ROOT = path.resolve(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '..',
+  'rules',
+);
+
+export async function loadRulePack<TData = unknown>(
+  domain: RuleDomain,
+  date: string,
+  variant?: string,
+): Promise<RulePack<TData>> {
+  const targetDate = parseDateOrThrow(date, 'date');
+  const rulesRoot = process.env.APGMS_RULES_ROOT ?? DEFAULT_RULES_ROOT;
+  const allPacks = await readAllRulePacks(rulesRoot);
+
+  const candidates = allPacks.filter((pack) => pack.meta.domain === domain);
+  const filteredByVariant = variant
+    ? candidates.filter((pack) => pack.meta.variant === variant)
+    : candidates;
+
+  const activeOnDate = filteredByVariant.filter((pack) => {
+    const from = parseDateOrThrow(pack.meta.effective_from, 'effective_from');
+    const to = pack.meta.effective_to
+      ? parseDateOrThrow(pack.meta.effective_to, 'effective_to')
+      : undefined;
+
+    return isDateInRange(targetDate, from, to);
+  });
+
+  const ordered = activeOnDate
+    .slice()
+    .sort((a, b) => compareDateTuples(
+      parseDateTuple(b.meta.effective_from),
+      parseDateTuple(a.meta.effective_from),
+    ));
+
+  const match = !variant
+    ? ordered.find((pack) => pack.meta.variant === undefined) ?? ordered[0]
+    : ordered[0];
+
+  if (!match) {
+    const variantMessage = variant ? ` and variant "${variant}"` : '';
+    throw new Error(
+      `No rule pack found for domain "${domain}"${variantMessage} on ${date}`,
+    );
+  }
+
+  return match as RulePack<TData>;
+}
+
+async function readAllRulePacks(root: string): Promise<RawRulePackWithFile[]> {
+  const filePaths = await listJsonFiles(root);
+  const packs: RawRulePackWithFile[] = [];
+
+  for (const filePath of filePaths) {
+    const contents = await fs.readFile(filePath, 'utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(contents);
+    } catch (error) {
+      throw new Error(`Failed to parse rule pack at ${filePath}: ${(error as Error).message}`);
+    }
+
+    const result = rulePackSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(buildValidationMessage(filePath, result.error.issues));
+    }
+
+    packs.push({ ...result.data, filePath });
+  }
+
+  return packs;
+}
+
+type RawRulePackWithFile = RawRulePack & { filePath: string };
+
+async function listJsonFiles(root: string): Promise<string[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Rules directory not found at ${root}`);
+    }
+
+    throw error;
+  }
+
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry);
+    const stat = await fs.stat(fullPath);
+    if (stat.isDirectory()) {
+      const nested = await listJsonFiles(fullPath);
+      results.push(...nested);
+    } else if (entry.endsWith('.json')) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+function buildValidationMessage(filePath: string, issues: z.ZodIssue[]): string {
+  const missingFields = new Set<string>();
+  const otherIssues: string[] = [];
+
+  for (const issue of issues) {
+    const pathString = issue.path.join('.') || '<root>';
+    const received = (issue as z.ZodInvalidTypeIssue).received;
+    if (
+      issue.code === 'invalid_type' &&
+      (received === 'undefined' || received === undefined)
+    ) {
+      missingFields.add(pathString);
+    } else {
+      otherIssues.push(`${pathString}: ${issue.message}`);
+    }
+  }
+
+  const parts: string[] = [];
+  if (missingFields.size > 0) {
+    parts.push(`missing fields: ${Array.from(missingFields).join(', ')}`);
+  }
+  if (otherIssues.length > 0) {
+    parts.push(`validation errors: ${otherIssues.join('; ')}`);
+  }
+
+  return `Invalid rule pack at ${filePath}${parts.length ? ` (${parts.join(' | ')})` : ''}`;
+}
+
+function isValidDateString(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
+function parseDateOrThrow(value: string, label: string): Date {
+  if (!isValidDateString(value)) {
+    throw new Error(`Invalid ${label} date: ${value}`);
+  }
+
+  return new Date(value + (value.endsWith('Z') || value.includes('T') ? '' : 'T00:00:00Z'));
+}
+
+function parseDateTuple(value: string): DateTuple {
+  const date = parseDateOrThrow(value, 'meta date');
+  return [date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()];
+}
+
+function compareDateTuples(a: DateTuple, b: DateTuple): number {
+  for (let i = 0; i < 3; i += 1) {
+    const diff = a[i] - b[i];
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  return 0;
+}
+
+function isDateInRange(target: Date, from: Date, to?: Date): boolean {
+  const targetTime = target.getTime();
+  const fromTime = from.getTime();
+  const toTime = to?.getTime();
+
+  if (targetTime < fromTime) {
+    return false;
+  }
+
+  if (typeof toTime === 'number' && targetTime > toTime) {
+    return false;
+  }
+
+  return true;
+}

--- a/apgms/rules/test/loadRulePack.test.ts
+++ b/apgms/rules/test/loadRulePack.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadRulePack } from '../src/index.js';
+
+const originalRoot = process.env.APGMS_RULES_ROOT;
+
+afterEach(() => {
+  if (originalRoot === undefined) {
+    delete process.env.APGMS_RULES_ROOT;
+  } else {
+    process.env.APGMS_RULES_ROOT = originalRoot;
+  }
+});
+
+test('returns the latest GST pack for the given date', async () => {
+  const pack = await loadRulePack('gst', '2024-08-01');
+
+  assert.equal(pack.meta.source, 'ATO GST reference 2024');
+  assert.deepEqual(pack.rules, { rate: 0.1, low_value_threshold: 82000 });
+});
+
+test('returns the variant specific pack when provided', async () => {
+  const pack = await loadRulePack('gst', '2024-08-01', 'reduced');
+
+  assert.equal(pack.meta.variant, 'reduced');
+  assert.deepEqual(pack.rules, { rate: 0.05, low_value_threshold: 60000 });
+});
+
+test('returns PAYGW pack matching the date range', async () => {
+  const pack = await loadRulePack('paygw', '2024-03-01');
+
+  assert.equal(pack.meta.effective_from, '2024-01-01');
+  assert.equal((pack.rules as Record<string, unknown>).tax_free_threshold, 18200);
+});
+
+test('throws when no pack covers the requested date', async () => {
+  await assert.rejects(
+    loadRulePack('gst', '2022-01-01'),
+    new Error('No rule pack found for domain "gst" on 2022-01-01'),
+  );
+});
+
+test('throws a descriptive validation error for invalid packs', async () => {
+  const tempRoot = await fs.mkdtemp(path.join(tmpdir(), 'rules-test-'));
+  const gstDir = path.join(tempRoot, 'gst');
+  await fs.mkdir(gstDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(gstDir, 'broken.json'),
+    JSON.stringify(
+      {
+        meta: {
+          domain: 'gst',
+          effective_from: '2024-01-01',
+          schema_version: '1.0.0',
+        },
+        rules: {},
+      },
+      null,
+      2,
+    ),
+  );
+
+  process.env.APGMS_RULES_ROOT = tempRoot;
+
+  await assert.rejects(loadRulePack('gst', '2024-05-01'), (error) => {
+    assert.match((error as Error).message, /missing fields: meta.source/);
+    return true;
+  });
+});

--- a/apgms/rules/tsconfig.json
+++ b/apgms/rules/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "test", "rules/**/*.json"]
+}


### PR DESCRIPTION
## Summary
- add a private @apgms/rules workspace that loads JSON rule packs with zod validation and best-match selection
- seed example GST and PAYGW rule packs to exercise date and variant resolution
- cover loader behaviours and validation errors with node:test-based unit tests

## Testing
- pnpm --filter @apgms/rules test

------
https://chatgpt.com/codex/tasks/task_e_68eb096a5ca883279cb470ec08fab6e3