### PR TITLE
feat: implement tax calculation domain and endpoints

### DIFF
--- a/apgms/services/tax-engine/app/calculations/__init__.py
+++ b/apgms/services/tax-engine/app/calculations/__init__.py
@@ -1,0 +1,12 @@
+from .base import CalculationError, TaxCalculationResult
+from .gst import GSTCalculationData, GSTCalculator
+from .payg import PAYGCalculationData, PAYGCalculator
+
+__all__ = [
+    "CalculationError",
+    "GSTCalculationData",
+    "GSTCalculator",
+    "PAYGCalculationData",
+    "PAYGCalculator",
+    "TaxCalculationResult",
+]

--- a/apgms/services/tax-engine/app/calculations/base.py
+++ b/apgms/services/tax-engine/app/calculations/base.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Dict
+
+
+class CalculationError(ValueError):
+    """Raised when a calculation receives invalid input."""
+
+
+def _quantize(value: Decimal) -> Decimal:
+    """Round currency values to two decimal places using bankers rounding."""
+
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+@dataclass(frozen=True)
+class TaxCalculationResult:
+    """Represents the result of applying a tax calculation rule set."""
+
+    liability: Decimal
+    breakdown: Dict[str, Decimal]
+
+    def normalized(self) -> "TaxCalculationResult":
+        """Return a result with every value rounded to currency precision."""
+
+        normalized_breakdown = {key: _quantize(amount) for key, amount in self.breakdown.items()}
+        return TaxCalculationResult(liability=_quantize(self.liability), breakdown=normalized_breakdown)
+
+    def to_payload(self) -> Dict[str, Decimal]:
+        """Convert the result into a structure suitable for API responses."""
+
+        normalized = self.normalized()
+        return {"liability": normalized.liability, "breakdown": normalized.breakdown}
+
+
+def ensure_non_negative(name: str, value: Decimal) -> Decimal:
+    """Validate a decimal currency field ensuring it is non-negative."""
+
+    if value < 0:
+        raise CalculationError(f"{name} must be zero or positive. Received {value}.")
+    return value
+
+
+def ensure_percentage(name: str, value: Decimal) -> Decimal:
+    """Validate that a decimal represents a percentage between 0 and 1."""
+
+    if value < 0 or value > 1:
+        raise CalculationError(f"{name} must be between 0 and 1 inclusive. Received {value}.")
+    return value
+
+
+__all__ = [
+    "CalculationError",
+    "TaxCalculationResult",
+    "ensure_non_negative",
+    "ensure_percentage",
+]

--- a/apgms/services/tax-engine/app/calculations/gst.py
+++ b/apgms/services/tax-engine/app/calculations/gst.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .base import CalculationError, TaxCalculationResult, ensure_non_negative
+
+
+@dataclass(frozen=True)
+class GSTCalculationData:
+    """Inputs required to determine a GST liability."""
+
+    gst_collected: Decimal
+    gst_paid: Decimal
+    adjustments: Decimal = Decimal("0")
+    credits: Decimal = Decimal("0")
+
+    def __post_init__(self) -> None:
+        ensure_non_negative("gst_collected", self.gst_collected)
+        ensure_non_negative("gst_paid", self.gst_paid)
+        ensure_non_negative("adjustments", self.adjustments)
+        ensure_non_negative("credits", self.credits)
+
+
+class GSTCalculator:
+    """GST computation rules for net tax calculation."""
+
+    def calculate(self, data: GSTCalculationData) -> TaxCalculationResult:
+        net_tax = data.gst_collected - data.gst_paid + data.adjustments - data.credits
+        breakdown = {
+            "gst_collected": data.gst_collected,
+            "gst_paid": -data.gst_paid,
+            "adjustments": data.adjustments,
+            "credits": -data.credits,
+        }
+
+        return TaxCalculationResult(liability=net_tax, breakdown=breakdown).normalized()
+
+
+__all__ = ["GSTCalculator", "GSTCalculationData", "CalculationError"]

