### PR TITLE
Implement tax engine event processing and reconciliation

### DIFF
--- a/apgms/services/tax-engine/app/__init__.py
+++ b/apgms/services/tax-engine/app/__init__.py
@@ -1,1 +1,3 @@
-﻿
+from .main import app
+
+__all__ = ["app"]

--- a/apgms/services/tax-engine/app/main.py
+++ b/apgms/services/tax-engine/app/main.py
@@ -1,5 +1,102 @@
-﻿from fastapi import FastAPI
-app = FastAPI()
-@app.get('/health')
-def health():
-    return {'ok': True}
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager, suppress
+
+from fastapi import FastAPI, status
+
+from .processor import EventProcessor
+from .repository import ObligationRepository
+from .rules.gst import GSTRuleSet
+from .rules.paygw import PaygwRuleSet
+from .schemas import (
+    EventType,
+    ObligationCollection,
+    PosEvent,
+    PayrollEvent,
+    QueuedEvent,
+    ReconciliationRequest,
+    ReconciliationResponse,
+    serialize_discrepancies,
+    serialize_obligations,
+)
+
+
+async def _event_consumer(queue: asyncio.Queue[QueuedEvent | None], processor: EventProcessor) -> None:
+    while True:
+        queued = await queue.get()
+        if queued is None:
+            queue.task_done()
+            break
+        try:
+            await processor.process_event(queued)
+        finally:
+            queue.task_done()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    queue: asyncio.Queue[QueuedEvent | None] = asyncio.Queue()
+    repository = ObligationRepository()
+    processor = EventProcessor(repository, PaygwRuleSet(), GSTRuleSet())
+    worker = asyncio.create_task(_event_consumer(queue, processor))
+    app.state.queue = queue
+    app.state.repository = repository
+    app.state.processor = processor
+    try:
+        yield
+    finally:
+        await queue.put(None)
+        await queue.join()
+        worker.cancel()
+        with suppress(asyncio.CancelledError):
+            await worker
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@app.post("/events/payroll", status_code=status.HTTP_202_ACCEPTED)
+async def queue_payroll_event(event: PayrollEvent) -> dict[str, str]:
+    await app.state.queue.put(QueuedEvent(EventType.PAYROLL, event))
+    return {"status": "queued"}
+
+
+@app.post("/events/pos", status_code=status.HTTP_202_ACCEPTED)
+async def queue_pos_event(event: PosEvent) -> dict[str, str]:
+    await app.state.queue.put(QueuedEvent(EventType.POS, event))
+    return {"status": "queued"}
+
+
+@app.post("/events/flush")
+async def flush_events() -> dict[str, str]:
+    await app.state.queue.join()
+    return {"status": "flushed"}
+
+
+@app.get("/obligations", response_model=ObligationCollection)
+async def get_obligations() -> ObligationCollection:
+    repository: ObligationRepository = app.state.repository
+    return ObligationCollection(
+        obligations=serialize_obligations(repository.all_snapshots())
+    )
+
+
+@app.post("/reconcile", response_model=ReconciliationResponse)
+async def reconcile_accounts(request: ReconciliationRequest) -> ReconciliationResponse:
+    repository: ObligationRepository = app.state.repository
+    discrepancies = repository.reconcile(request.account_balances)
+    return ReconciliationResponse(discrepancies=serialize_discrepancies(discrepancies))
+
+
+@app.get("/discrepancies", response_model=ReconciliationResponse)
+async def list_discrepancies() -> ReconciliationResponse:
+    repository: ObligationRepository = app.state.repository
+    return ReconciliationResponse(
+        discrepancies=serialize_discrepancies(repository.list_discrepancies())
+    )

