### PR TITLE
Use shared env and logger in API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
-    "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"
   },

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,22 +1,15 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { env, logger, prisma } from "@apgms/shared";
 
-const app = Fastify({ logger: true });
+const app = Fastify({
+  logger: logger.child({ service: "api-gateway" }),
+});
 
-await app.register(cors, { origin: true });
+await app.register(cors, { origin: env.CORS_ORIGIN });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+// Quick sanity log so you can verify the DSN being used
+app.log.info({ DATABASE_URL: env.DATABASE_URL }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -65,16 +58,16 @@ app.post("/bank-lines", async (req, rep) => {
   }
 });
 
-// Print routes so we can SEE POST /bank-lines is registered
+// Print all routes once ready (to verify POST exists)
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port: env.PORT, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
+      "@apgms/shared": ["shared/src/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   },

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,7 +8,9 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "dotenv": "^16.6.1",
+    "pino": "^9.5.0"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/src/env.ts
+++ b/apgms/shared/src/env.ts
@@ -1,0 +1,34 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const DEFAULT_PORT = 3000;
+
+const parsePort = (value: string | undefined): number => {
+  if (!value) return DEFAULT_PORT;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_PORT;
+};
+
+const parseCorsOrigin = (
+  value: string | undefined,
+): true | false | string | string[] => {
+  if (value === undefined || value.trim() === "") {
+    return true;
+  }
+
+  const normalized = value.trim();
+  if (normalized.toLowerCase() === "true") return true;
+  if (normalized.toLowerCase() === "false") return false;
+
+  const parts = normalized.split(",").map((part) => part.trim()).filter(Boolean);
+  return parts.length > 1 ? parts : normalized;
+};
+
+export const env = {
+  NODE_ENV: process.env.NODE_ENV ?? "development",
+  PORT: parsePort(process.env.PORT),
+  LOG_LEVEL: process.env.LOG_LEVEL ?? "info",
+  DATABASE_URL: process.env.DATABASE_URL,
+  CORS_ORIGIN: parseCorsOrigin(process.env.CORS_ORIGIN),
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,3 @@
-﻿// shared
+export { prisma } from "./db";
+export { env } from "./env";
+export { logger } from "./logger";

--- a/apgms/shared/src/logger.ts
+++ b/apgms/shared/src/logger.ts
@@ -1,0 +1,7 @@
+import pino from "pino";
+import { env } from "./env";
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  name: "apgms",
+});


### PR DESCRIPTION
## Summary
- add shared environment and logger utilities and re-export them
- update the API gateway to consume shared env, prisma, and logger instances
- respect the configured CORS origin and remove local dotenv wiring

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68eb127ce13c8327abc822a14b4d61f8