### PR TITLE
Implement connectors webhooks and event queue

### DIFF
--- a/apgms/services/connectors/package.json
+++ b/apgms/services/connectors/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@apgms/connectors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/webhooks.test.ts"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "@fastify/cors": "^11.1.0",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,16 @@
-﻿console.log('connectors service');
+import { buildServer } from "./server.js";
+
+async function start() {
+  const server = await buildServer();
+  const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+
+  try {
+    await server.listen({ port, host: "0.0.0.0" });
+    server.log.info(`Connectors service listening on port ${port}`);
+  } catch (error) {
+    server.log.error({ err: error }, "Failed to start connectors service");
+    process.exit(1);
+  }
+}
+
+void start();

--- a/apgms/services/connectors/src/server.ts
+++ b/apgms/services/connectors/src/server.ts
@@ -1,0 +1,178 @@
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
+import cors from "@fastify/cors";
+import { z, type ZodTypeAny } from "zod";
+import type { PrismaClient } from "@prisma/client";
+import { CONNECTOR_SOURCES, type ConnectorSource } from "@apgms/shared/connectors";
+import type { TaxEngineEvent, TaxEventQueue } from "@apgms/shared/queue";
+
+const payrollRunSchema = z.object({
+  runId: z.string(),
+  orgId: z.string(),
+  payPeriod: z.object({
+    start: z.string(),
+    end: z.string(),
+  }),
+  totalGross: z.number().nonnegative(),
+  employees: z.array(
+    z.object({
+      employeeId: z.string(),
+      grossPay: z.number(),
+      netPay: z.number().optional(),
+    })
+  ),
+});
+
+const posTransactionSchema = z.object({
+  transactionId: z.string(),
+  locationId: z.string(),
+  occurredAt: z.string(),
+  total: z.number(),
+  tax: z.number().optional(),
+  items: z.array(
+    z.object({
+      sku: z.string(),
+      quantity: z.number().int(),
+      price: z.number(),
+    })
+  ),
+});
+
+export interface ConnectorEventInput {
+  source: ConnectorSource;
+  type: string;
+  payload: unknown;
+}
+
+export interface ConnectorEventRecord extends ConnectorEventInput {
+  id: string;
+  receivedAt: Date;
+}
+
+export interface StagingRepository {
+  saveEvent(event: ConnectorEventInput): Promise<ConnectorEventRecord>;
+}
+
+export interface EventPublisher {
+  publish(event: TaxEngineEvent): Promise<void>;
+}
+
+type PrismaConnectorEventDelegate = {
+  create(args: { data: ConnectorEventInput }): Promise<{
+    id: string;
+    source: ConnectorSource;
+    type: string;
+    payload: unknown;
+    receivedAt: Date;
+  }>;
+};
+
+export const createStagingRepository = (client: PrismaClient): StagingRepository => {
+  const delegate = (client as unknown as { connectorEvent: PrismaConnectorEventDelegate }).connectorEvent;
+
+  return {
+    async saveEvent(event) {
+      const record = await delegate.create({ data: event });
+      return {
+        id: record.id,
+        source: record.source,
+        type: record.type,
+        payload: record.payload,
+        receivedAt: record.receivedAt,
+      };
+    },
+  };
+};
+
+export const createQueuePublisher = (queue: TaxEventQueue): EventPublisher => ({
+  async publish(event) {
+    queue.publish(event);
+  },
+});
+
+export interface BuildServerOptions {
+  stagingRepo?: StagingRepository;
+  publisher?: EventPublisher;
+}
+
+type WebhookRequest = FastifyRequest<{ Body: unknown }>;
+
+type WebhookHandlerMeta = {
+  source: ConnectorSource;
+  type: string;
+};
+
+async function handleWebhook(
+  request: WebhookRequest,
+  reply: FastifyReply,
+  schema: ZodTypeAny,
+  meta: WebhookHandlerMeta,
+  stagingRepo: StagingRepository,
+  publisher: EventPublisher
+) {
+  const validation = schema.safeParse(request.body);
+  if (!validation.success) {
+    return reply.status(400).send({
+      message: "Invalid payload",
+      issues: validation.error.issues,
+    });
+  }
+
+  try {
+    const saved = await stagingRepo.saveEvent({
+      source: meta.source,
+      type: meta.type,
+      payload: validation.data,
+    });
+
+    await publisher.publish({
+      id: saved.id,
+      source: saved.source,
+      type: saved.type,
+      payload: validation.data,
+      receivedAt: saved.receivedAt,
+    });
+
+    return reply.status(202).send({ id: saved.id });
+  } catch (error) {
+    request.log.error({ err: error }, "Failed to process webhook payload");
+    return reply.status(500).send({ message: "Failed to process webhook" });
+  }
+}
+
+export async function buildServer(options: BuildServerOptions = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true });
+  await app.register(cors, { origin: true });
+
+  let stagingRepo = options.stagingRepo;
+  let publisher = options.publisher;
+
+  if (!stagingRepo || !publisher) {
+    const shared = await import("@apgms/shared");
+    stagingRepo = stagingRepo ?? createStagingRepository(shared.prisma);
+    publisher = publisher ?? createQueuePublisher(shared.taxEventQueue);
+  }
+
+  app.post("/webhooks/payroll", (request, reply) =>
+    handleWebhook(
+      request,
+      reply,
+      payrollRunSchema,
+      { source: CONNECTOR_SOURCES.PAYROLL, type: "payroll.run" },
+      stagingRepo!,
+      publisher!
+    )
+  );
+
+  app.post("/webhooks/pos", (request, reply) =>
+    handleWebhook(
+      request,
+      reply,
+      posTransactionSchema,
+      { source: CONNECTOR_SOURCES.POS, type: "pos.transaction" },
+      stagingRepo!,
+      publisher!
+    )
+  );
+
+  return app;
+}

