### PR TITLE
Implement tax engine API and calculations

### DIFF
--- a/apgms/services/tax-engine/README.md
+++ b/apgms/services/tax-engine/README.md
@@ -1,0 +1,68 @@
+# APGMS Tax Engine
+
+The APGMS tax engine is a FastAPI application responsible for estimating liabilities, filing
+returns, and generating audit trails for compliance teams. The service exposes REST endpoints
+and can be deployed as part of the broader APGMS platform.
+
+## Application structure
+
+```
+app/
+├── api/               # FastAPI routers
+├── calculations.py    # Core calculation pipeline
+├── main.py            # FastAPI entrypoint
+├── schemas.py         # Pydantic models shared across endpoints
+├── services.py        # External integrations (tax rates, filing)
+└── validators.py      # Compliance validations
+```
+
+## Endpoints
+
+| Method | Path           | Description                                   |
+| ------ | -------------- | --------------------------------------------- |
+| GET    | `/health`      | Simple health probe.                          |
+| POST   | `/tax/estimate`| Generate a tax estimate and compliance notes. |
+| POST   | `/tax/file`    | Submit a filing request using a tax estimate. |
+| POST   | `/tax/audit`   | Produce audit trail entries for a filing.     |
+
+### Tax estimation (`POST /tax/estimate`)
+
+Request body (`TaxInput`):
+
+- `tax_year`: Target filing year.
+- `residency_status`: `resident` or `non_resident`.
+- `filing_status`: `single`, `married`, or `head_of_household`.
+- `dependents`: Count of dependents.
+- `incomes`: List of income streams (`source`, `type`, `amount`, `withholding`).
+- `deductions`: Optional deductions (`description`, `amount`).
+- `adjustments`: Credits or surcharges applied post-calculation.
+
+Response (`TaxEstimate`): provides the computed breakdown (taxable income, gross/net tax,
+credits, surcharges, and effective rate) as well as any compliance warnings triggered during
+validation.
+
+### Filing (`POST /tax/file`)
+
+Request body (`FilingSubmission`) includes a `taxpayer_id` alongside the `TaxInput`. The
+endpoint internally creates a `TaxEstimate`, persists it using the `FilingService`, and returns a
+`FilingResponse` with submission metadata.
+
+### Audit trail (`POST /tax/audit`)
+
+Accepts the same structure as filing but returns a list of `AuditLogEntry` records that can be
+stored in downstream compliance systems.
+
+## Tax rate integration
+
+`TaxRateService` retrieves tax brackets from an upstream Prisma-backed API (configured via the
+`TAX_RATE_SERVICE_URL` environment variable). When the variable is unset the service falls back to
+an in-memory schedule suitable for local development and unit tests.
+
+## Running locally
+
+1. Install dependencies using Poetry: `poetry install`
+2. Run the API: `poetry run uvicorn app.main:app --reload`
+3. Execute the test suite: `poetry run pytest`
+
+The FastAPI application also publishes an OpenAPI document at `/openapi.json` and interactive
+Swagger UI at `/docs` once the server is running.

--- a/apgms/services/tax-engine/app/__init__.py
+++ b/apgms/services/tax-engine/app/__init__.py
@@ -1,1 +1,5 @@
-﻿
+from __future__ import annotations
+
+from .main import app
+
+__all__ = ["app"]

--- a/apgms/services/tax-engine/app/api/__init__.py
+++ b/apgms/services/tax-engine/app/api/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from . import tax
+
+
+router = APIRouter()
+router.include_router(tax.router, prefix="/tax", tags=["tax"])

