### PR TITLE
feat: centralize runtime config validation

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/infra/dev/.env.example
+++ b/apgms/infra/dev/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration (no secrets)
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DATABASE
+JWT_ISSUER=apgms
+JWT_ACCESS_TTL=15m
+JWT_REFRESH_TTL=7d
+LOG_LEVEL=info
+RATE_LIMIT_RPM=600
+# Optional comma separated list of origins, e.g. http://localhost:5173
+CORS_ORIGIN=

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,9 +9,7 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
-    "dotenv": "^16.6.1",
-    "fastify": "^5.6.1",
-    "zod": "^4.1.12"
+    "fastify": "^5.6.1"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
+      "@apgms/shared": ["shared/src/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   },

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,7 +8,9 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "dotenv": "^16.4.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/src/config.ts
+++ b/apgms/shared/src/config.ts
@@ -1,0 +1,22 @@
+import 'dotenv/config';
+import { z } from 'zod';
+
+const Env = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().int().positive().default(3000),
+  DATABASE_URL: z.string().url(),
+  JWT_ISSUER: z.string().default('apgms'),
+  JWT_ACCESS_TTL: z.string().default('15m'),
+  JWT_REFRESH_TTL: z.string().default('7d'),
+  LOG_LEVEL: z.enum(['fatal','error','warn','info','debug','trace','silent']).default('info'),
+  RATE_LIMIT_RPM: z.coerce.number().int().positive().default(600),
+  CORS_ORIGIN: z.string().optional(),
+});
+
+const parsed = Env.safeParse(process.env);
+if (!parsed.success) {
+  console.error('Invalid environment:', parsed.error.flatten().fieldErrors);
+  process.exit(1);
+}
+
+export const env = parsed.data;

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,10 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { PrismaClient } from "@prisma/client";
+import { env } from "./config";
+
+export const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: env.DATABASE_URL,
+    },
+  },
+});

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from './config';
+export * from './db';

--- a/apgms/tsconfig.json
+++ b/apgms/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
+      "@apgms/shared": ["shared/src/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   }

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,13 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "echo test worker"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*"
+  }
+}

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,3 @@
-﻿console.log('worker');
+import { env } from "@apgms/shared";
+
+console.log(`worker running in ${env.NODE_ENV} mode`);

--- a/apgms/worker/tsconfig.json
+++ b/apgms/worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a shared environment validation module that loads from process.env and exits fast on invalid configuration
- re-export the configuration helper, wire Prisma to the validated database URL, and point service path aliases at the shared entrypoint
- update the API and worker services to rely on the shared config and document required variables in infra/dev/.env.example

## Testing
- pnpm --filter @apgms/api-gateway dev *(fails: shared package depends on dotenv which cannot be fetched in this environment)*
- pnpm install *(fails: registry access returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb121fafd88327bfab68b3c232a13c