### PR TITLE
Add dev automation scripts and workspace tooling

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
 jobs:
   build:
@@ -12,6 +12,7 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+      - run: pnpm install
+      - run: pnpm lint
+      - run: pnpm build
+      - run: pnpm test

--- a/apgms/README.md
+++ b/apgms/README.md
@@ -1,8 +1,52 @@
-﻿# APGMS
+# APGMS
 
-Quickstart:
-pnpm i
-pnpm -r build
-docker compose up -d
-pnpm -r test
-pnpm -w exec playwright test
+## Prerequisites
+
+- [pnpm](https://pnpm.io/) v9
+- Node.js 18+
+- Docker (required for Postgres/Redis)
+
+## Setup
+
+Install dependencies and generate Prisma client code:
+
+```bash
+pnpm install
+pnpm --filter @apgms/shared prisma:generate
+```
+
+## Running the development stack
+
+The `dev-up` scripts boot the entire stack:
+
+```bash
+./scripts/dev-up.sh
+```
+
+The script will:
+
+1. Start Docker Compose services (Postgres and Redis).
+2. Apply Prisma migrations and generate the client.
+3. Seed demo data.
+4. Launch the Fastify API and Vite dev server.
+5. Open the web application in your browser.
+
+Use the PowerShell alternative on Windows:
+
+```powershell
+pwsh scripts/dev-up.ps1
+```
+
+Pass `--no-browser` to either script to skip automatically opening the browser.
+
+## Testing & linting
+
+Run the workspace-wide commands:
+
+```bash
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Each package (`shared`, `services/api-gateway`, `webapp`, `worker`) also exposes these scripts individually if you need to scope execution with `pnpm --filter`.

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "lint": "pnpm -r run lint"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/dev-up.ps1
+++ b/apgms/scripts/dev-up.ps1
@@ -1,1 +1,51 @@
-﻿# dev-up script
+param(
+  [switch]$NoBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+Push-Location $repoRoot
+
+try {
+  Write-Host "[dev-up] Starting Docker Compose services..."
+  docker compose up -d | Out-Null
+
+  Write-Host "[dev-up] Applying Prisma migrations..."
+  pnpm --filter @apgms/shared db:migrate
+
+  Write-Host "[dev-up] Generating Prisma client..."
+  pnpm --filter @apgms/shared prisma:generate
+
+  Write-Host "[dev-up] Seeding database with demo data..."
+  pnpm exec tsx scripts/seed.ts
+
+  Write-Host "[dev-up] Launching Fastify API..."
+  $apiProcess = Start-Process pnpm -ArgumentList "--filter", "@apgms/api-gateway", "dev" -WorkingDirectory $repoRoot -PassThru
+
+  Write-Host "[dev-up] Launching web application..."
+  $webProcess = Start-Process pnpm -ArgumentList "--filter", "@apgms/webapp", "dev" -WorkingDirectory $repoRoot -PassThru
+
+  if (-not $NoBrowser) {
+    $url = "http://localhost:5173"
+    Write-Host "[dev-up] Opening browser at $url"
+    try {
+      Start-Process $url | Out-Null
+    } catch {
+      Write-Warning "[dev-up] Failed to open browser automatically: $_"
+    }
+  }
+
+  Write-Host "[dev-up] Development environment is ready. Press Ctrl+C to stop."
+  Wait-Process -InputObject @($apiProcess, $webProcess)
+} finally {
+  foreach ($proc in @($apiProcess, $webProcess)) {
+    if ($proc -and -not $proc.HasExited) {
+      try {
+        Stop-Process -Id $proc.Id -Force
+      } catch {
+      }
+    }
+  }
+  Pop-Location
+}

--- a/apgms/scripts/dev-up.sh
+++ b/apgms/scripts/dev-up.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NO_BROWSER=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-browser)
+      NO_BROWSER=1
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+log() {
+  echo "[dev-up] $*"
+}
+
+cleanup() {
+  trap - INT TERM EXIT
+  if [[ -n "${API_PID:-}" ]]; then
+    kill "$API_PID" 2>/dev/null || true
+  fi
+  if [[ -n "${WEB_PID:-}" ]]; then
+    kill "$WEB_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+log "Starting Docker Compose services..."
+docker compose up -d
+
+log "Applying Prisma migrations..."
+pnpm --filter @apgms/shared db:migrate
+
+log "Generating Prisma client..."
+pnpm --filter @apgms/shared prisma:generate
+
+log "Seeding database with demo data..."
+pnpm exec tsx scripts/seed.ts
+
+log "Launching Fastify API..."
+pnpm --filter @apgms/api-gateway dev &
+API_PID=$!
+
+log "Launching web application..."
+pnpm --filter @apgms/webapp dev &
+WEB_PID=$!
+
+if [[ "$NO_BROWSER" -eq 0 ]]; then
+  URL="http://localhost:5173"
+  log "Opening browser at $URL"
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$URL" >/dev/null 2>&1 || true
+  elif command -v open >/dev/null 2>&1; then
+    open "$URL" >/dev/null 2>&1 || true
+  elif command -v start >/dev/null 2>&1; then
+    start "$URL" >/dev/null 2>&1 || true
+  else
+    log "Please open $URL manually."
+  fi
+fi
+
+log "Development environment is ready. Press Ctrl+C to stop."
+
+wait

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "build": "tsc --project tsconfig.json --outDir dist",
+    "lint": "tsc --noEmit",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,86 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
 import dotenv from "dotenv";
+
+import { prisma } from "../../../shared/src/db";
 
 // Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+export async function buildApp(
+  options: FastifyServerOptions = {}
+): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true, ...options });
 
-const app = Fastify({ logger: true });
+  await app.register(cors, { origin: true });
 
-await app.register(cors, { origin: true });
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
+const app = await buildApp();
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/test/health.test.ts
+++ b/apgms/services/api-gateway/test/health.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildApp } from "../src/index";
+
+test("health endpoint returns ok", async () => {
+  const app = await buildApp({ logger: false });
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ok: true, service: "api-gateway" });
+
+  await app.close();
+});

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,13 +5,18 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "tsc --project tsconfig.json --outDir dist",
+    "db:migrate": "prisma migrate deploy --schema=shared/prisma/schema.prisma",
+    "lint": "tsc --noEmit",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"
   },
   "devDependencies": {
+    "@types/node": "^24.7.1",
     "prisma": "6.17.1",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }
 }

--- a/apgms/shared/test/index.test.ts
+++ b/apgms/shared/test/index.test.ts
@@ -1,1 +1,10 @@
-﻿// tests
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.DATABASE_URL ??= "postgresql://apgms:apgms@localhost:5432/apgms";
+
+test("prisma client exposes disconnect", async () => {
+  const { prisma } = await import("../src/db");
+  assert.ok(prisma);
+  assert.equal(typeof prisma.$disconnect, "function");
+});

--- a/apgms/shared/tsconfig.json
+++ b/apgms/shared/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,19 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "vite build",
+    "test": "tsx --test",
+    "dev": "vite",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vite": "^5.4.5"
+  },
+  "dependencies": {}
+}

--- a/apgms/webapp/test/app.test.ts
+++ b/apgms/webapp/test/app.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("webapp logs on startup", async () => {
+  const original = console.log;
+  const calls: unknown[][] = [];
+  console.log = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    await import("../src/main");
+  } finally {
+    console.log = original;
+  }
+
+  assert.ok(calls.some((args) => args.length === 1 && args[0] === "webapp"));
+});

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "preserve",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "test"]
+}

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,17 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --project tsconfig.json --outDir dist",
+    "test": "tsx --test",
+    "lint": "tsc --noEmit",
+    "dev": "tsx src/index.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/worker/test/index.test.ts
+++ b/apgms/worker/test/index.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("worker logs on startup", async () => {
+  const original = console.log;
+  const calls: unknown[][] = [];
+  console.log = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    await import("../src/index");
+  } finally {
+    console.log = original;
+  }
+
+  assert.ok(calls.some((args) => args.length === 1 && args[0] === "worker"));
+});

--- a/apgms/worker/tsconfig.json
+++ b/apgms/worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- add cross-platform `dev-up` scripts that start Docker services, run Prisma migrations, seed data, launch the API, and bring up the web app
- wire up lint/test/build scripts and lightweight Node-based tests across the API, shared library, web app, and worker packages
- refresh documentation and CI so the new commands are the standard workflow

## Testing
- pnpm lint *(fails: missing workspace node_modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f31c6435ac8327a746134e0a0cf6df