--- a/apgms/services/tax-engine/app/api/tax.py
+++ b/apgms/services/tax-engine/app/api/tax.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, status
+
+from ..calculations import build_estimate
+from ..services import FilingService, TaxRateService
+from ..validators import validate_tax_input
+from ..schemas import (
+    AuditLogEntry,
+    AuditTrailRequest,
+    FilingRequest,
+    FilingResponse,
+    FilingSubmission,
+    TaxEstimate,
+    TaxInput,
+)
+
+router = APIRouter()
+
+_rate_service = TaxRateService()
+_filing_service = FilingService()
+
+
+def get_rate_service() -> TaxRateService:
+    return _rate_service
+
+
+def get_filing_service() -> FilingService:
+    return _filing_service
+
+
+@router.post("/estimate", response_model=TaxEstimate, status_code=status.HTTP_200_OK)
+async def estimate_tax(
+    payload: TaxInput,
+    rate_service: TaxRateService = Depends(get_rate_service),
+) -> TaxEstimate:
+    schedule = await rate_service.get_schedule(
+        tax_year=payload.tax_year, residency_status=payload.residency_status
+    )
+    warnings = validate_tax_input(payload)
+    return build_estimate(payload, rules=schedule.rules, warnings=warnings)
+
+
+@router.post("/file", response_model=FilingResponse, status_code=status.HTTP_201_CREATED)
+async def file_return(
+    submission: FilingSubmission,
+    rate_service: TaxRateService = Depends(get_rate_service),
+    filing_service: FilingService = Depends(get_filing_service),
+) -> FilingResponse:
+    schedule = await rate_service.get_schedule(
+        tax_year=submission.input.tax_year, residency_status=submission.input.residency_status
+    )
+    warnings = validate_tax_input(submission.input)
+    estimate = build_estimate(submission.input, rules=schedule.rules, warnings=warnings)
+    filing_request = FilingRequest(taxpayer_id=submission.taxpayer_id, estimate=estimate)
+    return await filing_service.submit_filing(filing_request)
+
+
+@router.post("/audit", response_model=list[AuditLogEntry], status_code=status.HTTP_200_OK)
+async def audit_trail(
+    payload: AuditTrailRequest,
+    rate_service: TaxRateService = Depends(get_rate_service),
+    filing_service: FilingService = Depends(get_filing_service),
+) -> list[AuditLogEntry]:
+    schedule = await rate_service.get_schedule(
+        tax_year=payload.input.tax_year, residency_status=payload.input.residency_status
+    )
+    warnings = validate_tax_input(payload.input)
+    estimate = build_estimate(payload.input, rules=schedule.rules, warnings=warnings)
+    filing_request = FilingRequest(taxpayer_id=payload.taxpayer_id, estimate=estimate)
+    return await filing_service.audit_trail(filing_request)

--- a/apgms/services/tax-engine/app/calculations.py
+++ b/apgms/services/tax-engine/app/calculations.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, List, Sequence
+
+from .schemas import Adjustment, AdjustmentType, TaxBreakdown, TaxEstimate, TaxInput
+
+
+@dataclass(frozen=True)
+class TaxRule:
+    threshold: Decimal
+    rate: Decimal
+
+    def apply(self, taxable_income: Decimal, previous_threshold: Decimal) -> Decimal:
+        if taxable_income <= previous_threshold:
+            return Decimal("0")
+        band_amount = min(taxable_income, self.threshold) - previous_threshold
+        return band_amount * self.rate
+
+
+class CalculationError(Exception):
+    """Raised when a calculation cannot be performed."""
+
+
+def compute_progressive_tax(taxable_income: Decimal, rules: Sequence[TaxRule]) -> Decimal:
+    tax_total = Decimal("0")
+    last_threshold = Decimal("0")
+
+    for rule in rules:
+        if taxable_income <= last_threshold:
+            break
+        tax_total += rule.apply(taxable_income, last_threshold)
+        last_threshold = rule.threshold
+
+    if taxable_income > last_threshold:
+        # apply final bracket rate to remaining income
+        tax_total += (taxable_income - last_threshold) * rules[-1].rate
+
+    return tax_total.quantize(Decimal("0.01"))
+
+
+def apply_adjustments(adjustments: Iterable[Adjustment]) -> tuple[Decimal, Decimal]:
+    credits = Decimal("0")
+    surcharges = Decimal("0")
+
+    for adjustment in adjustments:
+        if adjustment.type == AdjustmentType.CREDIT:
+            credits += adjustment.amount
+        else:
+            surcharges += adjustment.amount
+
+    return credits, surcharges
+
+
+def build_tax_breakdown(
+    tax_input: TaxInput, *, rules: Sequence[TaxRule]
+) -> TaxBreakdown:
+    taxable_income = max(
+        Decimal("0"),
+        tax_input.total_income - tax_input.total_deductions,
+    )
+    gross_tax = compute_progressive_tax(taxable_income, rules)
+    credits, surcharges = apply_adjustments(tax_input.adjustments)
+
+    net_tax = max(Decimal("0"), gross_tax - credits + surcharges - tax_input.total_withheld)
+    effective_rate = (
+        (net_tax / tax_input.total_income).quantize(Decimal("0.0001"))
+        if tax_input.total_income > 0
+        else Decimal("0")
+    )
+
+    return TaxBreakdown(
+        taxable_income=taxable_income.quantize(Decimal("0.01")),
+        gross_tax=gross_tax,
+        credits=credits.quantize(Decimal("0.01")),
+        surcharges=surcharges.quantize(Decimal("0.01")),
+        net_tax=net_tax.quantize(Decimal("0.01")),
+        effective_rate=effective_rate,
+    )
+
+
+def build_estimate(tax_input: TaxInput, *, rules: Sequence[TaxRule], warnings: List[str]) -> TaxEstimate:
+    breakdown = build_tax_breakdown(tax_input, rules=rules)
+    return TaxEstimate(input=tax_input, breakdown=breakdown, compliance_warnings=warnings)

