### PR TITLE
Add shared environment example

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgresql://postgres:postgres@db:5432/apgms?schema=public
+SHADOW_DATABASE_URL=postgresql://postgres:postgres@db:5432/apgms_shadow?schema=public
+
+PORT=3000
+TAX_ENGINE_URL=http://tax-engine:8000
+WEBAPP_PORT=5173
+REDIS_URL=redis://redis:6379

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- add an `.env.example` file for the shared services configuration
- allow the example environment file to be tracked alongside other sources

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb1b5e99088327b91dc419c45b5e11