### PR TITLE
Add API gateway smoke tests for health and bank lines

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test test/health.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,74 @@
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import type { PrismaClient } from "@prisma/client";
+
+export interface CreateAppOptions {
+  prismaClient?: Pick<PrismaClient, "bankLine" | "user">;
+  fastifyOptions?: FastifyServerOptions;
+  enableCors?: boolean;
+}
+
+let defaultPrisma: Pick<PrismaClient, "bankLine" | "user"> | null = null;
+
+export async function createApp(options: CreateAppOptions = {}): Promise<FastifyInstance> {
+  const { prismaClient, fastifyOptions, enableCors = true } = options;
+
+  if (!defaultPrisma && !prismaClient) {
+    const module = await import("../../../shared/src/db");
+    defaultPrisma = module.prisma;
+  }
+
+  const prisma = prismaClient ?? defaultPrisma!;
+
+  const app = Fastify(fastifyOptions ?? { logger: true });
+
+  if (enableCors) {
+    await app.register(cors, { origin: true });
+  }
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as Record<string, string | undefined>).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,63 +7,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
+const app = await createApp();
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +26,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/test/health.test.ts
+++ b/apgms/services/api-gateway/test/health.test.ts
@@ -1,0 +1,108 @@
+import { randomUUID } from "node:crypto";
+import assert from "node:assert/strict";
+import { after, before, beforeEach, test } from "node:test";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { createApp } from "../src/app";
+
+interface BankLineRecord {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: string;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}
+
+const bankLines: BankLineRecord[] = [];
+
+const prismaMock = {
+  bankLine: {
+    async create({ data }: { data: Record<string, any> }) {
+      const record: BankLineRecord = {
+        id: randomUUID(),
+        orgId: data.orgId,
+        date: new Date(data.date),
+        amount: String(data.amount),
+        payee: data.payee,
+        desc: data.desc,
+        createdAt: new Date(),
+      };
+      bankLines.push(record);
+      bankLines.sort((a, b) => b.date.getTime() - a.date.getTime());
+      return record;
+    },
+    async findMany({ take }: { take?: number }) {
+      const limit = typeof take === "number" ? take : bankLines.length;
+      return bankLines.slice(0, limit);
+    },
+  },
+  user: {
+    async findMany() {
+      return [];
+    },
+  },
+} as unknown as Pick<PrismaClient, "bankLine" | "user">;
+
+let app: Awaited<ReturnType<typeof createApp>>;
+
+before(async () => {
+  app = await createApp({
+    prismaClient: prismaMock,
+    fastifyOptions: { logger: false },
+  });
+  await app.ready();
+});
+
+after(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  bankLines.length = 0;
+});
+
+test("health ok", async () => {
+  const res = await request(app).get("/health");
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, { ok: true, service: "api-gateway" });
+});
+
+test("bank lines create and read", async () => {
+  const payload = {
+    orgId: "org-123",
+    date: new Date("2024-01-01T00:00:00.000Z").toISOString(),
+    amount: 123.45,
+    payee: "Test Payee",
+    desc: "Test Description",
+  };
+
+  const createRes = await request(app).post("/bank-lines").send(payload);
+  assert.equal(createRes.status, 201);
+  assert.equal(typeof createRes.body.id, "string");
+  assert.equal(new Date(createRes.body.date).toISOString(), payload.date);
+  assert.deepEqual(createRes.body, {
+    id: createRes.body.id,
+    orgId: payload.orgId,
+    date: payload.date,
+    amount: String(payload.amount),
+    payee: payload.payee,
+    desc: payload.desc,
+    createdAt: createRes.body.createdAt,
+  });
+
+  const listRes = await request(app).get("/bank-lines");
+  assert.equal(listRes.status, 200);
+  assert.equal(Array.isArray(listRes.body.lines), true);
+  assert.equal(listRes.body.lines.length, 1);
+  assert.deepEqual(listRes.body.lines[0], {
+    id: createRes.body.id,
+    orgId: payload.orgId,
+    date: payload.date,
+    amount: String(payload.amount),
+    payee: payload.payee,
+    desc: payload.desc,
+    createdAt: listRes.body.lines[0].createdAt,
+  });
+});

--- a/apgms/services/api-gateway/test/utils/supertest.ts
+++ b/apgms/services/api-gateway/test/utils/supertest.ts
@@ -1,0 +1,102 @@
+import type { FastifyInstance, InjectOptions, LightMyRequestResponse } from "fastify";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD" | "OPTIONS";
+
+type RequestInit = {
+  method: HttpMethod;
+  url: string;
+};
+
+type SuperTestResponse = LightMyRequestResponse & {
+  status: number;
+  text: string;
+  body: any;
+  json(): any;
+};
+
+class RequestBuilder implements PromiseLike<SuperTestResponse> {
+  #app: FastifyInstance;
+  #init: RequestInit;
+  #payload: unknown;
+
+  constructor(app: FastifyInstance, init: RequestInit) {
+    this.#app = app;
+    this.#init = init;
+  }
+
+  send(body: unknown): this {
+    this.#payload = body;
+    return this;
+  }
+
+  then<TResult1 = SuperTestResponse, TResult2 = never>(
+    onfulfilled?: ((value: SuperTestResponse) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.#execute().then(onfulfilled, onrejected);
+  }
+
+  catch<TResult = never>(
+    onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<SuperTestResponse | TResult> {
+    return this.#execute().catch(onrejected);
+  }
+
+  finally(onfinally?: (() => void) | null): Promise<SuperTestResponse> {
+    return this.#execute().finally(onfinally ?? undefined);
+  }
+
+  #execute(): Promise<SuperTestResponse> {
+    const headers: Record<string, string> = {};
+    const payload = this.#payload;
+    if (payload !== undefined && typeof payload !== "string") {
+      headers["content-type"] = "application/json";
+    }
+
+    const options: InjectOptions = {
+      method: this.#init.method,
+      url: this.#init.url,
+      payload,
+      headers,
+    };
+
+    return this.#app.inject(options).then(adaptResponse);
+  }
+}
+
+function adaptResponse(res: LightMyRequestResponse): SuperTestResponse {
+  let parsed: any;
+  let isJson = false;
+  try {
+    parsed = res.json();
+    isJson = true;
+  } catch {
+    parsed = res.body;
+  }
+
+  const text = typeof res.body === "string" ? res.body : JSON.stringify(res.body);
+
+  const response: SuperTestResponse = Object.assign(res, {
+    status: res.statusCode,
+    text,
+    body: isJson ? parsed : res.body,
+    json: () => (isJson ? parsed : JSON.parse(String(res.body))),
+  });
+
+  return response;
+}
+
+function createRequest(app: FastifyInstance) {
+  const make = (method: HttpMethod, url: string) => new RequestBuilder(app, { method, url });
+  return {
+    get: (url: string) => make("GET", url),
+    post: (url: string) => make("POST", url),
+    put: (url: string) => make("PUT", url),
+    patch: (url: string) => make("PATCH", url),
+    delete: (url: string) => make("DELETE", url),
+    head: (url: string) => make("HEAD", url),
+    options: (url: string) => make("OPTIONS", url),
+  };
+}
+
+export default createRequest;

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,8 +9,9 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared/*": ["shared/src/*"],
+      "supertest": ["services/api-gateway/test/utils/supertest.ts"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- extract the Fastify app setup into a reusable `createApp` helper so tests can boot the service in memory
- add node:test-based smoke coverage for `/health` and `/bank-lines` create/read flows using a lightweight supertest wrapper
- wire up a local test script and TypeScript config paths so the smoke tests run inside the workspace

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68eb18aa35108327850116de062a8620