--- a/apgms/services/tax-engine/app/processor.py
+++ b/apgms/services/tax-engine/app/processor.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from .repository import ObligationRepository
+from .rules.gst import GSTRuleSet
+from .rules.paygw import PaygwRuleSet
+from .schemas import EventType, PosEvent, PayrollEvent, QueuedEvent, TaxType
+
+
+class EventProcessor:
+    """Applies tax rules to queued events and records obligations."""
+
+    def __init__(
+        self,
+        repository: ObligationRepository,
+        paygw_rules: PaygwRuleSet,
+        gst_rules: GSTRuleSet,
+    ) -> None:
+        self._repository = repository
+        self._paygw_rules = paygw_rules
+        self._gst_rules = gst_rules
+
+    async def process_event(self, event: QueuedEvent) -> None:
+        if event.type is EventType.PAYROLL:
+            payroll_event = event.payload
+            assert isinstance(payroll_event, PayrollEvent)
+            self._process_payroll_event(payroll_event)
+        elif event.type is EventType.POS:
+            pos_event = event.payload
+            assert isinstance(pos_event, PosEvent)
+            self._process_pos_event(pos_event)
+        else:
+            raise ValueError(f"Unknown event type {event.type}")
+
+    def _process_payroll_event(self, event: PayrollEvent) -> None:
+        withholding = self._paygw_rules.calculate_withholding(event.gross_pay)
+        context = {
+            "employee_id": event.employee_id,
+            "pay_period_ending": event.pay_period_ending.isoformat(),
+        }
+        self._repository.add_obligation(
+            entity_id=event.employer_id,
+            tax_type=TaxType.PAYGW,
+            amount=withholding,
+            context=context,
+        )
+
+    def _process_pos_event(self, event: PosEvent) -> None:
+        gst_amount = self._gst_rules.calculate_gst(
+            sale_amount=event.sale_amount,
+            gst_free=event.gst_free,
+            tax_rate_override=event.tax_rate_override,
+        )
+        context = {"gst_free": str(event.gst_free)}
+        self._repository.add_obligation(
+            entity_id=event.business_id,
+            tax_type=TaxType.GST,
+            amount=gst_amount,
+            context=context,
+        )
+
+
+__all__ = ["EventProcessor"]

--- a/apgms/services/tax-engine/app/repository.py
+++ b/apgms/services/tax-engine/app/repository.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from decimal import Decimal
+from typing import Dict, Iterable, List, Tuple
+
+from .schemas import (
+    AccountBalance,
+    DiscrepancyRecord,
+    ObligationSnapshot,
+    TaxType,
+)
+
+
+class ObligationRepository:
+    """In-memory persistence layer representing the shared database."""
+
+    def __init__(self) -> None:
+        self._obligations: Dict[Tuple[str, TaxType], ObligationSnapshot] = {}
+        self._discrepancies: List[DiscrepancyRecord] = []
+
+    def add_obligation(
+        self,
+        entity_id: str,
+        tax_type: TaxType,
+        amount: Decimal,
+        *,
+        context: Dict[str, str] | None = None,
+    ) -> ObligationSnapshot:
+        key = (entity_id, tax_type)
+        snapshot = self._obligations.get(key)
+        if snapshot is None:
+            snapshot = ObligationSnapshot(entity_id=entity_id, tax_type=tax_type)
+            self._obligations[key] = snapshot
+        snapshot.total_amount += amount
+        if context:
+            snapshot.details.update(context)
+        return snapshot
+
+    def all_snapshots(self) -> Iterable[ObligationSnapshot]:
+        return list(self._obligations.values())
+
+    def reconcile(self, balances: Iterable[AccountBalance]) -> List[DiscrepancyRecord]:
+        balance_map: Dict[Tuple[str, TaxType], Decimal] = defaultdict(lambda: Decimal("0"))
+        for balance in balances:
+            balance_map[(balance.entity_id, balance.tax_type)] = balance.balance
+
+        discrepancies: List[DiscrepancyRecord] = []
+        for key, snapshot in self._obligations.items():
+            expected = snapshot.total_amount
+            actual = balance_map.get(key, Decimal("0"))
+            if expected != actual:
+                discrepancy = DiscrepancyRecord(
+                    entity_id=snapshot.entity_id,
+                    tax_type=snapshot.tax_type,
+                    expected_amount=expected,
+                    actual_amount=actual,
+                    difference=expected - actual,
+                    context=snapshot.details.copy(),
+                )
+                self._discrepancies.append(discrepancy)
+                discrepancies.append(discrepancy)
+        # Detect extra balances without obligations
+        for key, balance in balance_map.items():
+            if key not in self._obligations and balance != Decimal("0"):
+                entity_id, tax_type = key
+                discrepancy = DiscrepancyRecord(
+                    entity_id=entity_id,
+                    tax_type=tax_type,
+                    expected_amount=Decimal("0"),
+                    actual_amount=balance,
+                    difference=Decimal("0") - balance,
+                    context={"note": "No obligation recorded"},
+                )
+                self._discrepancies.append(discrepancy)
+                discrepancies.append(discrepancy)
+        return discrepancies
+
+    def list_discrepancies(self) -> List[DiscrepancyRecord]:
+        return list(self._discrepancies)
+
+
+__all__ = ["ObligationRepository"]

