### PR TITLE
Add cross-workspace testing harness and CI workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,17 +1,47 @@
-﻿name: CI
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
 jobs:
-  build:
+  node-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 8
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+          node-version: 18
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+        working-directory: apgms
+      - name: Run unit tests
+        run: pnpm test
+        working-directory: apgms
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+        working-directory: apgms
+      - name: Run end-to-end tests
+        run: pnpm test:e2e
+        working-directory: apgms
+
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --with dev
+        working-directory: apgms/services/tax-engine
+      - name: Run pytest
+        run: poetry run pytest
+        working-directory: apgms/services/tax-engine

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,29 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "test:e2e": "pnpm exec playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.2",
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,16 @@
-﻿export default {};
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm --filter @apgms/webapp run dev -- --port 4173",
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/apgms/scripts/testing.ts
+++ b/apgms/scripts/testing.ts
@@ -1,0 +1,160 @@
+export type Hook = () => void | Promise<void>;
+export type TestFn = () => void | Promise<void>;
+
+export interface Suite {
+  name: string;
+  tests: { name: string; fn: TestFn }[];
+  suites: Suite[];
+  beforeEach: Hook[];
+  afterEach: Hook[];
+  afterAll: Hook[];
+}
+
+interface VitestState {
+  suites: Suite[];
+  currentSuite: Suite | null;
+  rootSuite?: Suite;
+}
+
+const state: VitestState = (globalThis as any).__vitestLiteState ?? {
+  suites: [],
+  currentSuite: null,
+};
+
+(globalThis as any).__vitestLiteState = state;
+
+if (typeof process !== "undefined") {
+  process.env.NODE_ENV ??= "test";
+}
+
+function createSuite(name: string): Suite {
+  return {
+    name,
+    tests: [],
+    suites: [],
+    beforeEach: [],
+    afterEach: [],
+    afterAll: [],
+  };
+}
+
+function getCurrentSuite(): Suite {
+  if (!state.currentSuite) {
+    if (!state.rootSuite) {
+      state.rootSuite = createSuite("root");
+      state.suites.push(state.rootSuite);
+    }
+    state.currentSuite = state.rootSuite;
+  }
+  return state.currentSuite;
+}
+
+export function describe(name: string, fn: () => void) {
+  const parent = getCurrentSuite();
+  const suite = createSuite(name);
+  parent.suites.push(suite);
+  state.currentSuite = suite;
+  try {
+    fn();
+  } finally {
+    state.currentSuite = parent;
+  }
+}
+
+export const it = test;
+export function test(name: string, fn: TestFn) {
+  const suite = getCurrentSuite();
+  suite.tests.push({ name, fn });
+}
+
+export function beforeEach(fn: Hook) {
+  const suite = getCurrentSuite();
+  suite.beforeEach.push(fn);
+}
+
+export function afterEach(fn: Hook) {
+  const suite = getCurrentSuite();
+  suite.afterEach.push(fn);
+}
+
+export function afterAll(fn: Hook) {
+  const suite = getCurrentSuite();
+  suite.afterAll.push(fn);
+}
+
+function deepEqual(a: any, b: any): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object" || a === null || b === null) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((value, index) => deepEqual(value, b[index]));
+  }
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) => deepEqual(a[key], b[key]));
+}
+
+function matchObject(actual: any, expected: any): boolean {
+  if (typeof actual !== "object" || actual === null) return false;
+  return Object.keys(expected).every((key) => {
+    const expectedValue = expected[key];
+    const actualValue = actual[key];
+    if (typeof expectedValue === "object" && expectedValue !== null) {
+      return matchObject(actualValue, expectedValue);
+    }
+    return deepEqual(actualValue, expectedValue);
+  });
+}
+
+function format(value: unknown): string {
+  return typeof value === "string" ? `"${value}"` : JSON.stringify(value);
+}
+
+export function expect(received: any) {
+  return {
+    toBe(expected: any) {
+      if (!Object.is(received, expected)) {
+        throw new Error(`Expected ${format(received)} to be ${format(expected)}`);
+      }
+    },
+    toEqual(expected: any) {
+      if (!deepEqual(received, expected)) {
+        throw new Error(`Expected ${format(received)} to equal ${format(expected)}`);
+      }
+    },
+    toMatchObject(expected: any) {
+      if (!matchObject(received, expected)) {
+        throw new Error(`Expected ${format(received)} to match object ${format(expected)}`);
+      }
+    },
+    toHaveLength(length: number) {
+      if ((received?.length ?? undefined) !== length) {
+        throw new Error(`Expected value to have length ${length} but received ${received?.length}`);
+      }
+    },
+    toBeCloseTo(expected: number, precision = 2) {
+      const diff = Math.abs(Number(received) - Number(expected));
+      const threshold = Math.pow(10, -precision) / 2;
+      if (Number.isNaN(diff) || diff > threshold) {
+        throw new Error(`Expected ${received} to be close to ${expected}`);
+      }
+    },
+    toBeDefined() {
+      if (typeof received === "undefined") {
+        throw new Error(`Expected value to be defined`);
+      }
+    },
+  };
+}
+
+export function getState() {
+  return state;
+}
+
+export function resetState() {
+  state.suites = [];
+  state.currentSuite = null;
+  state.rootSuite = undefined;
+}

