### PR TITLE
feat(webapp): scaffold react portal

### DIFF
--- a/apgms/.github/workflows/webapp.yml
+++ b/apgms/.github/workflows/webapp.yml
@@ -1,0 +1,46 @@
+name: Webapp CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - 'apgms/webapp/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/webapp.yml'
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint webapp
+        run: pnpm --filter @apgms/webapp lint
+
+      - name: Typecheck webapp
+        run: pnpm --filter @apgms/webapp typecheck
+
+      - name: Run tests
+        run: pnpm --filter @apgms/webapp test -- --run
+
+      - name: Build webapp
+        run: pnpm --filter @apgms/webapp build

--- a/apgms/webapp/.eslintrc.cjs
+++ b/apgms/webapp/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2024: true
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  plugins: ['@typescript-eslint', 'react-refresh', 'react-hooks'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:react-refresh/recommended',
+    'prettier'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react-refresh/only-export-components': 'warn',
+    '@typescript-eslint/explicit-module-boundary-types': 'off'
+  }
+};

--- a/apgms/webapp/README.md
+++ b/apgms/webapp/README.md
@@ -1,0 +1,73 @@
+# APGMS Webapp
+
+The APGMS web client is a React + TypeScript single-page application that surfaces onboarding,
+tax workflow, and compliance dashboards backed by the platform's API Gateway.
+
+## Getting started
+
+Install dependencies from the repository root using [pnpm](https://pnpm.io/):
+
+```bash
+pnpm install
+```
+
+### Available scripts
+
+```bash
+pnpm --filter @apgms/webapp dev       # Start the Vite development server with hot module reload
+pnpm --filter @apgms/webapp test      # Run unit and component tests via Vitest
+pnpm --filter @apgms/webapp lint      # Lint the source with ESLint
+pnpm --filter @apgms/webapp build     # Create a production build
+pnpm --filter @apgms/webapp preview   # Preview the production build locally
+pnpm --filter @apgms/webapp typecheck # Validate TypeScript types without emitting files
+```
+
+The development server defaults to `http://localhost:5173`.
+
+### Environment configuration
+
+The app expects an API Gateway base URL exposed as `VITE_API_BASE_URL`. Create a `.env.local`
+file inside `apgms/webapp` for local development:
+
+```
+VITE_API_BASE_URL=http://localhost:8080
+```
+
+When not provided the app falls back to `/api`, making it compatible with the platform's reverse
+proxy configuration.
+
+### API integration
+
+All API communication flows through `src/services/api.ts`, which automatically attaches bearer
+tokens and converts non-2xx responses into JavaScript errors. The Zustand store coordinates
+authentication and hydration logic so components only render when portal data is available.
+
+### Project layout
+
+- `src/App.tsx` – top-level routing configuration for onboarding, tax workflows, and compliance views.
+- `src/store/appStore.ts` – Zustand store handling authentication, portal data, and API interactions.
+- `src/pages/*` – page-level views composing layout primitives and store state.
+- `src/components` – shared layout and UI elements.
+- `src/styles.css` – global styling for the glassmorphic layout.
+- `tests` live alongside the modules they cover under `__tests__` directories.
+
+### Testing
+
+Vitest powers both unit and component tests. The suite includes:
+
+- Store tests validating authentication bootstrapping and onboarding updates.
+- Component tests covering form validation and user actions.
+
+End-to-end coverage can be layered on with Playwright. A stub configuration lives in
+`apgms/playwright.config.ts`; add scenarios under `tests/e2e` and wire them into CI when API stubs are ready.
+
+### Continuous integration
+
+The repository ships with a GitHub Actions workflow (`.github/workflows/webapp.yml`) that installs
+workspace dependencies and runs linting, type checks, tests, and production builds for the webapp.
+
+### Deployment
+
+Run `pnpm --filter @apgms/webapp build` to produce an optimized bundle in `dist/`. Serve the output
+behind the platform's CDN or a static hosting provider. Ensure that server-side routing rewrites
+all requests to `index.html` so React Router can resolve client-side routes.

--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>APGMS Compliance Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,40 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "lint": "eslint src --ext .ts,.tsx",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0",
+    "zustand": "^4.5.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
+    "@typescript-eslint/eslint-plugin": "^8.12.2",
+    "@typescript-eslint/parser": "^8.12.2",
+    "@vitejs/plugin-react": "^4.3.3",
+    "eslint": "^9.12.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
+    "eslint-plugin-react-refresh": "^0.4.12",
+    "jsdom": "^26.0.0",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10",
+    "vitest": "^2.1.5"
+  }
+}