--- a/apgms/services/tax-engine/app/calculations/payg.py
+++ b/apgms/services/tax-engine/app/calculations/payg.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from .base import CalculationError, TaxCalculationResult, ensure_non_negative, ensure_percentage
+
+
+@dataclass(frozen=True)
+class PAYGCalculationData:
+    """Inputs required to determine PAYG withholding obligations."""
+
+    gross_wages: Decimal
+    withholding_rate: Decimal
+    instalment_credits: Decimal = Decimal("0")
+    other_adjustments: Decimal = Decimal("0")
+
+    def __post_init__(self) -> None:
+        ensure_non_negative("gross_wages", self.gross_wages)
+        ensure_percentage("withholding_rate", self.withholding_rate)
+        ensure_non_negative("instalment_credits", self.instalment_credits)
+        ensure_non_negative("other_adjustments", self.other_adjustments)
+
+
+class PAYGCalculator:
+    """PAYG computation rules for withholding obligations."""
+
+    def calculate(self, data: PAYGCalculationData) -> TaxCalculationResult:
+        withholding_due = data.gross_wages * data.withholding_rate
+        liability = withholding_due - data.instalment_credits + data.other_adjustments
+        liability = max(liability, Decimal("0"))
+        breakdown = {
+            "withholding_due": withholding_due,
+            "instalment_credits": -data.instalment_credits,
+            "other_adjustments": data.other_adjustments,
+        }
+
+        return TaxCalculationResult(liability=liability, breakdown=breakdown).normalized()
+
+
+__all__ = ["PAYGCalculator", "PAYGCalculationData", "CalculationError"]

--- a/apgms/services/tax-engine/app/clients/__init__.py
+++ b/apgms/services/tax-engine/app/clients/__init__.py
@@ -1,0 +1,3 @@
+from .sbr import SBRClient
+
+__all__ = ["SBRClient"]

--- a/apgms/services/tax-engine/app/clients/sbr.py
+++ b/apgms/services/tax-engine/app/clients/sbr.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+class SBRClient:
+    """HTTP client adapter for interacting with the SBR submission service."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+
+    async def submit_liability(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Submit a liability payload to the SBR service."""
+
+        async with httpx.AsyncClient(base_url=self._base_url, timeout=self._timeout) as client:
+            response = await client.post("/submissions", json=payload)
+            response.raise_for_status()
+            return response.json()
+
+
+__all__ = ["SBRClient"]

--- a/apgms/services/tax-engine/app/main.py
+++ b/apgms/services/tax-engine/app/main.py
@@ -1,5 +1,103 @@
-﻿from fastapi import FastAPI
-app = FastAPI()
-@app.get('/health')
-def health():
-    return {'ok': True}
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from fastapi import Depends, FastAPI, HTTPException, status
+
+from .calculations import CalculationError, GSTCalculationData, PAYGCalculationData
+from .clients import SBRClient
+from .schemas import (
+    GSTLiabilityRequest,
+    GatewayPayload,
+    GatewayValidationResponse,
+    PAYGLiabilityRequest,
+    TaxCalculationResponse,
+)
+from .services import TaxEngineService
+
+app = FastAPI(title="APGMS Tax Engine")
+
+
+@lru_cache()
+def get_tax_service() -> TaxEngineService:
+    base_url = os.getenv("SBR_BASE_URL", "http://sbr:8080")
+    return TaxEngineService(SBRClient(base_url))
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@app.post("/gst/liability", response_model=TaxCalculationResponse)
+def compute_gst(
+    payload: GSTLiabilityRequest,
+    service: TaxEngineService = Depends(get_tax_service),
+) -> TaxCalculationResponse:
+    try:
+        data = GSTCalculationData(
+            gst_collected=payload.gst_collected,
+            gst_paid=payload.gst_paid,
+            adjustments=payload.adjustments,
+            credits=payload.credits,
+        )
+    except CalculationError as exc:  # pragma: no cover - defensive, inputs validated via Pydantic
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    result = service.calculate_gst(data)
+    return TaxCalculationResponse.from_result(result)
+
+
+@app.post("/payg/liability", response_model=TaxCalculationResponse)
+def compute_payg(
+    payload: PAYGLiabilityRequest,
+    service: TaxEngineService = Depends(get_tax_service),
+) -> TaxCalculationResponse:
+    try:
+        data = PAYGCalculationData(
+            gross_wages=payload.gross_wages,
+            withholding_rate=payload.withholding_rate,
+            instalment_credits=payload.instalment_credits,
+            other_adjustments=payload.other_adjustments,
+        )
+    except CalculationError as exc:  # pragma: no cover - defensive, inputs validated via Pydantic
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    result = service.calculate_payg(data)
+    return TaxCalculationResponse.from_result(result)
+
+
+@app.post("/gateway/validate", response_model=GatewayValidationResponse)
+async def validate_gateway_payload(
+    envelope: GatewayPayload,
+    service: TaxEngineService = Depends(get_tax_service),
+) -> GatewayValidationResponse:
+    if envelope.product == "GST":
+        try:
+            data = GSTCalculationData(
+                gst_collected=envelope.payload.gst_collected,
+                gst_paid=envelope.payload.gst_paid,
+                adjustments=envelope.payload.adjustments,
+                credits=envelope.payload.credits,
+            )
+        except CalculationError as exc:
+            return GatewayValidationResponse(valid=False, submission_id=envelope.submission_id, errors=[str(exc)])
+    else:
+        try:
+            data = PAYGCalculationData(
+                gross_wages=envelope.payload.gross_wages,
+                withholding_rate=envelope.payload.withholding_rate,
+                instalment_credits=envelope.payload.instalment_credits,
+                other_adjustments=envelope.payload.other_adjustments,
+            )
+        except CalculationError as exc:
+            return GatewayValidationResponse(valid=False, submission_id=envelope.submission_id, errors=[str(exc)])
+
+    validation = await service.validate_gateway_payload(
+        product=envelope.product,
+        submission_id=envelope.submission_id,
+        data=data,
+        submit=envelope.submit,
+    )
+    return GatewayValidationResponse.from_service(validation)

