### PR TITLE
feat: modularize api gateway with auth and validation

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "PRISMA_SKIP_LOAD=1 node --test --import tsx test/app.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,25 @@
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+
+import authPlugin from "./plugins/auth";
+import { registerModules } from "./modules";
+import { registerErrorHandling } from "./utils/errors";
+
+export async function createApp(options: FastifyServerOptions = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true, ...options });
+
+  await app.register(cors, { origin: true });
+  await authPlugin(app, {});
+
+  registerErrorHandling(app);
+  await registerModules(app);
+
+  app.ready(() => {
+    // Helpful when running locally but kept quiet in tests when logger is disabled
+    if (app.log && typeof app.log.debug === "function") {
+      app.log.debug(app.printRoutes());
+    }
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,74 +7,19 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await createApp();
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
+// Sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
-
 const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+const host = process.env.HOST ?? "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
+try {
+  await app.listen({ port, host });
+} catch (error) {
+  app.log.error(error);
   process.exit(1);
-});
-
+}

--- a/apgms/services/api-gateway/src/modules/bank-lines/index.ts
+++ b/apgms/services/api-gateway/src/modules/bank-lines/index.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import { bankLineService } from "../../services/bank-line.service";
+
+const listQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).default(20),
+});
+
+const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string(),
+  amount: z.number(),
+  payee: z.string(),
+  description: z.string(),
+  createdAt: z.string(),
+});
+
+const bankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+const createBankLineSchema = z.object({
+  orgId: z.string().min(1),
+  date: z.coerce.date().transform((value) => value.toISOString()),
+  amount: z.coerce.number(),
+  payee: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export async function registerBankLineModule(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/bank-lines",
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { take } = listQuerySchema.parse(request.query ?? {});
+      const lines = await bankLineService.listBankLines(take);
+      return bankLinesResponseSchema.parse({ lines });
+    },
+  );
+
+  app.post(
+    "/bank-lines",
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const body = createBankLineSchema.parse(request.body ?? {});
+      const created = await bankLineService.createBankLine({
+        orgId: body.orgId,
+        date: body.date,
+        amount: body.amount,
+        payee: body.payee,
+        description: body.description,
+      });
+
+      return reply.code(201).send(bankLineSchema.parse(created));
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/modules/health/index.ts
+++ b/apgms/services/api-gateway/src/modules/health/index.ts
@@ -1,0 +1,5 @@
+import type { FastifyInstance } from "fastify";
+
+export async function registerHealthModule(app: FastifyInstance): Promise<void> {
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+}

--- a/apgms/services/api-gateway/src/modules/index.ts
+++ b/apgms/services/api-gateway/src/modules/index.ts
@@ -1,0 +1,17 @@
+import type { FastifyInstance } from "fastify";
+
+import { registerHealthModule } from "./health";
+import { registerUserModule } from "./users";
+import { registerBankLineModule } from "./bank-lines";
+import { registerOrgModule } from "./orgs";
+import { registerReconciliationModule } from "./reconciliation";
+import { registerPaymentModule } from "./payments";
+
+export async function registerModules(app: FastifyInstance): Promise<void> {
+  await registerHealthModule(app);
+  await registerOrgModule(app);
+  await registerUserModule(app);
+  await registerBankLineModule(app);
+  await registerReconciliationModule(app);
+  await registerPaymentModule(app);
+}

--- a/apgms/services/api-gateway/src/modules/orgs/index.ts
+++ b/apgms/services/api-gateway/src/modules/orgs/index.ts
@@ -1,0 +1,73 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import { orgService } from "../../services/org.service";
+import { notFound } from "../../utils/errors";
+
+const orgSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.string(),
+});
+
+const orgWithUsersSchema = orgSchema.extend({
+  users: z.array(
+    z.object({
+      id: z.string(),
+      email: z.string().email(),
+      createdAt: z.string(),
+    }),
+  ),
+});
+
+const listResponseSchema = z.object({
+  orgs: z.array(orgSchema),
+});
+
+const getResponseSchema = z.object({
+  org: orgWithUsersSchema,
+});
+
+const createOrgSchema = z.object({
+  name: z.string().min(2),
+});
+
+const orgParamsSchema = z.object({
+  orgId: z.string().min(1),
+});
+
+export async function registerOrgModule(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/orgs",
+    { preHandler: app.authenticate },
+    async () => {
+      const orgs = await orgService.listOrgs();
+      return listResponseSchema.parse({ orgs });
+    },
+  );
+
+  app.post(
+    "/orgs",
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const body = createOrgSchema.parse(request.body ?? {});
+      const created = await orgService.createOrg(body.name);
+      return reply.code(201).send(orgSchema.parse(created));
+    },
+  );
+
+  app.get(
+    "/orgs/:orgId",
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { orgId } = orgParamsSchema.parse(request.params ?? {});
+      const org = await orgService.getOrgById(orgId);
+
+      if (!org) {
+        throw notFound("Organization not found");
+      }
+
+      return getResponseSchema.parse({ org });
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/modules/payments/index.ts
+++ b/apgms/services/api-gateway/src/modules/payments/index.ts
@@ -1,0 +1,59 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import { paymentService } from "../../services/payment.service";
+
+const paramsSchema = z.object({
+  orgId: z.string().min(1),
+});
+
+const paymentSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  amount: z.number(),
+  date: z.string(),
+  payee: z.string(),
+  memo: z.string(),
+  createdAt: z.string(),
+});
+
+const listResponseSchema = z.object({
+  payments: z.array(paymentSchema),
+});
+
+const createPaymentSchema = z.object({
+  amount: z.coerce.number(),
+  date: z.coerce.date().transform((value) => value.toISOString()),
+  payee: z.string().min(1),
+  memo: z.string().optional(),
+});
+
+export async function registerPaymentModule(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/orgs/:orgId/payments",
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { orgId } = paramsSchema.parse(request.params ?? {});
+      const payments = await paymentService.listPaymentsByOrg(orgId);
+      return listResponseSchema.parse({ payments });
+    },
+  );
+
+  app.post(
+    "/orgs/:orgId/payments",
+    { preHandler: app.authenticate },
+    async (request, reply) => {
+      const { orgId } = paramsSchema.parse(request.params ?? {});
+      const body = createPaymentSchema.parse(request.body ?? {});
+      const payment = await paymentService.createPayment({
+        orgId,
+        amount: body.amount,
+        date: body.date,
+        payee: body.payee,
+        memo: body.memo,
+      });
+
+      return reply.code(201).send(paymentSchema.parse(payment));
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/modules/reconciliation/index.ts
+++ b/apgms/services/api-gateway/src/modules/reconciliation/index.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import { reconciliationService } from "../../services/reconciliation.service";
+
+const paramsSchema = z.object({
+  orgId: z.string().min(1),
+});
+
+const reconciliationSchema = z.object({
+  orgId: z.string(),
+  totalCredits: z.number(),
+  totalDebits: z.number(),
+  netBalance: z.number(),
+  transactionCount: z.number(),
+});
+
+export async function registerReconciliationModule(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/orgs/:orgId/reconciliation",
+    { preHandler: app.authenticate },
+    async (request) => {
+      const { orgId } = paramsSchema.parse(request.params ?? {});
+      const reconciliation = await reconciliationService.getOrgReconciliation(orgId);
+      return reconciliationSchema.parse(reconciliation);
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/modules/users/index.ts
+++ b/apgms/services/api-gateway/src/modules/users/index.ts
@@ -1,0 +1,28 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+
+import { userService } from "../../services/user.service";
+
+const userSchema = z.object({
+  id: z.string(),
+  email: z.string().email(),
+  orgId: z.string(),
+  createdAt: z.string(),
+});
+
+const usersResponseSchema = z.object({
+  users: z.array(userSchema),
+});
+
+export async function registerUserModule(app: FastifyInstance): Promise<void> {
+  app.get(
+    "/users",
+    {
+      preHandler: app.authenticate,
+    },
+    async () => {
+      const users = await userService.listUsers();
+      return usersResponseSchema.parse({ users });
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,160 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+import { unauthorized } from "../utils/errors";
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  orgId: string;
+  [key: string]: unknown;
+}
+
+interface SessionRecord {
+  user: AuthenticatedUser;
+  expiresAt: number;
+}
+
+interface AuthPluginOptions {
+  sessionTTL?: number;
+  sessionStore?: Map<string, SessionRecord>;
+}
+
+interface TokenPayload {
+  sub: string;
+  email: string;
+  orgId: string;
+  exp?: number;
+}
+
+declare module "fastify" {
+  interface FastifyInstance {
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    createSession: (user: AuthenticatedUser) => string;
+    destroySession: (sessionId: string) => void;
+  }
+
+  interface FastifyRequest {
+    user: AuthenticatedUser | null;
+    sessionId: string | null;
+  }
+}
+
+const authPlugin: FastifyPluginAsync<AuthPluginOptions> = async (fastify, options) => {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) {
+    throw new Error("AUTH_SECRET environment variable must be configured");
+  }
+
+  const sessionTTL = options.sessionTTL ?? 1000 * 60 * 60;
+  const sessionStore = options.sessionStore ?? new Map<string, SessionRecord>();
+
+  fastify.decorateRequest("user", null);
+  fastify.decorateRequest("sessionId", null);
+
+  fastify.decorate("authenticate", async (request: FastifyRequest, _reply: FastifyReply) => {
+    const token = extractBearerToken(request);
+    if (token) {
+      const payload = verifyToken(token, secret);
+      request.user = normalizePayload(payload);
+      return;
+    }
+
+    const sessionTokenHeader = request.headers["x-session-token"];
+    if (typeof sessionTokenHeader === "string") {
+      const session = sessionStore.get(sessionTokenHeader);
+      if (session && session.expiresAt > Date.now()) {
+        request.sessionId = sessionTokenHeader;
+        request.user = session.user;
+        return;
+      }
+    }
+
+    throw unauthorized();
+  });
+
+  fastify.decorate("createSession", (user: AuthenticatedUser) => {
+    const sessionId = randomUUID();
+    sessionStore.set(sessionId, { user, expiresAt: Date.now() + sessionTTL });
+    return sessionId;
+  });
+
+  fastify.decorate("destroySession", (sessionId: string) => {
+    sessionStore.delete(sessionId);
+  });
+};
+
+function extractBearerToken(request: FastifyRequest): string | null {
+  const header = request.headers.authorization;
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, value] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !value) {
+    return null;
+  }
+
+  return value.trim();
+}
+
+function verifyToken(token: string, secret: string): TokenPayload {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw unauthorized("Invalid authentication token");
+  }
+
+  const [headerSegment, payloadSegment, signatureSegment] = segments;
+  const header = parseSegment(headerSegment);
+  if (header.alg !== "HS256") {
+    throw unauthorized("Unsupported token algorithm");
+  }
+
+  const expectedSignature = createHmac("sha256", secret)
+    .update(`${headerSegment}.${payloadSegment}`)
+    .digest();
+
+  const providedSignature = decodeBase64Url(signatureSegment);
+  if (providedSignature.length !== expectedSignature.length || !timingSafeEqual(providedSignature, expectedSignature)) {
+    throw unauthorized("Invalid authentication token");
+  }
+
+  const payload = parseSegment(payloadSegment) as TokenPayload;
+  if (!payload.sub || !payload.email || !payload.orgId) {
+    throw unauthorized("Invalid authentication token");
+  }
+
+  if (typeof payload.exp === "number" && payload.exp * 1000 <= Date.now()) {
+    throw unauthorized("Authentication token expired");
+  }
+
+  return payload;
+}
+
+function normalizePayload(payload: TokenPayload): AuthenticatedUser {
+  return {
+    id: payload.sub,
+    email: payload.email,
+    orgId: payload.orgId,
+  };
+}
+
+function parseSegment(segment: string): Record<string, any> {
+  try {
+    const json = Buffer.from(segment, "base64url").toString("utf8");
+    return JSON.parse(json);
+  } catch {
+    throw unauthorized("Invalid authentication token");
+  }
+}
+
+function decodeBase64Url(segment: string): Buffer {
+  try {
+    return Buffer.from(segment, "base64url");
+  } catch {
+    throw unauthorized("Invalid authentication token");
+  }
+}
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/services/bank-line.service.ts
+++ b/apgms/services/api-gateway/src/services/bank-line.service.ts
@@ -1,0 +1,64 @@
+import { prisma } from "@apgms/shared/src/db";
+
+export interface BankLineInput {
+  orgId: string;
+  date: string;
+  amount: number;
+  payee: string;
+  description: string;
+}
+
+export interface BankLineSummary {
+  id: string;
+  orgId: string;
+  date: string;
+  amount: number;
+  payee: string;
+  description: string;
+  createdAt: string;
+}
+
+function normalizeBankLine(line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: unknown;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}): BankLineSummary {
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amount: typeof line.amount === "number" ? line.amount : Number(line.amount),
+    payee: line.payee,
+    description: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+}
+
+export const bankLineService = {
+  async listBankLines(take: number): Promise<BankLineSummary[]> {
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    return lines.map(normalizeBankLine);
+  },
+
+  async createBankLine(input: BankLineInput): Promise<BankLineSummary> {
+    const created = await prisma.bankLine.create({
+      data: {
+        orgId: input.orgId,
+        date: new Date(input.date),
+        amount: input.amount,
+        payee: input.payee,
+        desc: input.description,
+      },
+    });
+
+    return normalizeBankLine(created);
+  },
+};

--- a/apgms/services/api-gateway/src/services/org.service.ts
+++ b/apgms/services/api-gateway/src/services/org.service.ts
@@ -1,0 +1,67 @@
+import { prisma } from "@apgms/shared/src/db";
+
+export interface OrgSummary {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface OrgWithUsers extends OrgSummary {
+  users: {
+    id: string;
+    email: string;
+    createdAt: string;
+  }[];
+}
+
+export const orgService = {
+  async listOrgs(): Promise<OrgSummary[]> {
+    const orgs = await prisma.org.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+
+    return orgs.map((org) => ({
+      id: org.id,
+      name: org.name,
+      createdAt: org.createdAt.toISOString(),
+    }));
+  },
+
+  async createOrg(name: string): Promise<OrgSummary> {
+    const created = await prisma.org.create({
+      data: { name },
+    });
+
+    return {
+      id: created.id,
+      name: created.name,
+      createdAt: created.createdAt.toISOString(),
+    };
+  },
+
+  async getOrgById(id: string): Promise<OrgWithUsers | null> {
+    const org = await prisma.org.findUnique({
+      where: { id },
+      include: {
+        users: {
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    });
+
+    if (!org) {
+      return null;
+    }
+
+    return {
+      id: org.id,
+      name: org.name,
+      createdAt: org.createdAt.toISOString(),
+      users: org.users.map((user) => ({
+        id: user.id,
+        email: user.email,
+        createdAt: user.createdAt.toISOString(),
+      })),
+    };
+  },
+};

--- a/apgms/services/api-gateway/src/services/payment.service.ts
+++ b/apgms/services/api-gateway/src/services/payment.service.ts
@@ -1,0 +1,70 @@
+import { prisma } from "@apgms/shared/src/db";
+
+export interface PaymentInput {
+  orgId: string;
+  amount: number;
+  date: string;
+  payee: string;
+  memo?: string;
+}
+
+export interface PaymentSummary {
+  id: string;
+  orgId: string;
+  amount: number;
+  date: string;
+  payee: string;
+  memo: string;
+  createdAt: string;
+}
+
+const PAYMENT_PREFIX = "PAYMENT";
+
+function normalizePayment(line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: unknown;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}): PaymentSummary {
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    amount: typeof line.amount === "number" ? line.amount : Number(line.amount),
+    date: line.date.toISOString(),
+    payee: line.payee,
+    memo: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+}
+
+export const paymentService = {
+  async listPaymentsByOrg(orgId: string): Promise<PaymentSummary[]> {
+    const payments = await prisma.bankLine.findMany({
+      where: { orgId, desc: { startsWith: PAYMENT_PREFIX } },
+      orderBy: { date: "desc" },
+    });
+
+    return payments.map(normalizePayment);
+  },
+
+  async createPayment(input: PaymentInput): Promise<PaymentSummary> {
+    const description = input.memo?.trim().length
+      ? `${PAYMENT_PREFIX}: ${input.memo.trim()}`
+      : `${PAYMENT_PREFIX}: Payment to ${input.payee}`;
+
+    const created = await prisma.bankLine.create({
+      data: {
+        orgId: input.orgId,
+        date: new Date(input.date),
+        amount: input.amount,
+        payee: input.payee,
+        desc: description,
+      },
+    });
+
+    return normalizePayment(created);
+  },
+};

--- a/apgms/services/api-gateway/src/services/reconciliation.service.ts
+++ b/apgms/services/api-gateway/src/services/reconciliation.service.ts
@@ -1,0 +1,39 @@
+import { prisma } from "@apgms/shared/src/db";
+
+export interface ReconciliationResult {
+  orgId: string;
+  totalCredits: number;
+  totalDebits: number;
+  netBalance: number;
+  transactionCount: number;
+}
+
+export const reconciliationService = {
+  async getOrgReconciliation(orgId: string): Promise<ReconciliationResult> {
+    const lines = await prisma.bankLine.findMany({
+      where: { orgId },
+      orderBy: { date: "desc" },
+    });
+
+    const totals = lines.reduce(
+      (acc, line) => {
+        const amount = Number(line.amount);
+        if (amount >= 0) {
+          acc.credits += amount;
+        } else {
+          acc.debits += amount;
+        }
+        return acc;
+      },
+      { credits: 0, debits: 0 },
+    );
+
+    return {
+      orgId,
+      totalCredits: Number(totals.credits.toFixed(2)),
+      totalDebits: Number(totals.debits.toFixed(2)),
+      netBalance: Number((totals.credits + totals.debits).toFixed(2)),
+      transactionCount: lines.length,
+    };
+  },
+};

--- a/apgms/services/api-gateway/src/services/user.service.ts
+++ b/apgms/services/api-gateway/src/services/user.service.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@apgms/shared/src/db";
+
+export interface UserSummary {
+  id: string;
+  email: string;
+  orgId: string;
+  createdAt: string;
+}
+
+export const userService = {
+  async listUsers(): Promise<UserSummary[]> {
+    const users = await prisma.user.findMany({
+      select: {
+        id: true,
+        email: true,
+        orgId: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return users.map((user) => ({
+      id: user.id,
+      email: user.email,
+      orgId: user.orgId,
+      createdAt: user.createdAt.toISOString(),
+    }));
+  },
+};

--- a/apgms/services/api-gateway/src/utils/errors.ts
+++ b/apgms/services/api-gateway/src/utils/errors.ts
@@ -1,0 +1,87 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { ZodError } from "zod";
+
+import { logError } from "./logging";
+
+export interface ErrorPayload {
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+export class AppError extends Error {
+  public readonly statusCode: number;
+  public readonly code: string;
+  public readonly details?: unknown;
+
+  constructor(statusCode: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError;
+}
+
+export function badRequest(message: string, details?: unknown): AppError {
+  return new AppError(400, "bad_request", message, details);
+}
+
+export function unauthorized(message = "Authentication required"): AppError {
+  return new AppError(401, "unauthorized", message);
+}
+
+export function forbidden(message = "Forbidden"): AppError {
+  return new AppError(403, "forbidden", message);
+}
+
+export function notFound(message = "Resource not found"): AppError {
+  return new AppError(404, "not_found", message);
+}
+
+function sendError(reply: FastifyReply, statusCode: number, payload: ErrorPayload): void {
+  if (!reply.sent) {
+    reply.code(statusCode).send({ error: payload });
+  }
+}
+
+export function registerErrorHandling(app: FastifyInstance): void {
+  app.setErrorHandler((error: unknown, request: FastifyRequest, reply: FastifyReply) => {
+    if (error instanceof ZodError) {
+      const payload: ErrorPayload = {
+        code: "validation_error",
+        message: "Request validation failed",
+        details: error.flatten(),
+      };
+      sendError(reply, 400, payload);
+      return;
+    }
+
+    if (isAppError(error)) {
+      const payload: ErrorPayload = {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      };
+      sendError(reply, error.statusCode, payload);
+      return;
+    }
+
+    logError(request, error, { type: "unhandled" });
+    const payload: ErrorPayload = {
+      code: "internal_server_error",
+      message: "An unexpected error occurred",
+    };
+    sendError(reply, 500, payload);
+  });
+
+  app.setNotFoundHandler((request, reply) => {
+    sendError(reply, 404, {
+      code: "not_found",
+      message: `Route ${request.method} ${request.url} was not found`,
+    });
+  });
+}

--- a/apgms/services/api-gateway/src/utils/logging.ts
+++ b/apgms/services/api-gateway/src/utils/logging.ts
@@ -1,0 +1,10 @@
+import type { FastifyBaseLogger, FastifyRequest } from "fastify";
+
+export function logError(
+  request: FastifyRequest,
+  error: unknown,
+  metadata: Record<string, unknown> = {},
+): void {
+  const logger: FastifyBaseLogger = request.log;
+  logger.error({ err: error, ...metadata }, "request_failed");
+}

--- a/apgms/services/api-gateway/test/app.test.ts
+++ b/apgms/services/api-gateway/test/app.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test, { before } from "node:test";
+
+import { createApp } from "../src/app";
+import { bankLineService } from "../src/services/bank-line.service";
+import { orgService } from "../src/services/org.service";
+import { paymentService } from "../src/services/payment.service";
+import { reconciliationService } from "../src/services/reconciliation.service";
+import { userService } from "../src/services/user.service";
+
+const TEST_SECRET = "test-secret";
+
+before(() => {
+  process.env.AUTH_SECRET = TEST_SECRET;
+});
+
+function signToken(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", TEST_SECRET).update(`${header}.${body}`).digest("base64url");
+  return `${header}.${body}.${signature}`;
+}
+
+function buildAuthHeader(overrides?: Partial<{ sub: string; email: string; orgId: string }>): Record<string, string> {
+  const token = signToken({
+    sub: overrides?.sub ?? "user-1",
+    email: overrides?.email ?? "user@example.com",
+    orgId: overrides?.orgId ?? "org-1",
+    exp: Math.floor(Date.now() / 1000) + 60 * 60,
+  });
+
+  return { authorization: `Bearer ${token}` };
+}
+
+async function withApp(handler: (app: Awaited<ReturnType<typeof createApp>>) => Promise<void>): Promise<void> {
+  const app = await createApp({ logger: false });
+  try {
+    await handler(app);
+  } finally {
+    await app.close();
+  }
+}
+
+test("health endpoint is publicly accessible", async () => {
+  await withApp(async (app) => {
+    const response = await app.inject({ method: "GET", url: "/health" });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { ok: true, service: "api-gateway" });
+  });
+});
+
+test("protected routes require authentication", async () => {
+  await withApp(async (app) => {
+    const response = await app.inject({ method: "GET", url: "/users" });
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(response.json(), {
+      error: { code: "unauthorized", message: "Authentication required" },
+    });
+  });
+});
+
+test("users endpoint returns summaries", async () => {
+  const original = userService.listUsers;
+  userService.listUsers = (async () => [
+    { id: "user-1", email: "user@example.com", orgId: "org-1", createdAt: new Date().toISOString() },
+  ]) as typeof userService.listUsers;
+
+  try {
+    await withApp(async (app) => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/users",
+        headers: buildAuthHeader(),
+      });
+
+      assert.equal(response.statusCode, 200);
+      const body = response.json() as { users: Array<Record<string, unknown>> };
+      assert.ok(Array.isArray(body.users));
+      assert.equal(body.users.length, 1);
+      assert.equal(body.users[0]?.email, "user@example.com");
+    });
+  } finally {
+    userService.listUsers = original;
+  }
+});
+
+test("bank line creation validates payload", async () => {
+  await withApp(async (app) => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      headers: buildAuthHeader(),
+      payload: { orgId: "org-1" },
+    });
+
+    assert.equal(response.statusCode, 400);
+    const body = response.json() as { error: { code: string } };
+    assert.equal(body.error.code, "validation_error");
+  });
+});
+
+test("bank line errors are wrapped by the error handler", async () => {
+  const original = bankLineService.createBankLine;
+  bankLineService.createBankLine = (async () => {
+    throw new Error("database down");
+  }) as typeof bankLineService.createBankLine;
+
+  try {
+    await withApp(async (app) => {
+      const response = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        headers: buildAuthHeader(),
+        payload: {
+          orgId: "org-1",
+          date: new Date().toISOString(),
+          amount: 100,
+          payee: "Acme",
+          description: "Invoice 123",
+        },
+      });
+
+      assert.equal(response.statusCode, 500);
+      assert.deepEqual(response.json(), {
+        error: { code: "internal_server_error", message: "An unexpected error occurred" },
+      });
+    });
+  } finally {
+    bankLineService.createBankLine = original;
+  }
+});
+
+test("missing organisations return a not found error", async () => {
+  const original = orgService.getOrgById;
+  orgService.getOrgById = (async () => null) as typeof orgService.getOrgById;
+
+  try {
+    await withApp(async (app) => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/orgs/missing",
+        headers: buildAuthHeader(),
+      });
+
+      assert.equal(response.statusCode, 404);
+      assert.deepEqual(response.json(), {
+        error: { code: "not_found", message: "Organization not found" },
+      });
+    });
+  } finally {
+    orgService.getOrgById = original;
+  }
+});
+
+test("reconciliation endpoint returns aggregates", async () => {
+  const original = reconciliationService.getOrgReconciliation;
+  reconciliationService.getOrgReconciliation = (async () => ({
+    orgId: "org-1",
+    totalCredits: 1200,
+    totalDebits: -400,
+    netBalance: 800,
+    transactionCount: 3,
+  })) as typeof reconciliationService.getOrgReconciliation;
+
+  try {
+    await withApp(async (app) => {
+      const response = await app.inject({
+        method: "GET",
+        url: "/orgs/org-1/reconciliation",
+        headers: buildAuthHeader(),
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.json(), {
+        orgId: "org-1",
+        totalCredits: 1200,
+        totalDebits: -400,
+        netBalance: 800,
+        transactionCount: 3,
+      });
+    });
+  } finally {
+    reconciliationService.getOrgReconciliation = original;
+  }
+});
+
+test("payments endpoints integrate with the payment service", async () => {
+  const originalList = paymentService.listPaymentsByOrg;
+  paymentService.listPaymentsByOrg = (async () => [
+    {
+      id: "payment-1",
+      orgId: "org-1",
+      amount: 250,
+      date: new Date().toISOString(),
+      payee: "Acme",
+      memo: "PAYMENT: Invoice 123",
+      createdAt: new Date().toISOString(),
+    },
+  ]) as typeof paymentService.listPaymentsByOrg;
+
+  const originalCreate = paymentService.createPayment;
+  let capturedPayload: Parameters<typeof paymentService.createPayment>[0] | null = null;
+  paymentService.createPayment = (async (payload) => {
+    capturedPayload = payload;
+    return {
+      id: "payment-2",
+      orgId: payload.orgId,
+      amount: payload.amount,
+      date: payload.date,
+      payee: payload.payee,
+      memo: "PAYMENT: Payment to Globex",
+      createdAt: new Date().toISOString(),
+    };
+  }) as typeof paymentService.createPayment;
+
+  try {
+    await withApp(async (app) => {
+      const listResponse = await app.inject({
+        method: "GET",
+        url: "/orgs/org-1/payments",
+        headers: buildAuthHeader(),
+      });
+
+      assert.equal(listResponse.statusCode, 200);
+      const listBody = listResponse.json() as { payments: unknown[] };
+      assert.ok(Array.isArray(listBody.payments));
+      assert.equal(listBody.payments.length, 1);
+
+      const createResponse = await app.inject({
+        method: "POST",
+        url: "/orgs/org-1/payments",
+        headers: buildAuthHeader(),
+        payload: {
+          amount: 300,
+          date: new Date().toISOString(),
+          payee: "Globex",
+        },
+      });
+
+      assert.equal(createResponse.statusCode, 201);
+      assert.ok(capturedPayload);
+      assert.equal(capturedPayload?.amount, 300);
+      assert.equal(capturedPayload?.payee, "Globex");
+    });
+  } finally {
+    paymentService.listPaymentsByOrg = originalList;
+    paymentService.createPayment = originalCreate;
+  }
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,22 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { createRequire } from "node:module";
+
+import type { PrismaClient as PrismaClientType } from "@prisma/client";
+
+function createPrismaClient(): PrismaClientType {
+  if (process.env.PRISMA_SKIP_LOAD === "1") {
+    return new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("Prisma client is disabled when PRISMA_SKIP_LOAD=1");
+        },
+      },
+    ) as PrismaClientType;
+  }
+
+  const require = createRequire(import.meta.url);
+  const { PrismaClient } = require("@prisma/client") as { PrismaClient: new () => PrismaClientType };
+  return new PrismaClient();
+}
+
+export const prisma: PrismaClientType = createPrismaClient();


### PR DESCRIPTION
## Summary
- add a Fastify app factory that wires in the auth plugin, validation-aware modules, and centralized error handling
- introduce service layers for users, orgs, bank lines, reconciliation, and payments backed by Zod schemas and Prisma helpers
- implement JWT/session authentication middleware, structured logging utilities, and node:test integration coverage via Fastify inject

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3000e3e348327821c87b2b672b21d