--- a/apgms/services/connectors/test/webhooks.test.ts
+++ b/apgms/services/connectors/test/webhooks.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildServer, type ConnectorEventRecord, type StagingRepository } from "../src/server.js";
+import { InMemoryTaxEventQueue } from "@apgms/shared/queue";
+
+type TestContext = {
+  queue: InMemoryTaxEventQueue;
+  savedEvents: ConnectorEventRecord[];
+  server: Awaited<ReturnType<typeof buildServer>>;
+};
+
+async function createTestContext(): Promise<TestContext> {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "postgresql://user:pass@localhost:5432/db";
+
+  const savedEvents: ConnectorEventRecord[] = [];
+  const queue = new InMemoryTaxEventQueue();
+
+  const stagingRepo: StagingRepository = {
+    async saveEvent(event) {
+      const record: ConnectorEventRecord = {
+        id: `evt_${savedEvents.length + 1}`,
+        receivedAt: new Date(),
+        ...event,
+      };
+      savedEvents.push(record);
+      return record;
+    },
+  };
+
+  const server = await buildServer({
+    stagingRepo,
+    publisher: {
+      async publish(event) {
+        queue.publish(event);
+      },
+    },
+  });
+
+  await server.ready();
+
+  return { queue, savedEvents, server };
+}
+
+test("connector webhooks persist and enqueue events", async (t) => {
+  await t.test("persists payroll runs and publishes to the queue", async () => {
+    const ctx = await createTestContext();
+
+    const payload = {
+      runId: "run-123",
+      orgId: "org-42",
+      payPeriod: { start: "2024-01-01", end: "2024-01-15" },
+      totalGross: 120000,
+      employees: [
+        { employeeId: "emp-1", grossPay: 60000 },
+        { employeeId: "emp-2", grossPay: 60000 },
+      ],
+    };
+
+    const response = await ctx.server.inject({
+      method: "POST",
+      url: "/webhooks/payroll",
+      payload,
+    });
+
+    assert.equal(response.statusCode, 202);
+    assert.equal(ctx.savedEvents.length, 1);
+    assert.equal(ctx.savedEvents[0].source, "PAYROLL");
+    assert.deepEqual(ctx.savedEvents[0].payload, payload);
+
+    const events = ctx.queue.getEvents();
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], {
+      id: ctx.savedEvents[0].id,
+      source: "PAYROLL",
+      type: "payroll.run",
+      payload,
+      receivedAt: ctx.savedEvents[0].receivedAt,
+    });
+
+    await ctx.server.close();
+  });
+
+  await t.test("persists POS transactions and publishes to the queue", async () => {
+    const ctx = await createTestContext();
+
+    const payload = {
+      transactionId: "txn-77",
+      locationId: "loc-9",
+      occurredAt: "2024-04-01T12:04:00Z",
+      total: 155.4,
+      tax: 14.6,
+      items: [
+        { sku: "coffee", quantity: 2, price: 5.2 },
+        { sku: "sandwich", quantity: 3, price: 25 },
+      ],
+    };
+
+    const response = await ctx.server.inject({
+      method: "POST",
+      url: "/webhooks/pos",
+      payload,
+    });
+
+    assert.equal(response.statusCode, 202);
+    assert.equal(ctx.savedEvents.length, 1);
+    assert.equal(ctx.savedEvents[0].source, "POS");
+
+    const events = ctx.queue.getEvents();
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], {
+      id: ctx.savedEvents[0].id,
+      source: "POS",
+      type: "pos.transaction",
+      payload,
+      receivedAt: ctx.savedEvents[0].receivedAt,
+    });
+
+    await ctx.server.close();
+  });
+});