--- a/apgms/services/tax-engine/app/schemas.py
+++ b/apgms/services/tax-engine/app/schemas.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Dict, Literal, Union
+
+from pydantic import BaseModel, Field
+
+
+class DecimalConfigMixin(BaseModel):
+    class Config:
+        json_encoders = {Decimal: lambda value: format(value, "f")}
+        arbitrary_types_allowed = True
+
+
+class GSTLiabilityRequest(DecimalConfigMixin):
+    gst_collected: Decimal = Field(..., ge=0)
+    gst_paid: Decimal = Field(..., ge=0)
+    adjustments: Decimal = Field(default=Decimal("0"), ge=0)
+    credits: Decimal = Field(default=Decimal("0"), ge=0)
+
+
+class PAYGLiabilityRequest(DecimalConfigMixin):
+    gross_wages: Decimal = Field(..., ge=0)
+    withholding_rate: Decimal = Field(..., ge=0, le=1)
+    instalment_credits: Decimal = Field(default=Decimal("0"), ge=0)
+    other_adjustments: Decimal = Field(default=Decimal("0"), ge=0)
+
+
+class TaxCalculationResponse(DecimalConfigMixin):
+    liability: Decimal
+    breakdown: Dict[str, Decimal]
+
+    @classmethod
+    def from_result(cls, result) -> "TaxCalculationResponse":
+        payload = result.to_payload()
+        return cls(**payload)
+
+
+class GatewayValidationResponse(DecimalConfigMixin):
+    valid: bool
+    submission_id: str | None = None
+    errors: list[str] = Field(default_factory=list)
+    liability: Decimal | None = None
+    breakdown: Dict[str, Decimal] | None = None
+    submitted: bool = False
+
+    @classmethod
+    def from_service(cls, result) -> "GatewayValidationResponse":
+        payload = {
+            "valid": result.valid,
+            "submission_id": result.submission_id,
+            "errors": result.errors,
+            "submitted": result.submitted,
+        }
+        if result.result is not None:
+            payload.update(result.result.to_payload())
+        return cls(**payload)
+
+
+class GatewayEnvelopeBase(DecimalConfigMixin):
+    submission_id: str = Field(..., min_length=1)
+    submit: bool = False
+
+
+class GatewayGSTEnvelope(GatewayEnvelopeBase):
+    product: Literal["GST"]
+    payload: GSTLiabilityRequest
+
+
+class GatewayPAYGEnvelope(GatewayEnvelopeBase):
+    product: Literal["PAYG"]
+    payload: PAYGLiabilityRequest
+
+
+GatewayPayload = Annotated[
+    Union[GatewayGSTEnvelope, GatewayPAYGEnvelope],
+    Field(discriminator="product"),
+]

