### PR TITLE
feat(webapp): scaffold Vite React dashboard

### DIFF
--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,13 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>APGMS Operator Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/jest.config.ts
+++ b/apgms/webapp/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
+  clearMocks: true
+};
+
+export default config;

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,32 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.1",
+    "@types/jest": "^29.5.12",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.6"
+  }
+}

--- a/apgms/webapp/setupTests.ts
+++ b/apgms/webapp/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/apgms/webapp/src/App.tsx
+++ b/apgms/webapp/src/App.tsx
@@ -1,0 +1,8 @@
+import { RouterProvider } from 'react-router-dom';
+import { router } from './routes';
+
+const App = () => {
+  return <RouterProvider router={router} />;
+};
+
+export default App;

--- a/apgms/webapp/src/api/client.ts
+++ b/apgms/webapp/src/api/client.ts
@@ -1,0 +1,205 @@
+import type {
+  AuthResponse,
+  AtoLodgement,
+  BankLine,
+  DashboardSummary,
+  PaymentApproval,
+  ReconciliationTask,
+  User,
+} from './types';
+
+export type ApiHandler = <T>(path: string, options: RequestInit & { body?: unknown }) => Promise<T>;
+
+const mockUser: User = {
+  id: 'user-1',
+  name: 'Alex Analyst',
+  email: 'alex.analyst@example.com',
+  role: 'analyst',
+};
+
+const bankLines: BankLine[] = [
+  {
+    id: 'bl-001',
+    accountName: 'Operating Account',
+    balance: 154230.45,
+    currency: 'AUD',
+    status: 'healthy',
+    lastUpdated: '2024-03-08T08:30:00Z',
+  },
+  {
+    id: 'bl-002',
+    accountName: 'Trust Account',
+    balance: 40210.12,
+    currency: 'AUD',
+    status: 'warning',
+    lastUpdated: '2024-03-08T08:15:00Z',
+  },
+  {
+    id: 'bl-003',
+    accountName: 'ATO Clearing',
+    balance: -5210.67,
+    currency: 'AUD',
+    status: 'attention',
+    lastUpdated: '2024-03-08T07:50:00Z',
+  },
+];
+
+const reconciliationTasks: ReconciliationTask[] = [
+  {
+    id: 'rec-001',
+    description: 'Match Stripe settlement for March 5',
+    status: 'in-progress',
+    assignedTo: 'Jamie Chen',
+    dueDate: '2024-03-09',
+  },
+  {
+    id: 'rec-002',
+    description: 'Investigate duplicate payment from Birchal Pty Ltd',
+    status: 'pending',
+    assignedTo: 'Pat Riley',
+    dueDate: '2024-03-11',
+  },
+  {
+    id: 'rec-003',
+    description: 'Reconcile interest accrual for trust account',
+    status: 'completed',
+    assignedTo: 'Alex Analyst',
+    dueDate: '2024-03-07',
+  },
+];
+
+const paymentApprovals: PaymentApproval[] = [
+  {
+    id: 'pay-001',
+    vendor: 'Cloud Services Co.',
+    amount: 1280,
+    currency: 'AUD',
+    status: 'pending',
+    submittedAt: '2024-03-07T12:00:00Z',
+    approver: 'Alex Analyst',
+  },
+  {
+    id: 'pay-002',
+    vendor: 'Regulatory Fees',
+    amount: 540,
+    currency: 'AUD',
+    status: 'approved',
+    submittedAt: '2024-03-06T09:20:00Z',
+    approver: 'Jamie Chen',
+  },
+  {
+    id: 'pay-003',
+    vendor: 'Marketing Agency',
+    amount: 3200,
+    currency: 'AUD',
+    status: 'pending',
+    submittedAt: '2024-03-05T15:45:00Z',
+    approver: 'Pat Riley',
+  },
+];
+
+const atoLodgements: AtoLodgement[] = [
+  {
+    id: 'ato-001',
+    period: 'BAS Q1 2024',
+    status: 'lodged',
+    lodgedAt: '2024-02-21',
+    dueDate: '2024-02-28',
+  },
+  {
+    id: 'ato-002',
+    period: 'PAYG March 2024',
+    status: 'pending',
+    lodgedAt: null,
+    dueDate: '2024-03-21',
+  },
+  {
+    id: 'ato-003',
+    period: 'SGC FY24',
+    status: 'overdue',
+    lodgedAt: null,
+    dueDate: '2024-03-01',
+  },
+];
+
+const getSummary = (): DashboardSummary => ({
+  bankLinesCount: bankLines.length,
+  reconciliationsInProgress: reconciliationTasks.filter((task) => task.status !== 'completed').length,
+  pendingApprovals: paymentApprovals.filter((approval) => approval.status === 'pending').length,
+  lodgementsDue: atoLodgements.filter((lodgement) => lodgement.status !== 'lodged').length,
+});
+
+const parseBody = (body: unknown) => {
+  if (typeof body === 'string') {
+    return body ? JSON.parse(body) : {};
+  }
+
+  if (body instanceof FormData) {
+    return Object.fromEntries(body.entries());
+  }
+
+  return (body as Record<string, unknown>) ?? {};
+};
+
+const defaultHandler: ApiHandler = async (path, options) => {
+  const method = (options.method ?? 'GET').toUpperCase();
+
+  switch (path) {
+    case '/auth/login': {
+      const body = parseBody(options.body);
+      const email = String(body.email ?? mockUser.email);
+      const name = email.split('@')[0]?.replace(/[-_.]/g, ' ') ?? mockUser.name;
+      const user: User = {
+        ...mockUser,
+        email,
+        name: name.replace(/\b\w/g, (char) => char.toUpperCase()),
+      };
+      return { user } as AuthResponse;
+    }
+    case '/auth/register': {
+      const body = parseBody(options.body);
+      const user: User = {
+        id: 'user-registered',
+        name: String(body.name ?? mockUser.name),
+        email: String(body.email ?? mockUser.email),
+        role: 'viewer',
+      };
+      return { user } as AuthResponse;
+    }
+    case '/bank-lines':
+      return bankLines as unknown as BankLine[];
+    case '/reconciliation':
+      return reconciliationTasks as unknown as ReconciliationTask[];
+    case '/payments/approvals':
+      return paymentApprovals as unknown as PaymentApproval[];
+    case '/ato/status':
+      return atoLodgements as unknown as AtoLodgement[];
+    case '/dashboard/summary':
+      return getSummary() as DashboardSummary;
+    default:
+      throw new Error(`No mock handler implemented for path: ${path}`);
+  }
+};
+
+let handler: ApiHandler = defaultHandler;
+
+export const setApiHandler = (customHandler?: ApiHandler) => {
+  handler = customHandler ?? defaultHandler;
+};
+
+export const apiClient = {
+  async get<T>(path: string, init?: RequestInit) {
+    return handler<T>(path, { ...(init ?? {}), method: 'GET' });
+  },
+  async post<T>(path: string, body: unknown, init?: RequestInit) {
+    return handler<T>(path, {
+      ...(init ?? {}),
+      method: 'POST',
+      body: typeof body === 'string' ? body : JSON.stringify(body ?? {}),
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init?.headers ?? {}),
+      },
+    });
+  },
+};

