### PR TITLE
Add API smoke page for webapp

### DIFF
--- a/apgms/apps/webapp/src/App.tsx
+++ b/apgms/apps/webapp/src/App.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+type BankLine = { id: string; amount: number; description: string; txDate: string };
+
+export default function App() {
+  const [health, setHealth] = useState<string>('checking...');
+  const [rows, setRows] = useState<BankLine[]>([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3000/health')
+      .then(r => r.json()).then(d => setHealth(d.ok ? 'ok' : 'not ok'))
+      .catch(() => setHealth('error'));
+
+    fetch('http://localhost:3000/bank-lines')
+      .then(r => r.json()).then(setRows)
+      .catch(() => setRows([]));
+  }, []);
+
+  return (
+    <main style={{ fontFamily: 'system-ui', padding: 24 }}>
+      <h1>APGMS Webapp</h1>
+      <p>API health: {health}</p>
+      <h2>BankLines</h2>
+      <ul>
+        {rows.map(r => (
+          <li key={r.id}>
+            {new Date(r.txDate).toLocaleDateString()} — {r.description} — ${r.amount}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apgms/apps/webapp/src/main.tsx
+++ b/apgms/apps/webapp/src/main.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode><App /></React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add a simple App component that checks the API health endpoint and lists bank lines
- add a React entry point that renders the App component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb187335e88327a0ae207bb8bd11db