### PR TITLE
feat(shared): add security utilities and tests

### DIFF
--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,13 +5,19 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "vitest run"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "argon2": "^0.40.3",
+    "fastify": "^5.6.1",
+    "fastify-plugin": "^5.0.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "prisma": "6.17.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,7 @@
-﻿// shared
+export * from './db';
+export * from './security/crypto';
+export * from './security/jwt';
+export * from './security/zod';
+export * from './security/rate';
+export * from './security/redact-logger';
+export * from './security/csrf';

--- a/apgms/shared/src/security/crypto.ts
+++ b/apgms/shared/src/security/crypto.ts
@@ -1,0 +1,40 @@
+import argon2, { Options as ArgonOptions } from 'argon2';
+
+export interface Argon2idOptions {
+  memoryCost: number;
+  timeCost: number;
+  parallelism: number;
+  saltLength?: number;
+}
+
+const defaultSaltLength = 16;
+
+function toArgonOptions(options: Argon2idOptions): ArgonOptions & { type: typeof argon2.argon2id } {
+  return {
+    type: argon2.argon2id,
+    memoryCost: options.memoryCost,
+    timeCost: options.timeCost,
+    parallelism: options.parallelism,
+    saltLength: options.saltLength ?? defaultSaltLength,
+  };
+}
+
+export async function hashPassword(plainText: string, options: Argon2idOptions): Promise<string> {
+  if (!plainText) {
+    throw new Error('Plain text value is required for hashing');
+  }
+
+  return argon2.hash(plainText, toArgonOptions(options));
+}
+
+export async function verifyPassword(hash: string, plainText: string, options: Argon2idOptions): Promise<boolean> {
+  if (!hash) {
+    throw new Error('Hash value is required for verification');
+  }
+
+  if (!plainText) {
+    return false;
+  }
+
+  return argon2.verify(hash, plainText, toArgonOptions(options));
+}

--- a/apgms/shared/src/security/csrf.ts
+++ b/apgms/shared/src/security/csrf.ts
@@ -1,0 +1,91 @@
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+export interface CsrfOptions {
+  enabled?: boolean;
+  cookieName?: string;
+  headerName?: string;
+  tokenLength?: number;
+  cookieAttributes?: Record<string, string | number | boolean>;
+}
+
+export interface IssuedCsrfToken {
+  token: string;
+  cookie: {
+    name: string;
+    value: string;
+    attributes: Record<string, string | number | boolean>;
+  };
+  headerName: string;
+}
+
+const defaultCookieName = 'csrf-token';
+const defaultHeaderName = 'x-csrf-token';
+const defaultTokenLength = 32;
+
+function generateToken(length: number): string {
+  return randomBytes(length).toString('base64url');
+}
+
+function safeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}
+
+export interface CsrfHelper {
+  issue(): IssuedCsrfToken | null;
+  verify(cookieToken?: string, headerToken?: string): boolean;
+  isEnabled(): boolean;
+}
+
+export function createCsrfHelper(options?: CsrfOptions): CsrfHelper {
+  const enabled = options?.enabled ?? true;
+  const cookieName = options?.cookieName ?? defaultCookieName;
+  const headerName = options?.headerName ?? defaultHeaderName;
+  const tokenLength = options?.tokenLength ?? defaultTokenLength;
+  const cookieAttributes = options?.cookieAttributes ?? {
+    httpOnly: false,
+    sameSite: 'lax',
+    path: '/',
+  };
+
+  return {
+    issue(): IssuedCsrfToken | null {
+      if (!enabled) {
+        return null;
+      }
+
+      const token = generateToken(tokenLength);
+
+      return {
+        token,
+        headerName,
+        cookie: {
+          name: cookieName,
+          value: token,
+          attributes: cookieAttributes,
+        },
+      };
+    },
+    verify(cookieToken?: string, headerToken?: string): boolean {
+      if (!enabled) {
+        return true;
+      }
+
+      if (!cookieToken || !headerToken) {
+        return false;
+      }
+
+      try {
+        return safeCompare(cookieToken, headerToken);
+      } catch (error) {
+        return false;
+      }
+    },
+    isEnabled(): boolean {
+      return enabled;
+    },
+  };
+}

