### PR TITLE
feat: implement SBR SOAP client and lodgement endpoints

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "node --test --import tsx ./test/soapClient.test.ts ./test/basHandler.test.ts ./test/payrollHandler.test.ts ./test/routes.test.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/app.ts
+++ b/apgms/services/sbr/src/app.ts
@@ -1,0 +1,69 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { z } from "zod";
+import {
+  BasSubmissionHandler,
+  type BasSubmissionPayload,
+  PayrollSubmissionHandler,
+  type PayrollSubmissionPayload,
+} from "./handlers";
+
+export interface AppOptions {
+  basHandler: BasSubmissionHandler;
+  payrollHandler: PayrollSubmissionHandler;
+  logger?: boolean;
+}
+
+const basSchema = z.object({
+  abn: z.string().min(11),
+  period: z.string().regex(/^\d{4}-\d{2}$/),
+  grossSales: z.number(),
+  gstOnSales: z.number(),
+  gstOnPurchases: z.number(),
+});
+
+const payrollSchema = z.object({
+  abn: z.string().min(11),
+  payPeriodStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  payPeriodEnd: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  employees: z
+    .array(
+      z.object({
+        tfnd: z.string().min(8),
+        gross: z.number(),
+        taxWithheld: z.number(),
+      }),
+    )
+    .min(1),
+});
+
+export function createServer(options: AppOptions): FastifyInstance {
+  const app = Fastify({ logger: options.logger ?? true });
+
+  app.get("/health", async () => ({ ok: true, service: "sbr" }));
+
+  app.post("/lodgements/bas", async (request, reply) => {
+    const parsed = basSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+
+    const result = await options.basHandler.submit(parsed.data as BasSubmissionPayload);
+    return reply.code(202).send(result);
+  });
+
+  app.post("/lodgements/payroll", async (request, reply) => {
+    const parsed = payrollSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply
+        .code(400)
+        .send({ error: "invalid_payload", details: parsed.error.flatten() });
+    }
+
+    const result = await options.payrollHandler.submit(
+      parsed.data as PayrollSubmissionPayload,
+    );
+    return reply.code(202).send(result);
+  });
+
+  return app;
+}

--- a/apgms/services/sbr/src/clients/errors.ts
+++ b/apgms/services/sbr/src/clients/errors.ts
@@ -1,0 +1,13 @@
+import type { SoapFault, SoapResponse } from "./types";
+
+export class SoapFaultError extends Error {
+  readonly fault: SoapFault;
+  readonly response: SoapResponse;
+
+  constructor(message: string, fault: SoapFault, response: SoapResponse) {
+    super(message);
+    this.name = "SoapFaultError";
+    this.fault = fault;
+    this.response = response;
+  }
+}

--- a/apgms/services/sbr/src/clients/index.ts
+++ b/apgms/services/sbr/src/clients/index.ts
@@ -1,0 +1,3 @@
+export * from "./soapClient";
+export * from "./errors";
+export * from "./types";

