### PR TITLE
feat: add API gateway error handling plugin

### DIFF
--- a/services/api-gateway/src/index.ts
+++ b/services/api-gateway/src/index.ts
@@ -11,9 +11,11 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { errorHandlerPlugin } from "./plugins/error-handler";
 
 const app = Fastify({ logger: true });
 
+await app.register(errorHandlerPlugin);
 await app.register(cors, { origin: true });
 
 // Quick sanity log so you can verify the DSN being used
@@ -42,28 +44,23 @@ app.get("/bank-lines", async (req) => {
 
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
+  const body = req.body as {
+    orgId: string;
+    date: string;
+    amount: number | string;
+    payee: string;
+    desc: string;
+  };
+  const created = await prisma.bankLine.create({
+    data: {
+      orgId: body.orgId,
+      date: new Date(body.date),
+      amount: body.amount as any,
+      payee: body.payee,
+      desc: body.desc,
+    },
+  });
+  return rep.code(201).send(created);
 });
 
 // Print all routes once ready (to verify POST exists)

--- a/services/api-gateway/src/plugins/error-handler.ts
+++ b/services/api-gateway/src/plugins/error-handler.ts
@@ -1,0 +1,18 @@
+import { FastifyPluginAsync } from "fastify";
+import { ZodError } from "zod";
+import { Prisma } from "@prisma/client";
+
+export const errorHandlerPlugin: FastifyPluginAsync = async (app) => {
+  app.setErrorHandler((err, req, reply) => {
+    if (err instanceof ZodError) {
+      return reply.status(422).send({ code: "validation_error", issues: err.issues });
+    }
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === "P2002") return reply.status(409).send({ code: "conflict", meta: err.meta });
+      if (err.code === "P2025") return reply.status(404).send({ code: "not_found", meta: err.meta });
+      return reply.status(400).send({ code: "bad_request", meta: err.meta });
+    }
+    req.log.error({ err }, "unhandled_error");
+    return reply.status(500).send({ code: "internal_error" });
+  });
+};


### PR DESCRIPTION
## Summary
- add a reusable Fastify error handler plugin to translate validation and Prisma errors into HTTP responses
- register the plugin during API gateway bootstrap so Prisma errors bubble to consistent status codes
- simplify bank line creation handler to rely on centralized error handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb125d676c8327bfd99410e53b18d6