--- a/apgms/services/tax-engine/app/rules/gst.py
+++ b/apgms/services/tax-engine/app/rules/gst.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict
+
+
+@dataclass(slots=True)
+class GstCategory:
+    name: str
+    rate: Decimal
+
+
+class GSTRuleSet:
+    """GST calculation rules for POS events."""
+
+    def __init__(self, categories: Dict[str, GstCategory] | None = None, default_rate: Decimal | None = None) -> None:
+        self._categories = categories or {
+            "standard": GstCategory(name="standard", rate=Decimal("0.1")),
+            "reduced": GstCategory(name="reduced", rate=Decimal("0.05")),
+        }
+        self._default_rate = default_rate if default_rate is not None else Decimal("0.1")
+
+    def calculate_gst(self, sale_amount: Decimal, gst_free: bool = False, tax_rate_override: Decimal | None = None) -> Decimal:
+        if sale_amount < Decimal("0"):
+            raise ValueError("Sale amount cannot be negative")
+        if gst_free:
+            return Decimal("0.00")
+        rate = self._default_rate
+        if tax_rate_override is not None:
+            rate = tax_rate_override
+        rate = rate.quantize(Decimal("0.0001"))
+        gst_amount = sale_amount * rate / (Decimal("1") + rate)
+        return gst_amount.quantize(Decimal("0.01"))
+
+    def rate_for_category(self, category: str) -> Decimal:
+        if category not in self._categories:
+            raise KeyError(f"Unknown GST category '{category}'")
+        return self._categories[category].rate
+
+
+__all__ = ["GSTRuleSet", "GstCategory"]

--- a/apgms/services/tax-engine/app/rules/paygw.py
+++ b/apgms/services/tax-engine/app/rules/paygw.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, List
+
+
+@dataclass(slots=True)
+class PaygwBracket:
+    threshold: Decimal
+    rate: Decimal
+    fixed: Decimal = Decimal("0")
+
+
+class PaygwRuleSet:
+    """Encapsulates PAYGW withholding rules for payroll events."""
+
+    def __init__(self, brackets: Iterable[PaygwBracket] | None = None) -> None:
+        self._brackets: List[PaygwBracket] = sorted(
+            brackets if brackets is not None else self._default_brackets(),
+            key=lambda bracket: bracket.threshold,
+        )
+
+    @staticmethod
+    def _default_brackets() -> List[PaygwBracket]:
+        return [
+            PaygwBracket(threshold=Decimal("0"), rate=Decimal("0.1")),
+            PaygwBracket(threshold=Decimal("1000"), rate=Decimal("0.2"), fixed=Decimal("100")),
+            PaygwBracket(threshold=Decimal("3000"), rate=Decimal("0.3"), fixed=Decimal("500")),
+        ]
+
+    def calculate_withholding(self, gross_pay: Decimal) -> Decimal:
+        if gross_pay < Decimal("0"):
+            raise ValueError("Gross pay cannot be negative")
+        bracket = self._brackets[0]
+        for candidate in self._brackets:
+            if gross_pay >= candidate.threshold:
+                bracket = candidate
+            else:
+                break
+        taxable_portion = gross_pay - bracket.threshold
+        if taxable_portion < Decimal("0"):
+            taxable_portion = Decimal("0")
+        withholding = bracket.fixed + taxable_portion * bracket.rate
+        return withholding.quantize(Decimal("0.01"))
+
+
+__all__ = ["PaygwRuleSet", "PaygwBracket"]

