### PR TITLE
Add Dockerfiles for API gateway and tax engine services

### DIFF
--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+RUN corepack enable
+COPY ../../pnpm-workspace.yaml ../../package.json ../../pnpm-lock.yaml ./
+RUN pnpm fetch
+COPY ../../ ./
+RUN pnpm -w install --frozen-lockfile
+RUN pnpm -r build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production PORT=3000
+COPY --from=deps /app .
+EXPOSE 3000
+CMD ["node","services/api-gateway/dist/index.js"]

--- a/apgms/services/tax-engine/Dockerfile
+++ b/apgms/services/tax-engine/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+RUN pip install --upgrade pip
+COPY services/tax-engine/requirements.txt ./requirements.txt
+RUN pip install -r requirements.txt
+COPY services/tax-engine /app
+EXPOSE 8000
+CMD ["uvicorn","main:app","--host","0.0.0.0","--port","8000"]

--- a/apgms/services/tax-engine/requirements.txt
+++ b/apgms/services/tax-engine/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the Node.js API gateway service
- add a Python-based Dockerfile for the tax engine service and include its requirements file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb1b82570483279f2ede3866c685f1