### PR TITLE
Add multi-page patent workflow GUI scaffold

### DIFF
--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,20 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo dev webapp",
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.48",
+    "@types/react-dom": "^18.2.18",
+    "typescript": "^5.4.5"
+  }
+}

--- a/apgms/webapp/src/App.tsx
+++ b/apgms/webapp/src/App.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import DashboardPage from './pages/DashboardPage';
+import ApplicationBuilderPage from './pages/ApplicationBuilderPage';
+import PriorArtSearchPage from './pages/PriorArtSearchPage';
+import CollaborationSuitePage from './pages/CollaborationSuitePage';
+import PortfolioInsightsPage from './pages/PortfolioInsightsPage';
+
+const App: React.FC = () => {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/application-builder" element={<ApplicationBuilderPage />} />
+        <Route path="/prior-art" element={<PriorArtSearchPage />} />
+        <Route path="/collaboration" element={<CollaborationSuitePage />} />
+        <Route path="/portfolio" element={<PortfolioInsightsPage />} />
+        <Route path="*" element={<Navigate to="/dashboard" replace />} />
+      </Routes>
+    </Layout>
+  );
+};
+
+export default App;

--- a/apgms/webapp/src/components/FormSection.tsx
+++ b/apgms/webapp/src/components/FormSection.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import SectionCard from './SectionCard';
+
+type FormSectionProps = {
+  title: string;
+  subtitle?: string;
+  description?: string;
+  children: React.ReactNode;
+  action?: React.ReactNode;
+};
+
+const FormSection: React.FC<FormSectionProps> = ({
+  title,
+  subtitle,
+  description,
+  children,
+  action,
+}) => {
+  return (
+    <SectionCard title={title} subtitle={subtitle} action={action}>
+      {description ? <p style={{ margin: 0, color: '#475467' }}>{description}</p> : null}
+      <div className="form-grid">{children}</div>
+    </SectionCard>
+  );
+};
+
+export default FormSection;

