### PR TITLE
feat: add settlement compliance models

### DIFF
--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,4 +1,5 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
+
 const prisma = new PrismaClient();
 
 async function main() {
@@ -17,15 +18,117 @@ async function main() {
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2),
+        amount: new Prisma.Decimal(1250.75),
+        payee: "Acme",
+        desc: "Office fit-out",
+      },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1),
+        amount: new Prisma.Decimal(-299.99),
+        payee: "CloudCo",
+        desc: "Monthly sub",
+      },
+      {
+        orgId: org.id,
+        date: today,
+        amount: new Prisma.Decimal(5000),
+        payee: "Birchal",
+        desc: "Investment received",
+      },
     ],
     skipDuplicates: true,
+  });
+
+  const designatedAccount = await prisma.designatedAccount.upsert({
+    where: { accountNo: "12345678" },
+    update: {
+      label: "Primary Settlement",
+      bankName: "Birchal Bank",
+      status: "ACTIVE",
+    },
+    create: {
+      orgId: org.id,
+      label: "Primary Settlement",
+      accountNo: "12345678",
+      bankName: "Birchal Bank",
+    },
+  });
+
+  await prisma.obligationSnapshot.upsert({
+    where: { id: "demo-obligation-snapshot" },
+    update: {
+      totalObligation: new Prisma.Decimal(8750.5),
+      notes: "Includes pending share issuance fees.",
+    },
+    create: {
+      id: "demo-obligation-snapshot",
+      orgId: org.id,
+      effectiveDate: today,
+      totalObligation: new Prisma.Decimal(8750.5),
+      notes: "Includes pending share issuance fees.",
+    },
+  });
+
+  const settlementInstruction = await prisma.settlementInstruction.upsert({
+    where: { instructionRef: "SI-0001" },
+    update: {
+      designatedAccountId: designatedAccount.id,
+      status: "SENT",
+    },
+    create: {
+      orgId: org.id,
+      designatedAccountId: designatedAccount.id,
+      counterparty: "Birchal Nominees",
+      amount: new Prisma.Decimal(4200),
+      dueDate: new Date(today.getFullYear(), today.getMonth(), today.getDate() + 2),
+      status: "PENDING",
+      instructionRef: "SI-0001",
+    },
+  });
+
+  await prisma.discrepancyEvent.upsert({
+    where: { id: "demo-discrepancy" },
+    update: {
+      instructionId: settlementInstruction.id,
+      resolutionNote: "Awaiting confirmation from counterparty.",
+    },
+    create: {
+      id: "demo-discrepancy",
+      orgId: org.id,
+      instructionId: settlementInstruction.id,
+      description: "Counterparty acknowledgement delayed",
+      severity: "MEDIUM",
+      resolutionNote: "Awaiting confirmation from counterparty.",
+    },
+  });
+
+  await prisma.complianceDocument.upsert({
+    where: { id: "demo-compliance-doc" },
+    update: {
+      expiresAt: new Date(today.getFullYear(), today.getMonth() + 3, today.getDate()),
+    },
+    create: {
+      id: "demo-compliance-doc",
+      orgId: org.id,
+      title: "AFS Licence",
+      documentType: "LICENCE",
+      storageUrl: "https://example.com/docs/afs-licence.pdf",
+      expiresAt: new Date(today.getFullYear(), today.getMonth() + 3, today.getDate()),
+    },
   });
 
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,96 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { prisma } from "../../../shared/src/db";
+
+export async function createApp() {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.get("/designated-accounts", async () => {
+    const accounts = await prisma.designatedAccount.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+    return { accounts };
+  });
+
+  app.get("/obligation-snapshots", async () => {
+    const snapshots = await prisma.obligationSnapshot.findMany({
+      orderBy: { effectiveDate: "desc" },
+    });
+    return { snapshots };
+  });
+
+  app.get("/settlement-instructions", async () => {
+    const instructions = await prisma.settlementInstruction.findMany({
+      orderBy: { dueDate: "asc" },
+    });
+    return { instructions };
+  });
+
+  app.get("/discrepancy-events", async () => {
+    const discrepancies = await prisma.discrepancyEvent.findMany({
+      orderBy: { detectedAt: "desc" },
+    });
+    return { discrepancies };
+  });
+
+  app.get("/compliance-documents", async () => {
+    const documents = await prisma.complianceDocument.findMany({
+      orderBy: { uploadedAt: "desc" },
+    });
+    return { documents };
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,21 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { createApp } from "./app";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await createApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/test/settlements.contract.test.ts
+++ b/apgms/services/api-gateway/test/settlements.contract.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp } from "../src/app";
+import { prisma } from "../../../shared/src/db";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("settlement contract endpoints", () => {
+  it("returns designated accounts", async () => {
+    vi.spyOn(prisma.designatedAccount, "findMany").mockResolvedValue([
+      {
+        id: "acct",
+        orgId: "demo-org",
+        label: "Primary",
+        accountNo: "12345678",
+        bankName: "Birchal Bank",
+        currency: "AUD",
+        status: "ACTIVE",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        updatedAt: new Date("2024-01-02T00:00:00Z"),
+      } as any,
+    ]);
+
+    const app = await createApp();
+    const response = await app.inject({ method: "GET", url: "/designated-accounts" });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      accounts: [
+        expect.objectContaining({
+          id: "acct",
+          accountNo: "12345678",
+          status: "ACTIVE",
+        }),
+      ],
+    });
+    await app.close();
+  });
+
+  it("returns settlement instruction discrepancies", async () => {
+    vi.spyOn(prisma.settlementInstruction, "findMany").mockResolvedValue([
+      {
+        id: "instr",
+        orgId: "demo-org",
+        designatedAccountId: "acct",
+        counterparty: "Birchal Nominees",
+        amount: 4200 as any,
+        currency: "AUD",
+        dueDate: new Date("2024-01-03T00:00:00Z"),
+        status: "PENDING",
+        instructionRef: "SI-0001",
+        createdAt: new Date("2024-01-01T00:00:00Z"),
+        updatedAt: new Date("2024-01-02T00:00:00Z"),
+      } as any,
+    ]);
+
+    vi.spyOn(prisma.discrepancyEvent, "findMany").mockResolvedValue([
+      {
+        id: "disc",
+        orgId: "demo-org",
+        instructionId: "instr",
+        description: "Delayed",
+        severity: "MEDIUM",
+        detectedAt: new Date("2024-01-02T00:00:00Z"),
+        resolvedAt: null,
+        resolutionNote: null,
+      } as any,
+    ]);
+
+    const app = await createApp();
+
+    const instructionsResponse = await app.inject({
+      method: "GET",
+      url: "/settlement-instructions",
+    });
+    expect(instructionsResponse.statusCode).toBe(200);
+    expect(instructionsResponse.json()).toEqual({
+      instructions: [
+        expect.objectContaining({
+          instructionRef: "SI-0001",
+          status: "PENDING",
+        }),
+      ],
+    });
+
+    const discrepancyResponse = await app.inject({
+      method: "GET",
+      url: "/discrepancy-events",
+    });
+    expect(discrepancyResponse.statusCode).toBe(200);
+    expect(discrepancyResponse.json()).toEqual({
+      discrepancies: [
+        expect.objectContaining({
+          description: "Delayed",
+          severity: "MEDIUM",
+        }),
+      ],
+    });
+
+    await app.close();
+  });
+});

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,13 +5,15 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "vitest run"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"
   },
   "devDependencies": {
     "prisma": "6.17.1",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.4"
   }
 }