--- a/apgms/services/tax-engine/app/main.py
+++ b/apgms/services/tax-engine/app/main.py
@@ -1,5 +1,20 @@
-﻿from fastapi import FastAPI
-app = FastAPI()
-@app.get('/health')
-def health():
-    return {'ok': True}
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .api import router as api_router
+
+
+app = FastAPI(
+    title="APGMS Tax Engine",
+    description="APIs for estimating, filing, and auditing tax returns.",
+    version="0.1.0",
+)
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+app.include_router(api_router)

--- a/apgms/services/tax-engine/app/schemas.py
+++ b/apgms/services/tax-engine/app/schemas.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, condecimal, validator
+
+
+Money = condecimal(max_digits=12, decimal_places=2, ge=Decimal("0"))
+
+
+class ResidencyStatus(str, Enum):
+    RESIDENT = "resident"
+    NON_RESIDENT = "non_resident"
+
+
+class FilingStatus(str, Enum):
+    SINGLE = "single"
+    MARRIED = "married"
+    HEAD_OF_HOUSEHOLD = "head_of_household"
+
+
+class IncomeType(str, Enum):
+    SALARY = "salary"
+    INVESTMENT = "investment"
+    BUSINESS = "business"
+    OTHER = "other"
+
+
+class AdjustmentType(str, Enum):
+    CREDIT = "credit"
+    SURCHARGE = "surcharge"
+
+
+class IncomeStream(BaseModel):
+    source: str = Field(..., description="Source of the income, e.g. employer or account name")
+    type: IncomeType = Field(..., description="Type of income stream")
+    amount: Money = Field(..., description="Gross amount received")
+    withholding: Optional[Money] = Field(
+        None, description="Tax already withheld for this income stream"
+    )
+
+    @validator("withholding")
+    def validate_withholding(cls, value: Optional[Decimal], values: dict[str, object]) -> Optional[Decimal]:
+        amount: Optional[Decimal] = values.get("amount")  # type: ignore[assignment]
+        if value is not None and amount is not None and value > amount:
+            raise ValueError("Withholding cannot exceed gross income")
+        return value
+
+
+class Deduction(BaseModel):
+    description: str
+    amount: Money
+
+
+class Adjustment(BaseModel):
+    description: str
+    amount: Money
+    type: AdjustmentType
+
+
+class TaxInput(BaseModel):
+    tax_year: int = Field(..., ge=2000, le=datetime.utcnow().year + 1)
+    residency_status: ResidencyStatus
+    filing_status: FilingStatus
+    incomes: List[IncomeStream] = Field(default_factory=list)
+    deductions: List[Deduction] = Field(default_factory=list)
+    adjustments: List[Adjustment] = Field(default_factory=list)
+    dependents: int = Field(0, ge=0)
+
+    @property
+    def total_income(self) -> Decimal:
+        return sum((income.amount for income in self.incomes), Decimal("0"))
+
+    @property
+    def total_withheld(self) -> Decimal:
+        return sum((income.withholding or Decimal("0") for income in self.incomes), Decimal("0"))
+
+    @property
+    def total_deductions(self) -> Decimal:
+        return sum((deduction.amount for deduction in self.deductions), Decimal("0"))
+
+
+class TaxBreakdown(BaseModel):
+    taxable_income: Decimal
+    gross_tax: Decimal
+    credits: Decimal
+    surcharges: Decimal
+    net_tax: Decimal
+    effective_rate: Decimal
+
+
+class TaxEstimate(BaseModel):
+    input: TaxInput
+    breakdown: TaxBreakdown
+    compliance_warnings: List[str] = Field(default_factory=list)
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class FilingRequest(BaseModel):
+    taxpayer_id: str = Field(..., min_length=3)
+    estimate: TaxEstimate
+
+
+class FilingSubmission(BaseModel):
+    taxpayer_id: str = Field(..., min_length=3)
+    input: TaxInput
+
+
+class FilingResponse(BaseModel):
+    submission_id: str
+    received_at: datetime
+    status: str
+
+
+class AuditLogEntry(BaseModel):
+    submission_id: str
+    taxpayer_id: str
+    action: str
+    details: dict[str, object] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class AuditTrailRequest(BaseModel):
+    taxpayer_id: str = Field(..., min_length=3)
+    input: TaxInput