--- a/apgms/scripts/vitest-runner.ts
+++ b/apgms/scripts/vitest-runner.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { getState, resetState, Suite, Hook, TestFn } from "./testing";
+
+type TestCase = { name: string; fn: TestFn };
+
+type RunResult = { passed: number; failed: number };
+
+async function findTestFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (["test", "tests", "__tests__"].includes(entry.name)) {
+        files.push(...(await collectTestsInDir(fullPath)));
+      } else {
+        files.push(...(await findTestFiles(fullPath)));
+      }
+    }
+  }
+  return files;
+}
+
+async function collectTestsInDir(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...(await collectTestsInDir(path.join(dir, entry.name))));
+    } else if (/\.test\.(ts|tsx|js|mjs)$/.test(entry.name)) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+async function loadTests(testFiles: string[]) {
+  resetState();
+  for (const file of testFiles) {
+    const url = pathToFileURL(file).href;
+    await import(url);
+  }
+}
+
+async function runSuite(
+  suite: Suite,
+  inheritedBefores: Hook[],
+  inheritedAfters: Hook[],
+): Promise<RunResult> {
+  let passed = 0;
+  let failed = 0;
+
+  const beforeEachHooks: Hook[] = [...inheritedBefores, ...suite.beforeEach];
+  const afterEachHooks: Hook[] = [...suite.afterEach, ...inheritedAfters];
+
+  for (const child of suite.suites) {
+    const childResult = await runSuite(child, beforeEachHooks, afterEachHooks);
+    passed += childResult.passed;
+    failed += childResult.failed;
+  }
+
+  for (const testCase of suite.tests as TestCase[]) {
+    try {
+      for (const hook of beforeEachHooks) {
+        await hook();
+      }
+      await testCase.fn();
+      for (const hook of afterEachHooks) {
+        await hook();
+      }
+      console.log(`✓ ${suite.name}: ${testCase.name}`);
+      passed += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(`✗ ${suite.name}: ${testCase.name}`);
+      console.error(error instanceof Error ? error.message : error);
+    }
+  }
+
+  for (const hook of suite.afterAll) {
+    try {
+      await hook();
+    } catch (error) {
+      console.error(`afterAll hook failed in suite ${suite.name}`);
+      console.error(error instanceof Error ? error.message : error);
+    }
+  }
+
+  return { passed, failed };
+}
+
+async function main() {
+  const cwd = process.cwd();
+  const tests = await findTestFiles(cwd);
+  if (tests.length === 0) {
+    console.warn("No tests found");
+    return;
+  }
+
+  await loadTests(tests);
+
+  const state = getState();
+  let totalPassed = 0;
+  let totalFailed = 0;
+
+  for (const suite of state.suites) {
+    const result = await runSuite(suite, suite.beforeEach, suite.afterEach);
+    totalPassed += result.passed;
+    totalFailed += result.failed;
+  }
+
+  console.log(`\nTest run complete: ${totalPassed} passed, ${totalFailed} failed`);
+  if (totalFailed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx ../../scripts/vitest-runner.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,104 @@
+import Fastify, { FastifyInstance, FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+
+type UserRecord = {
+  email: string;
+  orgId: string;
+  createdAt: Date;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+type FindManyArgs<T> = {
+  orderBy?: Partial<Record<keyof T, "asc" | "desc">>;
+  select?: Partial<Record<keyof T, boolean>>;
+  take?: number;
+};
+
+type CreateArgs<T> = {
+  data: T;
+};
+
+export interface PrismaLikeClient {
+  user: {
+    findMany(args: FindManyArgs<UserRecord>): Promise<UserRecord[]>;
+  };
+  bankLine: {
+    findMany(args: FindManyArgs<BankLineRecord>): Promise<BankLineRecord[]>;
+    create(args: CreateArgs<
+      Pick<BankLineRecord, "orgId" | "date" | "amount" | "payee" | "desc">
+    >): Promise<BankLineRecord>;
+  };
+}
+
+export interface CreateAppOptions {
+  prisma: PrismaLikeClient;
+  logger?: FastifyServerOptions["logger"];
+}
+
+export async function createApp({
+  prisma,
+  logger = true,
+}: CreateAppOptions): Promise<FastifyInstance> {
+  const app = Fastify({ logger });
+
+  await app.register(cors, { origin: true });
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: Number(body.amount),
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (error) {
+      req.log.error(error);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,24 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await createApp({ prisma });
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .then(() => {
+    app.log.info({ port, host }, "api-gateway listening");
+  })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/test/api-gateway.integration.test.ts
+++ b/apgms/services/api-gateway/test/api-gateway.integration.test.ts
@@ -1,0 +1,89 @@
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "../../../scripts/testing";
+import { createApp } from "../src/app";
+import { InMemoryDatabase } from "./test-database";
+
+const db = new InMemoryDatabase();
+
+describe("api-gateway integration", () => {
+  let app: Awaited<ReturnType<typeof createApp>>;
+  let orgId: string;
+
+  beforeEach(async () => {
+    db.reset();
+    const org = db.seedOrg("Acme", new Date("2024-01-01T00:00:00Z"));
+    orgId = org.id;
+    db.seedUser({
+      email: "zoe@example.com",
+      orgId,
+      createdAt: new Date("2024-01-05T10:00:00Z"),
+    });
+    db.seedUser({
+      email: "amy@example.com",
+      orgId,
+      createdAt: new Date("2024-01-10T10:00:00Z"),
+    });
+    db.seedBankLine({
+      orgId,
+      date: new Date("2024-02-01T00:00:00Z"),
+      amount: 1250.5,
+      payee: "Electric Co",
+      desc: "invoice",
+    });
+    db.seedBankLine({
+      orgId,
+      date: new Date("2024-02-05T00:00:00Z"),
+      amount: -210.75,
+      payee: "Coffee Shop",
+      desc: "team event",
+    });
+    app = await createApp({ prisma: db, logger: false });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  test("health endpoint reports status", async () => {
+    const response = await app.inject({ method: "GET", url: "/health" });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, service: "api-gateway" });
+  });
+
+  test("lists newest users first", async () => {
+    const response = await app.inject({ method: "GET", url: "/users" });
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.users).toHaveLength(2);
+    expect(payload.users[0]).toMatchObject({
+      email: "amy@example.com",
+    });
+    expect(payload.users[1]).toMatchObject({
+      email: "zoe@example.com",
+    });
+  });
+
+  test("creates a bank line and respects pagination", async () => {
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId,
+        date: "2024-02-10T00:00:00.000Z",
+        amount: 512.25,
+        payee: "SaaS",
+        desc: "subscription",
+      },
+    });
+    expect(createResponse.statusCode).toBe(201);
+
+    const listResponse = await app.inject({ method: "GET", url: "/bank-lines?take=2" });
+    expect(listResponse.statusCode).toBe(200);
+    const payload = listResponse.json();
+    expect(payload.lines).toHaveLength(2);
+    expect(payload.lines[0]).toMatchObject({ payee: "SaaS" });
+  });
+});

--- a/apgms/services/api-gateway/test/test-database.ts
+++ b/apgms/services/api-gateway/test/test-database.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { PrismaLikeClient } from "../src/app";
+
+type Org = {
+  id: string;
+  name: string;
+  createdAt: Date;
+};
+
+type User = {
+  id: string;
+  email: string;
+  password: string;
+  orgId: string;
+  createdAt: Date;
+};
+
+type BankLine = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+export class InMemoryDatabase implements PrismaLikeClient {
+  private orgs = new Map<string, Org>();
+  private users = new Map<string, User>();
+  private bankLines = new Map<string, BankLine>();
+
+  seedOrg(name: string, createdAt = new Date()): Org {
+    const org: Org = { id: randomUUID(), name, createdAt };
+    this.orgs.set(org.id, org);
+    return org;
+  }
+
+  seedUser(data: Partial<User> & { email: string; orgId: string }): User {
+    const user: User = {
+      id: data.id ?? randomUUID(),
+      email: data.email,
+      password: data.password ?? "secret",
+      orgId: data.orgId,
+      createdAt: data.createdAt ?? new Date(),
+    };
+    this.users.set(user.id, user);
+    return user;
+  }
+
+  seedBankLine(
+    data: Partial<BankLine> & {
+      orgId: string;
+      date?: Date;
+      amount?: number;
+      payee?: string;
+      desc?: string;
+    },
+  ): BankLine {
+    const bankLine: BankLine = {
+      id: data.id ?? randomUUID(),
+      orgId: data.orgId,
+      date: data.date ?? new Date(),
+      amount: data.amount ?? 0,
+      payee: data.payee ?? "unknown",
+      desc: data.desc ?? "",
+      createdAt: data.createdAt ?? new Date(),
+    };
+    this.bankLines.set(bankLine.id, bankLine);
+    return bankLine;
+  }
+
+  reset() {
+    this.orgs.clear();
+    this.users.clear();
+    this.bankLines.clear();
+  }
+
+  async $disconnect() {
+    this.reset();
+  }
+
+  user = {
+    findMany: async ({ orderBy }: { orderBy?: { createdAt?: "asc" | "desc" } }) => {
+      const records = Array.from(this.users.values());
+      if (orderBy?.createdAt) {
+        const direction = orderBy.createdAt === "desc" ? -1 : 1;
+        records.sort((a, b) =>
+          a.createdAt.getTime() === b.createdAt.getTime()
+            ? 0
+            : a.createdAt.getTime() > b.createdAt.getTime()
+              ? direction * 1
+              : direction * -1,
+        );
+      }
+      return records.map(({ email, orgId, createdAt }) => ({ email, orgId, createdAt }));
+    },
+  };
+
+  bankLine = {
+    findMany: async ({
+      orderBy,
+      take,
+    }: {
+      orderBy?: { date?: "asc" | "desc" };
+      take?: number;
+    }) => {
+      let records = Array.from(this.bankLines.values());
+      if (orderBy?.date) {
+        const direction = orderBy.date === "desc" ? -1 : 1;
+        records = records.sort((a, b) =>
+          a.date.getTime() === b.date.getTime()
+            ? 0
+            : a.date.getTime() > b.date.getTime()
+              ? direction * 1
+              : direction * -1,
+        );
+      }
+      if (take !== undefined) {
+        records = records.slice(0, take);
+      }
+      return records;
+    },
+    create: async ({
+      data,
+    }: {
+      data: {
+        orgId: string;
+        date: Date;
+        amount: number;
+        payee: string;
+        desc: string;
+      };
+    }) => {
+      const bankLine: BankLine = {
+        id: randomUUID(),
+        createdAt: new Date(),
+        ...data,
+      };
+      this.bankLines.set(bankLine.id, bankLine);
+      return bankLine;
+    },
+  };
+}

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/services/api-gateway/vitest.config.ts
+++ b/apgms/services/api-gateway/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "html"],
+    },
+  },
+});

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,22 @@
-﻿[tool.poetry]
-name='apgms-tax-engine'
-version='0.1.0'
+[tool.poetry]
+name = "apgms-tax-engine"
+version = "0.1.0"
+description = "APGMS tax engine service"
+package-mode = false
+
 [tool.poetry.dependencies]
