### PR TITLE
feat: scaffold service topology and messaging contracts

### DIFF
--- a/apgms/docs/architecture/services.md
+++ b/apgms/docs/architecture/services.md
@@ -1,0 +1,53 @@
+# Service topology and messaging contracts
+
+The platform is composed of discrete Fastify-based services that communicate through Redis-backed [BullMQ](https://docs.bullmq.io/) queues. Each service loads configuration via `@apgms/shared` so that environment variables and queue prefixes are resolved consistently from the repository root `.env` file.
+
+## Entrypoints and health checks
+
+| Service | Entrypoint | Notes |
+| --- | --- | --- |
+| Connectors | `services/connectors/src/index.ts` | Ingests bank feeds and publishes reconciliation + audit jobs. |
+| Recon | `services/recon/src/index.ts` | Runs a worker that performs ledger reconciliation and forwards payables + audit messages. |
+| Payments | `services/payments/src/index.ts` | Exposes a `/payments` endpoint and processes lifecycle jobs to settle payables. |
+| Audit | `services/audit/src/index.ts` | Stores audit trail events and exposes `/events` for inspection. |
+| CDR | `services/cdr/src/index.ts` | Placeholder consent endpoints to support Consumer Data Right integrations. |
+| Registries | `services/registries/src/index.ts` | Registry façade for entity lookups. |
+| SBR | `services/sbr/src/index.ts` | Secure Business Reporting façade for form submission workflows. |
+
+Each service registers `/health` so orchestration platforms can monitor process liveness.
+
+## Queue contracts
+
+The `@apgms/shared` workspace defines the queue contracts in `shared/src/messaging/contracts.ts`. BullMQ queues share the same Redis connection and are created with a service-specific prefix. The contracts include:
+
+- **`bank-feed.ingest`** (`bankFeedIngestContract`): payload describing the full bank feed (`feedId`, `orgId`, source system, and individual entries). Produced by the connectors service and consumed by the reconciliation worker.
+- **`payments.lifecycle`** (`paymentLifecycleContract`): payable lifecycle events generated during reconciliation and processed by the payments worker.
+- **`audit.events`** (`auditEventContract`): canonical audit records emitted by all services; consumed by the audit worker to persist the event trail.
+
+Helper utilities `createQueue`, `createWorker`, and `createRedisConnection` handle queue/worker instantiation while enforcing schema validation via Zod.
+
+## Local startup
+
+Each service has a `dev` script wired for `pnpm`:
+
+```bash
+pnpm --filter @apgms/connectors dev
+pnpm --filter @apgms/recon dev
+pnpm --filter @apgms/payments dev
+pnpm --filter @apgms/audit dev
+pnpm --filter @apgms/cdr dev
+pnpm --filter @apgms/registries dev
+pnpm --filter @apgms/sbr dev
+```
+
+Start Redis locally (for example using `docker compose up redis`) before launching services that rely on BullMQ.
+
+## Tests
+
+Run the full service test suite with:
+
+```bash
+pnpm --filter "@apgms/*" test
+```
+
+Unit tests exercise Fastify handlers and queue processors using lightweight stubs so they complete quickly without Redis.

--- a/apgms/services/audit/package.json
+++ b/apgms/services/audit/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/audit",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/audit/src/index.ts
+++ b/apgms/services/audit/src/index.ts
@@ -1,1 +1,27 @@
-﻿console.log('audit service');
+import { fileURLToPath } from "node:url";
+import { createQueue, createRedisConnection, loadServiceConfig, queueContracts } from "@apgms/shared";
+import { createAuditServer, createAuditWorker } from "./server";
+
+async function start() {
+  const config = loadServiceConfig("audit", import.meta.url);
+  const redis = createRedisConnection(config.redisUrl);
+  const auditQueue = await createQueue(queueContracts.auditEvent, redis, { prefix: config.bullQueuePrefix });
+
+  const app = createAuditServer({ auditQueue, serviceName: config.serviceName });
+  await createAuditWorker(redis);
+
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "audit service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export { createAuditServer, createAuditWorker };
+export type { AuditDependencies } from "./server";

--- a/apgms/services/audit/src/modules/audit-trail.ts
+++ b/apgms/services/audit/src/modules/audit-trail.ts
@@ -1,0 +1,17 @@
+import { auditEventContract, type AuditEventJob } from "@apgms/shared";
+
+const events: AuditEventJob[] = [];
+
+export function recordAuditEvent(event: AuditEventJob): AuditEventJob {
+  const parsed = auditEventContract.schema.parse(event);
+  events.push(parsed);
+  return parsed;
+}
+
+export function listAuditEvents(): AuditEventJob[] {
+  return [...events];
+}
+
+export function resetAuditEvents(): void {
+  events.length = 0;
+}

--- a/apgms/services/audit/src/server.ts
+++ b/apgms/services/audit/src/server.ts
@@ -1,0 +1,35 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import type IORedis from "ioredis";
+import { auditEventContract, createWorker, queueContracts, type AuditEventJob, type QueueClient } from "@apgms/shared";
+import { listAuditEvents, recordAuditEvent } from "./modules/audit-trail";
+
+export interface AuditDependencies {
+  auditQueue: QueueClient<AuditEventJob>;
+  serviceName?: string;
+}
+
+export function createAuditServer({ auditQueue, serviceName = "audit" }: AuditDependencies): FastifyInstance {
+  const app = Fastify({ logger: true });
+
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+
+  app.get("/events", async () => ({ events: listAuditEvents() }));
+
+  app.post("/events", async (request, reply) => {
+    const event = auditEventContract.schema.parse(request.body);
+    const recorded = recordAuditEvent(event);
+    await auditQueue.add(queueContracts.auditEvent.jobName, recorded, {
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+    return reply.code(202).send({ eventId: recorded.eventId });
+  });
+
+  return app;
+}
+
+export async function createAuditWorker(connection: IORedis) {
+  return createWorker(queueContracts.auditEvent, connection, async (payload) => {
+    recordAuditEvent(payload);
+  });
+}

--- a/apgms/services/audit/test/audit-trail.test.ts
+++ b/apgms/services/audit/test/audit-trail.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AuditEventJob, QueueClient } from "@apgms/shared";
+import { createAuditServer } from "../src/server";
+import { resetAuditEvents } from "../src/modules/audit-trail";
+
+const sampleEvent: AuditEventJob = {
+  eventId: "evt-1",
+  entityId: "feed-1",
+  eventType: "TEST_EVENT",
+  occurredAt: new Date().toISOString(),
+  payload: { status: "ok" },
+};
+
+test.afterEach(() => {
+  resetAuditEvents();
+});
+
+test("audit service persists events and forwards to queue", async () => {
+  const auditCalls: unknown[][] = [];
+  const auditQueue = {
+    add: async (...args: unknown[]) => {
+      auditCalls.push(args);
+    },
+  } as unknown as QueueClient<AuditEventJob>;
+
+  const app = createAuditServer({ auditQueue });
+
+  const response = await app.inject({ method: "POST", url: "/events", payload: sampleEvent });
+  assert.equal(response.statusCode, 202);
+  assert.equal(auditCalls.length, 1);
+
+  const eventsResponse = await app.inject({ method: "GET", url: "/events" });
+  const body = eventsResponse.json() as { events: AuditEventJob[] };
+  assert.equal(body.events.length, 1);
+  assert.equal(body.events[0].eventId, sampleEvent.eventId);
+});

--- a/apgms/services/audit/tsconfig.json
+++ b/apgms/services/audit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/cdr/package.json
+++ b/apgms/services/cdr/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/cdr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/cdr/src/index.ts
+++ b/apgms/services/cdr/src/index.ts
@@ -1,1 +1,26 @@
-﻿console.log('cdr service');
+import { fileURLToPath } from "node:url";
+import Fastify, { type FastifyInstance } from "fastify";
+import { loadServiceConfig } from "@apgms/shared";
+
+export function buildCdrServer(serviceName = "cdr"): FastifyInstance {
+  const app = Fastify({ logger: true });
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+  app.get("/cdr/consents", async () => ({ consents: [] }));
+  return app;
+}
+
+async function start() {
+  const config = loadServiceConfig("cdr", import.meta.url);
+  const app = buildCdrServer(config.serviceName);
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "cdr service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apgms/services/cdr/test/health.test.ts
+++ b/apgms/services/cdr/test/health.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildCdrServer } from "../src/index";
+
+test("cdr service reports health", async () => {
+  const app = buildCdrServer();
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.deepEqual(response.json(), { status: "ok", service: "cdr" });
+});

--- a/apgms/services/cdr/tsconfig.json
+++ b/apgms/services/cdr/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/connectors/package.json
+++ b/apgms/services/connectors/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@apgms/connectors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "@fastify/cors": "^11.1.0",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,31 @@
-﻿console.log('connectors service');
+import { fileURLToPath } from "node:url";
+import { createQueue, createRedisConnection, loadServiceConfig, queueContracts } from "@apgms/shared";
+import { createConnectorsServer } from "./server";
+
+async function start() {
+  const config = loadServiceConfig("connectors", import.meta.url);
+  const redis = createRedisConnection(config.redisUrl);
+  const bankFeedQueue = await createQueue(queueContracts.bankFeedIngest, redis, { prefix: config.bullQueuePrefix });
+  const auditQueue = await createQueue(queueContracts.auditEvent, redis, { prefix: config.bullQueuePrefix });
+
+  const app = createConnectorsServer({
+    bankFeedQueue,
+    auditQueue,
+    serviceName: config.serviceName,
+  });
+
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "connectors service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export { createConnectorsServer };
+export type { ConnectorsDependencies } from "./server";

--- a/apgms/services/connectors/src/modules/bank-feeds.ts
+++ b/apgms/services/connectors/src/modules/bank-feeds.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { auditEventContract, bankFeedIngestContract, type AuditEventJob, type BankFeedIngestJob, type QueueClient } from "@apgms/shared";
+
+export interface IngestBankFeedResult {
+  feedId: string;
+  queuedJobs: number;
+}
+
+export async function ingestBankFeed(
+  payload: unknown,
+  bankFeedQueue: QueueClient<BankFeedIngestJob>,
+  auditQueue?: QueueClient<AuditEventJob>
+): Promise<IngestBankFeedResult> {
+  const data = bankFeedIngestContract.schema.parse(payload);
+  await bankFeedQueue.add(bankFeedIngestContract.jobName, data, {
+    removeOnComplete: true,
+    removeOnFail: true,
+  });
+
+  if (auditQueue) {
+    await auditQueue.add(auditEventContract.jobName, {
+      eventId: randomUUID(),
+      entityId: data.feedId,
+      eventType: "BANK_FEED_RECEIVED",
+      occurredAt: new Date().toISOString(),
+      payload: {
+        orgId: data.orgId,
+        source: data.source,
+        entries: data.entries.length,
+      },
+    });
+  }
+
+  return { feedId: data.feedId, queuedJobs: data.entries.length };
+}

--- a/apgms/services/connectors/src/server.ts
+++ b/apgms/services/connectors/src/server.ts
@@ -1,0 +1,26 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { type AuditEventJob, type BankFeedIngestJob, type QueueClient } from "@apgms/shared";
+import { ingestBankFeed } from "./modules/bank-feeds";
+
+export interface ConnectorsDependencies {
+  bankFeedQueue: QueueClient<BankFeedIngestJob>;
+  auditQueue?: QueueClient<AuditEventJob>;
+  serviceName?: string;
+}
+
+export function createConnectorsServer({
+  bankFeedQueue,
+  auditQueue,
+  serviceName = "connectors",
+}: ConnectorsDependencies): FastifyInstance {
+  const app = Fastify({ logger: true });
+
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+
+  app.post("/bank-feeds", async (request, reply) => {
+    const result = await ingestBankFeed(request.body, bankFeedQueue, auditQueue);
+    return reply.code(202).send(result);
+  });
+
+  return app;
+}

--- a/apgms/services/connectors/test/bank-feeds.test.ts
+++ b/apgms/services/connectors/test/bank-feeds.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AuditEventJob, BankFeedIngestJob, QueueClient } from "@apgms/shared";
+import { createConnectorsServer } from "../src/server";
+
+const sampleFeed = {
+  feedId: "feed-001",
+  orgId: "org-123",
+  source: "bank-x",
+  entries: [
+    { id: "1", amount: 120.55, currency: "AUD", postedAt: new Date().toISOString() },
+    { id: "2", amount: -20, currency: "AUD", postedAt: new Date().toISOString() },
+  ],
+};
+
+test("connectors queues bank feeds and audit events", async () => {
+  const bankCalls: unknown[][] = [];
+  const auditCalls: unknown[][] = [];
+
+  const bankQueue = {
+    add: async (...args: unknown[]) => {
+      bankCalls.push(args);
+    },
+  } as unknown as QueueClient<BankFeedIngestJob>;
+
+  const auditQueue = {
+    add: async (...args: unknown[]) => {
+      auditCalls.push(args);
+    },
+  } as unknown as QueueClient<AuditEventJob>;
+
+  const app = createConnectorsServer({ bankFeedQueue: bankQueue, auditQueue });
+  const response = await app.inject({ method: "POST", url: "/bank-feeds", payload: sampleFeed });
+
+  assert.equal(response.statusCode, 202);
+  const body = response.json() as { feedId: string; queuedJobs: number };
+  assert.equal(body.feedId, sampleFeed.feedId);
+  assert.equal(body.queuedJobs, sampleFeed.entries.length);
+  assert.equal(bankCalls.length, 1);
+  assert.equal(auditCalls.length, 1);
+});

--- a/apgms/services/connectors/tsconfig.json
+++ b/apgms/services/connectors/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/payments/package.json
+++ b/apgms/services/payments/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/payments",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/payments/src/index.ts
+++ b/apgms/services/payments/src/index.ts
@@ -1,1 +1,27 @@
-﻿console.log('payments service');
+import { fileURLToPath } from "node:url";
+import { createQueue, createRedisConnection, loadServiceConfig, queueContracts } from "@apgms/shared";
+import { createPaymentsServer, createPaymentsWorker } from "./server";
+
+async function start() {
+  const config = loadServiceConfig("payments", import.meta.url);
+  const redis = createRedisConnection(config.redisUrl);
+  const paymentQueue = await createQueue(queueContracts.paymentLifecycle, redis, { prefix: config.bullQueuePrefix });
+  const auditQueue = await createQueue(queueContracts.auditEvent, redis, { prefix: config.bullQueuePrefix });
+
+  await createPaymentsWorker(redis, auditQueue);
+
+  const app = createPaymentsServer({ paymentQueue, auditQueue, serviceName: config.serviceName });
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "payments service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export { createPaymentsServer, createPaymentsWorker };

--- a/apgms/services/payments/src/modules/payables.ts
+++ b/apgms/services/payments/src/modules/payables.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from "node:crypto";
+import { auditEventContract, paymentLifecycleContract, type AuditEventJob, type PaymentLifecycleJob, type QueueClient } from "@apgms/shared";
+
+export interface CreatePaymentPayload {
+  orgId: string;
+  amount: number;
+  currency?: string;
+  dueDate: string;
+  supplierName: string;
+}
+
+export async function queuePaymentLifecycle(
+  payload: CreatePaymentPayload,
+  paymentQueue: QueueClient<PaymentLifecycleJob>,
+  auditQueue?: QueueClient<AuditEventJob>
+) {
+  const job = paymentLifecycleContract.schema.parse({
+    payableId: randomUUID(),
+    orgId: payload.orgId,
+    amount: payload.amount,
+    currency: payload.currency ?? "AUD",
+    dueDate: payload.dueDate,
+    supplierName: payload.supplierName,
+  });
+
+  await paymentQueue.add(paymentLifecycleContract.jobName, job, {
+    removeOnComplete: true,
+    removeOnFail: true,
+  });
+
+  if (auditQueue) {
+    await auditQueue.add(auditEventContract.jobName, {
+      eventId: randomUUID(),
+      entityId: job.payableId,
+      eventType: "PAYMENT_REQUESTED",
+      occurredAt: new Date().toISOString(),
+      payload: { orgId: job.orgId, amount: job.amount, supplierName: job.supplierName },
+    });
+  }
+
+  return job;
+}
+
+export async function handlePaymentLifecycle(
+  job: PaymentLifecycleJob,
+  auditQueue?: QueueClient<AuditEventJob>
+) {
+  if (auditQueue) {
+    await auditQueue.add(auditEventContract.jobName, {
+      eventId: randomUUID(),
+      entityId: job.payableId,
+      eventType: "PAYMENT_SETTLED",
+      occurredAt: new Date().toISOString(),
+      payload: { amount: job.amount, orgId: job.orgId },
+    });
+  }
+
+  return { payableId: job.payableId, settled: true };
+}

--- a/apgms/services/payments/src/server.ts
+++ b/apgms/services/payments/src/server.ts
@@ -1,0 +1,31 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import type IORedis from "ioredis";
+import { createWorker, queueContracts, type AuditEventJob, type PaymentLifecycleJob, type QueueClient } from "@apgms/shared";
+import { handlePaymentLifecycle, queuePaymentLifecycle, type CreatePaymentPayload } from "./modules/payables";
+
+export interface PaymentsDependencies {
+  paymentQueue: QueueClient<PaymentLifecycleJob>;
+  auditQueue?: QueueClient<AuditEventJob>;
+  serviceName?: string;
+}
+
+export function createPaymentsServer({ paymentQueue, auditQueue, serviceName = "payments" }: PaymentsDependencies): FastifyInstance {
+  const app = Fastify({ logger: true });
+
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+
+  app.post<{
+    Body: CreatePaymentPayload;
+  }>("/payments", async (request, reply) => {
+    const job = await queuePaymentLifecycle(request.body, paymentQueue, auditQueue);
+    return reply.code(202).send({ payableId: job.payableId });
+  });
+
+  return app;
+}
+
+export async function createPaymentsWorker(connection: IORedis, auditQueue?: QueueClient<AuditEventJob>) {
+  return createWorker(queueContracts.paymentLifecycle, connection, async (payload) => {
+    await handlePaymentLifecycle(payload, auditQueue);
+  });
+}

--- a/apgms/services/payments/test/payables.test.ts
+++ b/apgms/services/payments/test/payables.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AuditEventJob, PaymentLifecycleJob, QueueClient } from "@apgms/shared";
+import { createPaymentsServer } from "../src/server";
+import { handlePaymentLifecycle } from "../src/modules/payables";
+
+const payload = {
+  orgId: "org-10",
+  amount: 150,
+  dueDate: new Date().toISOString(),
+  supplierName: "ACME Pty Ltd",
+};
+
+test("payments route queues lifecycle job", async () => {
+  const paymentCalls: unknown[][] = [];
+  const auditCalls: unknown[][] = [];
+
+  const paymentQueue = {
+    add: async (...args: unknown[]) => {
+      paymentCalls.push(args);
+    },
+  } as unknown as QueueClient<PaymentLifecycleJob>;
+
+  const auditQueue = {
+    add: async (...args: unknown[]) => {
+      auditCalls.push(args);
+    },
+  } as unknown as QueueClient<AuditEventJob>;
+
+  const app = createPaymentsServer({ paymentQueue, auditQueue });
+  const response = await app.inject({ method: "POST", url: "/payments", payload });
+
+  assert.equal(response.statusCode, 202);
+  assert.equal(paymentCalls.length, 1);
+  assert.equal(auditCalls.length, 1);
+});
+
+test("handlePaymentLifecycle emits settlement audit event", async () => {
+  const auditCalls: unknown[][] = [];
+  const auditQueue = {
+    add: async (...args: unknown[]) => {
+      auditCalls.push(args);
+    },
+  } as unknown as QueueClient<AuditEventJob>;
+
+  const result = await handlePaymentLifecycle(
+    {
+      payableId: "pay-1",
+      orgId: payload.orgId,
+      amount: payload.amount,
+      currency: "AUD",
+      dueDate: payload.dueDate,
+      supplierName: payload.supplierName,
+    },
+    auditQueue
+  );
+
+  assert.equal(result.payableId, "pay-1");
+  assert.equal(result.settled, true);
+  assert.equal(auditCalls.length, 1);
+});

--- a/apgms/services/payments/tsconfig.json
+++ b/apgms/services/payments/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/recon/package.json
+++ b/apgms/services/recon/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/recon",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/recon/src/index.ts
+++ b/apgms/services/recon/src/index.ts
@@ -1,1 +1,27 @@
-﻿console.log('recon service');
+import { fileURLToPath } from "node:url";
+import { createQueue, createRedisConnection, loadServiceConfig, queueContracts } from "@apgms/shared";
+import { createReconServer, startReconciliationWorker } from "./server";
+
+async function start() {
+  const config = loadServiceConfig("recon", import.meta.url);
+  const redis = createRedisConnection(config.redisUrl);
+  const auditQueue = await createQueue(queueContracts.auditEvent, redis, { prefix: config.bullQueuePrefix });
+  const paymentQueue = await createQueue(queueContracts.paymentLifecycle, redis, { prefix: config.bullQueuePrefix });
+
+  await startReconciliationWorker(redis, { auditQueue, paymentQueue });
+
+  const app = createReconServer(config.serviceName);
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "recon service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+export { createReconServer, startReconciliationWorker };

--- a/apgms/services/recon/src/modules/reconciliation.ts
+++ b/apgms/services/recon/src/modules/reconciliation.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+import { auditEventContract, paymentLifecycleContract, type AuditEventJob, type BankFeedIngestJob, type PaymentLifecycleJob, type QueueClient } from "@apgms/shared";
+
+export interface ReconciliationResult {
+  feedId: string;
+  credits: number;
+  debits: number;
+  total: number;
+}
+
+export interface ReconciliationDependencies {
+  auditQueue?: QueueClient<AuditEventJob>;
+  paymentQueue?: QueueClient<PaymentLifecycleJob>;
+}
+
+export async function reconcileBankFeed(
+  feed: BankFeedIngestJob,
+  { auditQueue, paymentQueue }: ReconciliationDependencies = {}
+): Promise<ReconciliationResult> {
+  const credits = feed.entries.filter((entry) => entry.amount > 0).length;
+  const debits = feed.entries.filter((entry) => entry.amount < 0).length;
+  const total = feed.entries.reduce((acc, entry) => acc + entry.amount, 0);
+
+  if (paymentQueue) {
+    await Promise.all(
+      feed.entries
+        .filter((entry) => entry.amount < 0)
+        .map((entry) =>
+          paymentQueue.add(paymentLifecycleContract.jobName, {
+            payableId: randomUUID(),
+            orgId: feed.orgId,
+            amount: Math.abs(entry.amount),
+            currency: entry.currency,
+            dueDate: entry.postedAt,
+            supplierName: entry.description ?? "Unknown supplier",
+          })
+        )
+    );
+  }
+
+  if (auditQueue) {
+    await auditQueue.add(auditEventContract.jobName, {
+      eventId: randomUUID(),
+      entityId: feed.feedId,
+      eventType: "RECON_COMPLETED",
+      occurredAt: new Date().toISOString(),
+      payload: { credits, debits, total },
+    });
+  }
+
+  return { feedId: feed.feedId, credits, debits, total };
+}

--- a/apgms/services/recon/src/server.ts
+++ b/apgms/services/recon/src/server.ts
@@ -1,0 +1,16 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import type IORedis from "ioredis";
+import { createWorker, queueContracts } from "@apgms/shared";
+import { reconcileBankFeed, type ReconciliationDependencies } from "./modules/reconciliation";
+
+export function createReconServer(serviceName = "recon"): FastifyInstance {
+  const app = Fastify({ logger: true });
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+  return app;
+}
+
+export async function startReconciliationWorker(connection: IORedis, dependencies: ReconciliationDependencies) {
+  return createWorker(queueContracts.bankFeedIngest, connection, async (payload) => {
+    await reconcileBankFeed(payload, dependencies);
+  });
+}

--- a/apgms/services/recon/test/reconciliation.test.ts
+++ b/apgms/services/recon/test/reconciliation.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AuditEventJob, PaymentLifecycleJob, QueueClient } from "@apgms/shared";
+import { reconcileBankFeed } from "../src/modules/reconciliation";
+
+const feed = {
+  feedId: "feed-1",
+  orgId: "org-9",
+  source: "bank-x",
+  entries: [
+    { id: "1", amount: 100, currency: "AUD", postedAt: "2024-01-01T00:00:00.000Z", description: "Customer payment" },
+    { id: "2", amount: -50, currency: "AUD", postedAt: "2024-01-02T00:00:00.000Z", description: "Supplier" },
+  ],
+};
+
+test("reconcileBankFeed summarises data and enqueues follow-up jobs", async () => {
+  const auditCalls: unknown[][] = [];
+  const paymentCalls: unknown[][] = [];
+
+  const auditQueue = {
+    add: async (...args: unknown[]) => {
+      auditCalls.push(args);
+    },
+  } as unknown as QueueClient<AuditEventJob>;
+
+  const paymentQueue = {
+    add: async (...args: unknown[]) => {
+      paymentCalls.push(args);
+    },
+  } as unknown as QueueClient<PaymentLifecycleJob>;
+
+  const result = await reconcileBankFeed(feed, { auditQueue, paymentQueue });
+
+  assert.equal(result.feedId, feed.feedId);
+  assert.equal(result.credits, 1);
+  assert.equal(result.debits, 1);
+  assert.equal(result.total, 50);
+  assert.equal(auditCalls.length, 1);
+  assert.equal(paymentCalls.length, 1);
+});

--- a/apgms/services/recon/tsconfig.json
+++ b/apgms/services/recon/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/registries/package.json
+++ b/apgms/services/registries/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/registries",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/registries/src/index.ts
+++ b/apgms/services/registries/src/index.ts
@@ -1,1 +1,26 @@
-﻿console.log('registries service');
+import { fileURLToPath } from "node:url";
+import Fastify, { type FastifyInstance } from "fastify";
+import { loadServiceConfig } from "@apgms/shared";
+
+export function buildRegistriesServer(serviceName = "registries"): FastifyInstance {
+  const app = Fastify({ logger: true });
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+  app.get("/registries/entities", async () => ({ entities: [] }));
+  return app;
+}
+
+async function start() {
+  const config = loadServiceConfig("registries", import.meta.url);
+  const app = buildRegistriesServer(config.serviceName);
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "registries service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apgms/services/registries/test/health.test.ts
+++ b/apgms/services/registries/test/health.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildRegistriesServer } from "../src/index";
+
+test("registries service reports health", async () => {
+  const app = buildRegistriesServer();
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.deepEqual(response.json(), { status: "ok", service: "registries" });
+});

--- a/apgms/services/registries/tsconfig.json
+++ b/apgms/services/registries/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,26 @@
-﻿console.log('sbr service');
+import { fileURLToPath } from "node:url";
+import Fastify, { type FastifyInstance } from "fastify";
+import { loadServiceConfig } from "@apgms/shared";
+
+export function buildSbrServer(serviceName = "sbr"): FastifyInstance {
+  const app = Fastify({ logger: true });
+  app.get("/health", async () => ({ status: "ok", service: serviceName }));
+  app.get("/sbr/forms", async () => ({ forms: [] }));
+  return app;
+}
+
+async function start() {
+  const config = loadServiceConfig("sbr", import.meta.url);
+  const app = buildSbrServer(config.serviceName);
+  const address = await app.listen({ host: config.host, port: config.port });
+  app.log.info({ address, env: config.env }, "sbr service ready");
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  start().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apgms/services/sbr/test/health.test.ts
+++ b/apgms/services/sbr/test/health.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildSbrServer } from "../src/index";
+
+test("sbr service reports health", async () => {
+  const app = buildSbrServer();
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.deepEqual(response.json(), { status: "ok", service: "sbr" });
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist"]
+}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,7 +8,11 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "bullmq": "^5.21.0",
+    "dotenv": "^16.6.1",
+    "ioredis": "^5.4.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/src/config.ts
+++ b/apgms/shared/src/config.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+
+export interface ServiceConfig {
+  serviceName: string;
+  env: string;
+  host: string;
+  port: number;
+  redisUrl: string;
+  bullQueuePrefix: string;
+}
+
+function findEnvFile(startDir: string): string | undefined {
+  let current = startDir;
+  while (true) {
+    const candidate = path.join(current, ".env");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return undefined;
+    }
+    current = parent;
+  }
+}
+
+export function loadServiceConfig(serviceName: string, importMetaUrl: string, overrides: Partial<ServiceConfig> = {}): ServiceConfig {
+  const filePath = fileURLToPath(importMetaUrl);
+  const envPath = findEnvFile(path.dirname(filePath));
+  if (envPath) {
+    dotenv.config({ path: envPath });
+  } else {
+    dotenv.config();
+  }
+
+  const port = overrides.port ?? (process.env.PORT ? Number(process.env.PORT) : undefined) ?? 3000;
+  const host = overrides.host ?? process.env.HOST ?? "0.0.0.0";
+  const redisUrl = overrides.redisUrl ?? process.env.REDIS_URL ?? "redis://localhost:6379";
+  const bullQueuePrefix = overrides.bullQueuePrefix ?? process.env.BULLMQ_PREFIX ?? `apgms:${serviceName}`;
+  const env = overrides.env ?? process.env.NODE_ENV ?? "development";
+
+  return {
+    serviceName,
+    env,
+    host,
+    port,
+    redisUrl,
+    bullQueuePrefix,
+  };
+}

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./config";
+export * from "./messaging";

--- a/apgms/shared/src/messaging/contracts.ts
+++ b/apgms/shared/src/messaging/contracts.ts
@@ -1,0 +1,159 @@
+import IORedis, { type RedisOptions } from "ioredis";
+import { z } from "zod";
+
+export interface Job<T> {
+  readonly id?: string;
+  readonly data: T;
+}
+
+export interface JobsOptions {
+  removeOnComplete?: boolean | number;
+  removeOnFail?: boolean | number;
+}
+
+export interface QueueOptions {
+  prefix?: string;
+  concurrency?: number;
+}
+
+export interface WorkerOptions {
+  concurrency?: number;
+}
+
+export interface BullQueue<T> {
+  add(name: string, data: T, opts?: JobsOptions): Promise<unknown>;
+  defaultJobOptions?: JobsOptions;
+}
+
+export interface BullWorker<T> {
+  close(): Promise<void>;
+}
+
+export interface BullQueueEvents {
+  close(): Promise<void>;
+}
+
+export interface QueueContract<T> {
+  queueName: string;
+  jobName: string;
+  schema: z.ZodType<T>;
+}
+
+export type QueueClient<T> = Pick<BullQueue<T>, "add">;
+export type RedisConnection = IORedis | RedisOptions;
+
+function createContract<T>(queueName: string, jobName: string, schema: z.ZodType<T>): QueueContract<T> {
+  return { queueName, jobName, schema };
+}
+
+const bankFeedEntrySchema = z.object({
+  id: z.string(),
+  amount: z.number(),
+  currency: z.string().default("AUD"),
+  postedAt: z.string(),
+  description: z.string().optional(),
+});
+
+export const bankFeedIngestContract = createContract(
+  "bank-feed.ingest",
+  "bank-feed.ingested",
+  z.object({
+    feedId: z.string(),
+    orgId: z.string(),
+    source: z.string(),
+    entries: z.array(bankFeedEntrySchema).nonempty(),
+  })
+);
+export type BankFeedIngestJob = z.infer<typeof bankFeedIngestContract.schema>;
+
+export const paymentLifecycleContract = createContract(
+  "payments.lifecycle",
+  "payments.progress",
+  z.object({
+    payableId: z.string(),
+    orgId: z.string(),
+    amount: z.number(),
+    currency: z.string().default("AUD"),
+    dueDate: z.string(),
+    supplierName: z.string(),
+  })
+);
+export type PaymentLifecycleJob = z.infer<typeof paymentLifecycleContract.schema>;
+
+export const auditEventContract = createContract(
+  "audit.events",
+  "audit.record",
+  z.object({
+    eventId: z.string(),
+    entityId: z.string(),
+    eventType: z.string(),
+    occurredAt: z.string(),
+    payload: z.record(z.any()).default({}),
+  })
+);
+export type AuditEventJob = z.infer<typeof auditEventContract.schema>;
+
+async function loadBullmq() {
+  try {
+    return await import("bullmq");
+  } catch (error) {
+    throw new Error("bullmq is required. Install it in the workspace before starting queue-enabled services.");
+  }
+}
+
+export function createRedisConnection(connection: RedisConnection): IORedis {
+  if (connection instanceof IORedis) {
+    return connection;
+  }
+  return new IORedis(connection);
+}
+
+export async function createQueue<T>(
+  contract: QueueContract<T>,
+  connection: IORedis,
+  options: Omit<QueueOptions, "connection"> = {},
+  jobsOptions?: JobsOptions
+): Promise<BullQueue<T>> {
+  const { Queue } = await loadBullmq();
+  const queue = new Queue<T>(contract.queueName, {
+    connection,
+    sharedConnection: true,
+    ...options,
+  });
+  if (jobsOptions && Object.keys(jobsOptions).length > 0) {
+    queue.defaultJobOptions = { ...queue.defaultJobOptions, ...jobsOptions };
+  }
+  return queue;
+}
+
+export async function createWorker<T>(
+  contract: QueueContract<T>,
+  connection: IORedis,
+  handler: (payload: T, job: Job<T>) => unknown | Promise<unknown>,
+  options: Omit<WorkerOptions, "connection"> = {}
+): Promise<BullWorker<T>> {
+  const { Worker } = await loadBullmq();
+  return new Worker<T>(
+    contract.queueName,
+    async (job) => {
+      const payload = contract.schema.parse(job.data);
+      return handler(payload, job);
+    },
+    {
+      connection,
+      ...options,
+    }
+  );
+}
+
+export async function createQueueEvents<T>(contract: QueueContract<T>, connection: IORedis): Promise<BullQueueEvents> {
+  const { QueueEvents } = await loadBullmq();
+  return new QueueEvents(contract.queueName, { connection });
+}
+
+export const queueContracts = {
+  bankFeedIngest: bankFeedIngestContract,
+  paymentLifecycle: paymentLifecycleContract,
+  auditEvent: auditEventContract,
+};
+

--- a/apgms/shared/src/messaging/index.ts
+++ b/apgms/shared/src/messaging/index.ts
@@ -1,0 +1,1 @@
+export * from "./contracts";


### PR DESCRIPTION
## Summary
- scaffold Fastify entrypoints for the connectors, recon, payments, audit, CDR, registries, and SBR services with shared config loading and health endpoints
- add shared messaging contracts and queue helpers plus service-specific modules for bank feeds, reconciliation, payments, and audit event persistence
- document startup instructions and provide node:test coverage for HTTP handlers and queue interactions across the services

## Testing
- `pnpm --filter "@apgms/*" test`


------
https://chatgpt.com/codex/tasks/task_e_68f30011122883279cc42dcd64573a26