### PR TITLE
Add health endpoints and noop command handlers for stub services

### DIFF
--- a/apgms/services/audit/src/index.ts
+++ b/apgms/services/audit/src/index.ts
@@ -1,1 +1,41 @@
-﻿console.log('audit service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import Fastify from "fastify";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const SERVICE_NAME = "audit" as const;
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: SERVICE_NAME }));
+
+type CommandEnvelope = {
+  type?: string;
+  payload?: unknown;
+};
+
+app.post("/commands", async (request, reply) => {
+  const command = request.body as CommandEnvelope | undefined;
+
+  request.log.info({ command }, "noop command handler");
+
+  return reply.code(202).send({
+    ok: true,
+    service: SERVICE_NAME,
+    handled: false,
+  });
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((error) => {
+  app.log.error(error);
+  process.exit(1);
+});

--- a/apgms/services/cdr/src/index.ts
+++ b/apgms/services/cdr/src/index.ts
@@ -1,1 +1,41 @@
-﻿console.log('cdr service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import Fastify from "fastify";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const SERVICE_NAME = "cdr" as const;
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: SERVICE_NAME }));
+
+type CommandEnvelope = {
+  type?: string;
+  payload?: unknown;
+};
+
+app.post("/commands", async (request, reply) => {
+  const command = request.body as CommandEnvelope | undefined;
+
+  request.log.info({ command }, "noop command handler");
+
+  return reply.code(202).send({
+    ok: true,
+    service: SERVICE_NAME,
+    handled: false,
+  });
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((error) => {
+  app.log.error(error);
+  process.exit(1);
+});

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,41 @@
-﻿console.log('connectors service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import Fastify from "fastify";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const SERVICE_NAME = "connectors" as const;
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: SERVICE_NAME }));
+
+type CommandEnvelope = {
+  type?: string;
+  payload?: unknown;
+};
+
+app.post("/commands", async (request, reply) => {
+  const command = request.body as CommandEnvelope | undefined;
+
+  request.log.info({ command }, "noop command handler");
+
+  return reply.code(202).send({
+    ok: true,
+    service: SERVICE_NAME,
+    handled: false,
+  });
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((error) => {
+  app.log.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add Fastify-based skeleton servers for the audit, cdr, and connectors stubs
- expose GET /health endpoints that identify each service
- implement POST /commands handlers that log and accept commands without performing side effects

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eb1baa2818832783e7d5c8f19beff4