### PR TITLE
Add testing strategy and traceability documentation

### DIFF
--- a/apgms/docs/architecture/README.md
+++ b/apgms/docs/architecture/README.md
@@ -1,1 +1,20 @@
-﻿# C4 + Sequences
+# Architecture Documentation Roadmap
+
+## Deliverables
+- System context diagram highlighting user channels, external regulators, and partner integrations.
+- Container diagram detailing microservices (`api-gateway`, `payments`, `tax-engine`, etc.) and shared infrastructure (databases, message buses).
+- Component diagrams per critical service (e.g., tax calculation pipeline, reconciliation workflows).
+- Deployment topology across environments (dev, staging, prod) including observability stack.
+
+## Sources
+- Service definitions under `apgms/services/` and shared modules under `apgms/shared/`.
+- Infrastructure code under `apgms/infra/`.
+- Patent specification references (pending legal approval).
+
+## Next Steps
+1. Collect up-to-date architecture decisions (ADRs) from engineering leads.
+2. Choose diagram-as-code tooling (Structurizr, C4-PlantUML, or Diagrams.net) and store under `apgms/docs/architecture/diagrams/`.
+3. Automate diagram generation in CI once pipeline is in place.
+4. Link diagrams to corresponding sections in the runbooks and traceability matrix.
+
+> **Status:** Documentation scaffolding created; diagrams to be produced in subsequent iterations.

--- a/apgms/docs/operations/RUNBOOKS.md
+++ b/apgms/docs/operations/RUNBOOKS.md
@@ -1,0 +1,27 @@
+# Operational Runbooks (Draft Outline)
+
+## Deployment
+1. Validate service health checks via `pnpm test --filter <service>`.
+2. Promote container images from staging ECR to production ECR.
+3. Apply infrastructure changes through Terraform in `apgms/infra` with workspace targeting.
+4. Monitor rollout with synthetic probes and dashboards.
+
+## Rollback
+1. Identify failing release (timestamp, git SHA).
+2. Trigger automated rollback pipeline to previous artefact version.
+3. Flush message queues where safe; replay events if required.
+4. Document incident in postmortem template and link to traceability matrix.
+
+## Incident Response
+- **Detection**: Alerts via Prometheus Alertmanager on SLA breaches, error rate anomalies, or missing telemetry.
+- **Diagnosis**: Use OpenTelemetry traces, structured logs, and Grafana dashboards to isolate failing service.
+- **Mitigation**: Apply feature flags, scale affected service, or execute rollback procedure.
+- **Communication**: Update status page and notify stakeholders via runbook steps.
+
+## Compliance Exports
+1. Run scheduled export job in `apgms/services/audit`.
+2. Verify checksum and signature before delivery to regulators.
+3. Store immutable copy in `sbr` repository with retention policy.
+4. Capture evidence in audit trail dashboard.
+
+> Detailed service-specific runbooks remain TODO until instrumentation and automation tasks are completed.