--- a/apgms/webapp/src/api/hooks.ts
+++ b/apgms/webapp/src/api/hooks.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { apiClient } from './client';
+import type {
+  AtoLodgement,
+  BankLine,
+  DashboardSummary,
+  PaymentApproval,
+  ReconciliationTask,
+} from './types';
+
+export interface ApiQueryState<T> {
+  data: T | null;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export const useApiQuery = <T>(fetcher: () => Promise<T>, deps: unknown[] = []): ApiQueryState<T> => {
+  const [data, setData] = useState<T | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const execute = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetcher();
+      if (!mountedRef.current) {
+        return;
+      }
+      setData(response);
+    } catch (err) {
+      if (!mountedRef.current) {
+        return;
+      }
+      const message = err instanceof Error ? err : new Error('Unknown error');
+      setError(message);
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, deps);
+
+  useEffect(() => {
+    execute();
+  }, [execute]);
+
+  return useMemo(
+    () => ({
+      data,
+      isLoading,
+      error,
+      refetch: execute,
+    }),
+    [data, error, execute, isLoading]
+  );
+};
+
+export const useDashboardSummary = () =>
+  useApiQuery(() => apiClient.get<DashboardSummary>('/dashboard/summary'), []);
+
+export const useBankLines = () => useApiQuery(() => apiClient.get<BankLine[]>('/bank-lines'), []);
+
+export const useReconciliationWorkflow = () =>
+  useApiQuery(() => apiClient.get<ReconciliationTask[]>('/reconciliation'), []);
+
+export const usePaymentsApprovals = () =>
+  useApiQuery(() => apiClient.get<PaymentApproval[]>('/payments/approvals'), []);
+
+export const useAtoLodgementStatus = () =>
+  useApiQuery(() => apiClient.get<AtoLodgement[]>('/ato/status'), []);

--- a/apgms/webapp/src/api/types.ts
+++ b/apgms/webapp/src/api/types.ts
@@ -1,0 +1,52 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'analyst' | 'viewer';
+}
+
+export interface AuthResponse {
+  user: User;
+}
+
+export interface BankLine {
+  id: string;
+  accountName: string;
+  balance: number;
+  currency: string;
+  status: 'healthy' | 'warning' | 'attention';
+  lastUpdated: string;
+}
+
+export interface ReconciliationTask {
+  id: string;
+  description: string;
+  status: 'completed' | 'in-progress' | 'pending';
+  assignedTo: string;
+  dueDate: string;
+}
+
+export interface PaymentApproval {
+  id: string;
+  vendor: string;
+  amount: number;
+  currency: string;
+  status: 'pending' | 'approved' | 'rejected';
+  submittedAt: string;
+  approver: string;
+}
+
+export interface AtoLodgement {
+  id: string;
+  period: string;
+  status: 'lodged' | 'pending' | 'overdue';
+  lodgedAt: string | null;
+  dueDate: string;
+}
+
+export interface DashboardSummary {
+  bankLinesCount: number;
+  reconciliationsInProgress: number;
+  pendingApprovals: number;
+  lodgementsDue: number;
+}

