### PR TITLE
Add API key enforcement and payload validation to API gateway

### DIFF
--- a/apgms/docs/security/npm-audit.md
+++ b/apgms/docs/security/npm-audit.md
@@ -1,0 +1,13 @@
+# npm Audit Status
+
+## Summary
+
+Running `pnpm audit` currently fails because the registry (https://registry.npmjs.org/-/npm/v1/security/audits) returns HTTP 403. The request requires authentication tokens that are not available in this environment.
+
+## Next steps
+
+1. Configure the required authentication for the npm registry (e.g. by running `pnpm login` or by populating the appropriate token in `.npmrc`).
+2. Re-run `pnpm audit` once registry access is restored.
+3. Review the generated report and upgrade any vulnerable packages. Document the outcome alongside the remediation steps taken.
+
+Until registry access is restored it is not possible to obtain vulnerability data or automatically apply the recommended upgrades.

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,11 +9,30 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import { z } from "zod";
+import { apiKeyAuthPlugin } from "../../../shared/src/auth";
 import { prisma } from "../../../shared/src/db";
+
+const DEFAULT_BANK_LINE_LIMIT = 20;
+
+const bankLineQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+const createBankLineSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  date: z.coerce.date({ required_error: "date is required" }),
+  amount: z.coerce.number({ required_error: "amount is required" }),
+  payee: z.string().min(1, "payee is required"),
+  desc: z.string().min(1, "desc is required"),
+});
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(apiKeyAuthPlugin, {
+  exemptRoutes: ["/health"],
+});
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -31,37 +50,42 @@ app.get("/users", async () => {
 
 // List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+  const { take } = bankLineQuerySchema.parse(req.query ?? {});
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+    take: take ?? DEFAULT_BANK_LINE_LIMIT,
   });
   return { lines };
 });
 
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
+  const parsedBody = createBankLineSchema.safeParse(req.body);
+
+  if (!parsedBody.success) {
+    return rep.code(400).send({
+      error: "bad_request",
+      message: "Invalid bank line payload",
+      issues: parsedBody.error.format(),
+    });
+  }
+
+  const { orgId, date, amount, payee, desc } = parsedBody.data;
+
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
     const created = await prisma.bankLine.create({
       data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
+        orgId,
+        date,
+        amount,
+        payee,
+        desc,
       },
     });
     return rep.code(201).send(created);
   } catch (e) {
     req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+    return rep.code(500).send({ error: "internal_error" });
   }
 });
 
@@ -77,4 +101,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/shared/src/auth.ts
+++ b/apgms/shared/src/auth.ts
@@ -1,0 +1,59 @@
+import crypto from "node:crypto";
+import type { FastifyPluginAsync } from "fastify";
+
+export interface ApiKeyAuthPluginOptions {
+  apiKey?: string;
+  headerName?: string;
+  exemptRoutes?: string[];
+  exemptMethods?: string[];
+}
+
+const timingSafeEqual = (expected: string, actual: string): boolean => {
+  const expectedBuffer = Buffer.from(expected);
+  const actualBuffer = Buffer.from(actual);
+  if (expectedBuffer.length !== actualBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
+};
+
+export const apiKeyAuthPlugin: FastifyPluginAsync<ApiKeyAuthPluginOptions> = async (
+  fastify,
+  options,
+) => {
+  const {
+    apiKey = process.env.API_GATEWAY_API_KEY ?? process.env.API_KEY,
+    headerName = "x-api-key",
+    exemptRoutes = ["/health"],
+    exemptMethods = ["OPTIONS"],
+  } = options;
+
+  if (!apiKey) {
+    throw new Error(
+      "API key authentication requires an apiKey option or API_GATEWAY_API_KEY / API_KEY environment variable.",
+    );
+  }
+
+  const normalizedHeader = headerName.toLowerCase();
+  const routes = new Set(exemptRoutes);
+  const methods = new Set(exemptMethods.map((method) => method.toUpperCase()));
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    const routeUrl = request.routeOptions?.url;
+
+    if ((routeUrl && routes.has(routeUrl)) || methods.has(request.method.toUpperCase())) {
+      return;
+    }
+
+    const providedHeader = request.headers[normalizedHeader];
+    const providedValue = Array.isArray(providedHeader) ? providedHeader[0] : providedHeader;
+
+    if (typeof providedValue !== "string" || providedValue.length === 0) {
+      return reply.code(401).send({ error: "unauthorized", message: "Missing API key" });
+    }
+
+    if (!timingSafeEqual(apiKey, providedValue)) {
+      return reply.code(403).send({ error: "forbidden", message: "Invalid API key" });
+    }
+  });
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./auth";
+export * from "./db";


### PR DESCRIPTION
## Summary
- add a reusable Fastify plugin for enforcing API key authentication across services
- apply the auth plugin to the API gateway and validate request payloads with zod
- document the current inability to run `pnpm audit` because the npm registry requires authentication

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f2eafd06f88327a0385b89cd29eb60