### PR TITLE
feat: introduce shared logger and harden service error handling

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,46 +9,76 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { prisma, createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "api-gateway", module: "bootstrap" });
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+logger.info("Environment configuration loaded", {
+  hasDatabaseUrl: Boolean(process.env.DATABASE_URL),
+});
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
+app.get("/users", async (req) => {
+  const routeLogger = logger.child({ module: "list-users" });
+  try {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    routeLogger.debug("Fetched users", { count: users.length });
+    return { users };
+  } catch (error) {
+    routeLogger.error("Failed to fetch users", error as Error);
+    req.log.error({ err: error }, "failed to fetch users");
+    throw error;
+  }
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
+app.get("/bank-lines", async (req, rep) => {
+  const routeLogger = logger.child({ module: "list-bank-lines" });
+  try {
+    const take = Number((req.query as any).take ?? 20);
+    const safeTake = Math.min(Math.max(take, 1), 200);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: safeTake,
+    });
+    routeLogger.debug("Fetched bank lines", { count: lines.length, take: safeTake });
+    return { lines };
+  } catch (error) {
+    routeLogger.error("Failed to fetch bank lines", error as Error);
+    req.log.error({ err: error }, "failed to fetch bank lines");
+    return rep.code(500).send({ error: "internal_error" });
+  }
 });
 
 // Create a bank line
+type BankLinePayload = {
+  orgId: string;
+  date: string;
+  amount: number | string;
+  payee: string;
+  desc: string;
+};
+
 app.post("/bank-lines", async (req, rep) => {
+  const routeLogger = logger.child({ module: "create-bank-line" });
+  let body: BankLinePayload | undefined;
+
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
+    body = req.body as BankLinePayload;
+    if (!body?.orgId || !body.date || !body.payee) {
+      routeLogger.warn("Invalid bank line payload", { body });
+      return rep.code(400).send({ error: "bad_request" });
+    }
+
     const created = await prisma.bankLine.create({
       data: {
         orgId: body.orgId,
@@ -58,23 +88,33 @@ app.post("/bank-lines", async (req, rep) => {
         desc: body.desc,
       },
     });
+
+    routeLogger.info("Created bank line", { id: created.id, orgId: created.orgId });
     return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
+  } catch (error) {
+    routeLogger.error("Failed to create bank line", {
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message, stack: error.stack }
+          : error,
+      body,
+    });
+    req.log.error({ err: error }, "failed to create bank line");
     return rep.code(400).send({ error: "bad_request" });
   }
 });
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
-  app.log.info(app.printRoutes());
+  logger.debug("Registered routes", { routes: app.printRoutes() });
 });
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
 app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
+  const error = err instanceof Error ? err : new Error(String(err));
+  logger.fatal("Failed to start Fastify server", error);
+  app.log.error({ err: error }, "failed to start server");
   process.exit(1);
 });
-

--- a/apgms/services/audit/src/index.ts
+++ b/apgms/services/audit/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('audit service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "audit" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/cdr/src/index.ts
+++ b/apgms/services/cdr/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('cdr service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "cdr" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('connectors service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "connectors" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/payments/src/index.ts
+++ b/apgms/services/payments/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('payments service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "payments" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/recon/src/index.ts
+++ b/apgms/services/recon/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('recon service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "recon" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/registries/src/index.ts
+++ b/apgms/services/registries/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('registries service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "registries" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,15 @@
-﻿console.log('sbr service');
+import { createLogger } from "../../../shared/src";
+
+const logger = createLogger({ service: "sbr" });
+
+async function main() {
+  logger.info("Service boot sequence started");
+  logger.warn("No runtime behaviour defined for this service yet");
+  logger.info("Service boot sequence completed");
+}
+
+main().catch((error) => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  logger.fatal("Service failed to start", err);
+  process.exit(1);
+});

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./logger";

--- a/apgms/shared/src/logger.ts
+++ b/apgms/shared/src/logger.ts
@@ -1,0 +1,119 @@
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "fatal";
+
+export type LogMetadata =
+  | Record<string, unknown>
+  | Error
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+export interface LogContext {
+  service: string;
+  module?: string;
+  [key: string]: string | undefined;
+}
+
+export interface Logger {
+  child(context: Partial<LogContext>): Logger;
+  trace(message: string, meta?: LogMetadata): void;
+  debug(message: string, meta?: LogMetadata): void;
+  info(message: string, meta?: LogMetadata): void;
+  warn(message: string, meta?: LogMetadata): void;
+  error(message: string, meta?: LogMetadata): void;
+  fatal(message: string, meta?: LogMetadata): void;
+}
+
+const consoleMethod: Record<LogLevel, keyof Console> = {
+  trace: "debug",
+  debug: "debug",
+  info: "info",
+  warn: "warn",
+  error: "error",
+  fatal: "error",
+};
+
+function normalizeMeta(meta: LogMetadata): Record<string, unknown> | undefined {
+  if (meta === undefined) {
+    return undefined;
+  }
+
+  if (meta instanceof Error) {
+    return {
+      error: {
+        name: meta.name,
+        message: meta.message,
+        stack: meta.stack,
+      },
+    };
+  }
+
+  if (meta === null) {
+    return { value: null };
+  }
+
+  if (typeof meta === "object") {
+    return meta as Record<string, unknown>;
+  }
+
+  return { value: meta };
+}
+
+function log(level: LogLevel, context: LogContext, message: string, meta?: LogMetadata) {
+  const entry: Record<string, unknown> = {
+    ts: new Date().toISOString(),
+    level,
+    service: context.service,
+    msg: message,
+  };
+
+  const { module: moduleName, ...restContext } = context;
+  if (moduleName) {
+    entry.module = moduleName;
+  }
+
+  for (const [key, value] of Object.entries(restContext)) {
+    if (key === "service" || key === "module") {
+      continue;
+    }
+    if (value !== undefined) {
+      entry[key] = value;
+    }
+  }
+
+  const normalizedMeta = normalizeMeta(meta);
+  if (normalizedMeta) {
+    entry.meta = normalizedMeta;
+  }
+
+  const method = consoleMethod[level];
+  const serialized = JSON.stringify(entry);
+  console[method](serialized);
+}
+
+export function createLogger(context: LogContext): Logger {
+  return {
+    child(childContext) {
+      return createLogger({ ...context, ...childContext });
+    },
+    trace(message, meta) {
+      log("trace", context, message, meta);
+    },
+    debug(message, meta) {
+      log("debug", context, message, meta);
+    },
+    info(message, meta) {
+      log("info", context, message, meta);
+    },
+    warn(message, meta) {
+      log("warn", context, message, meta);
+    },
+    error(message, meta) {
+      log("error", context, message, meta);
+    },
+    fatal(message, meta) {
+      log("fatal", context, message, meta);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared logger utility that emits structured, severity-aware log lines
- update the API gateway to use contextual logging and improved error responses
- align the remaining service entrypoints to the shared logger conventions

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f2eafc30bc8327a73f3e063f3f6090