### PR TITLE
feat: enforce org row level security

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,9 +9,48 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { prisma, withOrgContext } from "../../../shared/src/db";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    orgId?: string;
+  }
+}
 
 const app = Fastify({ logger: true });
+
+const decodeBase64Url = (input: string): string => {
+  input = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = input.length % 4;
+  if (pad) {
+    input = input + "=".repeat(4 - pad);
+  }
+  return Buffer.from(input, "base64").toString("utf8");
+};
+
+const extractOrgId = (authorization?: string): string | undefined => {
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return undefined;
+  }
+
+  const token = authorization.slice("Bearer ".length);
+  const segments = token.split(".");
+  if (segments.length < 2) {
+    return undefined;
+  }
+
+  try {
+    const payload = JSON.parse(decodeBase64Url(segments[1] ?? ""));
+    return payload.orgId ?? payload.org_id ?? payload.orgID;
+  } catch (err) {
+    app.log.warn({ err }, "failed to decode jwt payload");
+    return undefined;
+  }
+};
+
+app.addHook("onRequest", async (req) => {
+  req.orgId = extractOrgId(req.headers.authorization);
+});
 
 await app.register(cors, { origin: true });
 
@@ -21,44 +60,69 @@ app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+app.get("/users", async (req, rep) => {
+  if (!req.orgId) {
+    return rep.code(401).send({ error: "missing_org" });
+  }
+
+  return withOrgContext(req.orgId, async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
   });
-  return { users };
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+app.get("/bank-lines", async (req, rep) => {
+  if (!req.orgId) {
+    return rep.code(401).send({ error: "missing_org" });
+  }
+
+  return withOrgContext(req.orgId, async () => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
   });
-  return { lines };
 });
 
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
+  const body = req.body as {
+    orgId?: string;
+    date: string;
+    amount: number | string;
+    payee: string;
+    desc: string;
+  };
+
+  const orgId = req.orgId ?? body.orgId;
+
+  if (!orgId) {
+    return rep.code(401).send({ error: "missing_org" });
+  }
+
+  if (req.orgId && body.orgId && req.orgId !== body.orgId) {
+    return rep.code(403).send({ error: "org_mismatch" });
+  }
+
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+    return await withOrgContext(orgId, async () => {
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
     });