--- a/apgms/services/sbr/src/clients/soapClient.ts
+++ b/apgms/services/sbr/src/clients/soapClient.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { SoapFaultError } from "./errors";
+import type {
+  AuthCredentials,
+  SoapClientOptions,
+  SoapFault,
+  SoapRequest,
+  SoapResponse,
+  SoapTransport,
+} from "./types";
+
+const defaultTransport: SoapTransport = async (request: SoapRequest): Promise<SoapResponse> => {
+  const response = await fetch(request.url, {
+    method: "POST",
+    headers: request.headers,
+    body: request.body,
+  });
+
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key.toLowerCase()] = value;
+  });
+
+  return {
+    status: response.status,
+    headers,
+    body: await response.text(),
+  };
+};
+
+export class SoapClient {
+  private readonly endpoint: string;
+  private readonly productId: string;
+  private readonly credentials: AuthCredentials;
+  private readonly transport: SoapTransport;
+  private readonly userAgent: string;
+
+  constructor(options: SoapClientOptions) {
+    this.endpoint = options.endpoint;
+    this.productId = options.productId;
+    this.credentials = options.credentials;
+    this.transport = options.transport ?? defaultTransport;
+    this.userAgent = options.userAgent ?? "@apgms/sbr";
+  }
+
+  createEnvelope(body: string): string {
+    const messageId = randomUUID();
+    const securityHeader = this.buildSecurityHeader();
+    return `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:aus="http://ato.gov.au/auskey" xmlns:mg="http://ato.gov.au/mygovid" xmlns:com="http://ato.gov.au/common">
+  <soap:Header>
+    <com:MessageID>${messageId}</com:MessageID>
+    <com:ProductId>${this.productId}</com:ProductId>
+    ${securityHeader}
+  </soap:Header>
+  <soap:Body>
+    ${body}
+  </soap:Body>
+</soap:Envelope>`;
+  }
+
+  async send(action: string, body: string): Promise<Record<string, unknown>> {
+    const envelope = this.createEnvelope(body);
+    const response = await this.transport({
+      url: this.endpoint,
+      headers: {
+        "content-type": "text/xml; charset=utf-8",
+        soapaction: action,
+        "user-agent": this.userAgent,
+      },
+      body: envelope,
+    });
+
+    const parsed = this.parseResponse(response);
+    if (parsed.fault) {
+      throw new SoapFaultError(
+        `SOAP fault returned for action ${action}: ${parsed.fault.message}`,
+        parsed.fault,
+        response,
+      );
+    }
+
+    return parsed.body;
+  }
+
+  private buildSecurityHeader(): string {
+    if (this.credentials.type === "auskey") {
+      return `<aus:Authentication>
+        <aus:ABN>${this.credentials.abn}</aus:ABN>
+        <aus:SerialNumber>${this.credentials.serialNumber}</aus:SerialNumber>
+        <aus:KeystoreID>${this.credentials.keystoreId}</aus:KeystoreID>
+      </aus:Authentication>`;
+    }
+
+    return `<mg:Authentication>
+      <mg:ABN>${this.credentials.abn}</mg:ABN>
+      <mg:DeviceId>${this.credentials.deviceId}</mg:DeviceId>
+      <mg:AuthToken>${this.credentials.authToken}</mg:AuthToken>
+    </mg:Authentication>`;
+  }
+
+  private parseResponse(response: SoapResponse): {
+    body: Record<string, unknown>;
+    fault?: SoapFault;
+  } {
+    const bodyContent = this.extractTag(response.body, ["soap:Body", "env:Body", "Body"]);
+    if (!bodyContent) {
+      throw new Error("Malformed SOAP response: Body missing");
+    }
+
+    const faultContent = this.extractTag(bodyContent, ["soap:Fault", "Fault"]);
+    if (faultContent) {
+      return {
+        body: {},
+        fault: {
+          code: this.extractTagText(faultContent, ["faultcode", "code"]) ?? "UNKNOWN",
+          message: this.extractTagText(faultContent, ["faultstring", "message"]) ?? "Unknown fault",
+          detail: this.extractTag(faultContent, ["detail"]),
+        },
+      };
+    }
+
+    const operationMatch = bodyContent.match(/<([\w:]+)[^>]*>([\s\S]*)<\/\1>/);
+    if (!operationMatch) {
+      return { body: {} };
+    }
+
+    const operation = operationMatch[1];
+    const payload = operationMatch[2];
+    const parsedBody = this.parseChildren(payload);
+
+    return {
+      body: {
+        [operation]: parsedBody,
+      },
+    };
+  }
+
+  private extractTag(source: string, tags: string[]): string | undefined {
+    for (const tag of tags) {
+      const regex = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\/${tag}>`, "i");
+      const match = source.match(regex);
+      if (match) {
+        return match[1].trim();
+      }
+    }
+    return undefined;
+  }
+
+  private extractTagText(source: string, tags: string[]): string | undefined {
+    const content = this.extractTag(source, tags);
+    return content ? content.replace(/<[^>]+>/g, "").trim() : undefined;
+  }
+
+  private parseChildren(xml: string): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    const regex = /<([\w:]+)[^>]*>([\s\S]*?)<\/\1>/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(xml))) {
+      const key = match[1];
+      const inner = match[2].trim();
+      const value = /<([\w:]+)[^>]*>/.test(inner) ? this.parseChildren(inner) : inner;
+
+      if (result[key] === undefined) {
+        result[key] = value;
+      } else if (Array.isArray(result[key])) {
+        (result[key] as unknown[]).push(value);
+      } else {
+        result[key] = [result[key], value];
+      }
+    }
+    return result;
+  }
+}

--- a/apgms/services/sbr/src/clients/types.ts
+++ b/apgms/services/sbr/src/clients/types.ts
@@ -1,0 +1,43 @@
+export type AuskeyCredentials = {
+  type: "auskey";
+  abn: string;
+  serialNumber: string;
+  keystoreId: string;
+};
+
+export type MyGovIdCredentials = {
+  type: "mygovid";
+  abn: string;
+  deviceId: string;
+  authToken: string;
+};
+
+export type AuthCredentials = AuskeyCredentials | MyGovIdCredentials;
+
+export interface SoapRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface SoapResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export type SoapTransport = (request: SoapRequest) => Promise<SoapResponse>;
+
+export interface SoapClientOptions {
+  endpoint: string;
+  productId: string;
+  credentials: AuthCredentials;
+  transport?: SoapTransport;
+  userAgent?: string;
+}
+
+export interface SoapFault {
+  code: string;
+  message: string;
+  detail?: unknown;
+}

--- a/apgms/services/sbr/src/config.ts
+++ b/apgms/services/sbr/src/config.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+import type { AuthCredentials } from "./clients";
+
+const envSchema = z.object({
+  SBR_ENDPOINT: z.string().url(),
+  SBR_PRODUCT_ID: z.string().min(1),
+  SBR_AUTH_MODE: z.enum(["auskey", "mygovid"]).default("mygovid"),
+  SBR_ABN: z.string().min(11),
+  SBR_SERIAL_NUMBER: z.string().optional(),
+  SBR_KEYSTORE_ID: z.string().optional(),
+  SBR_DEVICE_ID: z.string().optional(),
+  SBR_AUTH_TOKEN: z.string().optional(),
+});
+
+export interface SbrConfig {
+  endpoint: string;
+  productId: string;
+  credentials: AuthCredentials;
+}
+
+export function loadConfig(env = process.env): SbrConfig {
+  const parsed = envSchema.safeParse(env);
+  if (!parsed.success) {
+    throw new Error(`Invalid SBR configuration: ${parsed.error.message}`);
+  }
+
+  const data = parsed.data;
+
+  if (data.SBR_AUTH_MODE === "auskey") {
+    if (!data.SBR_SERIAL_NUMBER || !data.SBR_KEYSTORE_ID) {
+      throw new Error("AUSkey mode requires SBR_SERIAL_NUMBER and SBR_KEYSTORE_ID");
+    }
+    return {
+      endpoint: data.SBR_ENDPOINT,
+      productId: data.SBR_PRODUCT_ID,
+      credentials: {
+        type: "auskey",
+        abn: data.SBR_ABN,
+        serialNumber: data.SBR_SERIAL_NUMBER,
+        keystoreId: data.SBR_KEYSTORE_ID,
+      },
+    };
+  }
+
+  if (!data.SBR_DEVICE_ID || !data.SBR_AUTH_TOKEN) {
+    throw new Error("MyGovID mode requires SBR_DEVICE_ID and SBR_AUTH_TOKEN");
+  }
+
+  return {
+    endpoint: data.SBR_ENDPOINT,
+    productId: data.SBR_PRODUCT_ID,
+    credentials: {
+      type: "mygovid",
+      abn: data.SBR_ABN,
+      deviceId: data.SBR_DEVICE_ID,
+      authToken: data.SBR_AUTH_TOKEN,
+    },
+  };
+}

--- a/apgms/services/sbr/src/handlers/bas.ts
+++ b/apgms/services/sbr/src/handlers/bas.ts
@@ -1,0 +1,101 @@
+import { decodeAtoFault, SubmissionError } from "./errors";
+import { SoapClient, SoapFaultError } from "../clients";
+
+export interface BasSubmissionPayload {
+  abn: string;
+  period: string; // YYYY-MM
+  grossSales: number;
+  gstOnSales: number;
+  gstOnPurchases: number;
+}
+
+export interface BasSubmissionResult {
+  receiptId: string;
+  lodgementTime: string;
+  status: "ACCEPTED" | "RECEIVED" | "ERROR";
+}
+
+export interface BasSubmissionHandlerOptions {
+  client: SoapClient;
+  maxRetries?: number;
+  sleep?: (attempt: number) => Promise<void>;
+}
+
+export class BasSubmissionHandler {
+  private readonly client: SoapClient;
+  private readonly maxRetries: number;
+  private readonly sleep: (attempt: number) => Promise<void>;
+
+  constructor(options: BasSubmissionHandlerOptions) {
+    this.client = options.client;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.sleep =
+      options.sleep ?? (async () => new Promise((resolve) => setTimeout(resolve, 250)));
+  }
+
+  async submit(payload: BasSubmissionPayload): Promise<BasSubmissionResult> {
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt <= this.maxRetries) {
+      try {
+        const response = await this.client.send("SubmitBAS", this.buildPayload(payload));
+        const body = this.extractResponse(response);
+        return {
+          receiptId: body.ReceiptNumber,
+          lodgementTime: body.LodgementTime,
+          status: (body.ProcessingStatus as BasSubmissionResult["status"]) ?? "ACCEPTED",
+        };
+      } catch (error) {
+        lastError = error;
+        if (error instanceof SoapFaultError) {
+          const decoded = decodeAtoFault(error.fault);
+          if (decoded.retryable && attempt < this.maxRetries) {
+            attempt += 1;
+            await this.sleep(attempt);
+            continue;
+          }
+
+          throw new SubmissionError(
+            `Failed to submit BAS form: ${decoded.message}`,
+            error.fault,
+            decoded,
+          );
+        }
+        throw error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("Failed to submit BAS form due to unknown error");
+  }
+
+  private buildPayload(payload: BasSubmissionPayload): string {
+    return `<bas:SubmitBASRequest xmlns:bas="http://ato.gov.au/sbr/bas">
+      <bas:ABN>${payload.abn}</bas:ABN>
+      <bas:Period>${payload.period}</bas:Period>
+      <bas:GrossSales>${payload.grossSales.toFixed(2)}</bas:GrossSales>
+      <bas:GstOnSales>${payload.gstOnSales.toFixed(2)}</bas:GstOnSales>
+      <bas:GstOnPurchases>${payload.gstOnPurchases.toFixed(2)}</bas:GstOnPurchases>
+    </bas:SubmitBASRequest>`;
+  }
+
+  private extractResponse(response: Record<string, unknown>) {
+    const submitResponse =
+      (response["SubmitBASResponse"] as Record<string, string> | undefined) ??
+      (response["bas:SubmitBASResponse"] as Record<string, string> | undefined);
+
+    if (!submitResponse) {
+      throw new Error("Unexpected BAS submission response shape");
+    }
+
+    return {
+      ReceiptNumber: submitResponse.ReceiptNumber ?? submitResponse["bas:ReceiptNumber"],
+      ProcessingStatus:
+        submitResponse.ProcessingStatus ?? submitResponse["bas:ProcessingStatus"] ?? "ACCEPTED",
+      LodgementTime:
+        submitResponse.LodgementTime ?? submitResponse["bas:LodgementTime"] ?? new Date().toISOString(),
+    };
+  }
+}

--- a/apgms/services/sbr/src/handlers/errors.ts
+++ b/apgms/services/sbr/src/handlers/errors.ts
@@ -1,0 +1,80 @@
+import type { SoapFault } from "../clients";
+
+export interface DecodedFault {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+const FAULT_MAPPINGS: Record<string, DecodedFault> = {
+  "ATO.SERVICE.UNAVAILABLE": {
+    code: "service_unavailable",
+    message: "ATO services are temporarily unavailable. Please retry shortly.",
+    retryable: true,
+  },
+  "ATO.GENERAL.RETRY": {
+    code: "general_retry",
+    message: "Temporary outage communicating with the ATO.",
+    retryable: true,
+  },
+  "ATO.AUTH.INVALID": {
+    code: "auth_invalid",
+    message: "Authentication with the ATO failed.",
+    retryable: false,
+  },
+  "ATO.BAS.FORM.INVALID": {
+    code: "bas_form_invalid",
+    message: "Submitted BAS form failed ATO validation.",
+    retryable: false,
+  },
+  "ATO.PAYROLL.OUTAGE": {
+    code: "payroll_outage",
+    message: "ATO payroll services are currently unavailable.",
+    retryable: true,
+  },
+  "ATO.PAYROLL.NOT_FOUND": {
+    code: "payroll_not_found",
+    message: "Payroll lodgement could not be found.",
+    retryable: false,
+  },
+};
+
+export const DEFAULT_DECODED_FAULT: DecodedFault = {
+  code: "unknown_fault",
+  message: "An unknown SOAP fault was returned by the ATO.",
+  retryable: false,
+};
+
+export function decodeAtoFault(fault: SoapFault): DecodedFault {
+  const detail =
+    typeof fault.detail === "string"
+      ? fault.detail
+      : (fault.detail && JSON.stringify(fault.detail)) || "";
+
+  const matchedKey = Object.keys(FAULT_MAPPINGS).find((key) => detail.includes(key));
+  if (matchedKey) {
+    return FAULT_MAPPINGS[matchedKey];
+  }
+
+  const normalized = fault.code.toUpperCase();
+  if (FAULT_MAPPINGS[normalized]) {
+    return FAULT_MAPPINGS[normalized];
+  }
+
+  return {
+    ...DEFAULT_DECODED_FAULT,
+    message: fault.message || DEFAULT_DECODED_FAULT.message,
+  };
+}
+
+export class SubmissionError extends Error {
+  readonly decodedFault: DecodedFault;
+  readonly fault: SoapFault;
+
+  constructor(message: string, fault: SoapFault, decodedFault: DecodedFault) {
+    super(message);
+    this.name = "SubmissionError";
+    this.decodedFault = decodedFault;
+    this.fault = fault;
+  }
+}

--- a/apgms/services/sbr/src/handlers/index.ts
+++ b/apgms/services/sbr/src/handlers/index.ts
@@ -1,0 +1,3 @@
+export * from "./bas";
+export * from "./payroll";
+export * from "./errors";

--- a/apgms/services/sbr/src/handlers/payroll.ts
+++ b/apgms/services/sbr/src/handlers/payroll.ts
@@ -1,0 +1,118 @@
+import { decodeAtoFault, SubmissionError } from "./errors";
+import { SoapClient, SoapFaultError } from "../clients";
+
+export interface PayrollEmployee {
+  tfnd: string;
+  gross: number;
+  taxWithheld: number;
+}
+
+export interface PayrollSubmissionPayload {
+  abn: string;
+  payPeriodStart: string; // YYYY-MM-DD
+  payPeriodEnd: string; // YYYY-MM-DD
+  employees: PayrollEmployee[];
+}
+
+export interface PayrollSubmissionResult {
+  receiptId: string;
+  lodgementTime: string;
+  status: "ACCEPTED" | "RECEIVED" | "ERROR";
+}
+
+export interface PayrollSubmissionHandlerOptions {
+  client: SoapClient;
+  maxRetries?: number;
+  sleep?: (attempt: number) => Promise<void>;
+}
+
+export class PayrollSubmissionHandler {
+  private readonly client: SoapClient;
+  private readonly maxRetries: number;
+  private readonly sleep: (attempt: number) => Promise<void>;
+
+  constructor(options: PayrollSubmissionHandlerOptions) {
+    this.client = options.client;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.sleep =
+      options.sleep ?? (async () => new Promise((resolve) => setTimeout(resolve, 250)));
+  }
+
+  async submit(payload: PayrollSubmissionPayload): Promise<PayrollSubmissionResult> {
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt <= this.maxRetries) {
+      try {
+        const response = await this.client.send(
+          "SubmitPayroll",
+          this.buildPayload(payload),
+        );
+        const body = this.extractResponse(response);
+        return {
+          receiptId: body.ReceiptNumber,
+          lodgementTime: body.LodgementTime,
+          status: (body.ProcessingStatus as PayrollSubmissionResult["status"]) ?? "ACCEPTED",
+        };
+      } catch (error) {
+        lastError = error;
+        if (error instanceof SoapFaultError) {
+          const decoded = decodeAtoFault(error.fault);
+          if (decoded.retryable && attempt < this.maxRetries) {
+            attempt += 1;
+            await this.sleep(attempt);
+            continue;
+          }
+
+          throw new SubmissionError(
+            `Failed to submit payroll event: ${decoded.message}`,
+            error.fault,
+            decoded,
+          );
+        }
+        throw error;
+      }
+    }
+
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("Failed to submit payroll event due to unknown error");
+  }
+
+  private buildPayload(payload: PayrollSubmissionPayload): string {
+    const employees = payload.employees
+      .map(
+        (emp) => `<pay:Employee>
+        <pay:TFND>${emp.tfnd}</pay:TFND>
+        <pay:Gross>${emp.gross.toFixed(2)}</pay:Gross>
+        <pay:TaxWithheld>${emp.taxWithheld.toFixed(2)}</pay:TaxWithheld>
+      </pay:Employee>`,
+      )
+      .join("");
+
+    return `<pay:SubmitPayrollRequest xmlns:pay="http://ato.gov.au/sbr/payroll">
+      <pay:ABN>${payload.abn}</pay:ABN>
+      <pay:PayPeriodStart>${payload.payPeriodStart}</pay:PayPeriodStart>
+      <pay:PayPeriodEnd>${payload.payPeriodEnd}</pay:PayPeriodEnd>
+      <pay:Employees>${employees}</pay:Employees>
+    </pay:SubmitPayrollRequest>`;
+  }
+
+  private extractResponse(response: Record<string, unknown>) {
+    const submitResponse =
+      (response["SubmitPayrollResponse"] as Record<string, string> | undefined) ??
+      (response["pay:SubmitPayrollResponse"] as Record<string, string> | undefined);
+
+    if (!submitResponse) {
+      throw new Error("Unexpected payroll submission response shape");
+    }
+
+    return {
+      ReceiptNumber: submitResponse.ReceiptNumber ?? submitResponse["pay:ReceiptNumber"],
+      ProcessingStatus:
+        submitResponse.ProcessingStatus ?? submitResponse["pay:ProcessingStatus"] ?? "ACCEPTED",
+      LodgementTime:
+        submitResponse.LodgementTime ?? submitResponse["pay:LodgementTime"] ?? new Date().toISOString(),
+    };
+  }
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,37 @@
-﻿console.log('sbr service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import { createServer } from "./app";
+import { SoapClient } from "./clients";
+import { loadConfig } from "./config";
+import { BasSubmissionHandler, PayrollSubmissionHandler } from "./handlers";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const config = loadConfig();
+const soapClient = new SoapClient({
+  endpoint: config.endpoint,
+  productId: config.productId,
+  credentials: config.credentials,
+});
+
+const app = createServer({
+  basHandler: new BasSubmissionHandler({ client: soapClient }),
+  payrollHandler: new PayrollSubmissionHandler({ client: soapClient }),
+});
+
+const port = Number(process.env.PORT ?? 3010);
+const host = "0.0.0.0";
+
+app
+  .listen({ port, host })
+  .then(() => {
+    app.log.info({ port }, "SBR service listening");
+  })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/sbr/test/basHandler.test.ts
+++ b/apgms/services/sbr/test/basHandler.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SoapClient } from "../src/clients";
+import { BasSubmissionHandler } from "../src/handlers";
+
+const basSuccess = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <SubmitBASResponse>
+      <ReceiptNumber>ABC123</ReceiptNumber>
+      <ProcessingStatus>ACCEPTED</ProcessingStatus>
+      <LodgementTime>2024-06-01T00:00:00Z</LodgementTime>
+    </SubmitBASResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const basFault = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>ATO.SERVICE.UNAVAILABLE</faultcode>
+      <faultstring>Service unavailable</faultstring>
+      <detail>
+        <ato:Code xmlns:ato="http://ato.gov.au/errors">ATO.SERVICE.UNAVAILABLE</ato:Code>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`;
+
+function createClient(responses: string[]) {
+  let count = 0;
+  return new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "mygovid",
+      abn: "12345678901",
+      deviceId: "device",
+      authToken: "token",
+    },
+    transport: async () => {
+      const body = responses[count++] ?? responses[responses.length - 1];
+      return { status: body === basFault ? 500 : 200, headers: {}, body };
+    },
+  });
+}
+
+const payload = {
+  abn: "12345678901",
+  period: "2024-06",
+  grossSales: 10000,
+  gstOnSales: 1000,
+  gstOnPurchases: 400,
+};
+
+test("BAS handler submits and returns a receipt", async () => {
+  const handler = new BasSubmissionHandler({
+    client: createClient([basSuccess]),
+    sleep: async () => {},
+  });
+
+  const result = await handler.submit(payload);
+  assert.equal(result.receiptId, "ABC123");
+});
+
+test("BAS handler retries transient faults", async () => {
+  const handler = new BasSubmissionHandler({
+    client: createClient([basFault, basSuccess]),
+    sleep: async () => {},
+  });
+
+  const result = await handler.submit(payload);
+  assert.equal(result.status, "ACCEPTED");
+});
+
+test("BAS handler surfaces decoded submission errors", async () => {
+  const client = new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "mygovid",
+      abn: "12345678901",
+      deviceId: "device",
+      authToken: "token",
+    },
+    transport: async () => ({
+      status: 400,
+      headers: {},
+      body: `<?xml version="1.0"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <soap:Fault>
+            <faultcode>ATO.BAS.FORM.INVALID</faultcode>
+            <faultstring>Validation failed</faultstring>
+            <detail>
+              <ato:Code xmlns:ato="http://ato.gov.au/errors">ATO.BAS.FORM.INVALID</ato:Code>
+            </detail>
+          </soap:Fault>
+        </soap:Body>
+      </soap:Envelope>`,
+    }),
+  });
+
+  const handler = new BasSubmissionHandler({ client, sleep: async () => {} });
+
+  await assert.rejects(async () => handler.submit(payload), (error: unknown) => {
+    return typeof error === "object" && error !== null && (error as any).decodedFault?.retryable === false;
+  });
+});