-python='^3.10'
-fastapi='*'
-uvicorn='*'
+python = "^3.10"
+fastapi = "^0.115.0"
+uvicorn = "^0.30.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.3"
+httpx = "^0.27.2"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]

--- a/apgms/services/tax-engine/tests/test_health.py
+++ b/apgms/services/tax-engine/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+def test_health_endpoint_reports_ok():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "tsx ../scripts/vitest-runner.ts"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,1 @@
-﻿// shared
+export * from "./utils/currency";

--- a/apgms/shared/src/utils/currency.ts
+++ b/apgms/shared/src/utils/currency.ts
@@ -1,0 +1,12 @@
+export function formatCurrency(amount: number, currency = "AUD"): string {
+  const formatter = new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  });
+  return formatter.format(amount);
+}
+
+export function sum(values: number[]): number {
+  return values.reduce((acc, value) => acc + value, 0);
+}

--- a/apgms/shared/test/currency.test.ts
+++ b/apgms/shared/test/currency.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "../../scripts/testing";
+import { formatCurrency, sum } from "../src";
+
+describe("currency helpers", () => {
+  test("formats currency using Australian locale by default", () => {
+    expect(formatCurrency(1234.5)).toBe("$1,234.50");
+  });
+
+  test("sums values safely", () => {
+    expect(sum([1, 2, 3.5])).toBeCloseTo(6.5);
+  });
+});