--- a/apgms/services/connectors/tsconfig.json
+++ b/apgms/services/connectors/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "baseUrl": "../../",
+    "paths": {
+      "@apgms/shared": ["shared/src/index.ts"],
+      "@apgms/shared/*": ["shared/src/*"]
+    }
+  },
+  "include": ["src", "test"]
+}

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,16 +1,17 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model Org {
-  id        String   @id @default(cuid())
+  id        String     @id @default(cuid())
   name      String
-  createdAt DateTime @default(now())
+  createdAt DateTime   @default(now())
   users     User[]
   lines     BankLine[]
 }
@@ -33,4 +34,17 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+}
+
+model ConnectorEvent {
+  id         String           @id @default(cuid())
+  source     ConnectorSource
+  type       String
+  payload    Json
+  receivedAt DateTime         @default(now())
+}
+
+enum ConnectorSource {
+  PAYROLL
+  POS
 }

--- a/apgms/shared/src/connectors.ts
+++ b/apgms/shared/src/connectors.ts
@@ -1,0 +1,6 @@
+export const CONNECTOR_SOURCES = {
+  PAYROLL: "PAYROLL",
+  POS: "POS",
+} as const;
+
+export type ConnectorSource = (typeof CONNECTOR_SOURCES)[keyof typeof CONNECTOR_SOURCES];

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,5 @@
-﻿import { PrismaClient } from "@prisma/client";
+import pkg from "@prisma/client";
+
+const { PrismaClient } = pkg;
+
 export const prisma = new PrismaClient();

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,3 @@
-﻿// shared
+export * from "./connectors";
+export * from "./db";
+export * from "./queue";

--- a/apgms/shared/src/queue.ts
+++ b/apgms/shared/src/queue.ts
@@ -1,0 +1,45 @@
+import type { ConnectorSource } from "./connectors.js";
+
+export interface TaxEngineEvent {
+  id: string;
+  source: ConnectorSource;
+  type: string;
+  payload: unknown;
+  receivedAt: Date;
+}
+
+export type TaxEngineEventHandler = (event: TaxEngineEvent) => void;
+
+export interface TaxEventQueue {
+  publish(event: TaxEngineEvent): void;
+  subscribe(handler: TaxEngineEventHandler): () => void;
+}
+
+export class InMemoryTaxEventQueue implements TaxEventQueue {
+  private subscribers = new Set<TaxEngineEventHandler>();
+  private events: TaxEngineEvent[] = [];
+
+  publish(event: TaxEngineEvent): void {
+    this.events.push(event);
+    for (const handler of this.subscribers) {
+      handler(event);
+    }
+  }
+
+  subscribe(handler: TaxEngineEventHandler): () => void {
+    this.subscribers.add(handler);
+    return () => {
+      this.subscribers.delete(handler);
+    };
+  }
+
+  getEvents(): TaxEngineEvent[] {
+    return [...this.events];
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+}
+
+export const taxEventQueue = new InMemoryTaxEventQueue();


### PR DESCRIPTION
## Summary
- extend the shared Prisma schema with a connector events staging table and expose connector/tax queue utilities
- stand up the connectors Fastify server to accept payroll and POS webhook payloads, persisting and publishing staged events
- add node:test integration coverage that exercises webhook ingestion, staging persistence, and queue publication

## Testing
- pnpm --filter @apgms/connectors test

------
https://chatgpt.com/codex/tasks/task_e_68f2979db058832788d74d74a9b569ea