--- a/apgms/webapp/src/components/Layout.tsx
+++ b/apgms/webapp/src/components/Layout.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+type LayoutProps = {
+  children: React.ReactNode;
+};
+
+const navigation = [
+  { to: '/dashboard', label: 'Patent cockpit' },
+  { to: '/application-builder', label: 'Application builder' },
+  { to: '/prior-art', label: 'Prior art intelligence' },
+  { to: '/collaboration', label: 'Collaboration suite' },
+  { to: '/portfolio', label: 'Portfolio insights' },
+];
+
+const Layout: React.FC<LayoutProps> = ({ children }) => {
+  return (
+    <div className="app-shell">
+      <aside className="app-shell__sidebar">
+        <div className="app-shell__logo">Astra Patent Studio</div>
+
+        <div className="nav-section">
+          <span className="nav-section__label">Workspace</span>
+          <nav className="nav-links">
+            {navigation.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  ['nav-link', isActive ? 'active' : ''].filter(Boolean).join(' ')
+                }
+              >
+                <span role="img" aria-label="compass">
+                  🧭
+                </span>
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+
+        <div className="nav-section">
+          <span className="nav-section__label">Active dossier</span>
+          <div className="section-card">
+            <div>
+              <div className="tag">
+                <span className="status-dot" />
+                Filing Q4 2024
+              </div>
+              <h3 style={{ marginBottom: 4 }}>Autonomous Greenhouse Mesh</h3>
+              <p style={{ margin: 0, color: 'rgba(248, 250, 252, 0.7)' }}>
+                Utility patent · Ref. PCT/US-24/01987
+              </p>
+            </div>
+            <button className="secondary-button" type="button">
+              Export dossier
+            </button>
+          </div>
+        </div>
+      </aside>
+
+      <main className="app-shell__content">{children}</main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/apgms/webapp/src/components/PageHeader.tsx
+++ b/apgms/webapp/src/components/PageHeader.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+type PageHeaderProps = {
+  title: string;
+  description: string;
+  actions?: React.ReactNode;
+};
+
+const PageHeader: React.FC<PageHeaderProps> = ({ title, description, actions }) => {
+  return (
+    <header className="page-header">
+      <div>
+        <h1 className="page-header__title">{title}</h1>
+        <p className="page-header__description">{description}</p>
+      </div>
+      {actions ? <div>{actions}</div> : null}
+    </header>
+  );
+};
+
+export default PageHeader;

--- a/apgms/webapp/src/components/PatentMetricCard.tsx
+++ b/apgms/webapp/src/components/PatentMetricCard.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type PatentMetricCardProps = {
+  label: string;
+  value: string;
+  trend?: string;
+  variant?: 'primary' | 'neutral';
+  context?: string;
+};
+
+const PatentMetricCard: React.FC<PatentMetricCardProps> = ({
+  label,
+  value,
+  trend,
+  variant = 'primary',
+  context,
+}) => {
+  const className = ['metric-card', variant === 'neutral' ? 'metric-card--neutral' : '']
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <article className={className}>
+      <span className="metric-card__label">{label}</span>
+      <span className="metric-card__value">{value}</span>
+      {trend ? <span className="metric-card__trend">{trend}</span> : null}
+      {context ? <small>{context}</small> : null}
+    </article>
+  );
+};
+
+export default PatentMetricCard;

--- a/apgms/webapp/src/components/SectionCard.tsx
+++ b/apgms/webapp/src/components/SectionCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type SectionCardProps = {
+  title: string;
+  subtitle?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const SectionCard: React.FC<SectionCardProps> = ({ title, subtitle, action, children }) => {
+  return (
+    <section className="section-card">
+      <div className="section-card__header">
+        <div>
+          <h2 className="section-card__title">{title}</h2>
+          {subtitle ? <p className="section-card__subtitle">{subtitle}</p> : null}
+        </div>
+        {action ? <div>{action}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+};
+
+export default SectionCard;

--- a/apgms/webapp/src/components/Timeline.tsx
+++ b/apgms/webapp/src/components/Timeline.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type TimelineEvent = {
+  date: string;
+  title: string;
+  description: string;
+  owner: string;
+};
+
+type TimelineProps = {
+  events: TimelineEvent[];
+};
+
+const Timeline: React.FC<TimelineProps> = ({ events }) => {
+  return (
+    <div className="timeline">
+      {events.map((event) => (
+        <div key={`${event.date}-${event.title}`} className="timeline-item">
+          <span className="timeline-item__date">{event.date}</span>
+          <div className="timeline-item__content">
+            <strong>{event.title}</strong>
+            <p style={{ margin: '8px 0 0' }}>{event.description}</p>
+            <small style={{ color: '#1d4ed8', fontWeight: 600 }}>Owner: {event.owner}</small>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export type { TimelineEvent };
+export default Timeline;

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,21 @@
-﻿console.log('webapp');
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Root element with id "root" not found');
+}
+
+const root = createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/pages/ApplicationBuilderPage.tsx
+++ b/apgms/webapp/src/pages/ApplicationBuilderPage.tsx
@@ -1,0 +1,155 @@
+import React, { useMemo, useState } from 'react';
+import PageHeader from '../components/PageHeader';
+import FormSection from '../components/FormSection';
+
+const claimTemplates = [
+  'An autonomous greenhouse mesh system comprising sensor clusters orchestrated by adaptive AI agents.',
+  'The system of claim 1 wherein predictive irrigation is tuned via reinforcement learning loops.',
+  'A method for dynamically allocating solar shading and nutrient delivery using digital twin feedback.',
+];
+
+const jurisdictions = ['United States (USPTO)', 'European Union (EPO)', 'Japan (JPO)', 'Australia (IP Australia)'];
+
+const ApplicationBuilderPage: React.FC = () => {
+  const [selectedTemplate, setSelectedTemplate] = useState(claimTemplates[0]);
+  const [selectedJurisdictions, setSelectedJurisdictions] = useState<string[]>(['United States (USPTO)']);
+
+  const jurisdictionSummary = useMemo(() => {
+    return selectedJurisdictions.join(', ');
+  }, [selectedJurisdictions]);
+
+  return (
+    <div className="page-grid" style={{ gap: 32 }}>
+      <PageHeader
+        title="Application builder"
+        description="Author, localize, and validate your patent package from a single workspace. Start with AI-assisted claim drafting, harmonize embodiments, and export to jurisdiction-ready formats."
+        actions={
+          <button className="primary-button" type="button">
+            Create filing packet
+          </button>
+        }
+      />
+
+      <FormSection
+        title="Filing overview"
+        subtitle="Foundation details shared across all jurisdictions"
+        description="Capture the commercial context and designate strategic territories. The studio pre-fills disclosure templates and harmonizes metadata for each office."
+      >
+        <div className="form-field">
+          <label htmlFor="working-title">Working title</label>
+          <input id="working-title" placeholder="Autonomous greenhouse mesh orchestration" defaultValue="Autonomous greenhouse mesh orchestration" />
+        </div>
+        <div className="form-field">
+          <label htmlFor="inventors">Inventors</label>
+          <input id="inventors" placeholder="Add inventors" defaultValue="Clara Preston, Tariq Menon" />
+        </div>
+        <div className="form-field">
+          <label htmlFor="jurisdictions">Target jurisdictions</label>
+          <select
+            id="jurisdictions"
+            multiple
+            value={selectedJurisdictions}
+            onChange={(event) => {
+              const options = Array.from(event.target.selectedOptions).map((option) => option.value);
+              setSelectedJurisdictions(options);
+            }}
+          >
+            {jurisdictions.map((region) => (
+              <option key={region} value={region}>
+                {region}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="form-field">
+          <label htmlFor="summary">Commercial summary</label>
+          <textarea
+            id="summary"
+            placeholder="What market problem does this invention solve?"
+            defaultValue="Our autonomous greenhouse mesh coordinates climate, nutrient, and energy systems across 80+ micro-zones with AI-driven control."
+          />
+        </div>
+        <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+          <label>Localization plan</label>
+          <div className="prior-art-result">
+            <strong>{jurisdictionSummary}</strong>
+            <span style={{ color: '#475467' }}>
+              Translation and formatting will be harmonized. Auto-generate country-specific figures and claim numbering.
+            </span>
+          </div>
+        </div>
+      </FormSection>
+
+      <FormSection
+        title="Claim architect"
+        subtitle="Curate independent and dependent claim sets"
+        description="Start from AI proposals, edit collaboratively, and map dependencies. Drafting insights surface enablement gaps before review."
+        action={<button className="secondary-button">Export claim tree</button>}
+      >
+        <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="claim-template">Suggested independent claim</label>
+          <select
+            id="claim-template"
+            value={selectedTemplate}
+            onChange={(event) => setSelectedTemplate(event.target.value)}
+          >
+            {claimTemplates.map((template) => (
+              <option key={template} value={template}>
+                {template}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="claim-draft">Current draft</label>
+          <textarea
+            id="claim-draft"
+            rows={8}
+            defaultValue={`${selectedTemplate} The system interfaces with distributed actuator arrays via a secure mesh protocol to maintain optimal agronomic conditions.`}
+          />
+        </div>
+        <div className="form-field">
+          <label htmlFor="claim-dependencies">Dependency map</label>
+          <textarea
+            id="claim-dependencies"
+            rows={6}
+            defaultValue={`Claim 2 depends on Claim 1 and restricts the irrigation agent to reinforcement tuning.\nClaim 3 depends on Claim 1 and adds solar shading orchestration.`}
+          />
+        </div>
+        <div className="form-field">
+          <label htmlFor="supporting-figures">Supporting figures</label>
+          <textarea
+            id="supporting-figures"
+            rows={6}
+            defaultValue={`Fig. 3: Sensor cluster architecture\nFig. 5: Digital twin feedback loop\nFig. 7: Reinforcement learning controller`}
+          />
+        </div>
+      </FormSection>
+
+      <FormSection
+        title="Enablement evidence"
+        subtitle="Attach experiments, data, and implementation detail"
+        description="Demonstrate the invention's reproducibility with structured annexes. Drag in CAD models, lab results, and code extracts."
+      >
+        <div className="form-field">
+          <label htmlFor="prototype-status">Prototype maturity</label>
+          <select id="prototype-status" defaultValue="Pilot validated">
+            <option>Concept validated</option>
+            <option>Pilot validated</option>
+            <option>Commercial deployment</option>
+          </select>
+        </div>
+        <div className="form-field">
+          <label htmlFor="evidence-links">Evidence repository</label>
+          <input id="evidence-links" placeholder="https://drive.com/patent-folder" defaultValue="https://drive.com/greenhouse-autonomy" />
+        </div>
+        <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+          <label htmlFor="notes">Reviewer notes</label>
+          <textarea id="notes" rows={4} placeholder="Add reviewer-specific context" />
+        </div>
+      </FormSection>
+    </div>
+  );
+};
+
+export default ApplicationBuilderPage;

--- a/apgms/webapp/src/pages/CollaborationSuitePage.tsx
+++ b/apgms/webapp/src/pages/CollaborationSuitePage.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import PageHeader from '../components/PageHeader';
+import SectionCard from '../components/SectionCard';
+
+const reviewers = [
+  { name: 'Clara Preston', role: 'Lead inventor', focus: 'Technical enablement', status: 'Online' },
+  { name: 'Sarah Ito', role: 'Patent counsel', focus: 'Claim strategy', status: 'Reviewing' },
+  { name: 'Diego Alvarez', role: 'Market analyst', focus: 'Commercial positioning', status: 'Offline' },
+];
+
+const tasks = [
+  { title: 'Validate AI search hits', owner: 'Sarah Ito', due: 'Apr 22', status: 'In review' },
+  { title: 'Upload pilot data annex', owner: 'Clara Preston', due: 'Apr 19', status: 'In progress' },
+  { title: 'Draft commercialization abstract', owner: 'Diego Alvarez', due: 'Apr 24', status: 'Not started' },
+];
+
+const comments = [
+  {
+    author: 'Sarah Ito',
+    message: 'Reviewed claims 1-8. Suggest clarifying actuator latency thresholds for international filing.',
+    time: '1 hour ago',
+  },
+  {
+    author: 'Clara Preston',
+    message: 'Uploaded greenhouse telemetry CSV — ready for enablement annex.',
+    time: 'Yesterday',
+  },
+  {
+    author: 'Tariq Menon',
+    message: 'Added reinforcement learning diagrams to figure library (see Fig. 9).',
+    time: 'Mon 09:30',
+  },
+];
+
+const CollaborationSuitePage: React.FC = () => {
+  return (
+    <div className="page-grid" style={{ gap: 32 }}>
+      <PageHeader
+        title="Collaboration suite"
+        description="Synchronize inventors, counsel, and analysts in one command center. Assign tasks, review drafts, and capture feedback anchored to each claim."
+        actions={<button className="primary-button">Start review session</button>}
+      />
+
+      <div className="page-grid page-grid--two-column">
+        <SectionCard title="Contributors" subtitle="Live presence across the patent team">
+          <div className="page-grid" style={{ gap: 16 }}>
+            {reviewers.map((reviewer) => (
+              <div key={reviewer.name} className="section-card" style={{ boxShadow: 'none', border: '1px solid #e2e8f0' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <strong>{reviewer.name}</strong>
+                  <span className="tag">
+                    <span className="status-dot" style={{ background: reviewer.status === 'Offline' ? '#94a3b8' : '#16a34a' }} />
+                    {reviewer.status}
+                  </span>
+                </div>
+                <p style={{ margin: '6px 0', color: '#475467' }}>{reviewer.role}</p>
+                <small style={{ color: '#155eef', fontWeight: 600 }}>{reviewer.focus}</small>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard title="Action items" subtitle="Workstream aligned with filing timeline">
+          <div className="task-list">
+            {tasks.map((task) => (
+              <div key={task.title} className="task-item">
+                <div>
+                  <strong>{task.title}</strong>
+                  <p style={{ margin: '4px 0 0', color: '#475467' }}>{task.owner}</p>
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  <span className="badge">Due {task.due}</span>
+                  <p style={{ margin: '6px 0 0', color: '#0f172a', fontWeight: 600 }}>{task.status}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard
+        title="Comment stream"
+        subtitle="Contextual feedback anchored to claims and annexes"
+        action={<button className="secondary-button">Open transcript</button>}
+      >
+        <div className="comment-thread">
+          {comments.map((comment) => (
+            <div key={comment.author + comment.time} className="comment">
+              <div className="status-dot" style={{ marginTop: 6 }} />
+              <div>
+                <div className="comment__author">{comment.author}</div>
+                <p style={{ margin: '6px 0', color: '#475467' }}>{comment.message}</p>
+                <small style={{ color: '#155eef', fontWeight: 600 }}>{comment.time}</small>
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+    </div>
+  );
+};
+
+export default CollaborationSuitePage;

--- a/apgms/webapp/src/pages/DashboardPage.tsx
+++ b/apgms/webapp/src/pages/DashboardPage.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import PageHeader from '../components/PageHeader';
+import SectionCard from '../components/SectionCard';
+import PatentMetricCard from '../components/PatentMetricCard';
+import Timeline, { TimelineEvent } from '../components/Timeline';
+
+const metrics = [
+  {
+    label: 'Prosecution velocity',
+    value: '42 days',
+    trend: '12 days faster than industry benchmark',
+  },
+  {
+    label: 'Claims defended',
+    value: '18 / 22',
+    trend: '81% acceptance rate',
+    variant: 'neutral' as const,
+  },
+  {
+    label: 'Office action risk',
+    value: 'Low',
+    trend: 'High novelty score (8.6 / 10)',
+    variant: 'neutral' as const,
+  },
+];
+
+const roadmap: TimelineEvent[] = [
+  {
+    date: 'Apr 18',
+    title: 'Draft utility specification',
+    description: 'Finalize enablement details for autonomous greenhouse coordination.',
+    owner: 'Clara Preston',
+  },
+  {
+    date: 'Apr 24',
+    title: 'Peer novelty audit',
+    description: 'Cross-reference generative coverage vs prior mesh patents.',
+    owner: 'Tariq Menon',
+  },
+  {
+    date: 'May 02',
+    title: 'USPTO readiness review',
+    description: 'Legal QA and translation package for PCT co-filing.',
+    owner: 'Sarah Ito',
+  },
+];
+
+const activityFeed = [
+  {
+    title: 'AI search insight',
+    description: 'Identified 3 comparable greenhouse automation filings with low overlap score.',
+    timestamp: '2 hours ago',
+  },
+  {
+    title: 'Claim harmonization',
+    description: 'Drafted claim dependencies for sensor cluster orchestration modules.',
+    timestamp: 'Yesterday',
+  },
+  {
+    title: 'Client briefing uploaded',
+    description: 'Founder updated commercialization roadmap with pilot data.',
+    timestamp: 'Monday',
+  },
+];
+
+const DashboardPage: React.FC = () => {
+  return (
+    <div className="page-grid" style={{ gap: 32 }}>
+      <PageHeader
+        title="Patent cockpit"
+        description="Monitor the end-to-end health of your flagship filing. Track prosecution velocity, collaborate with counsel, and anticipate blockers before they emerge."
+        actions={
+          <div style={{ display: 'flex', gap: 12 }}>
+            <button className="secondary-button" type="button">
+              Share live dossier
+            </button>
+            <button className="primary-button" type="button">
+              Generate USPTO brief
+            </button>
+          </div>
+        }
+      />
+
+      <div className="metric-grid">
+        {metrics.map((metric) => (
+          <PatentMetricCard key={metric.label} {...metric} />
+        ))}
+      </div>
+
+      <div className="page-grid page-grid--two-column">
+        <SectionCard
+          title="Execution roadmap"
+          subtitle="Milestones synced to prosecution calendar"
+          action={<button className="secondary-button">Sync to Outlook</button>}
+        >
+          <Timeline events={roadmap} />
+        </SectionCard>
+
+        <SectionCard title="Activity feed" subtitle="Everything your team touched this week">
+          <div className="activity-list">
+            {activityFeed.map((item) => (
+              <div key={item.title} className="activity-item">
+                <div className="activity-item__details">
+                  <strong>{item.title}</strong>
+                  <span>{item.description}</span>
+                </div>
+                <span style={{ color: '#475467' }}>{item.timestamp}</span>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard
+        title="Risk radar"
+        subtitle="AI signal scoring across novelty, enablement, and marketability"
+        action={<button className="secondary-button">Download diligence pack</button>}
+      >
+        <div style={{ display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+          {[
+            { label: 'Novelty overlap', score: '18%', insight: 'Low overlap vs 1,200 record prior-art set.' },
+            { label: 'Enablement coverage', score: '92%', insight: 'Draft describes autonomous mesh protocol in depth.' },
+            { label: 'Commercial readiness', score: '73%', insight: 'Pilot metrics ready for market application addendum.' },
+          ].map((risk) => (
+            <div key={risk.label} className="section-card" style={{ boxShadow: 'none', border: '1px solid #e2e8f0' }}>
+              <h3 style={{ margin: 0 }}>{risk.label}</h3>
+              <p style={{ fontSize: 32, margin: '12px 0', fontWeight: 700 }}>{risk.score}</p>
+              <p style={{ margin: 0, color: '#475467' }}>{risk.insight}</p>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/apgms/webapp/src/pages/PortfolioInsightsPage.tsx
+++ b/apgms/webapp/src/pages/PortfolioInsightsPage.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import PageHeader from '../components/PageHeader';
+import SectionCard from '../components/SectionCard';
+
+const holdings = [
+  { asset: 'Autonomous greenhouse mesh', jurisdiction: 'USPTO', stage: 'Drafting', budget: '$48k' },
+  { asset: 'Predictive irrigation AI', jurisdiction: 'EPO', stage: 'Office action', budget: '$32k' },
+  { asset: 'Robotic seeding drones', jurisdiction: 'USPTO', stage: 'Granted', budget: '$26k' },
+];
+
+const forecasts = [
+  { label: 'Estimated grant probability', value: '82%', detail: 'Weighted across US/EU filings' },
+  { label: 'Projected licensing revenue', value: '$2.4M', detail: '12-month rolling outlook' },
+  { label: 'Portfolio carbon offset impact', value: '18k tons', detail: 'Modelled from deployments' },
+];
+
+const PortfolioInsightsPage: React.FC = () => {
+  return (
+    <div className="page-grid" style={{ gap: 32 }}>
+      <PageHeader
+        title="Portfolio insights"
+        description="Compare budgets, grant forecasts, and commercial impact across your filings. Prioritize where to invest drafting cycles and counsel attention."
+        actions={<button className="primary-button">Export board report</button>}
+      />
+
+      <SectionCard title="Active holdings" subtitle="Snapshot of priority assets">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Asset</th>
+              <th>Jurisdiction</th>
+              <th>Stage</th>
+              <th>Allocated budget</th>
+            </tr>
+          </thead>
+          <tbody>
+            {holdings.map((row) => (
+              <tr key={row.asset}>
+                <td>{row.asset}</td>
+                <td>{row.jurisdiction}</td>
+                <td>{row.stage}</td>
+                <td>{row.budget}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </SectionCard>
+
+      <SectionCard title="Forecast outlook" subtitle="AI projections based on prosecution history">
+        <div className="metric-grid">
+          {forecasts.map((item) => (
+            <div key={item.label} className="section-card" style={{ boxShadow: 'none', border: '1px solid #e2e8f0' }}>
+              <h3 style={{ margin: 0 }}>{item.label}</h3>
+              <p style={{ fontSize: 32, margin: '12px 0', fontWeight: 700 }}>{item.value}</p>
+              <p style={{ margin: 0, color: '#475467' }}>{item.detail}</p>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Strategic guidance"
+        subtitle="Automated recommendations for next quarter"
+        action={<button className="secondary-button">Schedule strategy review</button>}
+      >
+        <ul style={{ margin: 0, paddingLeft: 20, color: '#475467', display: 'grid', gap: 12 }}>
+          <li>
+            Advance the autonomous greenhouse mesh filing to PCT within 60 days to maintain lead on reinforcement learning claims.
+          </li>
+          <li>
+            Convert irrigation AI office action insights into continuation applications for European coverage.
+          </li>
+          <li>
+            Activate licensing outreach for granted robotic seeding patents focusing on APAC agri-tech partners.
+          </li>
+        </ul>
+      </SectionCard>
+    </div>
+  );
+};
+
+export default PortfolioInsightsPage;

--- a/apgms/webapp/src/pages/PriorArtSearchPage.tsx
+++ b/apgms/webapp/src/pages/PriorArtSearchPage.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo, useState } from 'react';
+import PageHeader from '../components/PageHeader';
+import SectionCard from '../components/SectionCard';
+
+const sampleResults = [
+  {
+    patent: 'US 11,923,004',
+    title: 'Automated horticulture canopy control',
+    score: 0.34,
+    summary: 'Focuses on canopy sensors but lacks multi-agent mesh coordination.',
+    actions: ['Compare claims', 'Add to watchlist'],
+  },
+  {
+    patent: 'EP 3 876 211',
+    title: 'Greenhouse climate orchestration platform',
+    score: 0.58,
+    summary: 'Utilizes cloud orchestration but no reinforcement learning loops.',
+    actions: ['Compare claims'],
+  },
+  {
+    patent: 'JP 2023-771211',
+    title: 'Nutrient dosing control for vertical farms',
+    score: 0.27,
+    summary: 'Targets dosing but no predictive solar shading integration.',
+    actions: ['Translate', 'Notify counsel'],
+  },
+];
+
+const filters = ['Novelty overlap', 'Enablement depth', 'AI-generated'];
+
+const PriorArtSearchPage: React.FC = () => {
+  const [query, setQuery] = useState('autonomous greenhouse mesh');
+  const [activeFilters, setActiveFilters] = useState<string[]>(['Novelty overlap']);
+
+  const filteredResults = useMemo(() => {
+    if (!activeFilters.length) {
+      return sampleResults;
+    }
+    return sampleResults.filter((result) => result.score < 0.6);
+  }, [activeFilters]);
+
+  return (
+    <div className="page-grid" style={{ gap: 32 }}>
+      <PageHeader
+        title="Prior art intelligence"
+        description="Run semantic searches across 120M global assets. Blend USPTO, EPO, JPO and private data, and let the AI engine cluster results by novelty and enablement." 
+        actions={<button className="primary-button">Launch semantic map</button>}
+      />
+
+      <SectionCard
+        title="Query builder"
+        subtitle="Refine your search with semantic and Boolean inputs"
+        action={<button className="secondary-button">Save search profile</button>}
+      >
+        <div className="form-grid">
+          <div className="form-field" style={{ gridColumn: '1 / -1' }}>
+            <label htmlFor="query">Semantic query</label>
+            <textarea
+              id="query"
+              rows={3}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </div>
+          <div className="form-field">
+            <label htmlFor="boolean">Boolean must include</label>
+            <input id="boolean" placeholder="mesh AND greenhouse" defaultValue="mesh AND greenhouse" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="exclude">Exclude</label>
+            <input id="exclude" placeholder="hydroponics" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="published-after">Published after</label>
+            <input id="published-after" type="date" defaultValue="2021-01-01" />
+          </div>
+          <div className="form-field">
+            <label htmlFor="jurisdiction">Jurisdiction focus</label>
+            <select id="jurisdiction" defaultValue="Global">
+              <option>Global</option>
+              <option>United States</option>
+              <option>European Union</option>
+              <option>Japan</option>
+            </select>
+          </div>
+        </div>
+        <div className="prior-art-filters">
+          {filters.map((filter) => {
+            const active = activeFilters.includes(filter);
+            return (
+              <button
+                key={filter}
+                className={active ? 'primary-button' : 'secondary-button'}
+                type="button"
+                onClick={() => {
+                  setActiveFilters((prev) =>
+                    active ? prev.filter((item) => item !== filter) : [...prev, filter],
+                  );
+                }}
+              >
+                {filter}
+              </button>
+            );
+          })}
+        </div>
+      </SectionCard>
+
+      <SectionCard title="Result clusters" subtitle="AI-ranked assets sorted by semantic distance">
+        <div className="page-grid" style={{ gap: 20 }}>
+          {filteredResults.map((result) => (
+            <div key={result.patent} className="prior-art-result">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                <div>
+                  <strong>{result.patent}</strong>
+                  <p style={{ margin: '4px 0 0' }}>{result.title}</p>
+                </div>
+                <div className="badge">Overlap score {(result.score * 100).toFixed(0)}%</div>
+              </div>
+              <p style={{ margin: 0, color: '#475467' }}>{result.summary}</p>
+              <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+                {result.actions.map((action) => (
+                  <button key={action} className="secondary-button" type="button">
+                    {action}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </SectionCard>
+
+      <SectionCard
+        title="Signal analytics"
+        subtitle="Overlap trend vs last six searches"
+        action={<button className="secondary-button">Download CSV</button>}
+      >
+        <div className="mini-chart">
+          {[32, 44, 28, 51, 36, 22].map((value, index) => (
+            <div
+              key={index}
+              className={['mini-chart__bar', index === 3 ? 'mini-chart__bar--accent' : ''].join(' ')}
+              style={{ height: `${value + 10}px` }}
+            />
+          ))}
+        </div>
+        <p style={{ margin: 0, color: '#475467' }}>
+          Week-over-week novelty overlap trending downward 12%. Suggest exploring new reinforcement learning keywords for broader coverage.
+        </p>
+      </SectionCard>
+    </div>
+  );
+};
+
+export default PriorArtSearchPage;

--- a/apgms/webapp/src/styles.css
+++ b/apgms/webapp/src/styles.css
@@ -1,0 +1,415 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #101828;
+  background-color: #f5f7fb;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a.active {
+  color: #155eef;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.app-shell__sidebar {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.app-shell__logo {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.nav-section__label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 250, 252, 0.6);
+}
+
+.nav-links {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 500;
+  color: rgba(248, 250, 252, 0.8);
+  transition: background 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link.active {
+  background: rgba(148, 163, 184, 0.16);
+  color: #ffffff;
+}
+
+.app-shell__content {
+  padding: 32px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.page-header__title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.page-header__description {
+  margin: 6px 0 0;
+  color: #475467;
+  max-width: 640px;
+}
+
+.primary-button {
+  background: #155eef;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.secondary-button {
+  background: rgba(21, 94, 239, 0.08);
+  color: #155eef;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 20px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.page-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.page-grid--two-column {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.section-card {
+  background: white;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 18px 40px -24px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.section-card__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.section-card__subtitle {
+  margin: 0;
+  color: #475467;
+  font-size: 14px;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.metric-card {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: white;
+  border-radius: 20px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.metric-card--neutral {
+  background: white;
+  border: 1px solid #e2e8f0;
+  color: #0f172a;
+}
+
+.metric-card__label {
+  font-size: 14px;
+  opacity: 0.9;
+}
+
+.metric-card__value {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.metric-card__trend {
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.timeline-item__date {
+  font-size: 13px;
+  font-weight: 600;
+  color: #155eef;
+}
+
+.timeline-item__content {
+  background: rgba(21, 94, 239, 0.08);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.activity-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.activity-item__details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.08);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.form-field input,
+.form-field textarea,
+.form-field select {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid #cbd5f5;
+  font-size: 14px;
+  background: #f8fafc;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #16a34a;
+}
+
+.comment-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comment {
+  display: flex;
+  gap: 12px;
+  background: rgba(15, 23, 42, 0.04);
+  padding: 12px 16px;
+  border-radius: 14px;
+}
+
+.comment__author {
+  font-weight: 600;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.task-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(21, 94, 239, 0.08);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background: rgba(21, 94, 239, 0.12);
+  color: #155eef;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead {
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 12px;
+  font-size: 14px;
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.prior-art-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.prior-art-result {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.mini-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 64px;
+}
+
+.mini-chart__bar {
+  flex: 1;
+  border-radius: 6px 6px 0 0;
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.mini-chart__bar--accent {
+  background: rgba(21, 94, 239, 0.7);
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .app-shell__sidebar {
+    flex-direction: row;
+    overflow-x: auto;
+    gap: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a multi-page patent workflow interface with navigation, layout, and shared styling
- implement dashboard, application builder, prior art intelligence, collaboration, and portfolio insights views tailored to patent workflows
- add reusable components for metrics, sections, forms, and timelines to support the patent-focused UI

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f2eb25c83c8327b7bc1c731b9f5a9b