--- a/apgms/webapp/src/components/layout/AppShell.tsx
+++ b/apgms/webapp/src/components/layout/AppShell.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+export interface AppShellProps {
+  sidebar: ReactNode;
+  topbar: ReactNode;
+  children: ReactNode;
+}
+
+export const AppShell = ({ sidebar, topbar, children }: AppShellProps) => {
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      <aside className="hidden w-64 border-r border-slate-200 bg-white lg:block">{sidebar}</aside>
+      <div className="flex-1">
+        <header className="border-b border-slate-200 bg-white">{topbar}</header>
+        <main className="mx-auto max-w-6xl px-4 py-6 lg:px-8">{children}</main>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/apgms/webapp/src/components/layout/PageHeader.tsx
+++ b/apgms/webapp/src/components/layout/PageHeader.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+export interface PageHeaderProps {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}
+
+export const PageHeader = ({ title, description, actions }: PageHeaderProps) => {
+  return (
+    <div className="mb-6 flex flex-col gap-4 border-b border-slate-200 pb-4 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        {description ? <p className="mt-1 text-sm text-slate-500">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+};
+
+export default PageHeader;

--- a/apgms/webapp/src/components/navigation/Sidebar.tsx
+++ b/apgms/webapp/src/components/navigation/Sidebar.tsx
@@ -1,0 +1,44 @@
+import { NavLink } from 'react-router-dom';
+
+export interface SidebarItem {
+  label: string;
+  to: string;
+  icon?: string;
+}
+
+export interface SidebarProps {
+  items: SidebarItem[];
+}
+
+export const Sidebar = ({ items }: SidebarProps) => {
+  return (
+    <nav className="flex h-full flex-col justify-between">
+      <div>
+        <div className="px-6 py-4 text-lg font-semibold text-blue-600">APGMS Console</div>
+        <ul className="space-y-1 px-2">
+          {items.map((item) => (
+            <li key={item.to}>
+              <NavLink
+                to={item.to}
+                className={({ isActive }) =>
+                  [
+                    'flex items-center gap-3 rounded-md px-4 py-2 text-sm font-medium text-slate-600 transition-colors',
+                    isActive ? 'bg-blue-50 text-blue-600' : 'hover:bg-slate-100',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')
+                }
+              >
+                {item.icon ? <span aria-hidden>{item.icon}</span> : null}
+                <span>{item.label}</span>
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="px-4 pb-4 text-xs text-slate-400">© {new Date().getFullYear()} APGMS</div>
+    </nav>
+  );
+};
+
+export default Sidebar;

--- a/apgms/webapp/src/components/navigation/Topbar.tsx
+++ b/apgms/webapp/src/components/navigation/Topbar.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+export interface TopbarProps {
+  title?: string;
+  children?: ReactNode;
+}
+
+export const Topbar = ({ title, children }: TopbarProps) => {
+  return (
+    <div className="flex items-center justify-between px-6 py-4">
+      <div>
+        <p className="text-xs uppercase tracking-wider text-slate-400">Operational Dashboard</p>
+        <h2 className="text-lg font-semibold text-slate-900">{title ?? 'Welcome back'}</h2>
+      </div>
+      <div className="flex items-center gap-4">{children}</div>
+    </div>
+  );
+};
+
+export default Topbar;

--- a/apgms/webapp/src/components/ui/Button.tsx
+++ b/apgms/webapp/src/components/ui/Button.tsx
@@ -1,0 +1,37 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+const baseStyles =
+  'inline-flex items-center justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+
+const variants: Record<'primary' | 'secondary' | 'ghost', string> = {
+  primary: 'bg-blue-600 text-white hover:bg-blue-700 focus-visible:outline-blue-600',
+  secondary: 'bg-slate-100 text-slate-900 hover:bg-slate-200 focus-visible:outline-slate-400',
+  ghost: 'bg-transparent text-slate-700 hover:bg-slate-100 focus-visible:outline-slate-300',
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'ghost';
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+}
+
+export const Button = ({
+  variant = 'primary',
+  leftIcon,
+  rightIcon,
+  className,
+  children,
+  ...props
+}: ButtonProps) => {
+  const classes = [baseStyles, variants[variant], className].filter(Boolean).join(' ');
+
+  return (
+    <button className={classes} {...props}>
+      {leftIcon ? <span className="mr-2 inline-flex items-center">{leftIcon}</span> : null}
+      <span>{children}</span>
+      {rightIcon ? <span className="ml-2 inline-flex items-center">{rightIcon}</span> : null}
+    </button>
+  );
+};
+
+export default Button;

--- a/apgms/webapp/src/components/ui/Card.tsx
+++ b/apgms/webapp/src/components/ui/Card.tsx
@@ -1,0 +1,22 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+
+const baseStyles = 'rounded-xl border border-slate-200 bg-white shadow-sm';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  header?: ReactNode;
+  footer?: ReactNode;
+}
+
+export const Card = ({ header, footer, className, children, ...props }: CardProps) => {
+  const classes = [baseStyles, className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes} {...props}>
+      {header ? <div className="border-b border-slate-100 px-4 py-3 text-sm font-semibold text-slate-900">{header}</div> : null}
+      <div className="px-4 py-3 text-sm text-slate-700">{children}</div>
+      {footer ? <div className="border-t border-slate-100 px-4 py-3 text-xs text-slate-500">{footer}</div> : null}
+    </div>
+  );
+};
+
+export default Card;

--- a/apgms/webapp/src/components/ui/DataTable.tsx
+++ b/apgms/webapp/src/components/ui/DataTable.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react';
+
+export interface Column<T> {
+  header: ReactNode;
+  cell: (row: T) => ReactNode;
+  className?: string;
+}
+
+export interface DataTableProps<T> {
+  data: T[];
+  columns: Column<T>[];
+  getRowKey: (row: T) => string;
+  emptyState?: ReactNode;
+  onRowClick?: (row: T) => void;
+}
+
+export function DataTable<T>({ data, columns, getRowKey, emptyState, onRowClick }: DataTableProps<T>) {
+  if (!data.length) {
+    return <div className="rounded-lg border border-dashed border-slate-200 p-8 text-center text-sm text-slate-500">{emptyState ?? 'No data available.'}</div>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-200">
+        <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            {columns.map((column, index) => (
+              <th key={index} className={['px-4 py-3', column.className].filter(Boolean).join(' ')}>
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 text-sm text-slate-700">
+          {data.map((row) => {
+            const rowClasses = ['hover:bg-slate-50'];
+            if (onRowClick) {
+              rowClasses.push('cursor-pointer');
+            }
+
+            return (
+              <tr key={getRowKey(row)} className={rowClasses.join(' ')} onClick={() => onRowClick?.(row)}>
+                {columns.map((column, index) => (
+                  <td key={index} className={['px-4 py-3 align-middle', column.className].filter(Boolean).join(' ')}>
+                    {column.cell(row)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/ui/Input.tsx
+++ b/apgms/webapp/src/components/ui/Input.tsx
@@ -1,0 +1,13 @@
+import type { InputHTMLAttributes } from 'react';
+
+const baseStyles =
+  'w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:bg-slate-100';
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = ({ className, ...props }: InputProps) => {
+  const classes = [baseStyles, className].filter(Boolean).join(' ');
+  return <input className={classes} {...props} />;
+};
+
+export default Input;

--- a/apgms/webapp/src/components/ui/StatusPill.tsx
+++ b/apgms/webapp/src/components/ui/StatusPill.tsx
@@ -1,0 +1,31 @@
+import type { HTMLAttributes } from 'react';
+
+const toneMap: Record<string, string> = {
+  success: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+  warning: 'bg-amber-100 text-amber-700 border-amber-200',
+  danger: 'bg-rose-100 text-rose-700 border-rose-200',
+  info: 'bg-blue-100 text-blue-700 border-blue-200',
+  neutral: 'bg-slate-100 text-slate-700 border-slate-200',
+};
+
+export interface StatusPillProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: 'success' | 'warning' | 'danger' | 'info' | 'neutral';
+}
+
+export const StatusPill = ({ tone = 'neutral', className, children, ...props }: StatusPillProps) => {
+  const classes = [
+    'inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide',
+    toneMap[tone],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={classes} {...props}>
+      {children}
+    </span>
+  );
+};
+
+export default StatusPill;

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,24 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #f8fafc;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,16 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/pages/auth/AuthLayout.tsx
+++ b/apgms/webapp/src/pages/auth/AuthLayout.tsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router-dom';
+import Card from '@/components/ui/Card';
+
+export const AuthLayout = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-100 px-4">
+      <div className="w-full max-w-md">
+        <Card
+          header={<div className="text-center text-lg font-semibold text-blue-600">APGMS Access</div>}
+          footer={<p className="text-center text-xs text-slate-400">Secure entry to the operational console</p>}
+        >
+          <Outlet />
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default AuthLayout;

--- a/apgms/webapp/src/pages/auth/ForgotPasswordPage.tsx
+++ b/apgms/webapp/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,45 @@
+import { FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+
+export const ForgotPasswordPage = () => {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitted(true);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" aria-label="forgot password form">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Reset password</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Enter your email and we will send reset instructions.
+        </p>
+      </div>
+      <label className="block text-sm font-medium text-slate-700">
+        Email address
+        <Input type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+      </label>
+      {submitted ? (
+        <p className="text-sm text-emerald-600">
+          If an account exists, we have sent recovery instructions to {email}.
+        </p>
+      ) : null}
+      <Button type="submit" className="w-full" variant="secondary">
+        Send reset link
+      </Button>
+      <p className="text-center text-sm text-slate-500">
+        Remembered it?{' '}
+        <Link to="/auth/login" className="text-blue-600 hover:underline">
+          Back to sign in
+        </Link>
+      </p>
+    </form>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/apgms/webapp/src/pages/auth/LoginPage.test.tsx
+++ b/apgms/webapp/src/pages/auth/LoginPage.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import LoginPage from './LoginPage';
+import { useAuthStore } from '@/state/authStore';
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    useAuthStore.setState({ user: null, status: 'idle', error: null });
+  });
+
+  it('authenticates an operator and redirects to the dashboard', async () => {
+    render(
+      <MemoryRouter initialEntries={['/auth/login']}>
+        <Routes>
+          <Route path="/auth/login" element={<LoginPage />} />
+          <Route path="/" element={<div>dashboard home</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/email address/i), 'operator@example.com');
+    await userEvent.type(screen.getByLabelText(/password/i), 'super-secret');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(screen.getByText(/dashboard home/i)).toBeInTheDocument());
+    expect(useAuthStore.getState().user?.email).toBe('operator@example.com');
+  });
+});

--- a/apgms/webapp/src/pages/auth/LoginPage.tsx
+++ b/apgms/webapp/src/pages/auth/LoginPage.tsx
@@ -1,0 +1,72 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { useAuthStore } from '@/state/authStore';
+
+export const LoginPage = () => {
+  const navigate = useNavigate();
+  const { login, status, error } = useAuthStore((state) => ({
+    login: state.login,
+    status: state.status,
+    error: state.error,
+  }));
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await login({ email, password });
+    if (useAuthStore.getState().status === 'authenticated') {
+      navigate('/');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" aria-label="login form">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Sign in</h2>
+        <p className="mt-1 text-sm text-slate-500">Use your APGMS operator credentials.</p>
+      </div>
+      <label className="block text-sm font-medium text-slate-700">
+        Email address
+        <Input
+          type="email"
+          name="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+        />
+      </label>
+      <label className="block text-sm font-medium text-slate-700">
+        Password
+        <Input
+          type="password"
+          name="password"
+          autoComplete="current-password"
+          required
+          value={password}
+          onChange={(event) => setPassword(event.target.value)}
+        />
+      </label>
+      {error ? <p className="text-sm text-rose-600" role="alert">{error}</p> : null}
+      <Button type="submit" disabled={status === 'loading'} className="w-full">
+        {status === 'loading' ? 'Signing in…' : 'Sign in'}
+      </Button>
+      <div className="flex items-center justify-between text-sm text-slate-500">
+        <Link to="/auth/forgot-password" className="text-blue-600 hover:underline">
+          Forgot password?
+        </Link>
+        <span>
+          No account?{' '}
+          <Link to="/auth/register" className="text-blue-600 hover:underline">
+            Register
+          </Link>
+        </span>
+      </div>
+    </form>
+  );
+};
+
+export default LoginPage;

--- a/apgms/webapp/src/pages/auth/RegisterPage.tsx
+++ b/apgms/webapp/src/pages/auth/RegisterPage.tsx
@@ -1,0 +1,58 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Input from '@/components/ui/Input';
+import { useAuthStore } from '@/state/authStore';
+
+export const RegisterPage = () => {
+  const navigate = useNavigate();
+  const { register, status, error } = useAuthStore((state) => ({
+    register: state.register,
+    status: state.status,
+    error: state.error,
+  }));
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await register({ name, email, password });
+    if (useAuthStore.getState().status === 'authenticated') {
+      navigate('/');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4" aria-label="register form">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-900">Create operator account</h2>
+        <p className="mt-1 text-sm text-slate-500">Provision secure access for new team members.</p>
+      </div>
+      <label className="block text-sm font-medium text-slate-700">
+        Full name
+        <Input value={name} onChange={(event) => setName(event.target.value)} required />
+      </label>
+      <label className="block text-sm font-medium text-slate-700">
+        Email address
+        <Input type="email" value={email} onChange={(event) => setEmail(event.target.value)} required />
+      </label>
+      <label className="block text-sm font-medium text-slate-700">
+        Password
+        <Input type="password" value={password} onChange={(event) => setPassword(event.target.value)} required />
+      </label>
+      {error ? <p className="text-sm text-rose-600" role="alert">{error}</p> : null}
+      <Button type="submit" disabled={status === 'loading'} className="w-full" variant="secondary">
+        {status === 'loading' ? 'Provisioning…' : 'Register account'}
+      </Button>
+      <p className="text-center text-sm text-slate-500">
+        Already registered?{' '}
+        <Link to="/auth/login" className="text-blue-600 hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </form>
+  );
+};
+
+export default RegisterPage;

--- a/apgms/webapp/src/pages/dashboard/AtoLodgementPage.tsx
+++ b/apgms/webapp/src/pages/dashboard/AtoLodgementPage.tsx
@@ -1,0 +1,62 @@
+import { useAtoLodgementStatus } from '@/api/hooks';
+import type { AtoLodgement } from '@/api/types';
+import { DataTable } from '@/components/ui/DataTable';
+import StatusPill from '@/components/ui/StatusPill';
+
+const toneMap: Record<AtoLodgement['status'], 'success' | 'warning' | 'danger'> = {
+  lodged: 'success',
+  pending: 'warning',
+  overdue: 'danger',
+};
+
+export const AtoLodgementPage = () => {
+  const { data, isLoading, error } = useAtoLodgementStatus();
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading ATO lodgement status…</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm text-rose-600">Unable to load ATO lodgements.</p>;
+  }
+
+  const columns = [
+    {
+      header: 'Period',
+      cell: (lodgement: AtoLodgement) => (
+        <div className="flex flex-col">
+          <span className="font-medium text-slate-900">{lodgement.period}</span>
+          <span className="text-xs text-slate-500">Due {new Date(lodgement.dueDate).toLocaleDateString()}</span>
+        </div>
+      ),
+    },
+    {
+      header: 'Status',
+      cell: (lodgement: AtoLodgement) => <StatusPill tone={toneMap[lodgement.status]}>{lodgement.status}</StatusPill>,
+    },
+    {
+      header: 'Lodged at',
+      cell: (lodgement: AtoLodgement) => (
+        <span className="text-sm text-slate-600">
+          {lodgement.lodgedAt ? new Date(lodgement.lodgedAt).toLocaleDateString() : 'Awaiting submission'}
+        </span>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500">
+        Keep track of BAS, PAYG and other ATO obligations to ensure nothing slips through compliance windows.
+      </p>
+      <DataTable
+        data={data}
+        columns={columns}
+        getRowKey={(lodgement) => lodgement.id}
+        emptyState="No ATO lodgements scheduled."
+      />
+    </div>
+  );
+};
+
+export default AtoLodgementPage;

--- a/apgms/webapp/src/pages/dashboard/BankLinesPage.test.tsx
+++ b/apgms/webapp/src/pages/dashboard/BankLinesPage.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BankLinesPage from './BankLinesPage';
+import { useDashboardStore } from '@/state/dashboardStore';
+
+describe('BankLinesPage', () => {
+  beforeEach(() => {
+    useDashboardStore.setState({ selectedBankLineId: null, approvedPayments: [] });
+  });
+
+  it('displays bank lines and allows selection', async () => {
+    render(<BankLinesPage />);
+
+    await waitFor(() => expect(screen.getByText(/Operating Account/i)).toBeInTheDocument());
+
+    await userEvent.click(screen.getByText(/Operating Account/i));
+
+    expect(
+      screen.getByText(/Selected bank line: Operating Account/i)
+    ).toBeInTheDocument();
+    expect(useDashboardStore.getState().selectedBankLineId).toBe('bl-001');
+  });
+});

--- a/apgms/webapp/src/pages/dashboard/BankLinesPage.tsx
+++ b/apgms/webapp/src/pages/dashboard/BankLinesPage.tsx
@@ -1,0 +1,77 @@
+import { useBankLines } from '@/api/hooks';
+import type { BankLine } from '@/api/types';
+import { DataTable } from '@/components/ui/DataTable';
+import StatusPill from '@/components/ui/StatusPill';
+import { useDashboardStore } from '@/state/dashboardStore';
+
+const toneMap: Record<BankLine['status'], 'success' | 'warning' | 'danger'> = {
+  healthy: 'success',
+  warning: 'warning',
+  attention: 'danger',
+};
+
+export const BankLinesPage = () => {
+  const { data, isLoading, error } = useBankLines();
+  const { selectedBankLineId, selectBankLine } = useDashboardStore((state) => ({
+    selectedBankLineId: state.selectedBankLineId,
+    selectBankLine: state.selectBankLine,
+  }));
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading bank lines…</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm text-rose-600">Unable to load bank line data.</p>;
+  }
+
+  const columns = [
+    {
+      header: 'Account',
+      cell: (line: BankLine) => (
+        <div className="flex flex-col">
+          <span className="font-medium text-slate-900">{line.accountName}</span>
+          <span className="text-xs text-slate-500">Last updated {new Date(line.lastUpdated).toLocaleTimeString()}</span>
+        </div>
+      ),
+    },
+    {
+      header: 'Balance',
+      cell: (line: BankLine) => (
+        <span className="font-mono text-slate-900">
+          {line.currency} {line.balance.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+        </span>
+      ),
+    },
+    {
+      header: 'Status',
+      cell: (line: BankLine) => <StatusPill tone={toneMap[line.status]}>{line.status}</StatusPill>,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500">
+        Track bank line balances and quickly identify accounts requiring intervention.
+      </p>
+      <DataTable
+        data={data}
+        columns={columns}
+        getRowKey={(line) => line.id}
+        emptyState="No bank lines configured."
+        onRowClick={(line) => selectBankLine(line.id)}
+      />
+      {selectedBankLineId ? (
+        <div className="rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+          Selected bank line: {data.find((line) => line.id === selectedBankLineId)?.accountName}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-slate-200 px-4 py-3 text-sm text-slate-500">
+          Click a row to focus on a particular bank line.
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BankLinesPage;

--- a/apgms/webapp/src/pages/dashboard/DashboardLayout.tsx
+++ b/apgms/webapp/src/pages/dashboard/DashboardLayout.tsx
@@ -1,0 +1,53 @@
+import { Outlet, useNavigate } from 'react-router-dom';
+import AppShell from '@/components/layout/AppShell';
+import PageHeader from '@/components/layout/PageHeader';
+import Sidebar from '@/components/navigation/Sidebar';
+import Topbar from '@/components/navigation/Topbar';
+import Button from '@/components/ui/Button';
+import { useAuthStore } from '@/state/authStore';
+
+const navItems = [
+  { label: 'Overview', to: '/' },
+  { label: 'Bank lines', to: '/bank-lines' },
+  { label: 'Reconciliation', to: '/reconciliation' },
+  { label: 'Payments', to: '/payments' },
+  { label: 'ATO lodgement', to: '/ato-lodgement' },
+];
+
+export const DashboardLayout = () => {
+  const navigate = useNavigate();
+  const { user, logout } = useAuthStore((state) => ({
+    user: state.user,
+    logout: state.logout,
+  }));
+
+  const handleLogout = () => {
+    logout();
+    navigate('/auth/login');
+  };
+
+  return (
+    <AppShell
+      sidebar={<Sidebar items={navItems} />}
+      topbar={
+        <Topbar title="Birchal operator console">
+          <div className="flex flex-col text-right">
+            <span className="text-sm font-medium text-slate-900">{user?.name ?? 'Unknown user'}</span>
+            <span className="text-xs text-slate-500">{user?.email}</span>
+          </div>
+          <Button variant="ghost" onClick={handleLogout}>
+            Sign out
+          </Button>
+        </Topbar>
+      }
+    >
+      <PageHeader
+        title="Operational dashboard"
+        description="Monitor bank lines, reconciliations, payments approvals and ATO obligations in one workspace."
+      />
+      <Outlet />
+    </AppShell>
+  );
+};
+
+export default DashboardLayout;

--- a/apgms/webapp/src/pages/dashboard/OverviewPage.tsx
+++ b/apgms/webapp/src/pages/dashboard/OverviewPage.tsx
@@ -1,0 +1,37 @@
+import Card from '@/components/ui/Card';
+import StatusPill from '@/components/ui/StatusPill';
+import { useDashboardSummary } from '@/api/hooks';
+
+const summaryLabels: Record<string, { label: string; tone: 'info' | 'warning' | 'success' | 'danger' }> = {
+  bankLinesCount: { label: 'Bank lines monitored', tone: 'info' },
+  reconciliationsInProgress: { label: 'Reconciliations in progress', tone: 'warning' },
+  pendingApprovals: { label: 'Payments awaiting approval', tone: 'danger' },
+  lodgementsDue: { label: 'ATO lodgements due', tone: 'warning' },
+};
+
+export const OverviewPage = () => {
+  const { data, isLoading, error } = useDashboardSummary();
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading summary…</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm text-rose-600">Unable to load dashboard summary.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {Object.entries(summaryLabels).map(([key, meta]) => (
+        <Card key={key} header={meta.label} className="bg-gradient-to-br from-white via-white to-slate-50">
+          <div className="flex items-end justify-between">
+            <span className="text-3xl font-semibold text-slate-900">{(data as Record<string, number>)[key]}</span>
+            <StatusPill tone={meta.tone}>{meta.label.split(' ')[0]}</StatusPill>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default OverviewPage;

--- a/apgms/webapp/src/pages/dashboard/PaymentsApprovalsPage.test.tsx
+++ b/apgms/webapp/src/pages/dashboard/PaymentsApprovalsPage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PaymentsApprovalsPage from './PaymentsApprovalsPage';
+import { useDashboardStore } from '@/state/dashboardStore';
+
+describe('PaymentsApprovalsPage', () => {
+  beforeEach(() => {
+    useDashboardStore.setState({ selectedBankLineId: null, approvedPayments: [] });
+  });
+
+  it('allows toggling payment approvals locally', async () => {
+    render(<PaymentsApprovalsPage />);
+
+    await waitFor(() => expect(screen.getByText(/Cloud Services Co/i)).toBeInTheDocument());
+
+    const approveButton = screen.getAllByRole('button', { name: /approve now/i })[0];
+    await userEvent.click(approveButton);
+
+    expect(approveButton).toHaveTextContent(/mark as pending/i);
+    expect(useDashboardStore.getState().approvedPayments).toContain('pay-001');
+  });
+});

--- a/apgms/webapp/src/pages/dashboard/PaymentsApprovalsPage.tsx
+++ b/apgms/webapp/src/pages/dashboard/PaymentsApprovalsPage.tsx
@@ -1,0 +1,65 @@
+import { usePaymentsApprovals } from '@/api/hooks';
+import type { PaymentApproval } from '@/api/types';
+import Card from '@/components/ui/Card';
+import StatusPill from '@/components/ui/StatusPill';
+import Button from '@/components/ui/Button';
+import { useDashboardStore } from '@/state/dashboardStore';
+
+const toneMap: Record<PaymentApproval['status'], 'success' | 'warning' | 'danger'> = {
+  approved: 'success',
+  pending: 'warning',
+  rejected: 'danger',
+};
+
+export const PaymentsApprovalsPage = () => {
+  const { data, isLoading, error } = usePaymentsApprovals();
+  const { approvedPayments, togglePaymentApproval } = useDashboardStore((state) => ({
+    approvedPayments: state.approvedPayments,
+    togglePaymentApproval: state.togglePaymentApproval,
+  }));
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading payment approvals…</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm text-rose-600">Unable to load payment approvals.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {data.map((approval) => {
+        const isLocallyApproved = approvedPayments.includes(approval.id);
+        return (
+          <Card
+            key={approval.id}
+            header={
+              <div className="flex items-center justify-between">
+                <span>{approval.vendor}</span>
+                <StatusPill tone={toneMap[approval.status]}>{approval.status}</StatusPill>
+              </div>
+            }
+            footer={`Submitted ${new Date(approval.submittedAt).toLocaleString()} · Approver ${approval.approver}`}
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-slate-900">
+                  {approval.currency} {approval.amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+                </p>
+                <p className="text-xs text-slate-500">Review and approve this payment before settlement.</p>
+              </div>
+              <Button
+                variant={isLocallyApproved ? 'secondary' : 'primary'}
+                onClick={() => togglePaymentApproval(approval.id)}
+              >
+                {isLocallyApproved ? 'Mark as pending' : 'Approve now'}
+              </Button>
+            </div>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PaymentsApprovalsPage;

--- a/apgms/webapp/src/pages/dashboard/ReconciliationPage.tsx
+++ b/apgms/webapp/src/pages/dashboard/ReconciliationPage.tsx
@@ -1,0 +1,45 @@
+import { useReconciliationWorkflow } from '@/api/hooks';
+import type { ReconciliationTask } from '@/api/types';
+import Card from '@/components/ui/Card';
+import StatusPill from '@/components/ui/StatusPill';
+
+const toneMap: Record<ReconciliationTask['status'], 'success' | 'warning' | 'danger'> = {
+  'in-progress': 'warning',
+  pending: 'danger',
+  completed: 'success',
+};
+
+export const ReconciliationPage = () => {
+  const { data, isLoading, error } = useReconciliationWorkflow();
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-500">Loading reconciliation tasks…</p>;
+  }
+
+  if (error || !data) {
+    return <p className="text-sm text-rose-600">Unable to load reconciliation workflow.</p>;
+  }
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      {data.map((task) => (
+        <Card
+          key={task.id}
+          header={
+            <div className="flex items-center justify-between">
+              <span>{task.description}</span>
+              <StatusPill tone={toneMap[task.status]}>{task.status}</StatusPill>
+            </div>
+          }
+          footer={`Assigned to ${task.assignedTo} · Due ${new Date(task.dueDate).toLocaleDateString()}`}
+        >
+          <p className="text-sm text-slate-600">
+            Monitor outstanding reconciliation actions to maintain accurate settlement reporting.
+          </p>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default ReconciliationPage;

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,43 @@
+import { Navigate, createBrowserRouter } from 'react-router-dom';
+import AuthLayout from '@/pages/auth/AuthLayout';
+import ForgotPasswordPage from '@/pages/auth/ForgotPasswordPage';
+import LoginPage from '@/pages/auth/LoginPage';
+import RegisterPage from '@/pages/auth/RegisterPage';
+import AtoLodgementPage from '@/pages/dashboard/AtoLodgementPage';
+import BankLinesPage from '@/pages/dashboard/BankLinesPage';
+import DashboardLayout from '@/pages/dashboard/DashboardLayout';
+import OverviewPage from '@/pages/dashboard/OverviewPage';
+import PaymentsApprovalsPage from '@/pages/dashboard/PaymentsApprovalsPage';
+import ReconciliationPage from '@/pages/dashboard/ReconciliationPage';
+import ProtectedRoute from './protected-route';
+
+export const router = createBrowserRouter([
+  {
+    path: '/auth',
+    element: <AuthLayout />,
+    children: [
+      { index: true, element: <Navigate to="login" replace /> },
+      { path: 'login', element: <LoginPage /> },
+      { path: 'register', element: <RegisterPage /> },
+      { path: 'forgot-password', element: <ForgotPasswordPage /> },
+    ],
+  },
+  {
+    path: '/',
+    element: (
+      <ProtectedRoute>
+        <DashboardLayout />
+      </ProtectedRoute>
+    ),
+    children: [
+      { index: true, element: <OverviewPage /> },
+      { path: 'bank-lines', element: <BankLinesPage /> },
+      { path: 'reconciliation', element: <ReconciliationPage /> },
+      { path: 'payments', element: <PaymentsApprovalsPage /> },
+      { path: 'ato-lodgement', element: <AtoLodgementPage /> },
+    ],
+  },
+  { path: '*', element: <Navigate to="/" replace /> },
+]);
+
+export default router;

--- a/apgms/webapp/src/routes/protected-route.tsx
+++ b/apgms/webapp/src/routes/protected-route.tsx
@@ -1,0 +1,20 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '@/state/authStore';
+import type { ReactNode } from 'react';
+
+export interface ProtectedRouteProps {
+  children: ReactNode;
+}
+
+export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+  const location = useLocation();
+  const { user } = useAuthStore((state) => ({ user: state.user }));
+
+  if (!user) {
+    return <Navigate to="/auth/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/apgms/webapp/src/state/authStore.ts
+++ b/apgms/webapp/src/state/authStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { apiClient } from '@/api/client';
+import type { AuthResponse, User } from '@/api/types';
+
+export type AuthStatus = 'idle' | 'loading' | 'authenticated' | 'error';
+
+export interface AuthState {
+  user: User | null;
+  status: AuthStatus;
+  error: string | null;
+  login: (credentials: { email: string; password: string }) => Promise<void>;
+  register: (payload: { name: string; email: string; password: string }) => Promise<void>;
+  logout: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+  user: null,
+  status: 'idle',
+  error: null,
+  login: async (credentials) => {
+    set({ status: 'loading', error: null });
+    try {
+      const response = await apiClient.post<AuthResponse>('/auth/login', credentials);
+      set({ user: response.user, status: 'authenticated', error: null });
+    } catch (error) {
+      set({ status: 'error', error: error instanceof Error ? error.message : 'Unable to login' });
+    }
+  },
+  register: async (payload) => {
+    set({ status: 'loading', error: null });
+    try {
+      const response = await apiClient.post<AuthResponse>('/auth/register', payload);
+      set({ user: response.user, status: 'authenticated', error: null });
+    } catch (error) {
+      set({ status: 'error', error: error instanceof Error ? error.message : 'Unable to register' });
+    }
+  },
+  logout: () => set({ user: null, status: 'idle', error: null }),
+}));

--- a/apgms/webapp/src/state/dashboardStore.ts
+++ b/apgms/webapp/src/state/dashboardStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+export interface DashboardState {
+  selectedBankLineId: string | null;
+  approvedPayments: string[];
+  selectBankLine: (id: string) => void;
+  togglePaymentApproval: (id: string) => void;
+}
+
+export const useDashboardStore = create<DashboardState>((set) => ({
+  selectedBankLineId: null,
+  approvedPayments: [],
+  selectBankLine: (id) => set({ selectedBankLineId: id }),
+  togglePaymentApproval: (id) =>
+    set((state) => {
+      const isApproved = state.approvedPayments.includes(id);
+      return {
+        approvedPayments: isApproved
+          ? state.approvedPayments.filter((item) => item !== id)
+          : [...state.approvedPayments, id],
+      };
+    }),
+}));

--- a/apgms/webapp/tsconfig.app.json
+++ b/apgms/webapp/tsconfig.app.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "types": ["vite/client", "jest"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src", "setupTests.ts"],
+  "exclude": ["src/**/*.test.tsx"]
+}

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/apgms/webapp/tsconfig.node.json
+++ b/apgms/webapp/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- initialize a Vite-powered React application with routing, protected dashboard layout, and shared styling
- add authentication flow plus bank line, reconciliation, payments approval, and ATO lodgement views backed by mocked API hooks and Zustand stores
- create reusable UI components and cover key flows with Jest and React Testing Library

## Testing
- pnpm test --filter @apgms/webapp... *(fails: missing dependencies because registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3001d93d48327bf36f26263d171d5