### PR TITLE
Add regression tests for api-gateway routes

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --test --experimental-test-coverage --import tsx test/app.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -19,3 +20,4 @@
     "typescript": "^5.9.3"
   }
 }
+

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,156 @@
+import Fastify, { FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+
+export interface PrismaClientLike {
+  user: {
+    findMany: (args: {
+      select: { email: true; orgId: true; createdAt: true };
+      orderBy: { createdAt: "desc" };
+    }) => Promise<unknown[]>;
+  };
+  bankLine: {
+    findMany: (args: {
+      orderBy: { date: "desc" };
+      take: number;
+    }) => Promise<unknown[]>;
+    create: (args: {
+      data: {
+        orgId: string;
+        date: Date;
+        amount: unknown;
+        payee: string;
+        desc: string;
+      };
+    }) => Promise<unknown>;
+  };
+}
+
+interface CreateAppOptions {
+  prisma: PrismaClientLike;
+}
+
+interface PrismaErrorMapping {
+  status: number;
+  body: { error: string };
+}
+
+const isPrismaKnownRequestError = (error: unknown): error is { code: string } => {
+  return typeof error === "object" && error !== null && "code" in error;
+};
+
+const mapPrismaError = (error: unknown): PrismaErrorMapping | null => {
+  if (!isPrismaKnownRequestError(error)) {
+    return null;
+  }
+
+  switch (error.code) {
+    case "P2002":
+      return { status: 409, body: { error: "conflict" } };
+    case "P2025":
+      return { status: 404, body: { error: "not_found" } };
+    default:
+      return null;
+  }
+};
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const parseAmount = (value: unknown): number => {
+  if (typeof value === "number") {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    return Number(value);
+  }
+
+  return Number.NaN;
+};
+
+const isValidDate = (value: unknown): boolean => {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+};
+
+export const createApp = async ({ prisma }: CreateAppOptions): Promise<FastifyInstance> => {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as Record<string, unknown>).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+
+    const errors: string[] = [];
+
+    if (!isNonEmptyString(body["orgId"])) {
+      errors.push("orgId");
+    }
+
+    if (!isValidDate(body["date"])) {
+      errors.push("date");
+    }
+
+    const parsedAmount = parseAmount(body["amount"]);
+    if (!Number.isFinite(parsedAmount)) {
+      errors.push("amount");
+    }
+
+    if (!isNonEmptyString(body["payee"])) {
+      errors.push("payee");
+    }
+
+    if (!isNonEmptyString(body["desc"])) {
+      errors.push("desc");
+    }
+
+    if (errors.length > 0) {
+      return rep.code(422).send({ error: "validation_failed", fields: errors });
+    }
+
+    try {
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body["orgId"] as string,
+          date: new Date(body["date"] as string),
+          amount: body["amount"],
+          payee: body["payee"] as string,
+          desc: body["desc"] as string,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (error) {
+      const mapped = mapPrismaError(error);
+      if (mapped) {
+        return rep.code(mapped.status).send(mapped.body);
+      }
+
+      req.log.error(error);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  return app;
+};
+
+export type { FastifyInstance };

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,71 +1,16 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await createApp({ prisma });
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
@@ -77,4 +22,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/test/app.test.ts
+++ b/apgms/services/api-gateway/test/app.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createApp, PrismaClientLike } from "../src/app";
+
+interface MockFunction<TArgs extends unknown[] = unknown[], TResult = unknown> {
+  (...args: TArgs): TResult;
+  calls: TArgs[];
+  mockImplementation: (impl: (...args: TArgs) => TResult) => MockFunction<TArgs, TResult>;
+  mockResolvedValue: (value: unknown) => MockFunction<TArgs, Promise<unknown>>;
+  mockRejectedValue: (error: unknown) => MockFunction<TArgs, Promise<never>>;
+  clear: () => void;
+}
+
+const createMock = <TArgs extends unknown[] = unknown[], TResult = unknown>(
+  impl: (...args: TArgs) => TResult,
+): MockFunction<TArgs, TResult> => {
+  let implementation = impl;
+  const fn = ((...args: TArgs) => {
+    fn.calls.push(args);
+    return implementation(...args);
+  }) as MockFunction<TArgs, TResult>;
+  fn.calls = [];
+  fn.mockImplementation = (newImpl) => {
+    implementation = newImpl;
+    return fn;
+  };
+  fn.mockResolvedValue = (value) => {
+    implementation = () => Promise.resolve(value as any) as any;
+    return fn as any;
+  };
+  fn.mockRejectedValue = (error) => {
+    implementation = () => Promise.reject(error) as any;
+    return fn as any;
+  };
+  fn.clear = () => {
+    fn.calls = [];
+  };
+  return fn;
+};
+
+const createPrismaStub = () => {
+  const prisma: PrismaClientLike & {
+    user: { findMany: MockFunction<[any], Promise<unknown[]>> };
+    bankLine: {
+      findMany: MockFunction<[any], Promise<unknown[]>>;
+      create: MockFunction<[any], Promise<unknown>>;
+    };
+  } = {
+    user: {
+      findMany: createMock(() => Promise.resolve([])),
+    },
+    bankLine: {
+      findMany: createMock(() => Promise.resolve([])),
+      create: createMock(() => Promise.resolve({})),
+    },
+  } as any;
+
+  return prisma;
+};
+
+const createdMocks: MockFunction[] = [];
+
+const trackMock = <TArgs extends unknown[] = unknown[], TResult = unknown>(
+  mock: MockFunction<TArgs, TResult>,
+) => {
+  createdMocks.push(mock as MockFunction);
+  return mock;
+};
+
+afterEach(() => {
+  for (const mock of createdMocks) {
+    mock.clear();
+  }
+  createdMocks.length = 0;
+});
+
+describe("api-gateway routes", () => {
+  it("returns health information", async () => {
+    const prisma = createPrismaStub();
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({ method: "GET", url: "/health" });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { ok: true, service: "api-gateway" });
+
+    await app.close();
+  });
+
+  it("lists users using the prisma client", async () => {
+    const prisma = createPrismaStub();
+    const users = [
+      { email: "alpha@example.com", orgId: "org_1", createdAt: new Date("2024-01-01") },
+    ];
+    prisma.user.findMany = trackMock(createMock(() => Promise.resolve(users)));
+
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({ method: "GET", url: "/users" });
+    const body = response.json() as { users: Array<Record<string, unknown>> };
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(prisma.user.findMany.calls[0][0], {
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    assert.equal(body.users.length, 1);
+    assert.equal(body.users[0]?.email, users[0]?.email);
+    assert.equal(body.users[0]?.orgId, users[0]?.orgId);
+    assert.equal(body.users[0]?.createdAt, users[0]?.createdAt.toISOString());
+
+    await app.close();
+  });
+
+  it("validates the request body for bank lines", async () => {
+    const prisma = createPrismaStub();
+    prisma.bankLine.create = trackMock(createMock(() => Promise.resolve({}))); 
+
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {},
+    });
+
+    assert.equal(response.statusCode, 422);
+    assert.deepEqual(response.json().error, "validation_failed");
+    assert.equal(prisma.bankLine.create.calls.length, 0);
+
+    await app.close();
+  });
+
+  it("creates a bank line when the payload is valid", async () => {
+    const prisma = createPrismaStub();
+    const created = { id: "line_1" };
+    prisma.bankLine.create = trackMock(createMock(() => Promise.resolve(created)));
+
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "org_123",
+        date: "2024-01-01",
+        amount: "123.45",
+        payee: "Example Pty Ltd",
+        desc: "Subscription",
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(response.json(), created);
+    assert.deepEqual(prisma.bankLine.create.calls[0][0], {
+      data: {
+        orgId: "org_123",
+        date: new Date("2024-01-01"),
+        amount: "123.45",
+        payee: "Example Pty Ltd",
+        desc: "Subscription",
+      },
+    });
+
+    await app.close();
+  });
+
+  it("maps Prisma unique constraint errors to 409", async () => {
+    const prisma = createPrismaStub();
+    prisma.bankLine.create = trackMock(
+      createMock(() => Promise.reject({ code: "P2002" })),
+    );
+
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "org_123",
+        date: "2024-01-01",
+        amount: 100,
+        payee: "Example Pty Ltd",
+        desc: "Subscription",
+      },
+    });
+
+    assert.equal(response.statusCode, 409);
+    assert.deepEqual(response.json(), { error: "conflict" });
+
+    await app.close();
+  });
+
+  it("maps Prisma not found errors to 404", async () => {
+    const prisma = createPrismaStub();
+    prisma.bankLine.create = trackMock(
+      createMock(() => Promise.reject({ code: "P2025" })),
+    );
+
+    const app = await createApp({ prisma });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "org_123",
+        date: "2024-01-01",
+        amount: 100,
+        payee: "Example Pty Ltd",
+        desc: "Subscription",
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(response.json(), { error: "not_found" });
+
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/services/api-gateway/vitest.config.ts
+++ b/apgms/services/api-gateway/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add an app factory so routes can run against an injected Prisma client with validation and Prisma error mapping
- add coverage for /health, /users, and /bank-lines happy and error paths using a lightweight Prisma stub
- configure the service test command and provide an initial Vitest config file

## Testing
- pnpm -F @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68eb128f6bbc8327ab46602390606502