### PR TITLE
Add rule-based bank line categorisation

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/rules.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,7 +1,6 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
-
 // Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -9,7 +8,10 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import { Prisma } from "@prisma/client";
+import { z } from "zod";
 import { prisma } from "../../../shared/src/db";
+import { matchRule } from "./rules";
 
 const app = Fastify({ logger: true });
 
@@ -17,6 +19,164 @@ await app.register(cors, { origin: true });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+const bankLineCreateSchema = z.object({
+  orgId: z.string(),
+  date: z.coerce.date(),
+  amount: z.coerce.number(),
+  payee: z.string().trim().min(1),
+  desc: z.string().trim().min(1),
+  category: z.string().trim().min(1).max(64).optional(),
+});
+
+const ruleCreateSchema = z.object({
+  orgId: z.string(),
+  name: z.string().trim().min(1),
+  payeeRegex: z.union([z.string(), z.literal(null)]).optional(),
+  minAmount: z.union([z.coerce.number(), z.literal(null)]).optional(),
+  maxAmount: z.union([z.coerce.number(), z.literal(null)]).optional(),
+  containsDesc: z.union([z.string(), z.literal(null)]).optional(),
+  setCategory: z.string().trim().min(1).max(64),
+});
+
+const ruleUpdateSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  payeeRegex: z.union([z.string(), z.literal(null)]).optional(),
+  minAmount: z.union([z.coerce.number(), z.literal(null)]).optional(),
+  maxAmount: z.union([z.coerce.number(), z.literal(null)]).optional(),
+  containsDesc: z.union([z.string(), z.literal(null)]).optional(),
+  setCategory: z.string().trim().min(1).max(64).optional(),
+});
+
+const applyRulesSchema = z.object({
+  orgId: z.string(),
+});
+
+type RuleCreateInput = z.infer<typeof ruleCreateSchema>;
+type RuleUpdateInput = z.infer<typeof ruleUpdateSchema>;
+
+type NormalizedRuleInput<T> = T & {
+  payeeRegex?: string | null;
+  minAmount?: number | null;
+  maxAmount?: number | null;
+  containsDesc?: string | null;
+};
+
+function normalizeRuleInput<T extends RuleCreateInput | RuleUpdateInput>(
+  payload: T,
+): NormalizedRuleInput<T> {
+  const normalized: any = { ...payload };
+
+  if (Object.prototype.hasOwnProperty.call(normalized, "payeeRegex")) {
+    const value = normalized.payeeRegex;
+    if (value === undefined) {
+      // leave as undefined
+    } else if (value === null) {
+      normalized.payeeRegex = null;
+    } else {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        normalized.payeeRegex = null;
+      } else {
+        try {
+          new RegExp(trimmed);
+          normalized.payeeRegex = trimmed;
+        } catch {
+          throw new Error("Invalid payeeRegex");
+        }
+      }
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(normalized, "containsDesc")) {
+    const value = normalized.containsDesc;
+    if (value === undefined) {
+      // leave as undefined
+    } else if (value === null) {
+      normalized.containsDesc = null;
+    } else {
+      const trimmed = value.trim();
+      normalized.containsDesc = trimmed.length === 0 ? null : trimmed;
+    }
+  }
+
+  const normalizeAmount = (value: unknown) => {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === null) {
+      return null;
+    }
+    const num = Number(value);
+    if (!Number.isFinite(num)) {
+      throw new Error("Amount must be finite");
+    }
+    return num;
+  };
+
+  if (Object.prototype.hasOwnProperty.call(normalized, "minAmount")) {
+    normalized.minAmount = normalizeAmount(normalized.minAmount);
+  }
+  if (Object.prototype.hasOwnProperty.call(normalized, "maxAmount")) {
+    normalized.maxAmount = normalizeAmount(normalized.maxAmount);
+  }
+
+  const minAmount = normalized.minAmount;
+  const maxAmount = normalized.maxAmount;
+  if (
+    minAmount !== undefined &&
+    minAmount !== null &&
+    maxAmount !== undefined &&
+    maxAmount !== null &&
+    maxAmount < minAmount
+  ) {
+    throw new Error("maxAmount must be greater than or equal to minAmount");
+  }
+
+  return normalized;
+}
+
+function mapToRulePrismaData(
+  input: NormalizedRuleInput<Partial<RuleCreateInput & RuleUpdateInput>>,
+) {
+  const data: any = {};
+  if (Object.prototype.hasOwnProperty.call(input, "orgId") && input.orgId !== undefined) {
+    data.orgId = input.orgId;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "name") && input.name !== undefined) {
+    data.name = input.name;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "payeeRegex")) {
+    data.payeeRegex = input.payeeRegex ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "containsDesc")) {
+    data.containsDesc = input.containsDesc ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "setCategory") && input.setCategory !== undefined) {
+    data.setCategory = input.setCategory;
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "minAmount")) {
+    const value = input.minAmount;
+    if (value === undefined) {
+      // skip - undefined means omit
+    } else if (value === null) {
+      data.minAmount = null;
+    } else {
+      data.minAmount = new Prisma.Decimal(value);
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(input, "maxAmount")) {
+    const value = input.maxAmount;
+    if (value === undefined) {
+      // skip
+    } else if (value === null) {
+      data.maxAmount = null;
+    } else {
+      data.maxAmount = new Prisma.Decimal(value);
+    }
+  }
+  return data;
+}
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -42,26 +202,114 @@ app.get("/bank-lines", async (req) => {
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
+    const parsed = bankLineCreateSchema.parse(req.body ?? {});
     const created = await prisma.bankLine.create({
       data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
+        orgId: parsed.orgId,
+        date: parsed.date,
+        amount: new Prisma.Decimal(parsed.amount),
+        payee: parsed.payee,
+        desc: parsed.desc,
+        category: parsed.category,
       },
     });
     return rep.code(201).send(created);
-  } catch (e) {
+  } catch (e: any) {
     req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+    return rep.code(400).send({ error: "bad_request", message: e.message ?? "invalid payload" });
+  }
+});
+
+// Rules CRUD
+app.get("/rules", async (req, rep) => {
+  const orgId = (req.query as any).orgId;
+  if (!orgId || typeof orgId !== "string") {
+    return rep.code(400).send({ error: "bad_request", message: "orgId query param required" });
+  }
+  const rules = await prisma.rule.findMany({
+    where: { orgId },
+    orderBy: { createdAt: "asc" },
+  });
+  return { rules };
+});
+
+app.post("/rules", async (req, rep) => {
+  try {
+    const parsed = normalizeRuleInput(ruleCreateSchema.parse(req.body ?? {}));
+    const created = await prisma.rule.create({
+      data: mapToRulePrismaData(parsed),
+    });
+    return rep.code(201).send(created);
+  } catch (e: any) {
+    req.log.error(e);
+    return rep.code(400).send({ error: "bad_request", message: e.message ?? "invalid payload" });
+  }
+});
+
+app.put("/rules/:id", async (req, rep) => {
+  const params = req.params as { id: string };
+  try {
+    const parsed = normalizeRuleInput(ruleUpdateSchema.parse(req.body ?? {}));
+    const data = mapToRulePrismaData(parsed);
+    if (Object.keys(data).length === 0) {
+      return rep.code(400).send({ error: "bad_request", message: "no fields to update" });
+    }
+    const updated = await prisma.rule.update({
+      where: { id: params.id },
+      data,
+    });
+    return updated;
+  } catch (e: any) {
+    req.log.error(e);
+    return rep.code(400).send({ error: "bad_request", message: e.message ?? "invalid payload" });
+  }
+});
+
+app.delete("/rules/:id", async (req, rep) => {
+  const params = req.params as { id: string };
+  await prisma.rule.delete({ where: { id: params.id } });
+  return rep.code(204).send();
+});
+
+app.post("/rules/apply", async (req, rep) => {
+  try {
+    const parsed = applyRulesSchema.parse(req.body ?? {});
+    const [rules, lines] = await Promise.all([
+      prisma.rule.findMany({ where: { orgId: parsed.orgId }, orderBy: { createdAt: "asc" } }),
+      prisma.bankLine.findMany({ where: { orgId: parsed.orgId, category: null } }),
+    ]);
+
+    const updates: { id: string; category: string }[] = [];
+    for (const line of lines) {
+      for (const rule of rules) {
+        const matches = matchRule(
+          { amount: line.amount.toNumber(), payee: line.payee, desc: line.desc },
+          {
+            payeeRegex: rule.payeeRegex,
+            minAmount: rule.minAmount?.toNumber(),
+            maxAmount: rule.maxAmount?.toNumber(),
+            containsDesc: rule.containsDesc,
+          },
+        );
+        if (matches) {
+          updates.push({ id: line.id, category: rule.setCategory });
+          break;
+        }
+      }
+    }
+
+    if (updates.length > 0) {
+      await prisma.$transaction(
+        updates.map((update) =>
+          prisma.bankLine.update({ where: { id: update.id }, data: { category: update.category } }),
+        ),
+      );
+    }
+
+    return { updated: updates.length };
+  } catch (e: any) {
+    req.log.error(e);
+    return rep.code(400).send({ error: "bad_request", message: e.message ?? "invalid payload" });
   }
 });
 