--- a/apgms/services/tax-engine/app/services.py
+++ b/apgms/services/tax-engine/app/services.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import List, Sequence
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover - fallback path when httpx missing during tests
+    httpx = None  # type: ignore[assignment]
+
+from .calculations import TaxRule
+from .schemas import AuditLogEntry, FilingRequest, FilingResponse, ResidencyStatus
+
+
+@dataclass
+class TaxRateSchedule:
+    residency_status: ResidencyStatus
+    tax_year: int
+    rules: Sequence[TaxRule]
+
+
+class TaxRateService:
+    """Fetches tax rate schedules from an upstream service.
+
+    The service is expected to be Prisma-backed, however for offline usage the class falls
+    back to a static in-memory schedule that is adequate for unit testing.
+    """
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or os.getenv("TAX_RATE_SERVICE_URL")
+
+    async def get_schedule(self, *, tax_year: int, residency_status: ResidencyStatus) -> TaxRateSchedule:
+        if self.base_url:
+            if httpx is None:
+                raise RuntimeError("httpx is required when TAX_RATE_SERVICE_URL is configured")
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.base_url.rstrip('/')}/tax-rates/{tax_year}",
+                    params={"residency_status": residency_status.value},
+                    timeout=10.0,
+                )
+                response.raise_for_status()
+                payload = response.json()
+                rules = [
+                    TaxRule(threshold=Decimal(str(item["threshold"])), rate=Decimal(str(item["rate"])))
+                    for item in payload["brackets"]
+                ]
+                return TaxRateSchedule(residency_status=residency_status, tax_year=tax_year, rules=rules)
+
+        # Static fallback derived from generic progressive tax tables
+        fallback_rules = [
+            TaxRule(threshold=Decimal("18200"), rate=Decimal("0.0")),
+            TaxRule(threshold=Decimal("45000"), rate=Decimal("0.19")),
+            TaxRule(threshold=Decimal("120000"), rate=Decimal("0.325")),
+            TaxRule(threshold=Decimal("180000"), rate=Decimal("0.37")),
+            TaxRule(threshold=Decimal("999999999"), rate=Decimal("0.45")),
+        ]
+        return TaxRateSchedule(residency_status=residency_status, tax_year=tax_year, rules=fallback_rules)
+
+
+class FilingService:
+    """Persist filings and produce audit trail entries.
+
+    In a production environment this service would talk to a database or Prisma API. For the
+    purposes of automated testing we simply return deterministic responses.
+    """
+
+    async def submit_filing(self, request: FilingRequest) -> FilingResponse:
+        submission_id = f"{request.taxpayer_id}-{request.estimate.input.tax_year}"
+        return FilingResponse(submission_id=submission_id, received_at=request.estimate.generated_at, status="accepted")
+
+    async def audit_trail(self, request: FilingRequest) -> List[AuditLogEntry]:
+        return [
+            AuditLogEntry(
+                submission_id=f"{request.taxpayer_id}-{request.estimate.input.tax_year}",
+                taxpayer_id=request.taxpayer_id,
+                action="filed",
+                details={
+                    "net_tax": str(request.estimate.breakdown.net_tax),
+                    "warnings": request.estimate.compliance_warnings,
+                },
+            )
+        ]

--- a/apgms/services/tax-engine/app/validators.py
+++ b/apgms/services/tax-engine/app/validators.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import List
+
+from .schemas import TaxInput
+
+
+class ComplianceWarning(str):
+    """Simple alias to indicate compliance messages."""
+
+
+class ComplianceChecker:
+    def __init__(self) -> None:
+        self._warnings: List[ComplianceWarning] = []
+
+    def add_warning(self, message: str) -> None:
+        self._warnings.append(ComplianceWarning(message))
+
+    def results(self) -> List[str]:
+        return list(self._warnings)
+
+
+def validate_tax_input(tax_input: TaxInput) -> List[str]:
+    checker = ComplianceChecker()
+
+    if tax_input.total_income == Decimal("0"):
+        checker.add_warning("Total income is zero; confirm this is expected for the tax year.")
+
+    for deduction in tax_input.deductions:
+        if deduction.amount > tax_input.total_income:
+            checker.add_warning(
+                f"Deduction '{deduction.description}' exceeds total income and may trigger manual review."
+            )
+
+    if tax_input.dependents > 5:
+        checker.add_warning("Dependents exceed standard threshold and may require additional documentation.")
+
+    for income in tax_input.incomes:
+        if income.withholding and income.withholding == Decimal("0"):
+            checker.add_warning(
+                f"Income source '{income.source}' reports zero withholding; verify withholding details."
+            )
+
+    return checker.results()

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,16 @@
-﻿[tool.poetry]
-name='apgms-tax-engine'
-version='0.1.0'
+[tool.poetry]
+name = "apgms-tax-engine"
+version = "0.1.0"
+
 [tool.poetry.dependencies]
