### PR TITLE
Add Playwright health check test for webapp

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@apps/webapp-tests",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.43.1"
+  }
+}

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/apps/webapp/tests/app.spec.ts
+++ b/apps/webapp/tests/app.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('renders health', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await expect(page.getByText('API health: ok')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration and package for the webapp tests
- cover the homepage with a smoke test that asserts the API health banner shows "ok"

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb18b362248327b576c8a0d5928d6e