--- a/apgms/webapp/src/App.tsx
+++ b/apgms/webapp/src/App.tsx
@@ -1,0 +1,26 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+
+import { AppLayout } from './components/layout/AppLayout';
+import { ProtectedRoute } from './components/layout/ProtectedRoute';
+import { ComplianceDashboardPage } from './pages/ComplianceDashboardPage';
+import { LoginPage } from './pages/LoginPage';
+import { OnboardingPage } from './pages/OnboardingPage';
+import { TaxWorkflowPage } from './pages/TaxWorkflowPage';
+import { NotFoundPage } from './pages/NotFoundPage';
+
+const App = () => (
+  <Routes>
+    <Route path="/login" element={<LoginPage />} />
+    <Route element={<ProtectedRoute />}> 
+      <Route element={<AppLayout />}>
+        <Route path="/" element={<Navigate to="/onboarding" replace />} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
+        <Route path="/tax" element={<TaxWorkflowPage />} />
+        <Route path="/compliance" element={<ComplianceDashboardPage />} />
+      </Route>
+    </Route>
+    <Route path="*" element={<NotFoundPage />} />
+  </Routes>
+);
+
+export default App;

--- a/apgms/webapp/src/components/layout/AppLayout.tsx
+++ b/apgms/webapp/src/components/layout/AppLayout.tsx
@@ -1,0 +1,27 @@
+import { Outlet } from 'react-router-dom';
+import { useAppStore } from '../../store/appStore';
+import { ErrorBanner } from '../ui/ErrorBanner';
+import { LoadingOverlay } from '../ui/LoadingOverlay';
+import { Sidebar } from './Sidebar';
+import { TopBar } from './TopBar';
+
+export const AppLayout = () => {
+  const { globalError, isBootstrapping } = useAppStore((state) => ({
+    globalError: state.error,
+    isBootstrapping: state.isBootstrapping
+  }));
+
+  return (
+    <div className="app-shell">
+      <Sidebar />
+      <div className="app-content">
+        <TopBar />
+        <main className="app-main">
+          {globalError && <ErrorBanner message={globalError} />}
+          <LoadingOverlay isLoading={isBootstrapping} />
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/apgms/webapp/src/components/layout/ProtectedRoute.tsx
+++ b/apgms/webapp/src/components/layout/ProtectedRoute.tsx
@@ -1,0 +1,24 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+
+import { useAppStore } from '../../store/appStore';
+
+export const ProtectedRoute = () => {
+  const location = useLocation();
+  const { isAuthenticated, bootstrap } = useAppStore((state) => ({
+    isAuthenticated: state.isAuthenticated,
+    bootstrap: state.bootstrap
+  }));
+
+  useEffect(() => {
+    bootstrap().catch(() => {
+      /* handled by store */
+    });
+  }, [bootstrap]);
+
+  if (!isAuthenticated()) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />;
+};

--- a/apgms/webapp/src/components/layout/Sidebar.tsx
+++ b/apgms/webapp/src/components/layout/Sidebar.tsx
@@ -1,0 +1,27 @@
+import { NavLink } from 'react-router-dom';
+import clsx from 'clsx';
+
+const links = [
+  { to: '/onboarding', label: 'Onboarding' },
+  { to: '/tax', label: 'Tax Workflows' },
+  { to: '/compliance', label: 'Compliance' }
+];
+
+export const Sidebar = () => (
+  <aside className="sidebar">
+    <h1 className="sidebar__title">APGMS</h1>
+    <nav className="sidebar__nav">
+      {links.map((link) => (
+        <NavLink
+          key={link.to}
+          to={link.to}
+          className={({ isActive }) =>
+            clsx('sidebar__link', { 'sidebar__link--active': isActive })
+          }
+        >
+          {link.label}
+        </NavLink>
+      ))}
+    </nav>
+  </aside>
+);

--- a/apgms/webapp/src/components/layout/TopBar.tsx
+++ b/apgms/webapp/src/components/layout/TopBar.tsx
@@ -1,0 +1,24 @@
+import { useAppStore } from '../../store/appStore';
+
+export const TopBar = () => {
+  const { user, signOut } = useAppStore((state) => ({
+    user: state.user,
+    signOut: state.signOut
+  }));
+
+  return (
+    <header className="top-bar">
+      <div className="top-bar__content">
+        <div>
+          <h2 className="top-bar__title">{user?.organisation ?? 'APGMS'}</h2>
+          {user && <p className="top-bar__subtitle">{user.email}</p>}
+        </div>
+        {user && (
+          <button className="button button--ghost" type="button" onClick={signOut}>
+            Sign out
+          </button>
+        )}
+      </div>
+    </header>
+  );
+};

--- a/apgms/webapp/src/components/ui/DataCard.tsx
+++ b/apgms/webapp/src/components/ui/DataCard.tsx
@@ -1,0 +1,16 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+
+interface DataCardProps extends PropsWithChildren {
+  title: string;
+  action?: ReactNode;
+}
+
+export const DataCard = ({ title, action, children }: DataCardProps) => (
+  <section className="data-card">
+    <header className="data-card__header">
+      <h3>{title}</h3>
+      {action}
+    </header>
+    <div className="data-card__body">{children}</div>
+  </section>
+);

--- a/apgms/webapp/src/components/ui/ErrorBanner.tsx
+++ b/apgms/webapp/src/components/ui/ErrorBanner.tsx
@@ -1,0 +1,10 @@
+interface ErrorBannerProps {
+  message: string;
+}
+
+export const ErrorBanner = ({ message }: ErrorBannerProps) => (
+  <div role="alert" className="error-banner">
+    <span>⚠️</span>
+    <p>{message}</p>
+  </div>
+);

--- a/apgms/webapp/src/components/ui/LoadingOverlay.tsx
+++ b/apgms/webapp/src/components/ui/LoadingOverlay.tsx
@@ -1,0 +1,16 @@
+interface LoadingOverlayProps {
+  isLoading: boolean;
+}
+
+export const LoadingOverlay = ({ isLoading }: LoadingOverlayProps) => {
+  if (!isLoading) {
+    return null;
+  }
+
+  return (
+    <div className="loading-overlay" role="status" aria-live="polite">
+      <div className="loading-spinner" />
+      <span>Loading data…</span>
+    </div>
+  );
+};

--- a/apgms/webapp/src/components/ui/StatusBadge.tsx
+++ b/apgms/webapp/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,10 @@
+import clsx from 'clsx';
+
+interface StatusBadgeProps {
+  label: string;
+  tone?: 'default' | 'success' | 'warning' | 'danger';
+}
+
+export const StatusBadge = ({ label, tone = 'default' }: StatusBadgeProps) => (
+  <span className={clsx('status-badge', `status-badge--${tone}`)}>{label}</span>
+);

--- a/apgms/webapp/src/components/ui/TrendPill.tsx
+++ b/apgms/webapp/src/components/ui/TrendPill.tsx
@@ -1,0 +1,14 @@
+interface TrendPillProps {
+  trend: 'up' | 'down' | 'steady';
+}
+
+const trendCopy: Record<TrendPillProps['trend'], { label: string; symbol: string }> = {
+  up: { label: 'Improving', symbol: '⬆️' },
+  down: { label: 'Declining', symbol: '⬇️' },
+  steady: { label: 'Stable', symbol: '➡️' }
+};
+
+export const TrendPill = ({ trend }: TrendPillProps) => {
+  const { label, symbol } = trendCopy[trend];
+  return <span className={`trend-pill trend-pill--${trend}`}>{`${symbol} ${label}`}</span>;
+};

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,22 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+
+import App from './App';
+import './styles.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+const root = ReactDOM.createRoot(rootElement);
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/pages/ComplianceDashboardPage.tsx
+++ b/apgms/webapp/src/pages/ComplianceDashboardPage.tsx
@@ -1,0 +1,78 @@
+import { DataCard } from '../components/ui/DataCard';
+import { StatusBadge } from '../components/ui/StatusBadge';
+import { TrendPill } from '../components/ui/TrendPill';
+import { useAppStore } from '../store/appStore';
+
+const severityTone = {
+  low: 'default',
+  medium: 'warning',
+  high: 'danger'
+} as const;
+
+export const ComplianceDashboardPage = () => {
+  const { complianceMetrics, complianceNotices, acknowledgeNotice } = useAppStore((state) => ({
+    complianceMetrics: state.complianceMetrics,
+    complianceNotices: state.complianceNotices,
+    acknowledgeNotice: state.acknowledgeNotice
+  }));
+
+  return (
+    <div className="page">
+      <header className="page__header">
+        <div>
+          <h1>Compliance overview</h1>
+          <p>
+            Understand current filing health and address outstanding notices before they become
+            blockers.
+          </p>
+        </div>
+      </header>
+
+      <div className="grid">
+        {complianceMetrics.map((metric) => (
+          <DataCard
+            key={metric.id}
+            title={metric.label}
+            action={<TrendPill trend={metric.trend} />}
+          >
+            <p className="metric-value">{metric.value}</p>
+          </DataCard>
+        ))}
+      </div>
+
+      <section className="panel">
+        <header className="panel__header">
+          <h2>Open notices</h2>
+        </header>
+        {complianceNotices.length === 0 ? (
+          <p>You're fully compliant — no open notices.</p>
+        ) : (
+          <ul className="notice-list">
+            {complianceNotices.map((notice) => (
+              <li key={notice.id} className="notice-list__item">
+                <div>
+                  <h3>{notice.title}</h3>
+                  <p>{notice.description}</p>
+                </div>
+                <div className="notice-list__meta">
+                  <StatusBadge
+                    label={notice.severity.toUpperCase()}
+                    tone={severityTone[notice.severity] as 'default' | 'warning' | 'danger'}
+                  />
+                  <button
+                    className="button button--ghost"
+                    type="button"
+                    disabled={notice.acknowledged}
+                    onClick={() => acknowledgeNotice(notice.id)}
+                  >
+                    {notice.acknowledged ? 'Acknowledged' : 'Acknowledge'}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/apgms/webapp/src/pages/LoginPage.tsx
+++ b/apgms/webapp/src/pages/LoginPage.tsx
@@ -1,0 +1,77 @@
+import { FormEvent, useState } from 'react';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
+
+import { useAppStore } from '../store/appStore';
+
+export const LoginPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { signIn, isAuthenticated, error, isBootstrapping } = useAppStore((state) => ({
+    signIn: state.signIn,
+    isAuthenticated: state.isAuthenticated,
+    error: state.error,
+    isBootstrapping: state.isBootstrapping
+  }));
+
+  const [credentials, setCredentials] = useState({ email: '', password: '' });
+  const [formError, setFormError] = useState<string | null>(null);
+
+  if (isAuthenticated()) {
+    const redirectTo =
+      (location.state as { from?: { pathname?: string } } | undefined)?.from?.pathname ??
+      '/onboarding';
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setFormError(null);
+
+    if (!credentials.email || !credentials.password) {
+      setFormError('Enter both your email address and password');
+      return;
+    }
+
+    try {
+      await signIn(credentials.email, credentials.password);
+      navigate('/onboarding', { replace: true });
+    } catch (signInError) {
+      setFormError(
+        signInError instanceof Error ? signInError.message : 'Unable to sign in with those details'
+      );
+    }
+  };
+
+  return (
+    <div className="login">
+      <form className="login__form" aria-label="Sign in" onSubmit={onSubmit}>
+        <h1>Sign in to APGMS</h1>
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          type="email"
+          value={credentials.email}
+          onChange={(event) => setCredentials((prev) => ({ ...prev, email: event.target.value }))}
+          placeholder="finance@organisation.com"
+        />
+
+        <label htmlFor="password">Password</label>
+        <input
+          id="password"
+          type="password"
+          value={credentials.password}
+          onChange={(event) =>
+            setCredentials((prev) => ({ ...prev, password: event.target.value }))
+          }
+          placeholder="••••••••"
+        />
+
+        {(formError || error) && <p className="form-error">{formError ?? error}</p>}
+
+        <button className="button" type="submit" disabled={isBootstrapping}>
+          {isBootstrapping ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/apgms/webapp/src/pages/NotFoundPage.tsx
+++ b/apgms/webapp/src/pages/NotFoundPage.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+export const NotFoundPage = () => (
+  <div className="page page--centered">
+    <h1>Page not found</h1>
+    <p>The page you were looking for doesn\'t exist.</p>
+    <Link className="button" to="/onboarding">
+      Go back home
+    </Link>
+  </div>
+);

--- a/apgms/webapp/src/pages/OnboardingPage.tsx
+++ b/apgms/webapp/src/pages/OnboardingPage.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+
+import { StatusBadge } from '../components/ui/StatusBadge';
+import { useAppStore } from '../store/appStore';
+
+const statusCopy = {
+  pending: { label: 'Pending', tone: 'default' },
+  'in-progress': { label: 'In progress', tone: 'warning' },
+  complete: { label: 'Complete', tone: 'success' }
+} as const;
+
+export const OnboardingPage = () => {
+  const { onboardingSteps, updateOnboardingStep } = useAppStore((state) => ({
+    onboardingSteps: state.onboardingSteps,
+    updateOnboardingStep: state.updateOnboardingStep
+  }));
+
+  const sortedSteps = useMemo(
+    () =>
+      [...onboardingSteps].sort((stepA, stepB) => {
+        const priority = { pending: 0, 'in-progress': 1, complete: 2 } as const;
+        return priority[stepA.status] - priority[stepB.status];
+      }),
+    [onboardingSteps]
+  );
+
+  return (
+    <div className="page">
+      <header className="page__header">
+        <div>
+          <h1>Onboarding journey</h1>
+          <p>
+            Track progress across tax registrations, banking connections, and compliance approvals
+            as you bring a new organisation onto the platform.
+          </p>
+        </div>
+      </header>
+
+      <section className="panel">
+        {sortedSteps.length === 0 ? (
+          <p>No onboarding steps have been configured yet.</p>
+        ) : (
+          <ol className="onboarding-list">
+            {sortedSteps.map((step) => {
+              const { label, tone } = statusCopy[step.status];
+              return (
+                <li key={step.id} className="onboarding-list__item">
+                  <div>
+                    <h3>{step.title}</h3>
+                    <p>{step.description}</p>
+                  </div>
+                  <div className="onboarding-list__meta">
+                    <StatusBadge label={label} tone={tone} />
+                    {step.status !== 'complete' && (
+                      <button
+                        className="button button--ghost"
+                        type="button"
+                        onClick={() =>
+                          updateOnboardingStep(
+                            step.id,
+                            step.status === 'pending' ? 'in-progress' : 'complete'
+                          )
+                        }
+                      >
+                        {step.status === 'pending' ? 'Start step' : 'Mark complete'}
+                      </button>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/apgms/webapp/src/pages/TaxWorkflowPage.tsx
+++ b/apgms/webapp/src/pages/TaxWorkflowPage.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+
+import { StatusBadge } from '../components/ui/StatusBadge';
+import { useAppStore } from '../store/appStore';
+
+const statusTone = {
+  draft: 'default',
+  'in-progress': 'warning',
+  filed: 'success',
+  'awaiting-review': 'warning'
+} as const;
+
+const statusLabel = {
+  draft: 'Draft',
+  'in-progress': 'In progress',
+  filed: 'Filed',
+  'awaiting-review': 'Awaiting review'
+} as const;
+
+export const TaxWorkflowPage = () => {
+  const taxWorkflows = useAppStore((state) => state.taxWorkflows);
+  const [statusFilter, setStatusFilter] = useState<'all' | keyof typeof statusLabel>('all');
+  const [search, setSearch] = useState('');
+
+  const filteredWorkflows = useMemo(() => {
+    return taxWorkflows.filter((workflow) => {
+      const matchesStatus =
+        statusFilter === 'all' ? true : workflow.status === statusFilter;
+      const matchesSearch = `${workflow.jurisdiction} ${workflow.filingType} ${workflow.owner}`
+        .toLowerCase()
+        .includes(search.toLowerCase());
+      return matchesStatus && matchesSearch;
+    });
+  }, [search, statusFilter, taxWorkflows]);
+
+  return (
+    <div className="page">
+      <header className="page__header">
+        <div>
+          <h1>Tax workflows</h1>
+          <p>Monitor filing progress and ownership across your active tax workflows.</p>
+        </div>
+        <div className="filters">
+          <label>
+            <span>Status</span>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as typeof statusFilter)}
+            >
+              <option value="all">All statuses</option>
+              {Object.entries(statusLabel).map(([status, label]) => (
+                <option key={status} value={status}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span>Search</span>
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search by jurisdiction, filing or owner"
+            />
+          </label>
+        </div>
+      </header>
+
+      <section className="panel">
+        {filteredWorkflows.length === 0 ? (
+          <p>No workflows match your filters.</p>
+        ) : (
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Jurisdiction</th>
+                <th>Filing</th>
+                <th>Due date</th>
+                <th>Status</th>
+                <th>Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredWorkflows.map((workflow) => (
+                <tr key={workflow.id}>
+                  <td>{workflow.jurisdiction}</td>
+                  <td>{workflow.filingType}</td>
+                  <td>{new Date(workflow.dueDate).toLocaleDateString()}</td>
+                  <td>
+                    <StatusBadge
+                      label={statusLabel[workflow.status]}
+                      tone={statusTone[workflow.status] as 'default' | 'success' | 'warning'}
+                    />
+                  </td>
+                  <td>{workflow.owner}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+};

--- a/apgms/webapp/src/pages/__tests__/LoginPage.test.tsx
+++ b/apgms/webapp/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { renderWithRouter } from '../../test-utils';
+import { useAppStore, createInitialState } from '../../store/appStore';
+import { LoginPage } from '../LoginPage';
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    useAppStore.setState(() => ({
+      ...createInitialState(),
+      signIn: useAppStore.getState().signIn,
+      isAuthenticated: () => false
+    }));
+  });
+
+  it('validates required fields before submitting', async () => {
+    renderWithRouter(<LoginPage />, { initialEntries: ['/login'] });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(await screen.findByText(/enter both your email address/i)).toBeVisible();
+  });
+
+  it('calls signIn with entered credentials', async () => {
+    const signInSpy = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState((state) => ({
+      ...state,
+      signIn: signInSpy,
+      isBootstrapping: false,
+      isAuthenticated: () => false
+    }));
+
+    renderWithRouter(<LoginPage />, { initialEntries: ['/login'] });
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'user@example.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'password123' }
+    });
+
+    fireEvent.submit(screen.getByRole('form', { name: /sign in/i }));
+
+    expect(signInSpy).toHaveBeenCalledWith('user@example.com', 'password123');
+  });
+});

--- a/apgms/webapp/src/pages/__tests__/OnboardingPage.test.tsx
+++ b/apgms/webapp/src/pages/__tests__/OnboardingPage.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+
+import { renderWithRouter } from '../../test-utils';
+import { createInitialState, useAppStore } from '../../store/appStore';
+import { OnboardingPage } from '../OnboardingPage';
+
+describe('OnboardingPage', () => {
+  beforeEach(() => {
+    useAppStore.setState(() => ({
+      ...createInitialState(),
+      onboardingSteps: [
+        {
+          id: 'banking',
+          title: 'Connect banking',
+          description: 'Link the primary treasury accounts for reconciliations.',
+          status: 'pending'
+        }
+      ],
+      updateOnboardingStep: vi.fn()
+    }));
+  });
+
+  it('renders onboarding steps with actions', () => {
+    renderWithRouter(<OnboardingPage />);
+
+    expect(screen.getByText(/connect banking/i)).toBeVisible();
+    expect(screen.getByRole('button', { name: /start step/i })).toBeVisible();
+  });
+
+  it('invokes update handler when advancing step', () => {
+    renderWithRouter(<OnboardingPage />);
+    fireEvent.click(screen.getByRole('button', { name: /start step/i }));
+
+    expect(useAppStore.getState().updateOnboardingStep).toHaveBeenCalledWith(
+      'banking',
+      'in-progress'
+    );
+  });
+});

--- a/apgms/webapp/src/services/api.ts
+++ b/apgms/webapp/src/services/api.ts
@@ -1,0 +1,119 @@
+export interface LoginResponse {
+  token: string;
+  user: UserProfile;
+}
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  organisation: string;
+  name?: string;
+}
+
+export interface OnboardingStep {
+  id: string;
+  title: string;
+  description: string;
+  status: 'pending' | 'in-progress' | 'complete';
+}
+
+export interface TaxWorkflow {
+  id: string;
+  jurisdiction: string;
+  filingType: string;
+  dueDate: string;
+  status: 'draft' | 'in-progress' | 'filed' | 'awaiting-review';
+  owner: string;
+}
+
+export interface ComplianceMetric {
+  id: string;
+  label: string;
+  value: string;
+  trend: 'up' | 'down' | 'steady';
+}
+
+export interface ComplianceNotice {
+  id: string;
+  title: string;
+  description: string;
+  severity: 'low' | 'medium' | 'high';
+  acknowledged: boolean;
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api';
+
+const jsonHeaders = {
+  'Content-Type': 'application/json'
+};
+
+export class ApiGatewayClient {
+  constructor(private readonly getToken: () => string | null) {}
+
+  private buildHeaders(headers?: HeadersInit): HeadersInit {
+    const token = this.getToken();
+    return {
+      ...jsonHeaders,
+      ...(headers ?? {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {})
+    };
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const response = await fetch(`${API_BASE_URL}${path}`, {
+      ...init,
+      headers: this.buildHeaders(init?.headers)
+    });
+
+    if (!response.ok) {
+      let message = response.statusText;
+      try {
+        const payload = await response.json();
+        message = payload.message ?? message;
+      } catch (error) {
+        // ignore JSON parsing failures
+      }
+      throw new Error(message);
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  login(email: string, password: string) {
+    return this.request<LoginResponse>('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password })
+    });
+  }
+
+  fetchProfile() {
+    return this.request<UserProfile>('/auth/profile');
+  }
+
+  fetchOnboardingSteps() {
+    return this.request<OnboardingStep[]>('/onboarding/steps');
+  }
+
+  updateOnboardingStep(stepId: string, status: OnboardingStep['status']) {
+    return this.request<OnboardingStep>(`/onboarding/steps/${stepId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status })
+    });
+  }
+
+  fetchTaxWorkflows() {
+    return this.request<TaxWorkflow[]>('/tax/workflows');
+  }
+
+  fetchComplianceMetrics() {
+    return this.request<ComplianceMetric[]>('/compliance/metrics');
+  }
+
+  fetchComplianceNotices() {
+    return this.request<ComplianceNotice[]>('/compliance/notices');
+  }
+}

--- a/apgms/webapp/src/store/__tests__/appStore.test.ts
+++ b/apgms/webapp/src/store/__tests__/appStore.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAppStore, createInitialState } from '../appStore';
+
+const createResponse = (data: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init
+  });
+
+describe('appStore', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    useAppStore.setState(createInitialState());
+  });
+
+  it('signs users in and loads portal data', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        createResponse({
+          token: 'token-123',
+          user: { id: 'user-1', email: 'user@example.com', organisation: 'APGMS' }
+        })
+      )
+      .mockResolvedValueOnce(
+        createResponse({ id: 'user-1', email: 'user@example.com', organisation: 'APGMS' })
+      )
+      .mockResolvedValueOnce(
+        createResponse([
+          {
+            id: 'kyc',
+            title: 'Complete KYC',
+            description: 'Collect director IDs.',
+            status: 'in-progress'
+          }
+        ])
+      )
+      .mockResolvedValueOnce(
+        createResponse([
+          {
+            id: 'gst-1',
+            jurisdiction: 'Australia',
+            filingType: 'GST monthly',
+            dueDate: '2024-12-01',
+            status: 'in-progress',
+            owner: 'Jamie Lee'
+          }
+        ])
+      )
+      .mockResolvedValueOnce(
+        createResponse([
+          { id: 'filings', label: 'Filings submitted', value: '85%', trend: 'up' }
+        ])
+      )
+      .mockResolvedValueOnce(
+        createResponse([
+          {
+            id: 'late-fee',
+            title: 'Late fee waiver',
+            description: 'Confirm waiver approval.',
+            severity: 'medium',
+            acknowledged: false
+          }
+        ])
+      );
+
+    await useAppStore.getState().signIn('user@example.com', 'password');
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/login', expect.anything());
+    expect(useAppStore.getState().user?.email).toBe('user@example.com');
+    expect(useAppStore.getState().taxWorkflows).toHaveLength(1);
+    expect(useAppStore.getState().complianceNotices[0].id).toBe('late-fee');
+  });
+
+  it('updates onboarding step status', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(createResponse({
+        id: 'banking',
+        title: 'Banking integration',
+        description: 'Connect treasury accounts.',
+        status: 'complete'
+      }));
+
+    useAppStore.setState((state) => ({
+      ...state,
+      onboardingSteps: [
+        {
+          id: 'banking',
+          title: 'Banking integration',
+          description: 'Connect treasury accounts.',
+          status: 'in-progress'
+        }
+      ]
+    }));
+
+    await useAppStore.getState().updateOnboardingStep('banking', 'complete');
+
+    expect(useAppStore.getState().onboardingSteps[0].status).toBe('complete');
+  });
+});

--- a/apgms/webapp/src/store/appStore.ts
+++ b/apgms/webapp/src/store/appStore.ts
@@ -1,0 +1,167 @@
+import { create } from 'zustand';
+
+import {
+  ApiGatewayClient,
+  ComplianceMetric,
+  ComplianceNotice,
+  OnboardingStep,
+  TaxWorkflow,
+  UserProfile
+} from '../services/api';
+
+const TOKEN_STORAGE_KEY = 'apgms:webapp:token';
+
+const readToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(TOKEN_STORAGE_KEY);
+};
+
+const persistToken = (token: string | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (token) {
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+  } else {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  }
+};
+
+export interface AppState {
+  authToken: string | null;
+  user: UserProfile | null;
+  onboardingSteps: OnboardingStep[];
+  taxWorkflows: TaxWorkflow[];
+  complianceMetrics: ComplianceMetric[];
+  complianceNotices: ComplianceNotice[];
+  isBootstrapping: boolean;
+  error: string | null;
+}
+
+interface AppActions {
+  bootstrap: () => Promise<void>;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => void;
+  isAuthenticated: () => boolean;
+  updateOnboardingStep: (stepId: string, status: OnboardingStep['status']) => Promise<void>;
+  acknowledgeNotice: (noticeId: string) => void;
+}
+
+type AppStore = AppState & AppActions;
+
+export const createInitialState = (): AppState => ({
+  authToken: null,
+  user: null,
+  onboardingSteps: [],
+  taxWorkflows: [],
+  complianceMetrics: [],
+  complianceNotices: [],
+  isBootstrapping: false,
+  error: null
+});
+
+export const useAppStore = create<AppStore>((set, get) => {
+  const api = new ApiGatewayClient(() => get().authToken);
+
+  const loadPortalData = async () => {
+    set({ isBootstrapping: true, error: null });
+    try {
+      const [user, onboardingSteps, taxWorkflows, complianceMetrics, complianceNotices] =
+        await Promise.all([
+          api.fetchProfile(),
+          api.fetchOnboardingSteps(),
+          api.fetchTaxWorkflows(),
+          api.fetchComplianceMetrics(),
+          api.fetchComplianceNotices()
+        ]);
+
+      set({
+        user,
+        onboardingSteps,
+        taxWorkflows,
+        complianceMetrics,
+        complianceNotices,
+        isBootstrapping: false,
+        error: null
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to load workspace data';
+      set({ error: message, isBootstrapping: false });
+      throw error;
+    }
+  };
+
+  return {
+    ...createInitialState(),
+
+    bootstrap: async () => {
+      const { authToken } = get();
+      if (!authToken) {
+        const storedToken = readToken();
+        if (!storedToken) {
+          return;
+        }
+        set({ authToken: storedToken });
+      }
+
+      if (get().user) {
+        return;
+      }
+
+      try {
+        await loadPortalData();
+      } catch (error) {
+        // loadPortalData already captured error state
+      }
+    },
+
+    signIn: async (email, password) => {
+      set({ error: null, isBootstrapping: true });
+      try {
+        const response = await api.login(email, password);
+        persistToken(response.token);
+        set({ authToken: response.token, user: response.user });
+        await loadPortalData();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'We were unable to sign you in';
+        set({ error: message, isBootstrapping: false });
+        throw error;
+      }
+    },
+
+    signOut: () => {
+      persistToken(null);
+      set(createInitialState());
+    },
+
+    isAuthenticated: () => Boolean(get().authToken ?? readToken()),
+
+    updateOnboardingStep: async (stepId, status) => {
+      try {
+        const updatedStep = await api.updateOnboardingStep(stepId, status);
+        set((state) => ({
+          onboardingSteps: state.onboardingSteps.map((step) =>
+            step.id === stepId ? updatedStep : step
+          )
+        }));
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unable to update onboarding step';
+        set({ error: message });
+        throw error;
+      }
+    },
+
+    acknowledgeNotice: (noticeId) => {
+      set((state) => ({
+        complianceNotices: state.complianceNotices.map((notice) =>
+          notice.id === noticeId ? { ...notice, acknowledged: true } : notice
+        )
+      }));
+    }
+  };
+});

--- a/apgms/webapp/src/styles.css
+++ b/apgms/webapp/src/styles.css
@@ -1,0 +1,434 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+  font-weight: 400;
+  --color-background: #0f172a;
+  --color-panel: #111827;
+  --color-surface: rgba(30, 41, 59, 0.8);
+  --color-border: rgba(148, 163, 184, 0.2);
+  --color-text: #f8fafc;
+  --color-text-muted: #cbd5f5;
+  --color-primary: #60a5fa;
+  --color-success: #34d399;
+  --color-warning: #fbbf24;
+  --color-danger: #f87171;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1e293b, #0f172a 60%);
+  color: var(--color-text);
+}
+
+a {
+  color: inherit;
+}
+
+button,
+input,
+select {
+  font: inherit;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary);
+  color: #0b1120;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(59, 130, 246, 0.3);
+}
+
+.button--ghost {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+  backdrop-filter: blur(18px);
+}
+
+.sidebar {
+  padding: 2rem 1.5rem;
+  border-right: 1px solid var(--color-border);
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.6));
+}
+
+.sidebar__title {
+  margin: 0 0 1.5rem;
+  font-size: 1.5rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.sidebar__nav {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sidebar__link {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: var(--color-text-muted);
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.sidebar__link:hover,
+.sidebar__link--active {
+  background: rgba(96, 165, 250, 0.2);
+  color: var(--color-text);
+}
+
+.app-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 3rem;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 1rem;
+}
+
+.top-bar__content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.top-bar__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.top-bar__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.page__header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.page--centered {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 4rem 0;
+}
+
+.panel,
+.data-card,
+.table,
+.notice-list,
+.onboarding-list {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(8, 47, 73, 0.35);
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+}
+
+.filters input,
+.filters select {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-text);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.data-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.data-card__body {
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.metric-value {
+  margin: 0;
+}
+
+.notice-list,
+.onboarding-list {
+  display: grid;
+  gap: 1.25rem;
+  padding: 0;
+  list-style: none;
+}
+
+.notice-list__item,
+.onboarding-list__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.notice-list__meta,
+.onboarding-list__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.status-badge--default {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--color-text-muted);
+}
+
+.status-badge--success {
+  background: rgba(52, 211, 153, 0.2);
+  color: var(--color-success);
+}
+
+.status-badge--warning {
+  background: rgba(251, 191, 36, 0.2);
+  color: var(--color-warning);
+}
+
+.status-badge--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: var(--color-danger);
+}
+
+.trend-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(96, 165, 250, 0.1);
+}
+
+.trend-pill--up {
+  color: var(--color-success);
+}
+
+.trend-pill--down {
+  color: var(--color-danger);
+}
+
+.trend-pill--steady {
+  color: var(--color-text-muted);
+}
+
+.error-banner {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--color-danger);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.loading-overlay {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.loading-spinner {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 999px;
+  border: 2px solid rgba(148, 163, 184, 0.35);
+  border-top-color: var(--color-primary);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.login {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.login__form {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid var(--color-border);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  display: grid;
+  gap: 1rem;
+  width: min(420px, 100%);
+}
+
+.login__form h1 {
+  margin: 0 0 1rem;
+}
+
+.login__form input {
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--color-text);
+}
+
+.form-error {
+  color: var(--color-danger);
+  margin: 0;
+  font-weight: 500;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .sidebar__nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .filters {
+    flex-direction: column;
+  }
+
+  .notice-list__item,
+  .onboarding-list__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .notice-list__meta,
+  .onboarding-list__meta {
+    align-items: flex-start;
+  }
+}

--- a/apgms/webapp/src/test-utils.tsx
+++ b/apgms/webapp/src/test-utils.tsx
@@ -1,0 +1,14 @@
+import type { PropsWithChildren, ReactElement } from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+export const renderWithRouter = (
+  ui: ReactElement,
+  { initialEntries = ['/'] }: { initialEntries?: string[] } = {}
+) => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  );
+
+  return render(ui, { wrapper: Wrapper });
+};

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": ["vitest", "vite/client", "@testing-library/jest-dom"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apgms/webapp/tsconfig.node.json
+++ b/apgms/webapp/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    open: true
+  },
+  build: {
+    sourcemap: true
+  }
+});

--- a/apgms/webapp/vitest.config.ts
+++ b/apgms/webapp/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+    css: true
+  }
+});

--- a/apgms/webapp/vitest.setup.ts
+++ b/apgms/webapp/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- scaffold a Vite-powered React portal with authentication guard, routing, and shared layout components
- build onboarding, tax workflow, and compliance dashboard screens wired into a Zustand store and API gateway client
- add Vitest component/store tests, lint/type configs, CI workflow, and developer documentation

## Testing
- pnpm --filter @apgms/webapp test -- --run *(fails: vitest binary not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2f45576a48327977a9e281895ce5b