### PR TITLE
Add API gateway routes and environment configuration

### DIFF
--- a/apgms/.env
+++ b/apgms/.env
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://apgms:apgms@localhost:5432/apgms?schema=public
+SHADOW_DATABASE_URL=postgresql://apgms:apgms@localhost:5432/apgms_shadow?schema=public
+PORT=3000
+TAX_ENGINE_URL=http://localhost:8000
+REDIS_URL=redis://localhost:6379

--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://apgms:apgms@localhost:5432/apgms?schema=public
+SHADOW_DATABASE_URL=postgresql://apgms:apgms@localhost:5432/apgms_shadow?schema=public
+PORT=3000
+TAX_ENGINE_URL=http://localhost:8000
+REDIS_URL=redis://localhost:6379

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,49 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
-
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
+// health
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
+// bank-lines (adjust fields to match your schema)
+app.get("/bank-lines", async () => {
+  return prisma.bankLine.findMany({ orderBy: { createdAt: "desc" } });
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+app.post("/bank-lines", async (req, reply) => {
+  const b: any = req.body ?? {};
+  const row = await prisma.bankLine.create({
+    data: {
+      orgId: b.orgId ?? "demo-org",    // replace with real org linkage
+      date: b.date ? new Date(b.date) : new Date(),
+      amount: Number(b.amount ?? 0),
+      payee: String(b.payee ?? "n/a"),
+      desc: String(b.desc ?? "n/a"),
+    },
   });
-  return { lines };
+  reply.code(201);
+  return row;
 });
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
+// proxy to tax-engine /health
+app.get("/tax/health", async (req, reply) => {
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
+    const base = process.env.TAX_ENGINE_URL ?? "http://localhost:8000";
+    const r = await fetch(`${base}/health`);
+    return await r.json();
   } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+    app.log.error(e);
+    reply.code(502);
+    return { ok: false, error: "tax-engine unavailable" };
   }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
 });
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
-
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/tax-engine/requirements.txt
+++ b/apgms/services/tax-engine/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn==0.30.5


### PR DESCRIPTION
## Summary
- replace the API gateway entrypoint with simplified health, bank-line, and tax health routes
- add Python requirements for the tax-engine service
- provide environment variable defaults in .env and .env.example

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eb1d5aa3b88327ad2697d075c678c5