### PR TITLE
Add idempotency support for bank line creation endpoints

### DIFF
--- a/apgms/services/api-gateway/src/idempotency.ts
+++ b/apgms/services/api-gateway/src/idempotency.ts
@@ -1,0 +1,105 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { redis } from "../../../shared/src";
+
+const IDEMPOTENCY_KEY_PREFIX = "idem";
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+const PENDING_VALUE = JSON.stringify({ pending: true });
+const WAIT_TIMEOUT_MS = 1000;
+const WAIT_POLL_MS = 50;
+
+export interface IdempotentResult<T> {
+  statusCode: number;
+  body: T;
+}
+
+function isPending(value: unknown): value is { pending: true } {
+  return Boolean(value && typeof value === "object" && "pending" in value);
+}
+
+async function waitForCompletion<T>(key: string): Promise<IdempotentResult<T> | null> {
+  const end = Date.now() + WAIT_TIMEOUT_MS;
+  while (Date.now() < end) {
+    const raw = await redis.get(key);
+    if (!raw) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (!isPending(parsed)) {
+        return parsed;
+      }
+    } catch {
+      await redis.del(key);
+      return null;
+    }
+    await delay(WAIT_POLL_MS);
+  }
+
+  const raw = await redis.get(key);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return isPending(parsed) ? null : parsed;
+  } catch {
+    await redis.del(key);
+    return null;
+  }
+}
+
+async function readStoredResult<T>(key: string): Promise<IdempotentResult<T> | null> {
+  const raw = await redis.get(key);
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (isPending(parsed)) {
+      return waitForCompletion<T>(key);
+    }
+    return parsed;
+  } catch {
+    await redis.del(key);
+    return null;
+  }
+}
+
+export async function withIdempotency<T>(
+  orgId: string,
+  key: string | undefined,
+  handler: () => Promise<IdempotentResult<T>>,
+): Promise<IdempotentResult<T>> {
+  if (!key) {
+    return handler();
+  }
+
+  const redisKey = `${IDEMPOTENCY_KEY_PREFIX}:${orgId}:${key}`;
+
+  const existing = await readStoredResult<T>(redisKey);
+  if (existing) {
+    return existing;
+  }
+
+  const created = await redis.set(redisKey, PENDING_VALUE, { NX: true, PX: IDEMPOTENCY_TTL_MS });
+  if (created === null) {
+    const stored = await readStoredResult<T>(redisKey);
+    if (stored) {
+      return stored;
+    }
+  }
+
+  try {
+    const result = await handler();
+    const payload = JSON.stringify(result);
+    const stored = await redis.set(redisKey, payload, { XX: true, PX: IDEMPOTENCY_TTL_MS });
+    if (stored === null) {
+      await redis.set(redisKey, payload, { PX: IDEMPOTENCY_TTL_MS });
+    }
+    return result;
+  } catch (error) {
+    await redis.del(redisKey);
+    throw error;
+  }
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { withIdempotency } from "./idempotency";
 
 const app = Fastify({ logger: true });
 
@@ -49,16 +50,70 @@ app.post("/bank-lines", async (req, rep) => {
       payee: string;
       desc: string;
     };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+
+    const idempotencyKeyHeader = req.headers["idempotency-key"];
+    const idempotencyKey = (Array.isArray(idempotencyKeyHeader)
+      ? idempotencyKeyHeader[0]
+      : idempotencyKeyHeader)?.trim();
+
+    const result = await withIdempotency(body.orgId, idempotencyKey, async () => {
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      return { statusCode: 201, body: created };
     });
-    return rep.code(201).send(created);
+
+    return rep.code(result.statusCode).send(result.body);
+  } catch (e) {
+    req.log.error(e);
+    return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+app.post("/bank-lines/import", async (req, rep) => {
+  try {
+    const body = req.body as {
+      orgId: string;
+      lines: Array<{
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      }>;
+    };
+
+    if (!Array.isArray(body.lines) || body.lines.length === 0) {
+      return rep.code(400).send({ error: "bad_request" });
+    }
+
+    const idempotencyKeyHeader = req.headers["idempotency-key"];
+    const idempotencyKey = (Array.isArray(idempotencyKeyHeader)
+      ? idempotencyKeyHeader[0]
+      : idempotencyKeyHeader)?.trim();
+
+    const result = await withIdempotency(body.orgId, idempotencyKey, async () => {
+      const created = await prisma.bankLine.createMany({
+        data: body.lines.map((line) => ({
+          orgId: body.orgId,
+          date: new Date(line.date),
+          amount: line.amount as any,
+          payee: line.payee,
+          desc: line.desc,
+        })),
+        skipDuplicates: true,
+      });
+
+      return { statusCode: 201, body: { count: created.count } };
+    });
+
+    return rep.code(result.statusCode).send(result.body);
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./redis";

--- a/apgms/shared/src/redis.ts
+++ b/apgms/shared/src/redis.ts
@@ -1,0 +1,53 @@
+interface SetOptions {
+  NX?: boolean;
+  XX?: boolean;
+  PX?: number;
+}
+
+interface StoredValue {
+  value: string;
+  expiresAt: number | null;
+}
+
+class InMemoryRedis {
+  private readonly store = new Map<string, StoredValue>();
+
+  private cleanup(key: string): void {
+    const item = this.store.get(key);
+    if (!item) return;
+    if (item.expiresAt !== null && item.expiresAt <= Date.now()) {
+      this.store.delete(key);
+    }
+  }
+
+  async get(key: string): Promise<string | null> {
+    this.cleanup(key);
+    const item = this.store.get(key);
+    return item ? item.value : null;
+  }
+
+  async set(key: string, value: string, options: SetOptions = {}): Promise<"OK" | null> {
+    this.cleanup(key);
+    const exists = this.store.has(key);
+
+    if (options.NX && exists) {
+      return null;
+    }
+
+    if (options.XX && !exists) {
+      return null;
+    }
+
+    const expiresAt = options.PX != null ? Date.now() + options.PX : null;
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+
+  async del(key: string): Promise<number> {
+    this.cleanup(key);
+    return this.store.delete(key) ? 1 : 0;
+  }
+}
+
+export const redis = new InMemoryRedis();
+export type { SetOptions };


### PR DESCRIPTION
## Summary
- add a shared in-memory Redis-style store and idempotency helper for reuse
- wrap POST /bank-lines and new /bank-lines/import handlers with Idempotency-Key support
- ensure repeated requests reuse cached responses and avoid duplicate database writes

## Testing
- `pnpm --filter @apgms/api-gateway exec tsc --noEmit` *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68eb423c4fc08327b01e2d0d0792da07