--- a/apgms/docs/testing/TEST_STRATEGY.md
+++ b/apgms/docs/testing/TEST_STRATEGY.md
@@ -1,0 +1,61 @@
+# Testing and Observability Strategy
+
+## 1. Current Inventory
+
+### Source Repositories
+- `apgms/tests/contract`: Contract test stubs.
+- `apgms/tests/e2e`: Browser-driven end-to-end scenarios powered by Playwright.
+- `apgms/services/*/test`: Service-level unit and integration tests (varying coverage).
+- `apgms/k6`: Performance test harness using k6.
+- `apgms/infra`: Terraform modules and provisioning scripts with limited validation tests.
+- `apgms/docs`: Documentation stubs; no comprehensive test guidance yet.
+
+### Tooling & Pipelines
+- Local `pnpm test` scripts defined per package.
+- Shared Playwright configuration in `apgms/playwright.config.ts`.
+- No unified CI pipeline or coverage aggregation is currently configured in-repo.
+- Observability tooling (metrics, tracing, logs) is largely ad-hoc per service.
+
+## 2. Proposed Test Strategy
+
+| Layer | Scope | Tools | Ownership |
+| --- | --- | --- | --- |
+| Unit | Module-level logic within each service | Jest (Node), pytest (Python connectors), Go test (Go services) | Service teams |
+| Integration | Service API with internal dependencies (DB, queues) | Jest + Testcontainers, supertest; pytest w/ docker-compose | Service teams |
+| Contract | Provider/consumer interface tests | Pactflow via `apgms/tests/contract` | Platform QA |
+| End-to-End | Cross-service journeys (user onboarding, payment flows) | Playwright, mocked third parties | Platform QA |
+| Performance | Non-functional SLA validation | k6, Gatling (future) | SRE |
+| Observability Verification | Telemetry schema, alert coverage | OpenTelemetry collectors, log schema validators | SRE + QA |
+
+## 3. Implementation Roadmap
+
+1. Harmonise test runners per service and ensure `pnpm test` invokes the correct suite.
+2. Build reusable docker-compose profiles for integration tests.
+3. Expand Playwright coverage to include payment capture, reconciliation, and tax filing journeys.
+4. Leverage k6 scripts for load/perf against deployed staging environment.
+5. Introduce telemetry validation harness (OpenTelemetry collector w/ assertions).
+6. Capture coverage metrics using `nyc` (JS), `coverage.py` (Python), and Go `cover`.
+
+## 4. Observability Enhancements
+
+- Adopt OpenTelemetry SDK across services with consistent resource attributes.
+- Emit domain-specific metrics (latency, SLA, error budgets) via Prometheus exporters.
+- Enforce structured JSON logging with correlation IDs across services.
+- Define tracing expectations for cross-service flows (trace spans for API gateway → tax engine → payments → registries).
+- Create automated checks ensuring telemetry is generated in integration environments.
+
+## 5. Documentation & Traceability
+
+- Maintain architecture diagrams under `apgms/docs/architecture/`.
+- Create API reference docs sourced from OpenAPI specs.
+- Draft operational runbooks covering deployment, rollback, monitoring, and incident response.
+- Link patent claim IDs to features and validating tests via a traceability matrix.
+
+## 6. Outstanding Gaps
+
+- Automated CI pipelines remain unimplemented pending GitHub Actions or GitLab runners.
+- Cross-service test coverage is partial; requires dedicated time to add scenarios and fixtures.
+- Observability instrumentation has not yet been standardised in code; placeholders only.
+- Traceability matrix requires alignment with legal/patent documentation.
+
+> **Note:** This document establishes the baseline strategy and highlights the additional engineering work needed to fully satisfy the patent-aligned testing requirements.

--- a/apgms/docs/testing/TRACEABILITY_MATRIX.md
+++ b/apgms/docs/testing/TRACEABILITY_MATRIX.md
@@ -1,0 +1,11 @@
+# Patent Traceability Matrix (Draft)
+
+| Patent Claim ID | Feature / Capability | Implementing Services | Primary Tests | Observability Signals | Status |
+| --- | --- | --- | --- | --- | --- |
+| CLAIM-1 | Customer onboarding identity verification | `api-gateway`, `connectors/kyc`, `registries` | Playwright onboarding flow, contract tests for KYC API | Traces: `onboarding.*`; Metrics: `onboarding_success_total` | Pending mapping |
+| CLAIM-2 | Real-time payment instruction orchestration | `payments`, `recon`, `tax-engine` | Integration tests for payment submission, k6 load tests | Metrics: `payment_latency_bucket`; Logs: `payment_id` correlation | Pending mapping |
+| CLAIM-3 | Cross-jurisdiction tax compliance computation | `tax-engine`, `cdr`, `audit` | Unit tests for tax calculation rules, contract tests for audit feed | Traces: `tax_engine.compute`; Metrics: `tax_discrepancy_total` | Pending mapping |
+| CLAIM-4 | Immutable audit trail with regulatory export | `audit`, `registries`, `sbr` | Contract tests for registry push, E2E export scenario | Logs: structured ledger entries; Metrics: `export_failure_total` | Pending mapping |
+| CLAIM-5 | Adaptive connector framework for third-party APIs | `connectors/*`, `api-gateway` | Connector contract tests, integration harness with sandbox | Metrics: `connector_error_total`; Traces: `connector.call` | Pending mapping |
+
+> **Action Needed:** For each claim, populate the exact feature references (JIRA IDs, spec links), enumerate the validating tests (unit, integration, E2E), and document the telemetry that proves compliance.


### PR DESCRIPTION
## Summary
- add a testing and observability strategy document outlining current inventory, tooling, and roadmap
- add a draft patent traceability matrix capturing claims, features, tests, and telemetry placeholders
- scaffold architecture and operational documentation with next-step guidance

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68f2f45c11008327b48634e0d10b329a