--- a/apgms/shared/vitest.config.ts
+++ b/apgms/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/apgms/tests/e2e/dashboard.spec.ts
+++ b/apgms/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test("renders mocked users on dashboard", async ({ page }) => {
+  await page.route("**/api/users", async (route) => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify({
+        users: [
+          { email: "amy@example.com", orgId: "org-1" },
+          { email: "zoe@example.com", orgId: "org-2" },
+        ],
+      }),
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  await page.goto("/");
+
+  await expect(page.getByRole("heading", { name: "APGMS Control Center" })).toBeVisible();
+  await expect(page.getByTestId("user-item")).toHaveCount(2);
+  await expect(page.getByTestId("user-item").first()).toHaveText(
+    "amy@example.com (org-1)",
+  );
+});

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,14 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx server.ts",
+    "test": "tsx ../scripts/vitest-runner.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/webapp/server.ts
+++ b/apgms/webapp/server.ts
@@ -1,0 +1,88 @@
+import http from "node:http";
+import { URL } from "node:url";
+
+const html = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>APGMS Control Center</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 2rem; }
+      h1 { margin-bottom: 1rem; }
+      button { margin-bottom: 1rem; padding: 0.5rem 1rem; }
+      ul { list-style: none; padding: 0; }
+      li { padding: 0.25rem 0; }
+    </style>
+  </head>
+  <body>
+    <h1>APGMS Control Center</h1>
+    <button id="refresh">Refresh users</button>
+    <ul id="users"></ul>
+    <script type="module">
+      async function loadUsers() {
+        const response = await fetch('/api/users');
+        const data = await response.json();
+        const list = document.querySelector('#users');
+        list.innerHTML = '';
+        for (const user of data.users ?? []) {
+          const item = document.createElement('li');
+          item.dataset.testid = 'user-item';
+          item.textContent = user.email + ' (' + user.orgId + ')';
+          list.appendChild(item);
+        }
+      }
+      document.querySelector('#refresh').addEventListener('click', loadUsers);
+      loadUsers();
+    </script>
+  </body>
+</html>`;
+
+function resolvePort(defaultPort: number): number {
+  const portFlag = process.argv.findIndex((arg) => arg === "--port");
+  if (portFlag !== -1) {
+    const next = process.argv[portFlag + 1];
+    if (next) {
+      const parsed = Number(next);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return Number(process.env.PORT ?? defaultPort);
+}
+
+const host = "127.0.0.1";
+const port = resolvePort(4173);
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    res.statusCode = 400;
+    res.end("Bad request");
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === "GET" && url.pathname === "/") {
+    res.setHeader("content-type", "text/html; charset=utf-8");
+    res.end(html);
+    return;
+  }
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ ok: true }));
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end("Not found");
+});
+
+server.listen(port, host, () => {
+  console.log(`webapp listening on http://${host}:${port}`);
+});
+
+process.on("SIGINT", () => {
+  server.close(() => process.exit(0));
+});

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,5 @@
-﻿console.log('webapp');
+import { renderUserSummary } from "./userView";
+
+if (process.env.NODE_ENV !== "test") {
+  console.log(renderUserSummary([{ email: "demo@example.com", orgId: "org-1" }]));
+}