@@ -77,4 +325,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/rules.ts
+++ b/apgms/services/api-gateway/src/rules.ts
@@ -1,0 +1,59 @@
+import { Decimal } from "@prisma/client/runtime/library";
+
+export type BankLineLike = {
+  amount: number;
+  payee: string;
+  desc: string;
+};
+
+export type RuleLike = {
+  payeeRegex?: string | null;
+  minAmount?: number | Decimal | null;
+  maxAmount?: number | Decimal | null;
+  containsDesc?: string | null;
+};
+
+const normalizeAmount = (value: number | Decimal | null | undefined): number | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  return value.toNumber();
+};
+
+export function matchRule(line: BankLineLike, rule: RuleLike): boolean {
+  const payee = line.payee ?? "";
+  const desc = line.desc ?? "";
+
+  if (rule.payeeRegex) {
+    try {
+      const regex = new RegExp(rule.payeeRegex);
+      if (!regex.test(payee)) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  const minAmount = normalizeAmount(rule.minAmount);
+  if (minAmount !== undefined && line.amount < minAmount) {
+    return false;
+  }
+
+  const maxAmount = normalizeAmount(rule.maxAmount);
+  if (maxAmount !== undefined && line.amount > maxAmount) {
+    return false;
+  }
+
+  if (rule.containsDesc) {
+    const needle = rule.containsDesc.toLowerCase();
+    if (!desc.toLowerCase().includes(needle)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/apgms/services/api-gateway/test/rules.test.ts
+++ b/apgms/services/api-gateway/test/rules.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { matchRule } from "../src/rules";
+
+test("matches on regex", () => {
+  const line = { amount: 25, payee: "COLES 123", desc: "groceries" };
+  const rule = { payeeRegex: "^COLES" };
+  assert.equal(matchRule(line, rule), true);
+});
+
+test("fails regex when not matching", () => {
+  const line = { amount: 25, payee: "WOOLIES", desc: "groceries" };
+  const rule = { payeeRegex: "^COLES" };
+  assert.equal(matchRule(line, rule), false);
+});
+
+test("handles invalid regex by returning false", () => {
+  const line = { amount: 25, payee: "COLES", desc: "groceries" };
+  const rule = { payeeRegex: "[" };
+  assert.equal(matchRule(line, rule), false);
+});
+
+test("matches with amount bounds", () => {
+  const line = { amount: 50, payee: "ANY", desc: "" };
+  const rule = { minAmount: 10, maxAmount: 100 };
+  assert.equal(matchRule(line, rule), true);
+});
+
+test("rejects below minimum", () => {
+  const line = { amount: 5, payee: "ANY", desc: "" };
+  const rule = { minAmount: 10 };
+  assert.equal(matchRule(line, rule), false);
+});
+
+test("rejects above maximum", () => {
+  const line = { amount: 150, payee: "ANY", desc: "" };
+  const rule = { maxAmount: 100 };
+  assert.equal(matchRule(line, rule), false);
+});
+
+test("matches on description substring case insensitive", () => {
+  const line = { amount: 20, payee: "ANY", desc: "Uber Eats" };
+  const rule = { containsDesc: "uber" };
+  assert.equal(matchRule(line, rule), true);
+});
+
+test("requires all predicates to match", () => {
+  const line = { amount: 20, payee: "Uber BV", desc: "Rides" };
+  const rule = { containsDesc: "ride", payeeRegex: "^Uber", minAmount: 10 };
+  assert.equal(matchRule(line, rule), true);
+});
+
+test("any predicate failing rejects the rule", () => {
+  const line = { amount: 20, payee: "Uber BV", desc: "Rides" };
+  const rule = { containsDesc: "ride", payeeRegex: "^Lyft" };
+  assert.equal(matchRule(line, rule), false);
+});

--- a/apgms/shared/prisma/migrations/20251010133922_add_rules_and_category/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010133922_add_rules_and_category/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "Rule" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "payeeRegex" TEXT,
+    "minAmount" DECIMAL,
+    "maxAmount" DECIMAL,
+    "containsDesc" TEXT,
+    "setCategory" VARCHAR(64) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Rule_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Rule" ADD CONSTRAINT "Rule_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "Rule_orgId_idx" ON "Rule"("orgId");
+
+-- AlterTable
+ALTER TABLE "BankLine" ADD COLUMN "category" VARCHAR(64);
+
+-- CreateIndex
+CREATE INDEX "BankLine_category_idx" ON "BankLine"("category");

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -32,5 +32,24 @@ model BankLine {
   amount    Decimal
   payee     String
   desc      String
+  category  String?  @db.VarChar(64)
   createdAt DateTime @default(now())
+
+  @@index([category])
+}
+
+model Rule {
+  id           String   @id @default(cuid())
+  org          Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
+  name         String
+  payeeRegex   String?
+  minAmount    Decimal?
+  maxAmount    Decimal?
+  containsDesc String?
+  setCategory  String   @db.VarChar(64)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([orgId])
 }


### PR DESCRIPTION
## Summary
- add an optional category to bank lines and a rule model plus migration
- implement rule CRUD and apply endpoints that reuse a shared matcher
- cover matchRule logic with targeted node:test cases

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68eb422acdf48327b061998e4483b36b