--- a/apgms/shared/prisma/migrations/20251012140000_compliance_models/migration.sql
+++ b/apgms/shared/prisma/migrations/20251012140000_compliance_models/migration.sql
@@ -1,0 +1,107 @@
+-- CreateEnum
+CREATE TYPE "AccountStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'CLOSED');
+
+-- CreateEnum
+CREATE TYPE "SettlementStatus" AS ENUM ('PENDING', 'SENT', 'SETTLED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "DiscrepancySeverity" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+
+-- CreateTable
+CREATE TABLE "DesignatedAccount" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "accountNo" TEXT NOT NULL,
+    "bankName" TEXT NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'AUD',
+    "status" "AccountStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DesignatedAccount_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ObligationSnapshot" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "effectiveDate" TIMESTAMP(3) NOT NULL,
+    "totalObligation" DECIMAL(65,30) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'AUD',
+    "generatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "notes" TEXT,
+
+    CONSTRAINT "ObligationSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SettlementInstruction" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "designatedAccountId" TEXT,
+    "counterparty" TEXT NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'AUD',
+    "dueDate" TIMESTAMP(3) NOT NULL,
+    "status" "SettlementStatus" NOT NULL DEFAULT 'PENDING',
+    "instructionRef" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SettlementInstruction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DiscrepancyEvent" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "instructionId" TEXT,
+    "description" TEXT NOT NULL,
+    "severity" "DiscrepancySeverity" NOT NULL DEFAULT 'MEDIUM',
+    "detectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "resolvedAt" TIMESTAMP(3),
+    "resolutionNote" TEXT,
+
+    CONSTRAINT "DiscrepancyEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ComplianceDocument" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "documentType" TEXT NOT NULL,
+    "storageUrl" TEXT NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "ComplianceDocument_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DesignatedAccount_accountNo_key" ON "DesignatedAccount"("accountNo");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SettlementInstruction_instructionRef_key" ON "SettlementInstruction"("instructionRef");
+
+-- AddForeignKey
+ALTER TABLE "DesignatedAccount" ADD CONSTRAINT "DesignatedAccount_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ObligationSnapshot" ADD CONSTRAINT "ObligationSnapshot_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SettlementInstruction" ADD CONSTRAINT "SettlementInstruction_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SettlementInstruction" ADD CONSTRAINT "SettlementInstruction_designatedAccountId_fkey" FOREIGN KEY ("designatedAccountId") REFERENCES "DesignatedAccount"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscrepancyEvent" ADD CONSTRAINT "DiscrepancyEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DiscrepancyEvent" ADD CONSTRAINT "DiscrepancyEvent_instructionId_fkey" FOREIGN KEY ("instructionId") REFERENCES "SettlementInstruction"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ComplianceDocument" ADD CONSTRAINT "ComplianceDocument_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -13,6 +13,11 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  designatedAccounts    DesignatedAccount[]
+  obligationSnapshots   ObligationSnapshot[]
+  settlementInstructions SettlementInstruction[]
+  discrepancyEvents     DiscrepancyEvent[]
+  complianceDocuments   ComplianceDocument[]
 }
 
 model User {
@@ -33,4 +38,90 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+}
+
+enum AccountStatus {
+  ACTIVE
+  SUSPENDED
+  CLOSED
+}
+
+enum SettlementStatus {
+  PENDING
+  SENT
+  SETTLED
+  FAILED
+}
+
+enum DiscrepancySeverity {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
+model DesignatedAccount {
+  id          String         @id @default(cuid())
+  org         Org            @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  label       String
+  accountNo   String         @unique
+  bankName    String
+  currency    String         @default("AUD")
+  status      AccountStatus  @default(ACTIVE)
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+  instructions SettlementInstruction[]
+}
+
+model ObligationSnapshot {
+  id              String   @id @default(cuid())
+  org             Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId           String
+  effectiveDate   DateTime
+  totalObligation Decimal
+  currency        String   @default("AUD")
+  generatedAt     DateTime @default(now())
+  notes           String?
+}
+
+model SettlementInstruction {
+  id               String            @id @default(cuid())
+  org              Org               @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId            String
+  designatedAccount DesignatedAccount? @relation(fields: [designatedAccountId], references: [id], onDelete: SetNull)
+  designatedAccountId String?
+  counterparty      String
+  amount            Decimal
+  currency          String            @default("AUD")
+  dueDate           DateTime
+  status            SettlementStatus  @default(PENDING)
+  instructionRef    String            @unique
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  discrepancies     DiscrepancyEvent[]
+}
+
+model DiscrepancyEvent {
+  id             String              @id @default(cuid())
+  org            Org                 @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId          String
+  instruction    SettlementInstruction? @relation(fields: [instructionId], references: [id], onDelete: SetNull)
+  instructionId  String?
+  description    String
+  severity       DiscrepancySeverity @default(MEDIUM)
+  detectedAt     DateTime            @default(now())
+  resolvedAt     DateTime?
+  resolutionNote String?
+}
+
+model ComplianceDocument {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  title       String
+  documentType String
+  storageUrl  String
+  uploadedAt  DateTime @default(now())
+  expiresAt   DateTime?
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,15 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 export const prisma = new PrismaClient();
+
+export type {
+  Org,
+  User,
+  BankLine,
+  DesignatedAccount,
+  ObligationSnapshot,
+  SettlementInstruction,
+  DiscrepancyEvent,
+  ComplianceDocument,
+  Prisma,
+} from "@prisma/client";

--- a/apgms/shared/test/index.test.ts
+++ b/apgms/shared/test/index.test.ts
@@ -1,1 +1,63 @@
-﻿// tests
+import { describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+
+const datamodel = Prisma.dmmf.datamodel;
+
+const getModel = (name: string) =>
+  datamodel.models.find((model) => model.name === name);
+
+const getEnum = (name: string) =>
+  datamodel.enums.find((enumeration) => enumeration.name === name);
+
+describe("shared prisma schema", () => {
+  it("exposes extended compliance models", () => {
+    const requiredModels = [
+      "DesignatedAccount",
+      "ObligationSnapshot",
+      "SettlementInstruction",
+      "DiscrepancyEvent",
+      "ComplianceDocument",
+    ];
+
+    for (const modelName of requiredModels) {
+      const model = getModel(modelName);
+      expect(model, `${modelName} model is missing`).toBeDefined();
+    }
+  });
+
+  it("applies domain specific enumerations", () => {
+    const accountStatus = getEnum("AccountStatus");
+    expect(accountStatus?.values.map((value) => value.name)).toEqual([
+      "ACTIVE",
+      "SUSPENDED",
+      "CLOSED",
+    ]);
+
+    const settlementStatus = getEnum("SettlementStatus");
+    expect(settlementStatus?.values.map((value) => value.name)).toEqual([
+      "PENDING",
+      "SENT",
+      "SETTLED",
+      "FAILED",
+    ]);
+
+    const discrepancySeverity = getEnum("DiscrepancySeverity");
+    expect(discrepancySeverity?.values.map((value) => value.name)).toEqual([
+      "LOW",
+      "MEDIUM",
+      "HIGH",
+      "CRITICAL",
+    ]);
+  });
+
+  it("links settlement instructions to designated accounts and discrepancies", () => {
+    const settlementInstruction = getModel("SettlementInstruction");
+    expect(settlementInstruction?.fields.map((field) => field.name)).toEqual(
+      expect.arrayContaining([
+        "designatedAccountId",
+        "designatedAccount",
+        "discrepancies",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- extend the Prisma schema with compliance-focused models and create a migration to apply them
- expose the new Prisma types, enrich the shared seed data, and add Vitest coverage for the datamodel
- refactor the API gateway into a buildable app with endpoints for the new resources plus contract tests that stub Prisma responses

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @apgms/shared prisma:generate` *(fails: Prisma engines download blocked by 403 in the sandbox)*
- `pnpm --filter @apgms/shared test` *(fails: vitest binary unavailable because registry access is blocked)*
- `pnpm --filter @apgms/api-gateway test` *(fails: vitest binary unavailable because registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68f2979c4c688327b6319bed582133ec