--- a/apgms/webapp/src/userView.ts
+++ b/apgms/webapp/src/userView.ts
@@ -1,0 +1,11 @@
+export interface UserSummary {
+  email: string;
+  orgId: string;
+}
+
+export function renderUserSummary(users: UserSummary[]): string {
+  if (users.length === 0) {
+    return "No users connected";
+  }
+  return users.map((user) => `${user.email} (${user.orgId})`).join(", ");
+}

--- a/apgms/webapp/test/userView.test.ts
+++ b/apgms/webapp/test/userView.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "../../scripts/testing";
+import { renderUserSummary } from "../src/userView";
+
+describe("renderUserSummary", () => {
+  test("summarises user emails when available", () => {
+    expect(
+      renderUserSummary([
+        { email: "lee@example.com", orgId: "org-1" },
+        { email: "sam@example.com", orgId: "org-2" },
+      ]),
+    ).toBe("lee@example.com (org-1), sam@example.com (org-2)");
+  });
+
+  test("shows empty state when there are no users", () => {
+    expect(renderUserSummary([])).toBe("No users connected");
+  });
+});

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["src", "test", "server.ts"]
+}

--- a/apgms/webapp/vitest.config.ts
+++ b/apgms/webapp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,13 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "tsx ../scripts/vitest-runner.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,13 @@
-﻿console.log('worker');
+import { groupJobsByPriority } from "./job.js";
+
+const sample = groupJobsByPriority([
+  { id: "alpha", priority: 1 },
+  { id: "beta", priority: 2 },
+  { id: "gamma", priority: 1 },
+]);
+
+if (process.env.NODE_ENV !== "test") {
+  console.log("worker boot", Array.from(sample.entries()));
+}
+
+export { groupJobsByPriority };