-    return rep.code(201).send(created);
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "tsx --test src/**/*.test.ts"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/prisma/migrations/20251010140000_rls_guard/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010140000_rls_guard/migration.sql
@@ -1,0 +1,75 @@
+-- Convert primary and foreign keys to UUID and enable row level security policies
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Ensure new UUID identifiers exist
+ALTER TABLE "Org" ADD COLUMN IF NOT EXISTS "new_id" uuid DEFAULT gen_random_uuid();
+UPDATE "Org" SET "new_id" = COALESCE("new_id", gen_random_uuid());
+ALTER TABLE "Org" ALTER COLUMN "new_id" SET NOT NULL;
+
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "new_id" uuid DEFAULT gen_random_uuid();
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "new_orgId" uuid;
+UPDATE "User" SET "new_id" = COALESCE("new_id", gen_random_uuid());
+UPDATE "User" SET "new_orgId" = o."new_id"
+FROM "Org" o
+WHERE "User"."orgId" = o."id";
+ALTER TABLE "User" ALTER COLUMN "new_id" SET NOT NULL;
+ALTER TABLE "User" ALTER COLUMN "new_orgId" SET NOT NULL;
+
+ALTER TABLE "BankLine" ADD COLUMN IF NOT EXISTS "new_id" uuid DEFAULT gen_random_uuid();
+ALTER TABLE "BankLine" ADD COLUMN IF NOT EXISTS "new_orgId" uuid;
+UPDATE "BankLine" SET "new_id" = COALESCE("new_id", gen_random_uuid());
+UPDATE "BankLine" SET "new_orgId" = o."new_id"
+FROM "Org" o
+WHERE "BankLine"."orgId" = o."id";
+ALTER TABLE "BankLine" ALTER COLUMN "new_id" SET NOT NULL;
+ALTER TABLE "BankLine" ALTER COLUMN "new_orgId" SET NOT NULL;
+
+-- Rebuild primary keys
+ALTER TABLE "User" DROP CONSTRAINT IF EXISTS "User_pkey";
+ALTER TABLE "BankLine" DROP CONSTRAINT IF EXISTS "BankLine_pkey";
+ALTER TABLE "Org" DROP CONSTRAINT IF EXISTS "Org_pkey";
+
+ALTER TABLE "User" DROP CONSTRAINT IF EXISTS "User_orgId_fkey";
+ALTER TABLE "BankLine" DROP CONSTRAINT IF EXISTS "BankLine_orgId_fkey";
+
+ALTER TABLE "User" DROP CONSTRAINT IF EXISTS "User_email_key";
+
+ALTER TABLE "User" DROP COLUMN IF EXISTS "id";
+ALTER TABLE "User" DROP COLUMN IF EXISTS "orgId";
+ALTER TABLE "BankLine" DROP COLUMN IF EXISTS "id";
+ALTER TABLE "BankLine" DROP COLUMN IF EXISTS "orgId";
+ALTER TABLE "Org" DROP COLUMN IF EXISTS "id";
+
+ALTER TABLE "Org" RENAME COLUMN "new_id" TO "id";
+ALTER TABLE "User" RENAME COLUMN "new_id" TO "id";
+ALTER TABLE "User" RENAME COLUMN "new_orgId" TO "orgId";
+ALTER TABLE "BankLine" RENAME COLUMN "new_id" TO "id";
+ALTER TABLE "BankLine" RENAME COLUMN "new_orgId" TO "orgId";
+
+ALTER TABLE "Org" ADD PRIMARY KEY ("id");
+ALTER TABLE "User" ADD PRIMARY KEY ("id");
+ALTER TABLE "BankLine" ADD PRIMARY KEY ("id");
+
+ALTER TABLE "User" ADD CONSTRAINT "User_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BankLine" ADD CONSTRAINT "BankLine_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "User" ADD CONSTRAINT "User_email_key" UNIQUE ("email");
+
+ALTER TABLE "Org" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "User" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "User" ALTER COLUMN "orgId" SET DATA TYPE uuid USING "orgId";
+ALTER TABLE "BankLine" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "BankLine" ALTER COLUMN "orgId" SET DATA TYPE uuid USING "orgId";
+
+-- Enable row level security and policies
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "User" FORCE ROW LEVEL SECURITY;
+CREATE POLICY IF NOT EXISTS "user_org_isolation" ON "User"
+  USING ("orgId" = current_setting('apgms.org_id')::uuid)
+  WITH CHECK ("orgId" = current_setting('apgms.org_id')::uuid);
+
+ALTER TABLE "BankLine" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "BankLine" FORCE ROW LEVEL SECURITY;
+CREATE POLICY IF NOT EXISTS "bank_line_org_isolation" ON "BankLine"
+  USING ("orgId" = current_setting('apgms.org_id')::uuid)
+  WITH CHECK ("orgId" = current_setting('apgms.org_id')::uuid);

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -8,7 +8,7 @@ datasource db {
 }
 
 model Org {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid()) @db.Uuid
   name      String
   createdAt DateTime @default(now())
   users     User[]