--- a/apgms/services/tax-engine/app/services.py
+++ b/apgms/services/tax-engine/app/services.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Protocol, Union
+
+from .calculations import (
+    CalculationError,
+    GSTCalculationData,
+    GSTCalculator,
+    PAYGCalculationData,
+    PAYGCalculator,
+    TaxCalculationResult,
+)
+
+
+class SBRClientProtocol(Protocol):
+    async def submit_liability(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        ...
+
+
+@dataclass
+class GatewayValidationResult:
+    valid: bool
+    submission_id: str | None
+    errors: List[str] = field(default_factory=list)
+    result: TaxCalculationResult | None = None
+    submitted: bool = False
+
+
+class TaxEngineService:
+    """Application service coordinating tax calculations and submissions."""
+
+    def __init__(self, sbr_client: SBRClientProtocol) -> None:
+        self._sbr_client = sbr_client
+        self._gst_calculator = GSTCalculator()
+        self._payg_calculator = PAYGCalculator()
+
+    def calculate_gst(self, data: GSTCalculationData) -> TaxCalculationResult:
+        return self._gst_calculator.calculate(data)
+
+    def calculate_payg(self, data: PAYGCalculationData) -> TaxCalculationResult:
+        return self._payg_calculator.calculate(data)
+
+    async def validate_gateway_payload(
+        self,
+        *,
+        product: str,
+        submission_id: str,
+        data: Union[GSTCalculationData, PAYGCalculationData],
+        submit: bool = False,
+    ) -> GatewayValidationResult:
+        try:
+            if product == "GST":
+                result = self.calculate_gst(data)  # type: ignore[arg-type]
+            elif product == "PAYG":
+                result = self.calculate_payg(data)  # type: ignore[arg-type]
+            else:
+                return GatewayValidationResult(
+                    valid=False,
+                    submission_id=submission_id,
+                    errors=[f"Unsupported product '{product}'."],
+                )
+        except CalculationError as exc:  # pragma: no cover - defensive; constructors validate inputs
+            return GatewayValidationResult(
+                valid=False,
+                submission_id=submission_id,
+                errors=[str(exc)],
+            )
+
+        submitted = False
+        if submit:
+            payload = self._build_submission_payload(product=product, submission_id=submission_id, result=result)
+            await self._sbr_client.submit_liability(payload)
+            submitted = True
+
+        return GatewayValidationResult(
+            valid=True,
+            submission_id=submission_id,
+            result=result,
+            submitted=submitted,
+        )
+
+    def _build_submission_payload(
+        self, *, product: str, submission_id: str, result: TaxCalculationResult
+    ) -> Dict[str, Any]:
+        payload = result.normalized()
+        return {
+            "submissionId": submission_id,
+            "product": product,
+            "liability": str(payload.liability),
+            "breakdown": {key: str(value) for key, value in payload.breakdown.items()},
+        }
+
+
+__all__ = ["GatewayValidationResult", "TaxEngineService", "SBRClientProtocol"]

--- a/apgms/services/tax-engine/pyproject.toml
+++ b/apgms/services/tax-engine/pyproject.toml
@@ -1,7 +1,12 @@
-﻿[tool.poetry]
-name='apgms-tax-engine'
-version='0.1.0'
+[tool.poetry]
+name = "apgms-tax-engine"
+version = "0.1.0"
+
 [tool.poetry.dependencies]
-python='^3.10'
-fastapi='*'
-uvicorn='*'
+python = "^3.10"
+fastapi = "*"
+uvicorn = "*"
+httpx = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"

--- a/apgms/services/tax-engine/tests/test_api.py
+++ b/apgms/services/tax-engine/tests/test_api.py
@@ -1,0 +1,110 @@
+from typing import Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+from app.services import TaxEngineService
+
+
+class FakeSBRClient:
+    def __init__(self) -> None:
+        self.submissions: list[dict] = []
+
+    async def submit_liability(self, payload):  # pragma: no cover - simple passthrough
+        self.submissions.append(payload)
+        return {"status": "accepted", **payload}
+
+
+@pytest.fixture()
+def client() -> Tuple[TestClient, FakeSBRClient]:
+    fake_client = FakeSBRClient()
+    service = TaxEngineService(fake_client)
+    main.get_tax_service.cache_clear()
+    main.app.dependency_overrides[main.get_tax_service] = lambda: service
+    with TestClient(main.app) as test_client:
+        yield test_client, fake_client
+    main.app.dependency_overrides.clear()
+
+
+def test_compute_gst_liability_endpoint(client):
+    test_client, _ = client
+    response = test_client.post(
+        "/gst/liability",
+        json={
+            "gst_collected": "15000.00",
+            "gst_paid": "12000.00",
+            "adjustments": "500.00",
+            "credits": "200.00",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["liability"] == "3300.00"
+    assert body["breakdown"]["gst_paid"] == "-12000.00"
+
+
+def test_compute_payg_liability_endpoint(client):
+    test_client, _ = client
+    response = test_client.post(
+        "/payg/liability",
+        json={
+            "gross_wages": "80000.00",
+            "withholding_rate": "0.325",
+            "instalment_credits": "10000.00",
+            "other_adjustments": "500.00",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["liability"] == "16500.00"
+    assert body["breakdown"]["withholding_due"] == "26000.00"
+
+
+def test_gateway_validation_without_submission(client):
+    test_client, fake_client = client
+    response = test_client.post(
+        "/gateway/validate",
+        json={
+            "product": "PAYG",
+            "submission_id": "SUB-1",
+            "submit": False,
+            "payload": {
+                "gross_wages": "50000.00",
+                "withholding_rate": "0.3",
+                "instalment_credits": "5000.00",
+                "other_adjustments": "0.00",
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["valid"] is True
+    assert body["submitted"] is False
+    assert fake_client.submissions == []
+
+
+def test_gateway_validation_with_submission_triggers_sbr(client):
+    test_client, fake_client = client
+    response = test_client.post(
+        "/gateway/validate",
+        json={
+            "product": "GST",
+            "submission_id": "SUB-2",
+            "submit": True,
+            "payload": {
+                "gst_collected": "12000.00",
+                "gst_paid": "6000.00",
+                "adjustments": "0.00",
+                "credits": "0.00",
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["submitted"] is True
+    assert len(fake_client.submissions) == 1
+    submission = fake_client.submissions[0]
+    assert submission["submissionId"] == "SUB-2"
+    assert submission["product"] == "GST"
+    assert submission["liability"] == "6000.00"

--- a/apgms/services/tax-engine/tests/test_calculations.py
+++ b/apgms/services/tax-engine/tests/test_calculations.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+
+import pytest
+
+from app.calculations import (
+    CalculationError,
+    GSTCalculationData,
+    GSTCalculator,
+    PAYGCalculationData,
+    PAYGCalculator,
+)
+
+
+def test_gst_calculation_net_tax():
+    data = GSTCalculationData(
+        gst_collected=Decimal("15000.00"),
+        gst_paid=Decimal("12000.00"),
+        adjustments=Decimal("500.00"),
+        credits=Decimal("200.00"),
+    )
+    result = GSTCalculator().calculate(data)
+    assert result.liability == Decimal("3300.00")
+    assert result.breakdown == {
+        "gst_collected": Decimal("15000.00"),
+        "gst_paid": Decimal("-12000.00"),
+        "adjustments": Decimal("500.00"),
+        "credits": Decimal("-200.00"),
+    }
+
+
+def test_payg_calculation_withholding():
+    data = PAYGCalculationData(
+        gross_wages=Decimal("80000.00"),
+        withholding_rate=Decimal("0.325"),
+        instalment_credits=Decimal("10000.00"),
+        other_adjustments=Decimal("500.00"),
+    )
+    result = PAYGCalculator().calculate(data)
+    assert result.liability == Decimal("16500.00")
+    assert result.breakdown == {
+        "withholding_due": Decimal("26000.00"),
+        "instalment_credits": Decimal("-10000.00"),
+        "other_adjustments": Decimal("500.00"),
+    }
+
+
+def test_negative_values_raise_errors():
+    with pytest.raises(CalculationError):
+        GSTCalculationData(gst_collected=Decimal("-1"), gst_paid=Decimal("0"))
+
+    with pytest.raises(CalculationError):
+        PAYGCalculationData(gross_wages=Decimal("100"), withholding_rate=Decimal("-0.1"))


### PR DESCRIPTION
## Summary
- introduce GST and PAYG calculation modules for the tax engine
- expose FastAPI endpoints for liability computation and API gateway validation
- wire an SBR client adapter and add unit coverage for the calculation rules and API surface

## Testing
- PYTHONPATH=. pytest tests/test_calculations.py


------
https://chatgpt.com/codex/tasks/task_e_68f300192ad48327980c397574ec5f8c