### PR TITLE
Add services to compose stack

### DIFF
--- a/apgms/docker-compose.yml
+++ b/apgms/docker-compose.yml
@@ -1,11 +1,63 @@
-﻿services:
+version: "3.9"
+name: apgms
+services:
   postgres:
     image: postgres:15
     environment:
       POSTGRES_USER: apgms
       POSTGRES_PASSWORD: apgms
       POSTGRES_DB: apgms
-    ports: ['5432:5432']
+    ports:
+      - "5432:5432"
+    networks:
+      - apgmsnet
+
   redis:
     image: redis:7
-    ports: ['6379:6379']
+    ports:
+      - "6379:6379"
+    networks:
+      - apgmsnet
+
+  api-gateway:
+    build:
+      context: .
+      dockerfile: services/api-gateway/Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+    ports:
+      - "3000:3000"
+    networks:
+      - apgmsnet
+
+  tax-engine:
+    build:
+      context: .
+      dockerfile: services/tax-engine/Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      - postgres
+    ports:
+      - "8000:8000"
+    networks:
+      - apgmsnet
+
+  webapp:
+    build:
+      context: .
+      dockerfile: webapp/Dockerfile
+    env_file:
+      - .env
+    depends_on:
+      - api-gateway
+    ports:
+      - "5173:5173"
+    networks:
+      - apgmsnet
+
+networks:
+  apgmsnet:
+    driver: bridge


### PR DESCRIPTION
## Summary
- upgrade the docker compose file to version 3.9 with a named project and bridge network
- keep existing postgres and redis services while adding api-gateway, tax-engine, and webapp builds
- ensure the new services load the shared environment file and expose their development ports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb184f4e108327bb8ec1f553f5aa14