--- a/apgms/services/sbr/test/payrollHandler.test.ts
+++ b/apgms/services/sbr/test/payrollHandler.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SoapClient } from "../src/clients";
+import { PayrollSubmissionHandler } from "../src/handlers";
+
+const payrollSuccess = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <SubmitPayrollResponse>
+      <ReceiptNumber>PAY123</ReceiptNumber>
+      <ProcessingStatus>RECEIVED</ProcessingStatus>
+      <LodgementTime>2024-06-02T00:00:00Z</LodgementTime>
+    </SubmitPayrollResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const payrollFault = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>ATO.PAYROLL.OUTAGE</faultcode>
+      <faultstring>Outage</faultstring>
+      <detail>
+        <ato:Code xmlns:ato="http://ato.gov.au/errors">ATO.PAYROLL.OUTAGE</ato:Code>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`;
+
+function createClient(responses: string[]) {
+  let count = 0;
+  return new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "mygovid",
+      abn: "12345678901",
+      deviceId: "device",
+      authToken: "token",
+    },
+    transport: async () => {
+      const body = responses[count++] ?? responses[responses.length - 1];
+      return { status: body === payrollFault ? 500 : 200, headers: {}, body };
+    },
+  });
+}
+
+const payload = {
+  abn: "12345678901",
+  payPeriodStart: "2024-05-26",
+  payPeriodEnd: "2024-06-01",
+  employees: [
+    { tfnd: "123456789", gross: 5000, taxWithheld: 1200 },
+    { tfnd: "987654321", gross: 4200, taxWithheld: 900 },
+  ],
+};
+
+test("Payroll handler submits events", async () => {
+  const handler = new PayrollSubmissionHandler({
+    client: createClient([payrollSuccess]),
+    sleep: async () => {},
+  });
+
+  const result = await handler.submit(payload);
+  assert.equal(result.receiptId, "PAY123");
+  assert.equal(result.status, "RECEIVED");
+});
+
+test("Payroll handler retries outages", async () => {
+  const handler = new PayrollSubmissionHandler({
+    client: createClient([payrollFault, payrollSuccess]),
+    sleep: async () => {},
+  });
+
+  const result = await handler.submit(payload);
+  assert.equal(result.receiptId, "PAY123");
+});

--- a/apgms/services/sbr/test/routes.test.ts
+++ b/apgms/services/sbr/test/routes.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "../src/app";
+import type {
+  BasSubmissionHandler,
+  BasSubmissionPayload,
+  PayrollSubmissionHandler,
+  PayrollSubmissionPayload,
+} from "../src/handlers";
+
+const basResult = {
+  receiptId: "ABC123",
+  lodgementTime: "2024-06-01T00:00:00Z",
+  status: "ACCEPTED" as const,
+};
+
+const payrollResult = {
+  receiptId: "PAY123",
+  lodgementTime: "2024-06-02T00:00:00Z",
+  status: "RECEIVED" as const,
+};
+
+type BasStub = Pick<BasSubmissionHandler, "submit"> & { calls: BasSubmissionPayload[] };
+type PayrollStub = Pick<PayrollSubmissionHandler, "submit"> & {
+  calls: PayrollSubmissionPayload[];
+};
+
+function createBasStub(): BasStub {
+  const calls: BasSubmissionPayload[] = [];
+  return {
+    calls,
+    async submit(payload: BasSubmissionPayload) {
+      calls.push(payload);
+      return basResult;
+    },
+  };
+}
+
+function createPayrollStub(): PayrollStub {
+  const calls: PayrollSubmissionPayload[] = [];
+  return {
+    calls,
+    async submit(payload: PayrollSubmissionPayload) {
+      calls.push(payload);
+      return payrollResult;
+    },
+  };
+}
+
+test("BAS endpoint validates payloads and triggers submissions", async () => {
+  const basHandler = createBasStub();
+  const payrollHandler = createPayrollStub();
+  const app = createServer({
+    basHandler: basHandler as unknown as BasSubmissionHandler,
+    payrollHandler: payrollHandler as unknown as PayrollSubmissionHandler,
+    logger: false,
+  });
+
+  const invalid = await app.inject({
+    method: "POST",
+    url: "/lodgements/bas",
+    payload: { abn: "123", period: "2024-06", grossSales: 10, gstOnSales: 1, gstOnPurchases: 0 },
+  });
+
+  assert.equal(invalid.statusCode, 400);
+
+  const valid = await app.inject({
+    method: "POST",
+    url: "/lodgements/bas",
+    payload: {
+      abn: "12345678901",
+      period: "2024-06",
+      grossSales: 10000,
+      gstOnSales: 1000,
+      gstOnPurchases: 400,
+    },
+  });
+
+  assert.equal(valid.statusCode, 202);
+  assert.equal(basHandler.calls.length, 1);
+
+  await app.close();
+});
+
+test("Payroll endpoint validates payloads and triggers submissions", async () => {
+  const basHandler = createBasStub();
+  const payrollHandler = createPayrollStub();
+  const app = createServer({
+    basHandler: basHandler as unknown as BasSubmissionHandler,
+    payrollHandler: payrollHandler as unknown as PayrollSubmissionHandler,
+    logger: false,
+  });
+
+  const invalid = await app.inject({
+    method: "POST",
+    url: "/lodgements/payroll",
+    payload: {
+      abn: "12345678901",
+      payPeriodStart: "2024-06-01",
+      payPeriodEnd: "2024-06-15",
+      employees: [],
+    },
+  });
+
+  assert.equal(invalid.statusCode, 400);
+
+  const valid = await app.inject({
+    method: "POST",
+    url: "/lodgements/payroll",
+    payload: {
+      abn: "12345678901",
+      payPeriodStart: "2024-06-01",
+      payPeriodEnd: "2024-06-15",
+      employees: [{ tfnd: "123456789", gross: 5000, taxWithheld: 1200 }],
+    },
+  });
+
+  assert.equal(valid.statusCode, 202);
+  assert.equal(payrollHandler.calls.length, 1);
+
+  await app.close();
+});

--- a/apgms/services/sbr/test/soapClient.test.ts
+++ b/apgms/services/sbr/test/soapClient.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SoapClient, SoapFaultError } from "../src/clients";
+
+const successResponse = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <SubmitBASResponse>
+      <ReceiptNumber>12345</ReceiptNumber>
+      <ProcessingStatus>ACCEPTED</ProcessingStatus>
+      <LodgementTime>2024-06-01T00:00:00Z</LodgementTime>
+    </SubmitBASResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const faultResponse = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>ATO.SERVICE.UNAVAILABLE</faultcode>
+      <faultstring>Service unavailable</faultstring>
+      <detail>
+        <ato:Code xmlns:ato="http://ato.gov.au/errors">ATO.SERVICE.UNAVAILABLE</ato:Code>
+      </detail>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`;
+
+test("SoapClient builds envelopes with AUSkey authentication", () => {
+  const client = new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "auskey",
+      abn: "12345678901",
+      serialNumber: "SERIAL",
+      keystoreId: "KEYSTORE",
+    },
+    transport: async () => ({ status: 200, headers: {}, body: successResponse }),
+  });
+
+  const envelope = client.createEnvelope("<Test>ok</Test>");
+  assert.ok(envelope.includes("<aus:ABN>12345678901</aus:ABN>"));
+  assert.ok(envelope.includes("<aus:SerialNumber>SERIAL</aus:SerialNumber>"));
+  assert.ok(envelope.includes("<aus:KeystoreID>KEYSTORE</aus:KeystoreID>"));
+  assert.ok(envelope.includes("<Test>ok</Test>"));
+});
+
+test("SoapClient parses SOAP responses", async () => {
+  const client = new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "mygovid",
+      abn: "12345678901",
+      deviceId: "device",
+      authToken: "token",
+    },
+    transport: async () => ({ status: 200, headers: {}, body: successResponse }),
+  });
+
+  const body = await client.send("SubmitBAS", "<SubmitBASRequest />");
+  assert.ok(body.SubmitBASResponse);
+});
+
+test("SoapClient throws on SOAP faults", async () => {
+  const client = new SoapClient({
+    endpoint: "https://example.com",
+    productId: "PID",
+    credentials: {
+      type: "mygovid",
+      abn: "12345678901",
+      deviceId: "device",
+      authToken: "token",
+    },
+    transport: async () => ({ status: 500, headers: {}, body: faultResponse }),
+  });
+
+  await assert.rejects(() => client.send("SubmitBAS", "<SubmitBASRequest />"), SoapFaultError);
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add configurable SOAP client adapters supporting AUSkey and MyGovID credentials
- implement BAS and payroll lodgement handlers with retry/error decoding and expose Fastify REST endpoints
- add targeted node:test suites covering SOAP parsing, handler retries, and HTTP routing with mocked ATO responses

## Testing
- `pnpm --filter @apgms/sbr test`


------
https://chatgpt.com/codex/tasks/task_e_68f3001b451c83279bea831094a6b40c