### PR TITLE
feat: add reports summary endpoint

### DIFF
--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -17,9 +17,9 @@ async function main() {
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, category: "Operations", payee: "Acme", desc: "Office fit-out" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, category: "Software", payee: "CloudCo", desc: "Monthly sub" },
+      { orgId: org.id, date: today, amount: 5000.0, category: "Capital", payee: "Birchal", desc: "Investment received" },
     ],
     skipDuplicates: true,
   });

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,6 +9,8 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import { z } from "zod";
+import type { Prisma } from "@prisma/client";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
@@ -46,6 +48,7 @@ app.post("/bank-lines", async (req, rep) => {
       orgId: string;
       date: string;
       amount: number | string;
+      category?: string;
       payee: string;
       desc: string;
     };
@@ -54,6 +57,7 @@ app.post("/bank-lines", async (req, rep) => {
         orgId: body.orgId,
         date: new Date(body.date),
         amount: body.amount as any,
+        category: body.category?.trim() || "Uncategorized",
         payee: body.payee,
         desc: body.desc,
       },
@@ -62,6 +66,126 @@ app.post("/bank-lines", async (req, rep) => {
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+const summaryQuerySchema = z.object({
+  orgId: z.string().min(1),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+const parseDate = (value?: string) => {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("invalid_date");
+  }
+  return parsed;
+};
+
+const formatMonth = (date: Date) => {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  return `${year}-${month}`;
+};
+
+app.get("/reports/summary", async (req, rep) => {
+  try {
+    const query = summaryQuerySchema.parse(req.query);
+    const from = parseDate(query.from);
+    const to = parseDate(query.to);
+
+    const where: Prisma.BankLineWhereInput = {
+      orgId: query.orgId,
+      ...(from || to
+        ? {
+            date: {
+              ...(from ? { gte: from } : {}),
+              ...(to ? { lte: to } : {}),
+            },
+          }
+        : {}),
+    };
+
+    const [categoryGroups, inflowAgg, outflowAgg, positiveByDate, negativeByDate] =
+      await Promise.all([
+        prisma.bankLine.groupBy({
+          by: ["category"],
+          where,
+          _sum: { amount: true },
+          _count: { _all: true },
+        }),
+        prisma.bankLine.aggregate({
+          where: { ...where, amount: { gt: 0 } },
+          _sum: { amount: true },
+        }),
+        prisma.bankLine.aggregate({
+          where: { ...where, amount: { lt: 0 } },
+          _sum: { amount: true },
+        }),
+        prisma.bankLine.groupBy({
+          by: ["date"],
+          where: { ...where, amount: { gt: 0 } },
+          _sum: { amount: true },
+        }),
+        prisma.bankLine.groupBy({
+          by: ["date"],
+          where: { ...where, amount: { lt: 0 } },
+          _sum: { amount: true },
+        }),
+      ]);
+
+    const totalsByCategory = categoryGroups
+      .map((group) => ({
+        category: group.category ?? "Uncategorized",
+        total: Number(group._sum.amount ?? 0),
+        count: group._count._all,
+      }))
+      .sort((a, b) => Math.abs(b.total) - Math.abs(a.total));
+
+    const inflow = Number(inflowAgg._sum.amount ?? 0);
+    const outflow = Math.abs(Number(outflowAgg._sum.amount ?? 0));
+    const net = inflow - outflow;
+
+    const monthlyMap = new Map<string, { inflow: number; outflow: number }>();
+
+    for (const group of positiveByDate) {
+      const month = formatMonth(group.date);
+      const entry = monthlyMap.get(month) ?? { inflow: 0, outflow: 0 };
+      entry.inflow += Number(group._sum.amount ?? 0);
+      monthlyMap.set(month, entry);
+    }
+
+    for (const group of negativeByDate) {
+      const month = formatMonth(group.date);
+      const entry = monthlyMap.get(month) ?? { inflow: 0, outflow: 0 };
+      entry.outflow += Math.abs(Number(group._sum.amount ?? 0));
+      monthlyMap.set(month, entry);
+    }
+
+    const monthly = Array.from(monthlyMap.entries())
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([month, values]) => ({
+        month,
+        inflow: values.inflow,
+        outflow: values.outflow,
+        net: values.inflow - values.outflow,
+      }));
+
+    return {
+      totalsByCategory,
+      inflow,
+      outflow,
+      net,
+      monthly,
+    };
+  } catch (error) {
+    req.log.error(error);
+    if (error instanceof z.ZodError || (error as Error).message === "invalid_date") {
+      return rep.code(400).send({ error: "bad_request" });
+    }
+    return rep.code(500).send({ error: "internal_error" });
   }
 });
 

--- a/apgms/shared/prisma/migrations/20251010140000_add_bankline_category/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010140000_add_bankline_category/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BankLine" ADD COLUMN     "category" TEXT NOT NULL DEFAULT 'Uncategorized';

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -30,6 +30,7 @@ model BankLine {
   orgId     String
   date      DateTime
   amount    Decimal
+  category  String   @default("Uncategorized")
   payee     String
   desc      String
   createdAt DateTime @default(now())


### PR DESCRIPTION
## Summary
- add a GET /reports/summary endpoint that aggregates transactions by category and month
- extend bank line records with a category field and update seeds with sample data
- calculate inflow, outflow, and net totals using Prisma aggregations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eb42354f88832791183e4b5e1fc334