-python='^3.10'
-fastapi='*'
-uvicorn='*'
+python = "^3.10"
+fastapi = "*"
+uvicorn = "*"
+httpx = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/apgms/services/tax-engine/tests/test_tax_engine.py
+++ b/apgms/services/tax-engine/tests/test_tax_engine.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_estimate_tax_basic_scenario() -> None:
+    payload = {
+        "tax_year": 2024,
+        "residency_status": "resident",
+        "filing_status": "single",
+        "dependents": 1,
+        "incomes": [
+            {
+                "source": "Acme Corp",
+                "type": "salary",
+                "amount": "120000",
+                "withholding": "10000",
+            }
+        ],
+        "deductions": [
+            {"description": "Retirement contribution", "amount": "5000"}
+        ],
+        "adjustments": [
+            {"description": "Low income offset", "amount": "200", "type": "credit"},
+            {"description": "Medicare levy", "amount": "100", "type": "surcharge"},
+        ],
+    }
+
+    response = client.post("/tax/estimate", json=payload)
+    assert response.status_code == 200, response.text
+
+    data = response.json()
+    breakdown = data["breakdown"]
+
+    assert Decimal(breakdown["taxable_income"]) == Decimal("115000.00")
+    assert Decimal(breakdown["gross_tax"]) == Decimal("27842.00")
+    assert Decimal(breakdown["net_tax"]) == Decimal("17742.00")
+    assert Decimal(breakdown["effective_rate"]) == Decimal("0.1479")
+    assert data["compliance_warnings"] == []
+
+
+def test_estimate_flags_zero_income() -> None:
+    payload = {
+        "tax_year": 2024,
+        "residency_status": "resident",
+        "filing_status": "single",
+        "dependents": 0,
+        "incomes": [],
+        "deductions": [],
+        "adjustments": [],
+    }
+
+    response = client.post("/tax/estimate", json=payload)
+    assert response.status_code == 200
+
+    warnings = response.json()["compliance_warnings"]
+    assert any("Total income is zero" in warning for warning in warnings)
+
+
+def test_file_return_creates_submission() -> None:
+    payload = {
+        "taxpayer_id": "TAX123",
+        "input": {
+            "tax_year": 2024,
+            "residency_status": "resident",
+            "filing_status": "single",
+            "dependents": 1,
+            "incomes": [
+                {
+                    "source": "Acme Corp",
+                    "type": "salary",
+                    "amount": "75000",
+                    "withholding": "5000",
+                }
+            ],
+            "deductions": [],
+            "adjustments": [],
+        },
+    }
+
+    response = client.post("/tax/file", json=payload)
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["submission_id"] == "TAX123-2024"
+    assert data["status"] == "accepted"
+
+
+def test_audit_trail_returns_entries() -> None:
+    payload = {
+        "taxpayer_id": "TAX999",
+        "input": {
+            "tax_year": 2024,
+            "residency_status": "resident",
+            "filing_status": "single",
+            "dependents": 0,
+            "incomes": [
+                {"source": "Side gig", "type": "business", "amount": "20000", "withholding": "0"}
+            ],
+            "deductions": [],
+            "adjustments": [],
+        },
+    }
+
+    response = client.post("/tax/audit", json=payload)
+    assert response.status_code == 200
+
+    entries = response.json()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["taxpayer_id"] == "TAX999"
+    assert entry["action"] == "filed"
+    assert "warnings" in entry["details"]


### PR DESCRIPTION
## Summary
- introduce comprehensive Pydantic schemas for tax inputs, adjustments, and responses
- add calculation, validation, and service layers for estimates, filings, and audit logs
- expose FastAPI endpoints alongside documentation and automated tests for the tax engine

## Testing
- pytest *(fails: fastapi dependency unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2f45256d08327a8c70778e8653a79