### PR TITLE
Add tax engine health proxy endpoint

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import taxRoutes from "./routes/tax";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(taxRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/routes/tax.ts
+++ b/apgms/services/api-gateway/src/routes/tax.ts
@@ -1,0 +1,20 @@
+import { FastifyInstance } from "fastify";
+
+export default async function taxRoutes(app: FastifyInstance) {
+  const base = process.env.TAX_ENGINE_URL ?? "http://tax-engine:8000";
+
+  app.get("/tax/health", async (_req, reply) => {
+    try {
+      const res = await fetch(`${base}/health`);
+      if (!res.ok) {
+        throw new Error(`tax-engine responded with ${res.status}`);
+      }
+      const data = await res.json();
+      return data;
+    } catch (e) {
+      app.log.error(e);
+      reply.code(502);
+      return { ok: false, error: "tax-engine unavailable" };
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a Fastify route that proxies the tax engine health endpoint using the TAX_ENGINE_URL base URL
- register the tax routes module with the API gateway server

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb189696bc8327adf63230c5715722