@@ -16,18 +16,18 @@ model Org {
 }
 
 model User {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid()) @db.Uuid
   email     String   @unique
   password  String
   createdAt DateTime @default(now())
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
+  orgId     String   @db.Uuid
 }
 
 model BankLine {
-  id        String   @id @default(cuid())
+  id        String   @id @default(uuid()) @db.Uuid
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
+  orgId     String   @db.Uuid
   date      DateTime
   amount    Decimal
   payee     String

--- a/apgms/shared/src/__tests__/prisma-middleware.test.ts
+++ b/apgms/shared/src/__tests__/prisma-middleware.test.ts
@@ -1,0 +1,94 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { after, before, describe, it } from "node:test";
+
+const defaultDbUrl = "postgresql://apgms:apgms@localhost:5432/apgms?schema=prisma_middleware_test";
+const dbUrl = process.env.TEST_DATABASE_URL ?? defaultDbUrl;
+const shadowUrl = process.env.TEST_SHADOW_DATABASE_URL ?? `${dbUrl}_shadow`;
+
+process.env.DATABASE_URL = dbUrl;
+process.env.SHADOW_DATABASE_URL = shadowUrl;
+
+const { prisma, withOrgContext } = await import("../db");
+
+const schemaName = (() => {
+  const url = new URL(dbUrl);
+  const schemaParam = url.searchParams.get("schema");
+  return schemaParam ?? "public";
+})();
+
+const migrationsDir = path.resolve(fileURLToPath(new URL("../..", import.meta.url)), "prisma", "migrations");
+
+const applyMigration = async (fileName: string) => {
+  const filePath = path.join(migrationsDir, fileName, "migration.sql");
+  const sql = await readFile(filePath, "utf8");
+  const statements = sql
+    .split(/;\s*\n/)
+    .map((stmt) => stmt.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    await prisma.$executeRawUnsafe(statement);
+  }
+};
+
+before(async () => {
+  await prisma.$executeRawUnsafe(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+  await prisma.$executeRawUnsafe(`CREATE SCHEMA "${schemaName}"`);
+  await applyMigration("20251010133921_init");
+  await applyMigration("20251010140000_rls_guard");
+});
+
+after(async () => {
+  await prisma.$disconnect();
+});
+
+describe("Prisma RLS middleware", () => {
+  it("rejects access when org context is missing", async () => {
+    await assert.rejects(prisma.user.findMany(), /apgms\.org_id/);
+  });
+
+  it("allows access when context is provided", async () => {
+    const org = await prisma.org.create({ data: { name: `Org-${randomUUID()}` } });
+
+    await withOrgContext(org.id, () =>
+      prisma.user.create({
+        data: {
+          email: `${randomUUID()}@example.com`,
+          password: "password123",
+          orgId: org.id,
+        },
+      })
+    );
+
+    const users = await withOrgContext(org.id, () => prisma.user.findMany());
+    assert.equal(users.length, 1);
+    assert.equal(users[0]?.orgId, org.id);
+  });
+
+  it("isolates data between organisations", async () => {
+    const primaryOrg = await prisma.org.create({ data: { name: `Org-${randomUUID()}` } });
+    const otherOrg = await prisma.org.create({ data: { name: `Org-${randomUUID()}` } });
+
+    await withOrgContext(primaryOrg.id, () =>
+      prisma.bankLine.create({
+        data: {
+          orgId: primaryOrg.id,
+          amount: 100,
+          date: new Date(),
+          payee: "Vendor",
+          desc: "Subscription",
+        },
+      })
+    );
+
+    const visibleToPrimary = await withOrgContext(primaryOrg.id, () => prisma.bankLine.findMany());
+    assert.equal(visibleToPrimary.length, 1);
+
+    const visibleToOther = await withOrgContext(otherOrg.id, () => prisma.bankLine.findMany());
+    assert.equal(visibleToOther.length, 0);
+  });
+});

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,57 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { AsyncLocalStorage } from "node:async_hooks";
+import PrismaPkg from "@prisma/client";
+
+const { PrismaClient } = PrismaPkg as typeof import("@prisma/client");
+
+type PrismaRequestContext = {
+  orgId?: string;
+  skipGuard?: boolean;
+};
+
+const contextStorage = new AsyncLocalStorage<PrismaRequestContext>();
+
+const basePrisma = new PrismaClient();
+
+const getModelDelegate = (client: PrismaClient, modelName: string) => {
+  const key = modelName.charAt(0).toLowerCase() + modelName.slice(1);
+  const delegate = (client as unknown as Record<string, any>)[key];
+  if (!delegate) {
+    throw new Error(`Prisma delegate for model ${modelName} was not found`);
+  }
+  return delegate;
+};
+
+basePrisma.$use(async (params, next) => {
+  const store = contextStorage.getStore();
+
+  if (!store?.orgId || store.skipGuard || !params.model) {
+    return next(params);
+  }
+
+  return basePrisma.$transaction(async (tx) => {
+    return contextStorage.run({ ...store, skipGuard: true }, async () => {
+      await tx.$executeRaw`SET LOCAL "apgms.org_id" = ${store.orgId}`;
+      const delegate = getModelDelegate(tx as unknown as PrismaClient, params.model!);
+      const action = params.action as keyof typeof delegate;
+      const operation = delegate[action];
+
+      if (typeof operation !== "function") {
+        throw new Error(`Unsupported Prisma action: ${String(params.action)}`);
+      }
+
+      return operation.call(delegate, params.args);
+    });
+  });
+});
+
+export const prisma = basePrisma;
+
+export const withOrgContext = async <T>(orgId: string | undefined, fn: () => Promise<T> | T): Promise<T> => {
+  if (!orgId) {
+    return contextStorage.run({}, fn);
+  }
+
+  return contextStorage.run({ orgId }, fn);
+};
+
+export const getOrgContext = (): string | undefined => contextStorage.getStore()?.orgId;


### PR DESCRIPTION
## Summary
- convert org, user, and bank line identifiers to UUIDs and add row-level security policies enforcing apgms.org_id
- add Prisma middleware with request-scoped context that sets apgms.org_id from JWT claims for every query
- require an organisation context on API routes and cover the guard behaviour with integration tests

## Testing
- pnpm --filter @apgms/shared test *(fails: Prisma client generation requires downloading Prisma engines, which is blocked in this offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb12d1be9c8327b0680d1a95acd1d4