### PR TITLE
Add Prisma management scripts and environment example

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/apgms?schema=public
+SHADOW_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/apgms_shadow?schema=public
+
+PORT=3000
+TAX_ENGINE_URL=http://tax-engine:8000
+WEBAPP_PORT=5173

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,30 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "prisma:generate": "pnpm -w exec prisma generate --schema shared/prisma/schema.prisma",
+    "prisma:migrate": "pnpm -w exec prisma migrate dev --schema shared/prisma/schema.prisma",
+    "prisma:seed": "node shared/scripts/seed.cjs"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}


### PR DESCRIPTION
## Summary
- add workspace-level Prisma generate, migrate, and seed scripts that target the shared schema
- provide an example environment file with database URLs and common service ports
- adjust gitignore to ensure the example environment file is versioned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb18597f50832789c819cdb0ca4c83