--- a/apgms/services/tax-engine/app/schemas.py
+++ b/apgms/services/tax-engine/app/schemas.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Dict, Iterable, List
+
+from pydantic import BaseModel, Field
+
+
+class TaxType(str, Enum):
+    """Supported obligation types within the tax engine."""
+
+    PAYGW = "PAYGW"
+    GST = "GST"
+
+
+class EventType(str, Enum):
+    """Types of queued events the engine can consume."""
+
+    PAYROLL = "payroll"
+    POS = "pos"
+
+
+class PayrollEvent(BaseModel):
+    """Inbound payroll event reported by payroll integrations."""
+
+    employer_id: str = Field(..., description="Identifier of the employing entity")
+    employee_id: str = Field(..., description="Identifier of the employee")
+    gross_pay: Decimal = Field(..., ge=Decimal("0"), description="Gross pay for the period")
+    pay_period_ending: date = Field(..., description="Date the pay period ends")
+
+
+class PosEvent(BaseModel):
+    """Inbound point-of-sale event for GST calculations."""
+
+    business_id: str = Field(..., description="Identifier for the business entity")
+    sale_amount: Decimal = Field(
+        ..., ge=Decimal("0"), description="Total sale amount including any GST"
+    )
+    gst_free: bool = Field(
+        False, description="Whether the sale item is GST-free (e.g. basic food)"
+    )
+    tax_rate_override: Decimal | None = Field(
+        None,
+        ge=Decimal("0"),
+        description="Optional override for GST rate for special categories",
+    )
+
+
+@dataclass(slots=True)
+class QueuedEvent:
+    """Wrapper for queued inbound events."""
+
+    type: EventType
+    payload: BaseModel
+
+
+@dataclass(slots=True)
+class ObligationSnapshot:
+    """Current obligation state for a tax type and entity."""
+
+    entity_id: str
+    tax_type: TaxType
+    total_amount: Decimal = field(default=Decimal("0"))
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["total_amount"] = str(self.total_amount)
+        payload["tax_type"] = self.tax_type.value
+        return payload
+
+
+@dataclass(slots=True)
+class DiscrepancyRecord:
+    """Recorded mismatch between calculated obligations and ledger balances."""
+
+    entity_id: str
+    tax_type: TaxType
+    expected_amount: Decimal
+    actual_amount: Decimal
+    difference: Decimal
+    context: Dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["expected_amount"] = str(self.expected_amount)
+        payload["actual_amount"] = str(self.actual_amount)
+        payload["difference"] = str(self.difference)
+        payload["tax_type"] = self.tax_type.value
+        return payload
+
+
+class AccountBalance(BaseModel):
+    """Reported balance for a tax-designated ledger account."""
+
+    entity_id: str
+    tax_type: TaxType
+    balance: Decimal
+    reference: str | None = None
+
+
+class ReconciliationRequest(BaseModel):
+    """Request payload for performing reconciliation."""
+
+    account_balances: List[AccountBalance]
+
+
+class ReconciliationResponse(BaseModel):
+    """Response payload for reconciliation results."""
+
+    discrepancies: List[Dict[str, Any]]
+
+
+class ObligationCollection(BaseModel):
+    """Response payload for listing obligation snapshots."""
+
+    obligations: List[Dict[str, Any]]
+
+
+def serialize_discrepancies(records: Iterable[DiscrepancyRecord]) -> List[Dict[str, Any]]:
+    return [record.as_dict() for record in records]
+
+
+def serialize_obligations(records: Iterable[ObligationSnapshot]) -> List[Dict[str, Any]]:
+    return [record.as_dict() for record in records]

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,11 @@
-﻿[tool.poetry]
-name='apgms-tax-engine'
-version='0.1.0'
+[tool.poetry]
+name = "apgms-tax-engine"
+version = "0.1.0"
+
 [tool.poetry.dependencies]
-python='^3.10'
-fastapi='*'
-uvicorn='*'
+python = "^3.10"
+fastapi = "*"
+uvicorn = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"