--- a/apgms/shared/src/security/jwt.ts
+++ b/apgms/shared/src/security/jwt.ts
@@ -1,0 +1,298 @@
+import { createHmac, randomUUID, timingSafeEqual as nodeTimingSafeEqual } from 'node:crypto';
+
+type SupportedAlgorithm = 'HS256' | 'HS384' | 'HS512';
+
+const algorithmMap: Record<SupportedAlgorithm, string> = {
+  HS256: 'sha256',
+  HS384: 'sha384',
+  HS512: 'sha512',
+};
+
+export interface JwtConfig {
+  issuer: string;
+  audience: string | string[];
+  accessTokenTtl: string | number;
+  refreshTokenTtl: string | number;
+  clockSkewInSeconds?: number;
+}
+
+export type AdditionalClaims = Record<string, unknown>;
+
+export interface JwtSecrets {
+  access: string | Uint8Array;
+  refresh: string | Uint8Array;
+  algorithm?: SupportedAlgorithm;
+}
+
+export interface IssueTokensOptions {
+  subject: string;
+  claims?: AdditionalClaims;
+  accessJti?: string;
+  refreshJti?: string;
+}
+
+export interface IssuedTokens {
+  accessToken: string;
+  refreshToken: string;
+  accessJti: string;
+  refreshJti: string;
+}
+
+export interface RotateTokensOptions {
+  refreshToken: string;
+  expectedRefreshJti?: string;
+  subject?: string;
+  claims?: AdditionalClaims;
+  accessJti?: string;
+  refreshJti?: string;
+}
+
+interface JwtHeader {
+  alg: SupportedAlgorithm;
+  typ: 'JWT';
+}
+
+interface VerificationResult {
+  header: JwtHeader;
+  payload: Record<string, any>;
+}
+
+function base64urlEncode(input: string | Buffer): string {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buffer
+    .toString('base64')
+    .replace(/=+$/u, '')
+    .replace(/\+/gu, '-')
+    .replace(/\//gu, '_');
+}
+
+function base64urlDecode(input: string): Buffer {
+  const normalized = input.replace(/-/gu, '+').replace(/_/gu, '/');
+  const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
+  return Buffer.from(normalized + padding, 'base64');
+}
+
+function toBuffer(secret: string | Uint8Array): Buffer {
+  return Buffer.isBuffer(secret) ? secret : Buffer.from(secret);
+}
+
+function durationToSeconds(value: string | number): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  const match = /^([0-9]+)([smhd])$/iu.exec(value.trim());
+
+  if (!match) {
+    throw new Error(`Unsupported duration format: ${value}`);
+  }
+
+  const amount = Number.parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  switch (unit) {
+    case 's':
+      return amount;
+    case 'm':
+      return amount * 60;
+    case 'h':
+      return amount * 60 * 60;
+    case 'd':
+      return amount * 60 * 60 * 24;
+    default:
+      throw new Error(`Unsupported duration unit: ${unit}`);
+  }
+}
+
+function normalizeAudience(audience: string | string[]): string[] {
+  return Array.isArray(audience) ? audience : [audience];
+}
+
+function filterClaims(claims?: AdditionalClaims): AdditionalClaims {
+  if (!claims) {
+    return {};
+  }
+
+  const reserved = new Set(['iss', 'aud', 'exp', 'nbf', 'iat', 'jti', 'sub']);
+
+  return Object.entries(claims).reduce<AdditionalClaims>((acc, [key, value]) => {
+    if (!reserved.has(key)) {
+      acc[key] = value;
+    }
+
+    return acc;
+  }, {});
+}
+
+function createPayload(
+  config: JwtConfig,
+  subject: string,
+  ttl: string | number,
+  jti: string,
+  claims?: AdditionalClaims,
+): Record<string, unknown> {
+  const now = Math.floor(Date.now() / 1000);
+  const expiresIn = now + durationToSeconds(ttl);
+
+  return {
+    iss: config.issuer,
+    aud: config.audience,
+    sub: subject,
+    iat: now,
+    exp: expiresIn,
+    jti,
+    ...filterClaims(claims),
+  };
+}
+
+function signToken(
+  payload: Record<string, unknown>,
+  algorithm: SupportedAlgorithm,
+  secret: string | Uint8Array,
+): string {
+  const header: JwtHeader = { alg: algorithm, typ: 'JWT' };
+  const encodedHeader = base64urlEncode(JSON.stringify(header));
+  const encodedPayload = base64urlEncode(JSON.stringify(payload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const hash = algorithmMap[algorithm];
+  const signature = createHmac(hash, toBuffer(secret)).update(data).digest();
+  return `${data}.${base64urlEncode(signature)}`;
+}
+
+function assertAudience(aud: unknown, expected: string[]): void {
+  if (Array.isArray(aud)) {
+    const hasIntersection = aud.some((value) => expected.includes(value));
+    if (!hasIntersection) {
+      throw new Error('Audience mismatch');
+    }
+    return;
+  }
+
+  if (typeof aud === 'string') {
+    if (!expected.includes(aud)) {
+      throw new Error('Audience mismatch');
+    }
+    return;
+  }
+
+  throw new Error('Invalid token audience');
+}
+
+function verifyToken(
+  token: string,
+  secret: string | Uint8Array,
+  config: JwtConfig,
+  algorithm: SupportedAlgorithm,
+): VerificationResult {
+  const segments = token.split('.');
+
+  if (segments.length !== 3) {
+    throw new Error('Invalid token structure');
+  }
+
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const hash = algorithmMap[algorithm];
+  const expectedSignature = base64urlEncode(createHmac(hash, toBuffer(secret)).update(data).digest());
+
+  if (!timingSafeEqual(signature, expectedSignature)) {
+    throw new Error('Token signature mismatch');
+  }
+
+  const header = JSON.parse(base64urlDecode(encodedHeader).toString('utf8')) as JwtHeader;
+
+  if (header.alg !== algorithm) {
+    throw new Error('Unexpected signing algorithm');
+  }
+
+  const payload = JSON.parse(base64urlDecode(encodedPayload).toString('utf8')) as Record<string, any>;
+  const now = Math.floor(Date.now() / 1000);
+  const tolerance = config.clockSkewInSeconds ?? 0;
+
+  if (payload.iss !== config.issuer) {
+    throw new Error('Issuer mismatch');
+  }
+
+  assertAudience(payload.aud, normalizeAudience(config.audience));
+
+  if (typeof payload.exp === 'number' && now - tolerance >= payload.exp) {
+    throw new Error('Token expired');
+  }
+
+  if (typeof payload.nbf === 'number' && now + tolerance < payload.nbf) {
+    throw new Error('Token not yet valid');
+  }
+
+  return { header, payload };
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+
+  return nodeTimingSafeEqual(aBuffer, bBuffer);
+}
+
+function resolveAlgorithm(secrets: JwtSecrets): SupportedAlgorithm {
+  return secrets.algorithm ?? 'HS256';
+}
+
+export async function issueTokens(
+  config: JwtConfig,
+  secrets: JwtSecrets,
+  options: IssueTokensOptions,
+): Promise<IssuedTokens> {
+  const algorithm = resolveAlgorithm(secrets);
+  const accessJti = options.accessJti ?? randomUUID();
+  const refreshJti = options.refreshJti ?? randomUUID();
+
+  const accessPayload = createPayload(config, options.subject, config.accessTokenTtl, accessJti, options.claims);
+  const refreshPayload = createPayload(config, options.subject, config.refreshTokenTtl, refreshJti, options.claims);
+
+  return {
+    accessToken: signToken(accessPayload, algorithm, secrets.access),
+    refreshToken: signToken(refreshPayload, algorithm, secrets.refresh),
+    accessJti,
+    refreshJti,
+  };
+}
+
+export async function verifyAccessToken(token: string, config: JwtConfig, secrets: JwtSecrets) {
+  const algorithm = resolveAlgorithm(secrets);
+  return verifyToken(token, secrets.access, config, algorithm);
+}
+
+export async function verifyRefreshToken(token: string, config: JwtConfig, secrets: JwtSecrets) {
+  const algorithm = resolveAlgorithm(secrets);
+  return verifyToken(token, secrets.refresh, config, algorithm);
+}
+
+export async function rotateTokens(
+  config: JwtConfig,
+  secrets: JwtSecrets,
+  options: RotateTokensOptions,
+): Promise<IssuedTokens> {
+  const verification = await verifyRefreshToken(options.refreshToken, config, secrets);
+  const currentJti = verification.payload.jti;
+
+  if (options.expectedRefreshJti && currentJti !== options.expectedRefreshJti) {
+    throw new Error('Refresh token identifier mismatch');
+  }
+
+  const subject = options.subject ?? verification.payload.sub;
+
+  if (!subject || typeof subject !== 'string') {
+    throw new Error('Refresh token subject missing');
+  }
+
+  return issueTokens(config, secrets, {
+    subject,
+    claims: options.claims,
+    accessJti: options.accessJti,
+    refreshJti: options.refreshJti,
+  });
+}

--- a/apgms/shared/src/security/rate.ts
+++ b/apgms/shared/src/security/rate.ts
@@ -1,0 +1,187 @@
+import fp from 'fastify-plugin';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+
+export interface RateLimitOptions {
+  max: number;
+  timeWindow: number;
+  keyGenerator?: (request: FastifyRequest) => string;
+}
+
+export interface IdempotencyOptions {
+  enabled?: boolean;
+  header?: string;
+  storageTtlMs?: number;
+}
+
+export interface SecurityPluginOptions {
+  rateLimit?: RateLimitOptions;
+  idempotency?: IdempotencyOptions;
+}
+
+interface RateState {
+  count: number;
+  resetAt: number;
+}
+
+interface IdempotentEntry {
+  payload: string;
+  statusCode: number;
+  headers: Record<string, string>;
+  expiresAt: number;
+}
+
+interface IdempotencyContext {
+  key: string;
+  ttl: number;
+}
+
+const defaultIdempotencyHeader = 'idempotency-key';
+const defaultIdempotencyTtl = 86_400_000; // 24 hours
+const retryAfterHeader = 'retry-after';
+const idempotencyReplayHeader = 'idempotent-replay';
+const IDEMPOTENCY_SYMBOL: unique symbol = Symbol('idempotency-context');
+
+type RequestWithIdempotency = FastifyRequest & {
+  [IDEMPOTENCY_SYMBOL]?: IdempotencyContext;
+};
+
+function rateLimitHook(options: RateLimitOptions) {
+  const store = new Map<string, RateState>();
+
+  return (request: FastifyRequest, reply: FastifyReply, done: () => void) => {
+    const key = options.keyGenerator ? options.keyGenerator(request) : request.ip;
+    const now = Date.now();
+    const windowMs = options.timeWindow;
+    const existing = store.get(key);
+
+    if (!existing || existing.resetAt <= now) {
+      store.set(key, { count: 1, resetAt: now + windowMs });
+      reply.header(retryAfterHeader, Math.ceil(windowMs / 1000));
+      done();
+      return;
+    }
+
+    if (existing.count >= options.max) {
+      void reply.status(429).send({ error: 'Too Many Requests' });
+      return;
+    }
+
+    existing.count += 1;
+    reply.header(retryAfterHeader, Math.ceil((existing.resetAt - now) / 1000));
+    done();
+  };
+}
+
+function normalizeHeaderName(value: string): string {
+  return value.toLowerCase();
+}
+
+function getHeader(request: FastifyRequest, name: string): string | undefined {
+  const normalized = normalizeHeaderName(name);
+  const value = request.headers[name] ?? request.headers[normalized];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return typeof value === 'string' ? value : undefined;
+}
+
+function idempotencyPreHandler(
+  store: Map<string, IdempotentEntry>,
+  options: Required<IdempotencyOptions>,
+) {
+  return (request: FastifyRequest, reply: FastifyReply, done: () => void) => {
+    if (!options.enabled) {
+      done();
+      return;
+    }
+
+    const key = getHeader(request, options.header);
+
+    if (!key) {
+      done();
+      return;
+    }
+
+    const entry = store.get(key);
+    const now = Date.now();
+
+    if (entry && entry.expiresAt > now) {
+      reply.header(idempotencyReplayHeader, 'true');
+      for (const [headerKey, headerValue] of Object.entries(entry.headers)) {
+        reply.header(headerKey, headerValue);
+      }
+
+      void reply.status(entry.statusCode).send(entry.payload);
+      return;
+    }
+
+    (request as RequestWithIdempotency)[IDEMPOTENCY_SYMBOL] = {
+      key,
+      ttl: options.storageTtlMs ?? defaultIdempotencyTtl,
+    };
+
+    done();
+  };
+}
+
+function idempotencyOnSend(store: Map<string, IdempotentEntry>) {
+  return (request: FastifyRequest, reply: FastifyReply, payload: unknown, done: () => void) => {
+    const context = (request as RequestWithIdempotency)[IDEMPOTENCY_SYMBOL];
+
+    if (!context) {
+      done();
+      return;
+    }
+
+    let serialized: string;
+
+    if (typeof payload === 'string') {
+      serialized = payload;
+    } else if (payload === undefined || payload === null) {
+      serialized = '';
+    } else if (payload instanceof Buffer) {
+      serialized = payload.toString('utf8');
+    } else {
+      serialized = JSON.stringify(payload);
+    }
+
+    const headers: Record<string, string> = {};
+    for (const [headerKey, headerValue] of Object.entries(reply.getHeaders())) {
+      if (typeof headerValue === 'string') {
+        headers[headerKey] = headerValue;
+      }
+    }
+
+    store.set(context.key, {
+      payload: serialized,
+      statusCode: reply.statusCode,
+      headers,
+      expiresAt: Date.now() + context.ttl,
+    });
+
+    done();
+  };
+}
+
+const securityPlugin: FastifyPluginAsync<SecurityPluginOptions> = async (instance, options) => {
+  if (options.rateLimit) {
+    instance.addHook('onRequest', rateLimitHook(options.rateLimit));
+  }
+
+  if (options.idempotency && options.idempotency.enabled) {
+    const store = new Map<string, IdempotentEntry>();
+    const resolved: Required<IdempotencyOptions> = {
+      enabled: options.idempotency.enabled,
+      header: options.idempotency.header ?? defaultIdempotencyHeader,
+      storageTtlMs: options.idempotency.storageTtlMs ?? defaultIdempotencyTtl,
+    };
+
+    instance.addHook('preHandler', idempotencyPreHandler(store, resolved));
+    instance.addHook('onSend', idempotencyOnSend(store));
+  }
+};
+
+export const securityMiddleware = fp(securityPlugin, {
+  name: 'shared-security-middleware',
+});

--- a/apgms/shared/src/security/redact-logger.ts
+++ b/apgms/shared/src/security/redact-logger.ts
@@ -1,0 +1,98 @@
+export interface PinoLikeHooks {
+  logMethod(args: unknown[], method: (...args: unknown[]) => void): void;
+}
+
+export interface PinoChildOptions {
+  redact?: {
+    paths: string[];
+    censor: string;
+  };
+  hooks?: PinoLikeHooks;
+}
+
+export interface PinoLikeLogger {
+  child(bindings?: Record<string, unknown>, options?: PinoChildOptions): PinoLikeLogger;
+  [key: string]: unknown;
+}
+
+export interface RedactLoggerOptions {
+  paths?: string[];
+  censor?: string;
+}
+
+const defaultPaths = [
+  'password',
+  'secret',
+  'token',
+  'headers.authorization',
+  'req.headers.authorization',
+];
+
+const sensitiveKeyPattern = /(password|secret|token|key)$/i;
+const TFN_REGEX = /\b\d{8,9}\b/g;
+const ABN_REGEX = /\b\d{11}\b/g;
+const PAN_REGEX = /\b(?:\d[ -]?){13,19}\b/g;
+const REDACTION = '[REDACTED]';
+
+function redactString(value: string): string {
+  return value.replace(TFN_REGEX, REDACTION).replace(ABN_REGEX, REDACTION).replace(PAN_REGEX, REDACTION);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function deepRedact(
+  value: unknown,
+  matchers: string[][],
+  currentPath: string[] = [],
+  parentKey?: string,
+): unknown {
+  if (typeof value === 'string') {
+    return redactString(value);
+  }
+
+  const shouldRedactPath = matchers.some((matcher) => matcher.every((segment, index) => segment === currentPath[index]));
+
+  if (shouldRedactPath || (typeof parentKey === 'string' && sensitiveKeyPattern.test(parentKey))) {
+    return REDACTION;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => deepRedact(item, matchers, [...currentPath, String(index)], parentKey));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.entries(value).reduce<Record<string, unknown>>((acc, [key, val]) => {
+      const nextPath = [...currentPath, key];
+      acc[key] = deepRedact(val, matchers, nextPath, key);
+      return acc;
+    }, {});
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value;
+}
+
+export function createRedactingLogger(baseLogger: PinoLikeLogger, options?: RedactLoggerOptions): PinoLikeLogger {
+  const paths = Array.from(new Set([...(options?.paths ?? []), ...defaultPaths]));
+  const censor = options?.censor ?? REDACTION;
+  const matchers = paths.map((path) => path.split('.'));
+  const childOptions: PinoChildOptions = {
+    redact: {
+      paths,
+      censor,
+    },
+    hooks: {
+      logMethod(args, method) {
+        const redactedArgs = args.map((value) => deepRedact(value, matchers));
+        method.apply(this, redactedArgs);
+      },
+    },
+  };
+
+  return baseLogger.child({}, childOptions);
+}

--- a/apgms/shared/src/security/zod.ts
+++ b/apgms/shared/src/security/zod.ts
@@ -1,0 +1,84 @@
+import { ZodError, ZodIssue, ZodSchema } from 'zod';
+
+export interface HttpValidationIssue {
+  path: string;
+  message: string;
+  code: ZodIssue['code'];
+}
+
+export interface HttpValidationError {
+  statusCode: number;
+  message: string;
+  issues: HttpValidationIssue[];
+}
+
+export class ZodValidationError extends Error {
+  constructor(public readonly details: HttpValidationError) {
+    super(details.message);
+    this.name = 'ZodValidationError';
+  }
+}
+
+export function zodErrorToHttp(error: ZodError, statusCode = 400): HttpValidationError {
+  return {
+    statusCode,
+    message: 'Validation failed',
+    issues: error.issues.map((issue) => ({
+      path: issue.path.join('.'),
+      message: issue.message,
+      code: issue.code,
+    })),
+  };
+}
+
+export interface RequestValidationSchemas {
+  body?: ZodSchema;
+  query?: ZodSchema;
+  params?: ZodSchema;
+  headers?: ZodSchema;
+}
+
+export type ValidatedRequest<T extends RequestValidationSchemas> = {
+  [K in keyof T]: T[K] extends ZodSchema<infer U> ? U : never;
+};
+
+export function validateRequest<T extends RequestValidationSchemas>(
+  schemas: T,
+  data: Partial<Record<keyof T, unknown>>,
+): ValidatedRequest<T> {
+  const result: Partial<ValidatedRequest<T>> = {};
+  const issues: ZodIssue[] = [];
+
+  (Object.keys(schemas) as Array<keyof T>).forEach((key) => {
+    const schema = schemas[key];
+
+    if (!schema) {
+      return;
+    }
+
+    const parsed = schema.safeParse(data[key]);
+
+    if (!parsed.success) {
+      issues.push(...parsed.error.issues);
+      return;
+    }
+
+    result[key] = parsed.data as ValidatedRequest<T>[typeof key];
+  });
+
+  if (issues.length) {
+    throw new ZodValidationError(zodErrorToHttp(new ZodError(issues)));
+  }
+
+  return result as ValidatedRequest<T>;
+}
+
+export function validateResponse<T>(schema: ZodSchema<T>, payload: unknown): T {
+  const parsed = schema.safeParse(payload);
+
+  if (!parsed.success) {
+    throw new ZodValidationError(zodErrorToHttp(parsed.error));
+  }
+
+  return parsed.data;
+}

--- a/apgms/shared/src/types/argon2.d.ts
+++ b/apgms/shared/src/types/argon2.d.ts
@@ -1,0 +1,17 @@
+declare module 'argon2' {
+  export interface Options {
+    type?: number;
+    memoryCost?: number;
+    timeCost?: number;
+    parallelism?: number;
+    saltLength?: number;
+  }
+
+  export const argon2id: number;
+
+  export default {
+    hash(plain: string, options?: Options): Promise<string>;
+    verify(hash: string, plain: string, options?: Options): Promise<boolean>;
+    argon2id: number;
+  };
+}

--- a/apgms/shared/test/security/crypto.test.ts
+++ b/apgms/shared/test/security/crypto.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('argon2', () => ({
+  default: {
+    argon2id: 2,
+    async hash(plain: string) {
+      return `hashed:${plain}`;
+    },
+    async verify(hash: string, plain: string) {
+      return hash === `hashed:${plain}`;
+    },
+  },
+  argon2id: 2,
+}), { virtual: true });
+
+import { hashPassword, verifyPassword } from '../../src/security/crypto';
+
+const options = {
+  memoryCost: 2 ** 12,
+  timeCost: 2,
+  parallelism: 1,
+};
+
+describe('crypto helpers', () => {
+  it('hashes and verifies passwords', async () => {
+    const hash = await hashPassword('s3cret', options);
+
+    expect(hash).toBeTypeOf('string');
+    expect(await verifyPassword(hash, 's3cret', options)).toBe(true);
+  });
+
+  it('rejects invalid passwords', async () => {
+    const hash = await hashPassword('password', options);
+
+    expect(await verifyPassword(hash, 'other', options)).toBe(false);
+  });
+
+  it('requires a hash to verify', async () => {
+    await expect(verifyPassword('', 'value', options)).rejects.toThrow(/Hash value/);
+  });
+});

--- a/apgms/shared/test/security/csrf.test.ts
+++ b/apgms/shared/test/security/csrf.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createCsrfHelper } from '../../src/security/csrf';
+
+describe('csrf helper', () => {
+  it('issues matching cookie and header tokens when enabled', () => {
+    const helper = createCsrfHelper({ tokenLength: 16 });
+    const issued = helper.issue();
+
+    expect(issued).not.toBeNull();
+    expect(issued?.cookie.value).toBe(issued?.token);
+    expect(helper.verify(issued?.cookie.value, issued?.token)).toBe(true);
+  });
+
+  it('rejects mismatched tokens', () => {
+    const helper = createCsrfHelper();
+
+    expect(helper.verify('cookie', 'header')).toBe(false);
+  });
+
+  it('becomes a no-op when disabled', () => {
+    const helper = createCsrfHelper({ enabled: false });
+
+    expect(helper.issue()).toBeNull();
+    expect(helper.verify(undefined, undefined)).toBe(true);
+    expect(helper.isEnabled()).toBe(false);
+  });
+});

--- a/apgms/shared/test/security/jwt.test.ts
+++ b/apgms/shared/test/security/jwt.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { issueTokens, JwtConfig, JwtSecrets, rotateTokens, verifyAccessToken, verifyRefreshToken } from '../../src/security/jwt';
+
+const config: JwtConfig = {
+  issuer: 'apgms',
+  audience: 'shared-service',
+  accessTokenTtl: '2m',
+  refreshTokenTtl: '10m',
+  clockSkewInSeconds: 5,
+};
+
+const secrets: JwtSecrets = {
+  access: 'access-secret',
+  refresh: 'refresh-secret',
+};
+
+describe('jwt helpers', () => {
+  it('issues and verifies access and refresh tokens', async () => {
+    const tokens = await issueTokens(config, secrets, {
+      subject: 'user-1',
+      claims: { role: 'admin' },
+      accessJti: 'access-1',
+      refreshJti: 'refresh-1',
+    });
+
+    expect(tokens.accessToken).toBeTruthy();
+    expect(tokens.refreshToken).toBeTruthy();
+
+    const accessVerification = await verifyAccessToken(tokens.accessToken, config, secrets);
+    const refreshVerification = await verifyRefreshToken(tokens.refreshToken, config, secrets);
+
+    expect(accessVerification.payload.sub).toBe('user-1');
+    expect(accessVerification.payload.role).toBe('admin');
+    expect(accessVerification.payload.jti).toBe('access-1');
+    expect(refreshVerification.payload.jti).toBe('refresh-1');
+  });
+
+  it('rotates tokens when refresh token is valid', async () => {
+    const initial = await issueTokens(config, secrets, {
+      subject: 'user-2',
+      refreshJti: 'refresh-2',
+    });
+
+    const rotated = await rotateTokens(config, secrets, {
+      refreshToken: initial.refreshToken,
+      expectedRefreshJti: 'refresh-2',
+      accessJti: 'access-rotated',
+      refreshJti: 'refresh-rotated',
+      claims: { scope: ['read'] },
+    });
+
+    expect(rotated.refreshToken).not.toBe(initial.refreshToken);
+
+    const verification = await verifyAccessToken(rotated.accessToken, config, secrets);
+    expect(verification.payload.scope).toEqual(['read']);
+    expect(verification.payload.jti).toBe('access-rotated');
+  });
+
+  it('throws when refresh token JTI does not match expectation', async () => {
+    const initial = await issueTokens(config, secrets, {
+      subject: 'user-3',
+      refreshJti: 'refresh-expected',
+    });
+
+    await expect(
+      rotateTokens(config, secrets, {
+        refreshToken: initial.refreshToken,
+        expectedRefreshJti: 'different',
+      }),
+    ).rejects.toThrow(/identifier mismatch/);
+  });
+});

--- a/apgms/shared/test/security/rate.test.ts
+++ b/apgms/shared/test/security/rate.test.ts
@@ -1,0 +1,70 @@
+import fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+import { securityMiddleware } from '../../src/security/rate';
+
+describe('security middleware', () => {
+  it('enforces rate limiting per key', async () => {
+    const app = fastify();
+    app.register(securityMiddleware, {
+      rateLimit: {
+        max: 2,
+        timeWindow: 1_000,
+        keyGenerator: () => 'test-client',
+      },
+    });
+
+    app.get('/limited', async () => ({ status: 'ok' }));
+
+    await app.ready();
+
+    const first = await app.inject({ method: 'GET', url: '/limited' });
+    const second = await app.inject({ method: 'GET', url: '/limited' });
+    const third = await app.inject({ method: 'GET', url: '/limited' });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(third.statusCode).toBe(429);
+
+    await app.close();
+  });
+
+  it('caches responses when idempotency key is reused', async () => {
+    const app = fastify();
+    let counter = 0;
+
+    app.register(securityMiddleware, {
+      idempotency: {
+        enabled: true,
+        storageTtlMs: 5_000,
+      },
+    });
+
+    app.post('/resource', async () => {
+      counter += 1;
+      return { counter };
+    });
+
+    await app.ready();
+
+    const key = 'operation-1';
+    const first = await app.inject({
+      method: 'POST',
+      url: '/resource',
+      headers: { 'Idempotency-Key': key },
+    });
+
+    const second = await app.inject({
+      method: 'POST',
+      url: '/resource',
+      headers: { 'Idempotency-Key': key },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(counter).toBe(1);
+    expect(second.headers()['idempotent-replay']).toBe('true');
+    expect(second.json()).toEqual(first.json());
+
+    await app.close();
+  });
+});

--- a/apgms/shared/test/security/redact-logger.test.ts
+++ b/apgms/shared/test/security/redact-logger.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { createRedactingLogger, PinoChildOptions, PinoLikeLogger } from '../../src/security/redact-logger';
+
+class FakeLogger implements PinoLikeLogger {
+  constructor(private readonly sink: (args: unknown[]) => void, private readonly options?: PinoChildOptions) {}
+
+  child(_bindings: Record<string, unknown> = {}, options?: PinoChildOptions): PinoLikeLogger {
+    const merged: PinoChildOptions = {
+      ...this.options,
+      ...options,
+      hooks: options?.hooks ?? this.options?.hooks,
+      redact: options?.redact ?? this.options?.redact,
+    };
+
+    return new FakeLogger(this.sink, merged);
+  }
+
+  info(...args: unknown[]): void {
+    this.log('info', ...args);
+  }
+
+  private log(level: string, ...args: unknown[]) {
+    const invoke = (...processed: unknown[]) => {
+      this.sink([level, ...processed]);
+    };
+
+    if (this.options?.hooks?.logMethod) {
+      this.options.hooks.logMethod(args, invoke);
+    } else {
+      invoke(...args);
+    }
+  }
+}
+
+describe('redacting logger', () => {
+  it('redacts sensitive fields and configured paths', () => {
+    const entries: unknown[][] = [];
+    const base = new FakeLogger((payload) => entries.push(payload));
+    const logger = createRedactingLogger(base, { paths: ['metadata.clientId'] });
+
+    logger.info(
+      {
+        tfn: '123456782',
+        abn: '51824753556',
+        pan: '4111 1111 1111 1111',
+        password: 'super-secret',
+        metadata: {
+          apiKey: 'abc123',
+          clientId: 'client-001',
+        },
+        notes: ['card 4444 3333 2222 1111'],
+      },
+      'Customer TFN 987654321',
+    );
+
+    expect(entries).toHaveLength(1);
+    const [, payload, message] = entries[0];
+    const record = payload as Record<string, unknown>;
+
+    expect(record.tfn).toBe('[REDACTED]');
+    expect(record.abn).toBe('[REDACTED]');
+    expect(record.pan).toBe('[REDACTED]');
+    expect(record.password).toBe('[REDACTED]');
+    expect((record.metadata as Record<string, unknown>).apiKey).toBe('[REDACTED]');
+    expect((record.metadata as Record<string, unknown>).clientId).toBe('[REDACTED]');
+    expect((record.notes as string[])[0]).not.toContain('4444');
+    expect(typeof message).toBe('string');
+    expect((message as string)).not.toContain('987654321');
+  });
+});

--- a/apgms/shared/test/security/zod.test.ts
+++ b/apgms/shared/test/security/zod.test.ts
@@ -1,0 +1,57 @@
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { validateRequest, validateResponse, zodErrorToHttp, ZodValidationError } from '../../src/security/zod';
+
+describe('zod helpers', () => {
+  it('converts Zod errors into HTTP friendly format', () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({});
+
+    if (result.success) {
+      throw new Error('Expected validation to fail');
+    }
+
+    const httpError = zodErrorToHttp(result.error, 422);
+    expect(httpError.statusCode).toBe(422);
+    expect(httpError.issues[0]).toMatchObject({ path: 'name' });
+  });
+
+  it('validates requests using provided schemas', () => {
+    const data = validateRequest(
+      {
+        body: z.object({ email: z.string().email() }),
+        query: z.object({ page: z.coerce.number().int().min(1) }),
+      },
+      {
+        body: { email: 'user@example.com' },
+        query: { page: '2' },
+      },
+    );
+
+    expect(data.body.email).toBe('user@example.com');
+    expect(data.query.page).toBe(2);
+  });
+
+  it('throws when any request part fails validation', () => {
+    expect(() =>
+      validateRequest(
+        { body: z.object({ id: z.string().uuid() }) },
+        { body: { id: 'not-a-uuid' } },
+      ),
+    ).toThrow(ZodValidationError);
+  });
+
+  it('validates responses', () => {
+    const schema = z.object({ id: z.string().uuid() });
+    const payload = { id: randomUUID() };
+
+    expect(validateResponse(schema, payload)).toEqual(payload);
+  });
+
+  it('throws when response validation fails', () => {
+    const schema = z.object({ id: z.string().uuid() });
+
+    expect(() => validateResponse(schema, { id: '123' })).toThrow(ZodValidationError);
+  });
+});

--- a/apgms/shared/vitest.config.ts
+++ b/apgms/shared/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add reusable security helpers for crypto, JWTs, Zod validation, rate limiting, logging redaction, and CSRF
- expose new helpers via the shared package barrel
- add Vitest coverage for each helper and configure the shared Vitest runner

## Testing
- `pnpm --filter @apgms/shared test` *(fails: vitest binary is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eaaaab2ca4832791d95647710c6494