--- a/apgms/worker/src/job.ts
+++ b/apgms/worker/src/job.ts
@@ -1,0 +1,13 @@
+export interface Job {
+  id: string;
+  priority: number;
+}
+
+export function groupJobsByPriority(jobs: Job[]): Map<number, Job[]> {
+  return jobs.reduce((bucket, job) => {
+    const existing = bucket.get(job.priority) ?? [];
+    existing.push(job);
+    bucket.set(job.priority, existing);
+    return bucket;
+  }, new Map<number, Job[]>());
+}

--- a/apgms/worker/test/job.test.ts
+++ b/apgms/worker/test/job.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "../../scripts/testing";
+import { groupJobsByPriority } from "../src/job";
+
+describe("groupJobsByPriority", () => {
+  test("groups jobs by numeric priority", () => {
+    const grouped = groupJobsByPriority([
+      { id: "a", priority: 1 },
+      { id: "b", priority: 2 },
+      { id: "c", priority: 1 },
+    ]);
+
+    expect(grouped.get(1)).toHaveLength(2);
+    expect(grouped.get(2)).toHaveLength(1);
+  });
+});

--- a/apgms/worker/vitest.config.ts
+++ b/apgms/worker/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- introduce a lightweight Vitest-compatible harness and sample unit tests across the Node workspaces
- refactor the API gateway to support dependency injection and add integration tests backed by an in-memory seeded database
- scaffold a simple webapp server, Playwright e2e check, pytest health test, and wire everything into a CI workflow

## Testing
- pnpm --filter @apgms/api-gateway test
- pnpm --filter @apgms/shared test
- pnpm --filter @apgms/worker test
- pnpm --filter @apgms/webapp test
- pnpm test:e2e *(fails: Playwright CLI not installed in offline env)*
- poetry install --with dev *(fails: pypi.org unavailable in offline env)*
- poetry run pytest *(fails: fastapi dependency missing because install step failed)*

------
https://chatgpt.com/codex/tasks/task_e_68f30024334083279f94b28776354c5c