--- a/apgms/services/tax-engine/tests/conftest.py
+++ b/apgms/services/tax-engine/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/apgms/services/tax-engine/tests/test_app.py
+++ b/apgms/services/tax-engine/tests/test_app.py
@@ -1,0 +1,87 @@
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas import ReconciliationRequest, TaxType
+
+
+def test_event_processing_and_reconciliation() -> None:
+    with TestClient(app) as client:
+        payroll_payload = {
+            "employer_id": "EMP-001",
+            "employee_id": "E-123",
+            "gross_pay": "2500.00",
+            "pay_period_ending": "2023-06-30",
+        }
+        response = client.post("/events/payroll", json=payroll_payload)
+        assert response.status_code == 202
+
+        pos_payload = {
+            "business_id": "EMP-001",
+            "sale_amount": "220.00",
+            "gst_free": False,
+        }
+        response = client.post("/events/pos", json=pos_payload)
+        assert response.status_code == 202
+
+        flush_response = client.post("/events/flush")
+        assert flush_response.status_code == 200
+
+        obligations_response = client.get("/obligations")
+        assert obligations_response.status_code == 200
+        obligations = obligations_response.json()["obligations"]
+        assert len(obligations) == 2
+
+        paygw_snapshot = next(
+            snap for snap in obligations if snap["tax_type"] == TaxType.PAYGW.value
+        )
+        gst_snapshot = next(
+            snap for snap in obligations if snap["tax_type"] == TaxType.GST.value
+        )
+
+        assert paygw_snapshot["entity_id"] == "EMP-001"
+        assert Decimal(paygw_snapshot["total_amount"]) > Decimal("0")
+        assert gst_snapshot["entity_id"] == "EMP-001"
+        assert Decimal(gst_snapshot["total_amount"]) == Decimal("20.00")
+
+        request = ReconciliationRequest(
+            account_balances=[
+                {
+                    "entity_id": "EMP-001",
+                    "tax_type": TaxType.PAYGW,
+                    "balance": Decimal(paygw_snapshot["total_amount"]),
+                },
+                {
+                    "entity_id": "EMP-001",
+                    "tax_type": TaxType.GST,
+                    "balance": Decimal("20.00"),
+                },
+            ]
+        )
+        reconcile_response = client.post(
+            "/reconcile", json=request.model_dump(mode="json")
+        )
+        assert reconcile_response.status_code == 200
+        assert reconcile_response.json()["discrepancies"] == []
+
+        mismatched_request = ReconciliationRequest(
+            account_balances=[
+                {
+                    "entity_id": "EMP-001",
+                    "tax_type": TaxType.PAYGW,
+                    "balance": Decimal("0"),
+                }
+            ]
+        )
+        mismatch_response = client.post(
+            "/reconcile", json=mismatched_request.model_dump(mode="json")
+        )
+        assert mismatch_response.status_code == 200
+        discrepancies = mismatch_response.json()["discrepancies"]
+        assert len(discrepancies) == 1
+        assert discrepancies[0]["tax_type"] == TaxType.PAYGW.value
+
+        discrepancy_list_response = client.get("/discrepancies")
+        assert discrepancy_list_response.status_code == 200
+        assert len(discrepancy_list_response.json()["discrepancies"]) >= 1

--- a/apgms/services/tax-engine/tests/test_rules.py
+++ b/apgms/services/tax-engine/tests/test_rules.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+
+import pytest
+
+from app.rules.gst import GSTRuleSet
+from app.rules.paygw import PaygwBracket, PaygwRuleSet
+
+
+def test_paygw_default_brackets_progressive() -> None:
+    rules = PaygwRuleSet()
+    assert rules.calculate_withholding(Decimal("500")) == Decimal("50.00")
+    assert rules.calculate_withholding(Decimal("1500")) == Decimal("320.00")
+    assert rules.calculate_withholding(Decimal("4000")) == Decimal("800.00")
+
+
+def test_paygw_custom_brackets() -> None:
+    brackets = [
+        PaygwBracket(threshold=Decimal("0"), rate=Decimal("0.05")),
+        PaygwBracket(threshold=Decimal("2000"), rate=Decimal("0.1"), fixed=Decimal("150")),
+    ]
+    rules = PaygwRuleSet(brackets)
+    assert rules.calculate_withholding(Decimal("1000")) == Decimal("50.00")
+    assert rules.calculate_withholding(Decimal("3000")) == Decimal("350.00")
+
+
+def test_gst_standard_rate() -> None:
+    rules = GSTRuleSet()
+    gst_amount = rules.calculate_gst(Decimal("110.00"))
+    assert gst_amount == Decimal("10.00")
+
+
+def test_gst_free_sale() -> None:
+    rules = GSTRuleSet()
+    assert rules.calculate_gst(Decimal("100.00"), gst_free=True) == Decimal("0.00")
+
+
+def test_gst_override_rate() -> None:
+    rules = GSTRuleSet()
+    assert rules.calculate_gst(
+        Decimal("105.00"), tax_rate_override=Decimal("0.05")
+    ) == Decimal("5.00")
+
+
+def test_gst_negative_sale_amount_raises() -> None:
+    rules = GSTRuleSet()
+    with pytest.raises(ValueError):
+        rules.calculate_gst(Decimal("-1"))
+
+
+def test_paygw_negative_gross_pay_raises() -> None:
+    rules = PaygwRuleSet()
+    with pytest.raises(ValueError):
+        rules.calculate_withholding(Decimal("-1"))


### PR DESCRIPTION
## Summary
- add a FastAPI application lifecycle with background workers that consume payroll and POS events, update obligation snapshots, and expose reconciliation endpoints
- externalize PAYGW and GST calculations into configurable rule modules and persist obligation state through a repository abstraction
- cover rule logic and end-to-end flows with new tests and provide project metadata for local execution

## Testing
- pytest services/tax-engine/tests -q *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68f297a7e2dc8327b00c22285781407f