### PR TITLE
feat: build console onboarding and operations pages

### DIFF
--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,33 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.3",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.8.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.31",
+    "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.1.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8",
+    "vitest": "^1.2.1"
+  }
+}

--- a/apgms/webapp/src/components/ui/app-shell.tsx
+++ b/apgms/webapp/src/components/ui/app-shell.tsx
@@ -1,0 +1,24 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+
+interface AppShellProps extends PropsWithChildren {
+  navigation: ReactNode;
+}
+
+export function AppShell({ navigation, children }: AppShellProps) {
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">{navigation}</aside>
+      <main className="main-content">
+        <header className="app-header">
+          <h1 className="app-title">BIRChal Assurance Console</h1>
+          <p className="app-subtitle">
+            Operational controls, reconciliations, and anomaly triage for APGMS.
+          </p>
+        </header>
+        <section className="app-body" aria-live="polite">
+          {children}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/ui/button.tsx
+++ b/apgms/webapp/src/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'ghost';
+};
+
+export function Button({ className, variant = 'primary', ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        'btn',
+        variant === 'primary' && 'btn-primary',
+        variant === 'secondary' && 'btn-secondary',
+        variant === 'ghost' && 'btn-ghost',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apgms/webapp/src/components/ui/card.tsx
+++ b/apgms/webapp/src/components/ui/card.tsx
@@ -1,0 +1,18 @@
+import type { PropsWithChildren, ReactNode } from 'react';
+import { cn } from '../../lib/utils';
+
+interface CardProps extends PropsWithChildren {
+  className?: string;
+  header?: ReactNode;
+  footer?: ReactNode;
+}
+
+export function Card({ className, header, footer, children }: CardProps) {
+  return (
+    <section className={cn('card', className)}>
+      {header && <header className="card-header">{header}</header>}
+      <div className="card-content">{children}</div>
+      {footer && <footer className="card-footer">{footer}</footer>}
+    </section>
+  );
+}

--- a/apgms/webapp/src/components/ui/form-field.tsx
+++ b/apgms/webapp/src/components/ui/form-field.tsx
@@ -1,0 +1,46 @@
+import { cloneElement, isValidElement, type ReactNode } from 'react';
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  description?: string;
+  error?: string;
+  children: ReactNode;
+}
+
+export function FormField({ id, label, description, error, children }: FormFieldProps) {
+  const descriptionId = description ? `${id}-description` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const shouldEnhance =
+    isValidElement(children) &&
+    (typeof children.type !== 'string' || ['input', 'select', 'textarea'].includes(children.type));
+
+  const control = shouldEnhance
+    ? cloneElement(children, {
+        id,
+        'aria-describedby': [descriptionId, errorId, children.props['aria-describedby']]
+          .filter(Boolean)
+          .join(' ') || undefined,
+        'aria-invalid': Boolean(error) || undefined
+      })
+    : children;
+
+  return (
+    <div className="form-field">
+      <label className="label" htmlFor={id}>
+        {label}
+      </label>
+      {description && (
+        <p className="muted" id={descriptionId}>
+          {description}
+        </p>
+      )}
+      <div>{control}</div>
+      {error && (
+        <p role="alert" className="error-text" id={errorId}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/ui/input.tsx
+++ b/apgms/webapp/src/components/ui/input.tsx
@@ -1,0 +1,11 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, ...props },
+  ref
+) {
+  return <input ref={ref} className={cn('input', className)} {...props} />;
+});

--- a/apgms/webapp/src/components/ui/select.tsx
+++ b/apgms/webapp/src/components/ui/select.tsx
@@ -1,0 +1,15 @@
+import { forwardRef, type SelectHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { className, children, ...props },
+  ref
+) {
+  return (
+    <select ref={ref} className={cn('select', className)} {...props}>
+      {children}
+    </select>
+  );
+});

--- a/apgms/webapp/src/components/ui/tabs.tsx
+++ b/apgms/webapp/src/components/ui/tabs.tsx
@@ -1,0 +1,90 @@
+import React, { useId, useState, type PropsWithChildren } from 'react';
+import { cn } from '../../lib/utils';
+
+type TabsProps = PropsWithChildren<{ defaultValue: string; className?: string }>;
+
+type TabsContextValue = {
+  value: string;
+  setValue: (value: string) => void;
+  id: string;
+};
+
+const TabsContext = React.createContext<TabsContextValue | undefined>(undefined);
+
+function TabsRoot({ defaultValue, className, children }: TabsProps) {
+  const [value, setValue] = useState(defaultValue);
+  const id = useId();
+
+  return (
+    <TabsContext.Provider value={{ value, setValue, id }}>
+      <div className={cn('tabs', className)}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+function useTabsContext() {
+  const context = React.useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs components must be used within Tabs');
+  }
+  return context;
+}
+
+type TabsListProps = PropsWithChildren;
+
+function TabsList({ children }: TabsListProps) {
+  return (
+    <div className="tabs-list" role="tablist">
+      {children}
+    </div>
+  );
+}
+
+type TabsTriggerProps = PropsWithChildren<{ value: string }>;
+
+function TabsTrigger({ value, children }: TabsTriggerProps) {
+  const { value: selected, setValue, id } = useTabsContext();
+  const tabId = `${id}-tab-${value}`;
+  const panelId = `${id}-panel-${value}`;
+
+  return (
+    <button
+      id={tabId}
+      role="tab"
+      type="button"
+      aria-selected={selected === value}
+      aria-controls={panelId}
+      className={cn('tab-trigger', selected === value && 'active')}
+      onClick={() => setValue(value)}
+    >
+      {children}
+    </button>
+  );
+}
+
+type TabsContentProps = PropsWithChildren<{ value: string }>;
+
+function TabsContent({ value, children }: TabsContentProps) {
+  const { value: selected, id } = useTabsContext();
+  const isActive = selected === value;
+  const panelId = `${id}-panel-${value}`;
+  const tabId = `${id}-tab-${value}`;
+
+  return (
+    <div
+      id={panelId}
+      role="tabpanel"
+      aria-labelledby={tabId}
+      hidden={!isActive}
+      className="tab-content"
+    >
+      {isActive && children}
+    </div>
+  );
+}
+
+export const Tabs = Object.assign(TabsRoot, {
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Content: TabsContent
+});

--- a/apgms/webapp/src/components/ui/textarea.tsx
+++ b/apgms/webapp/src/components/ui/textarea.tsx
@@ -1,0 +1,11 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+import { cn } from '../../lib/utils';
+
+type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, ...props },
+  ref
+) {
+  return <textarea ref={ref} className={cn('textarea', className)} {...props} />;
+});

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,382 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.8) 0%, #e2e8f0 100%);
+}
+
+a {
+  color: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+button {
+  font: inherit;
+}
+
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+:focus-visible {
+  outline: 3px solid #38bdf8;
+  outline-offset: 2px;
+}
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  padding: 2rem 1.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: #f8fafc;
+}
+
+.nav-list {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.nav-link {
+  display: inline-flex;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  font-weight: 500;
+  background: rgba(148, 163, 184, 0.12);
+  color: inherit;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  background: rgba(148, 163, 184, 0.25);
+  transform: translateX(4px);
+}
+
+.nav-link.active {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+}
+
+.main-content {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  border-top-left-radius: 32px;
+  border-bottom-left-radius: 32px;
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  padding-bottom: 1rem;
+}
+
+.app-title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.app-subtitle {
+  margin-top: 0.25rem;
+  color: #475569;
+}
+
+.app-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .main-content {
+    border-radius: 0;
+    padding: 2rem 1.5rem;
+  }
+}
+.btn {
+  border: none;
+  cursor: pointer;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.25rem;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: white;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.2);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(79, 70, 229, 0.25);
+}
+
+.btn-secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #0f172a;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: inherit;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.9);
+  outline-offset: 2px;
+}
+
+.input,
+.textarea,
+.select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+.input:focus,
+.textarea:focus,
+.select:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
+  outline: none;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.muted {
+  color: #64748b;
+}
+
+.label {
+  font-weight: 500;
+  display: inline-flex;
+  margin-bottom: 0.35rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .form-grid.two-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 0.5rem;
+  text-align: left;
+}
+
+.table tbody tr:nth-child(even) {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  padding: 0.15rem 0.75rem;
+  font-size: 0.8rem;
+  background: rgba(99, 102, 241, 0.15);
+  color: #312e81;
+}
+.card-header {
+  margin-bottom: 1rem;
+}
+
+.card-footer {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+.tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.tabs-list {
+  display: inline-flex;
+  gap: 0.75rem;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.5rem;
+  border-radius: 0.75rem;
+}
+
+.tab-trigger {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  padding: 0.5rem 1rem;
+  border-radius: 0.65rem;
+  cursor: pointer;
+}
+
+.tab-trigger.active {
+  background: white;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
+}
+
+.tab-content {
+  padding-top: 0.5rem;
+}
+.form-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.error-text {
+  color: #dc2626;
+  font-size: 0.9rem;
+}
+.wizard-progress {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.wizard-progress li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid transparent;
+}
+
+.wizard-progress li.active {
+  border-color: rgba(59, 130, 246, 0.6);
+  background: rgba(191, 219, 254, 0.35);
+}
+
+.wizard-progress li.complete {
+  border-color: rgba(16, 185, 129, 0.6);
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.step-index {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background: white;
+  font-weight: 600;
+}
+
+.wizard-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+.toggle {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  background: rgba(148, 163, 184, 0.15);
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.toggle input {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}

--- a/apgms/webapp/src/lib/utils.ts
+++ b/apgms/webapp/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,13 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './routes/App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/routes/AllocationsGates.tsx
+++ b/apgms/webapp/src/routes/AllocationsGates.tsx
@@ -1,0 +1,127 @@
+import { useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Card } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { Button } from '../components/ui/button';
+import { FormField } from '../components/ui/form-field';
+import { Select } from '../components/ui/select';
+
+const allocationSchema = z.object({
+  gates: z.array(
+    z.object({
+      label: z.string().min(1, 'Gate label is required'),
+      threshold: z.number({ invalid_type_error: 'Provide a numeric threshold' }).min(0),
+      dimension: z.enum(['transaction_amount', 'liquidity_ratio', 'exposure']),
+      escalation: z.enum(['Notify', 'Block', 'Review'])
+    })
+  )
+});
+
+type AllocationFormValues = z.infer<typeof allocationSchema>;
+
+const defaultGate = {
+  label: 'Default limit',
+  threshold: 100000,
+  dimension: 'transaction_amount' as const,
+  escalation: 'Review' as const
+};
+
+export function AllocationsGates() {
+  const form = useForm<AllocationFormValues>({
+    resolver: zodResolver(allocationSchema),
+    defaultValues: {
+      gates: [defaultGate]
+    }
+  });
+
+  const { fields, append, remove } = useFieldArray({ control: form.control, name: 'gates' });
+
+  const onSubmit = (values: AllocationFormValues) => {
+    console.log('Allocation gates saved', values);
+  };
+
+  return (
+    <form className="container" onSubmit={form.handleSubmit(onSubmit)} noValidate>
+      <h2 className="section-title">Allocations & gating logic</h2>
+      <p className="muted">
+        Model allocation bands, gating thresholds, and escalation pathways that drive platform
+        automation.
+      </p>
+
+      <div className="grid">
+        {fields.map((field, index) => (
+          <Card
+            key={field.id}
+            header={<h3>{field.label || `Gate ${index + 1}`}</h3>}
+            footer={
+              <Button type="button" variant="ghost" onClick={() => remove(index)}>
+                Remove gate
+              </Button>
+            }
+          >
+            <div className="form-grid">
+              <FormField
+                id={`gates.${index}.label`}
+                label="Gate label"
+                error={form.formState.errors.gates?.[index]?.label?.message}
+              >
+                <Input id={`gates.${index}.label`} {...form.register(`gates.${index}.label` as const)} />
+              </FormField>
+
+              <FormField
+                id={`gates.${index}.threshold`}
+                label="Threshold"
+                error={form.formState.errors.gates?.[index]?.threshold?.message}
+              >
+                <Input
+                  id={`gates.${index}.threshold`}
+                  type="number"
+                  step="0.01"
+                  {...form.register(`gates.${index}.threshold` as const, { valueAsNumber: true })}
+                />
+              </FormField>
+
+              <FormField
+                id={`gates.${index}.dimension`}
+                label="Dimension"
+                error={form.formState.errors.gates?.[index]?.dimension?.message}
+              >
+                <Select id={`gates.${index}.dimension`} {...form.register(`gates.${index}.dimension` as const)}>
+                  <option value="transaction_amount">Transaction amount</option>
+                  <option value="liquidity_ratio">Liquidity ratio</option>
+                  <option value="exposure">Exposure</option>
+                </Select>
+              </FormField>
+
+              <FormField
+                id={`gates.${index}.escalation`}
+                label="Escalation action"
+                error={form.formState.errors.gates?.[index]?.escalation?.message}
+              >
+                <Select id={`gates.${index}.escalation`} {...form.register(`gates.${index}.escalation` as const)}>
+                  <option value="Notify">Notify</option>
+                  <option value="Block">Block</option>
+                  <option value="Review">Review</option>
+                </Select>
+              </FormField>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      <div className="wizard-actions" style={{ justifyContent: 'space-between' }}>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() =>
+            append({ label: '', threshold: 0, dimension: 'transaction_amount', escalation: 'Notify' })
+          }
+        >
+          Add gate
+        </Button>
+        <Button type="submit">Save gating</Button>
+      </div>
+    </form>
+  );
+}

--- a/apgms/webapp/src/routes/AnomalyInbox.tsx
+++ b/apgms/webapp/src/routes/AnomalyInbox.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Card } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import { Select } from '../components/ui/select';
+import { FormField } from '../components/ui/form-field';
+import { Textarea } from '../components/ui/textarea';
+
+const triageSchema = z.object({
+  decision: z.enum(['escalate', 'close', 'snooze']),
+  notes: z.string().min(5, 'Provide sufficient notes')
+});
+
+type TriageForm = z.infer<typeof triageSchema>;
+
+const anomalies = [
+  {
+    id: 'AN-912',
+    title: 'Settlement exceeds facility limit',
+    raisedAt: '2024-03-17T09:12:00Z',
+    severity: 'High',
+    description: 'Settlement batch 4821 breached platform-level exposure gate by 8%.'
+  },
+  {
+    id: 'AN-913',
+    title: 'Missing remittance advice',
+    raisedAt: '2024-03-18T04:21:00Z',
+    severity: 'Medium',
+    description: 'Expected remittance file from Gateway A not delivered in time.'
+  }
+];
+
+export function AnomalyInbox() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset
+  } = useForm<TriageForm>({
+    resolver: zodResolver(triageSchema),
+    defaultValues: { decision: 'escalate', notes: '' }
+  });
+
+  const sortedAnomalies = useMemo(() => anomalies, []);
+
+  const onSubmit = (values: TriageForm) => {
+    console.log('Triage decision', values);
+    reset();
+  };
+
+  return (
+    <div className="container">
+      <h2 className="section-title">Anomaly inbox</h2>
+      <p className="muted">
+        Review gating breaches and data quality issues. Capture triage actions with audit trails for
+        regulators.
+      </p>
+
+      <div className="grid">
+        {sortedAnomalies.map((anomaly) => (
+          <Card
+            key={anomaly.id}
+            header={<h3>{anomaly.title}</h3>}
+            footer={<span className="badge">{anomaly.severity}</span>}
+          >
+            <p>
+              <strong>ID:</strong> {anomaly.id}
+            </p>
+            <p>
+              <strong>Raised:</strong> {new Date(anomaly.raisedAt).toLocaleString()}
+            </p>
+            <p>{anomaly.description}</p>
+          </Card>
+        ))}
+      </div>
+
+      <Card header={<h3>Triage selected anomaly</h3>}>
+        <form className="form-grid" onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormField id="decision" label="Decision" error={errors.decision?.message}>
+            <Select id="decision" {...register('decision')}>
+              <option value="escalate">Escalate to control owner</option>
+              <option value="close">Close with justification</option>
+              <option value="snooze">Snooze and re-check</option>
+            </Select>
+          </FormField>
+
+          <FormField id="notes" label="Notes" error={errors.notes?.message}>
+            <Textarea
+              id="notes"
+              rows={4}
+              {...register('notes')}
+              placeholder="Summarise findings, attach evidence references, and note stakeholders notified."
+            />
+          </FormField>
+
+          <div className="wizard-actions" style={{ justifyContent: 'flex-start' }}>
+            <Button type="submit">Record triage</Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/App.tsx
+++ b/apgms/webapp/src/routes/App.tsx
@@ -1,0 +1,53 @@
+import { NavLink, Route, Routes } from 'react-router-dom';
+import { Home } from './Home';
+import { OnboardingWizard } from './onboarding/OnboardingWizard';
+import { DesignatedAccounts } from './DesignatedAccounts';
+import { AllocationsGates } from './AllocationsGates';
+import { ReconciliationAudit } from './ReconciliationAudit';
+import { AnomalyInbox } from './AnomalyInbox';
+import { Settings } from './Settings';
+import { AppShell } from '../components/ui/app-shell';
+
+const links = [
+  { to: '/', label: 'Overview' },
+  { to: '/onboarding', label: 'Onboarding' },
+  { to: '/designated-accounts', label: 'Designated Accounts' },
+  { to: '/allocations', label: 'Allocations & Gates' },
+  { to: '/reconciliation', label: 'Reconciliation & Audit' },
+  { to: '/anomalies', label: 'Anomaly Inbox' },
+  { to: '/settings', label: 'Settings' }
+];
+
+export default function App() {
+  return (
+    <AppShell
+      navigation={
+        <nav aria-label="Main navigation">
+          <ul className="nav-list">
+            {links.map((link) => (
+              <li key={link.to}>
+                <NavLink
+                  to={link.to}
+                  className={({ isActive }) => (isActive ? 'nav-link active' : 'nav-link')}
+                  end={link.to === '/'}
+                >
+                  {link.label}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      }
+    >
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/onboarding" element={<OnboardingWizard />} />
+        <Route path="/designated-accounts" element={<DesignatedAccounts />} />
+        <Route path="/allocations" element={<AllocationsGates />} />
+        <Route path="/reconciliation" element={<ReconciliationAudit />} />
+        <Route path="/anomalies" element={<AnomalyInbox />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </AppShell>
+  );
+}

--- a/apgms/webapp/src/routes/DesignatedAccounts.tsx
+++ b/apgms/webapp/src/routes/DesignatedAccounts.tsx
@@ -1,0 +1,106 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Card } from '../components/ui/card';
+import { Input } from '../components/ui/input';
+import { Button } from '../components/ui/button';
+import { FormField } from '../components/ui/form-field';
+import { Select } from '../components/ui/select';
+
+const designatedAccountSchema = z.object({
+  accountName: z.string().min(2, 'Account name is required'),
+  institution: z.string().min(1, 'Institution is required'),
+  accountNumber: z.string().min(4, 'Account number is required'),
+  owner: z.string().min(1, 'Owner is required'),
+  attestationCadence: z.enum(['Monthly', 'Quarterly', 'Annually'])
+});
+
+type DesignatedAccountForm = z.infer<typeof designatedAccountSchema>;
+
+const designatedAccounts = [
+  { accountName: 'Client Trust', institution: 'ANZ', accountNumber: '123-456', owner: 'Finance', status: 'Verified' },
+  { accountName: 'Operational', institution: 'CBA', accountNumber: '789-123', owner: 'Treasury', status: 'Pending' }
+];
+
+export function DesignatedAccounts() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<DesignatedAccountForm>({
+    resolver: zodResolver(designatedAccountSchema),
+    defaultValues: {
+      accountName: '',
+      institution: '',
+      accountNumber: '',
+      owner: '',
+      attestationCadence: 'Monthly'
+    }
+  });
+
+  const onSubmit = (values: DesignatedAccountForm) => {
+    console.log('Designated account submitted', values);
+  };
+
+  return (
+    <div className="container">
+      <h2 className="section-title">Designated accounts register</h2>
+      <p className="muted">
+        Track bank accounts under AFSL controls. Document ownership, attestations, and attach source
+        references for auditors.
+      </p>
+
+      <div className="card-grid">
+        {designatedAccounts.map((account) => (
+          <Card
+            key={account.accountName}
+            header={<h3>{account.accountName}</h3>}
+            footer={<span className="badge">{account.status}</span>}
+          >
+            <p>
+              <strong>Institution:</strong> {account.institution}
+            </p>
+            <p>
+              <strong>Account number:</strong> {account.accountNumber}
+            </p>
+            <p>
+              <strong>Owner:</strong> {account.owner}
+            </p>
+          </Card>
+        ))}
+      </div>
+
+      <Card header={<h3>Add designated account</h3>}>
+        <form className="form-grid two-columns" onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormField id="accountName" label="Account name" error={errors.accountName?.message}>
+            <Input id="accountName" {...register('accountName')} placeholder="Client Trust" />
+          </FormField>
+
+          <FormField id="institution" label="Institution" error={errors.institution?.message}>
+            <Input id="institution" {...register('institution')} placeholder="ANZ" />
+          </FormField>
+
+          <FormField id="accountNumber" label="Account number" error={errors.accountNumber?.message}>
+            <Input id="accountNumber" {...register('accountNumber')} placeholder="123-456" />
+          </FormField>
+
+          <FormField id="owner" label="Owner" error={errors.owner?.message}>
+            <Input id="owner" {...register('owner')} placeholder="Finance" />
+          </FormField>
+
+          <FormField id="attestationCadence" label="Attestation cadence">
+            <Select id="attestationCadence" {...register('attestationCadence')}>
+              <option value="Monthly">Monthly</option>
+              <option value="Quarterly">Quarterly</option>
+              <option value="Annually">Annually</option>
+            </Select>
+          </FormField>
+
+          <div className="form-field" style={{ alignSelf: 'end' }}>
+            <Button type="submit">Save account</Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/Home.tsx
+++ b/apgms/webapp/src/routes/Home.tsx
@@ -1,0 +1,40 @@
+import { Card } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+
+const summaryCards = [
+  {
+    title: 'Onboarding progress',
+    value: '3 / 5 tasks complete',
+    description: 'Finish configuring BAS schedule and enable connectors to go live.'
+  },
+  {
+    title: 'Designated accounts',
+    value: '12 accounts',
+    description: '5 accounts pending attestation'
+  },
+  {
+    title: 'Open anomalies',
+    value: '7 flagged',
+    description: 'Most recent: payment mismatch on 22 Mar 2024'
+  }
+];
+
+export function Home() {
+  return (
+    <div className="container">
+      <h2 className="section-title">Operational overview</h2>
+      <div className="card-grid">
+        {summaryCards.map((card) => (
+          <Card
+            key={card.title}
+            header={<h3>{card.title}</h3>}
+            footer={<Button variant="secondary">View details</Button>}
+          >
+            <p className="muted">{card.value}</p>
+            <p>{card.description}</p>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/ReconciliationAudit.tsx
+++ b/apgms/webapp/src/routes/ReconciliationAudit.tsx
@@ -1,0 +1,202 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  ResponsiveContainer,
+  LineChart,
+  CartesianGrid,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip
+} from 'recharts';
+import { Card } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import { FormField } from '../components/ui/form-field';
+import { Select } from '../components/ui/select';
+import { Input } from '../components/ui/input';
+
+const reconciliationSchema = z.object({
+  ledger: z.enum(['General', 'Client trust', 'Settlement']),
+  periodStart: z.string().min(1, 'Start date required'),
+  periodEnd: z.string().min(1, 'End date required'),
+  tolerance: z.number({ invalid_type_error: 'Tolerance must be numeric' }).min(0)
+});
+
+type ReconciliationFilters = z.infer<typeof reconciliationSchema>;
+
+const chartData = [
+  { period: 'W1', ledgerBalance: 120, bankBalance: 118 },
+  { period: 'W2', ledgerBalance: 124, bankBalance: 123 },
+  { period: 'W3', ledgerBalance: 119, bankBalance: 118 },
+  { period: 'W4', ledgerBalance: 128, bankBalance: 127 }
+];
+
+const hashChain = [
+  {
+    sequence: 98,
+    hash: '0x6f3a...',
+    previousHash: '0xd121...'
+  },
+  {
+    sequence: 99,
+    hash: '0xd121...',
+    previousHash: '0xba42...'
+  },
+  {
+    sequence: 100,
+    hash: '0xba42...',
+    previousHash: '0xa7f1...'
+  }
+];
+
+const reconciliationFindings = [
+  { reference: 'INV-245', amount: 3200, variance: '+$50', status: 'Investigating' },
+  { reference: 'PAY-903', amount: 1200, variance: '-$10', status: 'Resolved' }
+];
+
+export function ReconciliationAudit() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<ReconciliationFilters>({
+    resolver: zodResolver(reconciliationSchema),
+    defaultValues: {
+      ledger: 'Client trust',
+      periodStart: '2024-02-01',
+      periodEnd: '2024-02-29',
+      tolerance: 5
+    }
+  });
+
+  const onSubmit = (filters: ReconciliationFilters) => {
+    console.log('Reconciliation filters', filters);
+  };
+
+  const summary = useMemo(
+    () => ({
+      unmatched: 3,
+      cleared: 42,
+      variance: 187
+    }),
+    []
+  );
+
+  return (
+    <div className="container">
+      <h2 className="section-title">Reconciliation & audit</h2>
+      <p className="muted">
+        Run reconciliations, review audit hash chains, and export evidence packages for auditors.
+      </p>
+
+      <Card header={<h3>Reconciliation parameters</h3>}>
+        <form className="form-grid two-columns" onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormField id="ledger" label="Ledger" error={errors.ledger?.message}>
+            <Select id="ledger" {...register('ledger')}>
+              <option value="General">General ledger</option>
+              <option value="Client trust">Client trust</option>
+              <option value="Settlement">Settlement account</option>
+            </Select>
+          </FormField>
+
+          <FormField id="tolerance" label="Variance tolerance" error={errors.tolerance?.message}>
+            <Input id="tolerance" type="number" step="0.1" {...register('tolerance', { valueAsNumber: true })} />
+          </FormField>
+
+          <FormField id="periodStart" label="Start" error={errors.periodStart?.message}>
+            <Input id="periodStart" type="date" {...register('periodStart')} />
+          </FormField>
+
+          <FormField id="periodEnd" label="End" error={errors.periodEnd?.message}>
+            <Input id="periodEnd" type="date" {...register('periodEnd')} />
+          </FormField>
+
+          <div className="form-field" style={{ alignSelf: 'end' }}>
+            <Button type="submit">Run reconciliation</Button>
+          </div>
+        </form>
+      </Card>
+
+      <div className="grid">
+        <Card header={<h3>Ledger vs bank balance</h3>}>
+          <ResponsiveContainer width="100%" height={240}>
+            <LineChart data={chartData} aria-label="Ledger vs bank balance trend">
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="period" />
+              <YAxis />
+              <Tooltip />
+              <Line type="monotone" dataKey="ledgerBalance" stroke="#6366f1" name="Ledger" />
+              <Line type="monotone" dataKey="bankBalance" stroke="#22d3ee" name="Bank" />
+            </LineChart>
+          </ResponsiveContainer>
+        </Card>
+
+        <Card header={<h3>Variance summary</h3>}>
+          <ul>
+            <li>
+              <strong>{summary.unmatched}</strong> unmatched items
+            </li>
+            <li>
+              <strong>{summary.cleared}</strong> cleared during the period
+            </li>
+            <li>
+              <strong>${summary.variance}</strong> net variance
+            </li>
+          </ul>
+        </Card>
+      </div>
+
+      <Card header={<h3>Audit hash chain</h3>}>
+        <table className="table" aria-label="Hash chain viewer">
+          <thead>
+            <tr>
+              <th scope="col">Sequence</th>
+              <th scope="col">Hash</th>
+              <th scope="col">Previous hash</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hashChain.map((item) => (
+              <tr key={item.sequence}>
+                <td>{item.sequence}</td>
+                <td>
+                  <code>{item.hash}</code>
+                </td>
+                <td>
+                  <code>{item.previousHash}</code>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+
+      <Card header={<h3>Exceptions</h3>}>
+        <table className="table" aria-label="Reconciliation findings">
+          <thead>
+            <tr>
+              <th scope="col">Reference</th>
+              <th scope="col">Amount</th>
+              <th scope="col">Variance</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reconciliationFindings.map((item) => (
+              <tr key={item.reference}>
+                <td>{item.reference}</td>
+                <td>${item.amount.toLocaleString()}</td>
+                <td>{item.variance}</td>
+                <td>
+                  <span className="badge">{item.status}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/Settings.tsx
+++ b/apgms/webapp/src/routes/Settings.tsx
@@ -1,0 +1,79 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Card } from '../components/ui/card';
+import { FormField } from '../components/ui/form-field';
+import { Input } from '../components/ui/input';
+import { Select } from '../components/ui/select';
+import { Button } from '../components/ui/button';
+
+const notificationSchema = z.object({
+  timezone: z.string().min(1, 'Timezone required'),
+  locale: z.enum(['en-AU', 'en-NZ', 'en-UK']),
+  digestFrequency: z.enum(['Daily', 'Weekly', 'Monthly']),
+  accessibilityMode: z.boolean()
+});
+
+type SettingsForm = z.infer<typeof notificationSchema>;
+
+export function Settings() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<SettingsForm>({
+    resolver: zodResolver(notificationSchema),
+    defaultValues: {
+      timezone: 'Australia/Sydney',
+      locale: 'en-AU',
+      digestFrequency: 'Daily',
+      accessibilityMode: true
+    }
+  });
+
+  const onSubmit = (values: SettingsForm) => {
+    console.log('Settings saved', values);
+  };
+
+  return (
+    <div className="container">
+      <h2 className="section-title">Workspace settings</h2>
+      <p className="muted">Configure defaults for notifications, locale, and accessibility.</p>
+
+      <Card header={<h3>Notifications & locale</h3>}>
+        <form className="form-grid two-columns" onSubmit={handleSubmit(onSubmit)} noValidate>
+          <FormField id="timezone" label="Timezone" error={errors.timezone?.message}>
+            <Input id="timezone" {...register('timezone')} />
+          </FormField>
+
+          <FormField id="locale" label="Locale" error={errors.locale?.message}>
+            <Select id="locale" {...register('locale')}>
+              <option value="en-AU">English (Australia)</option>
+              <option value="en-NZ">English (New Zealand)</option>
+              <option value="en-UK">English (UK)</option>
+            </Select>
+          </FormField>
+
+          <FormField id="digestFrequency" label="Digest frequency" error={errors.digestFrequency?.message}>
+            <Select id="digestFrequency" {...register('digestFrequency')}>
+              <option value="Daily">Daily</option>
+              <option value="Weekly">Weekly</option>
+              <option value="Monthly">Monthly</option>
+            </Select>
+          </FormField>
+
+          <FormField id="accessibilityMode" label="Accessibility mode">
+            <label className="toggle" htmlFor="accessibilityMode">
+              <input id="accessibilityMode" type="checkbox" {...register('accessibilityMode')} />
+              <span>Enable high-contrast UI</span>
+            </label>
+          </FormField>
+
+          <div className="form-field" style={{ alignSelf: 'end' }}>
+            <Button type="submit">Save settings</Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/onboarding/OnboardingWizard.tsx
+++ b/apgms/webapp/src/routes/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,319 @@
+import { useMemo, useState } from 'react';
+import { FormProvider, useForm, useFormContext, useWatch, type UseFormRegister } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Button } from '../../components/ui/button';
+import { Card } from '../../components/ui/card';
+import { Input } from '../../components/ui/input';
+import { Textarea } from '../../components/ui/textarea';
+import { Select } from '../../components/ui/select';
+import { FormField } from '../../components/ui/form-field';
+
+const onboardingSchema = z.object({
+  organisationName: z.string().min(2, 'Organisation name is required'),
+  registrationNumber: z.string().min(3, 'Registration number is required'),
+  contactEmail: z.string().email('Provide a valid email'),
+  narrative: z.string().max(500).optional(),
+  basFrequency: z.enum(['Monthly', 'Quarterly', 'Annually'], {
+    required_error: 'Choose a BAS filing frequency'
+  }),
+  basDay: z.string().min(1, 'Provide due day of month'),
+  basTimezone: z.string().min(1, 'Timezone is required'),
+  connectors: z
+    .array(
+      z.object({
+        provider: z.string().min(1, 'Provider is required'),
+        status: z.enum(['pending', 'configured', 'needs-approval'])
+      })
+    )
+    .min(1, 'At least one connector is required')
+});
+
+type OnboardingFormValues = z.infer<typeof onboardingSchema>;
+
+const defaultValues: OnboardingFormValues = {
+  organisationName: '',
+  registrationNumber: '',
+  contactEmail: '',
+  narrative: '',
+  basFrequency: 'Monthly',
+  basDay: '21',
+  basTimezone: 'Australia/Sydney',
+  connectors: [
+    {
+      provider: 'Xero Accounting',
+      status: 'pending'
+    }
+  ]
+};
+
+type WizardStep = {
+  id: 'organisation' | 'bas' | 'connectors';
+  title: string;
+  description: string;
+};
+
+const steps: WizardStep[] = [
+  {
+    id: 'organisation',
+    title: 'Organisation profile',
+    description: 'Legal metadata and narrative used for attestations.'
+  },
+  {
+    id: 'bas',
+    title: 'BAS schedule',
+    description: 'Define the cadence of Business Activity Statements.'
+  },
+  {
+    id: 'connectors',
+    title: 'Connector readiness',
+    description: 'Document integrations required to fetch evidence.'
+  }
+];
+
+export function OnboardingWizard() {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const form = useForm<OnboardingFormValues>({
+    resolver: zodResolver(onboardingSchema),
+    mode: 'onBlur',
+    defaultValues
+  });
+
+  const currentStep = steps[currentStepIndex];
+  const errors = form.formState.errors;
+
+  const canContinue = useMemo(() => {
+    switch (currentStep.id) {
+      case 'organisation':
+        return (
+          !errors.organisationName &&
+          !errors.registrationNumber &&
+          !errors.contactEmail &&
+          form.watch('organisationName') !== '' &&
+          form.watch('registrationNumber') !== '' &&
+          form.watch('contactEmail') !== ''
+        );
+      case 'bas':
+        return !errors.basFrequency && !errors.basDay && !errors.basTimezone;
+      case 'connectors':
+        return !errors.connectors;
+      default:
+        return false;
+    }
+  }, [currentStep.id, errors, form]);
+
+  const goNext = () => setCurrentStepIndex((step) => Math.min(step + 1, steps.length - 1));
+  const goPrevious = () => setCurrentStepIndex((step) => Math.max(step - 1, 0));
+
+  const handleSubmit = (values: OnboardingFormValues) => {
+    console.table(values);
+  };
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="container" noValidate>
+        <header>
+          <h2 className="section-title">Onboarding wizard</h2>
+          <p className="muted">
+            Capture the organisation profile, BAS cycle, and integration inventory needed before
+            first reconciliation.
+          </p>
+        </header>
+
+        <ol className="wizard-progress" aria-label="Onboarding progress">
+          {steps.map((step, index) => (
+            <li
+              key={step.id}
+              className={
+                index === currentStepIndex ? 'active' : index < currentStepIndex ? 'complete' : ''
+              }
+            >
+              <span className="step-index" aria-hidden>
+                {index + 1}
+              </span>
+              <div>
+                <p className="step-title">{step.title}</p>
+                <p className="muted step-description">{step.description}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+
+        <Card>
+          {currentStep.id === 'organisation' && <OrganisationStep />}
+          {currentStep.id === 'bas' && <BasStep />}
+          {currentStep.id === 'connectors' && <ConnectorsStep />}
+        </Card>
+
+        <div className="wizard-actions">
+          <Button type="button" variant="ghost" onClick={goPrevious} disabled={currentStepIndex === 0}>
+            Back
+          </Button>
+          {currentStepIndex < steps.length - 1 ? (
+            <Button type="button" onClick={goNext} disabled={!canContinue}>
+              Continue
+            </Button>
+          ) : (
+            <Button type="submit">Submit onboarding</Button>
+          )}
+        </div>
+      </form>
+    </FormProvider>
+  );
+}
+
+function OrganisationStep() {
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext<OnboardingFormValues>();
+
+  return (
+    <div className="form-grid">
+      <FormField
+        id="organisationName"
+        label="Legal entity name"
+        error={errors.organisationName?.message}
+      >
+        <Input id="organisationName" {...register('organisationName')} placeholder="Birchal Pty Ltd" />
+      </FormField>
+
+      <FormField
+        id="registrationNumber"
+        label="ABN / ACN"
+        error={errors.registrationNumber?.message}
+      >
+        <Input
+          id="registrationNumber"
+          {...register('registrationNumber')}
+          placeholder="12 345 678 910"
+        />
+      </FormField>
+
+      <FormField id="contactEmail" label="Primary contact" error={errors.contactEmail?.message}>
+        <Input
+          id="contactEmail"
+          type="email"
+          {...register('contactEmail')}
+          placeholder="ops@birchal.com"
+        />
+      </FormField>
+
+      <FormField
+        id="narrative"
+        label="Control narrative"
+        description="Summarise onboarding scope for auditors"
+        error={errors.narrative?.message}
+      >
+        <Textarea
+          id="narrative"
+          {...register('narrative')}
+          rows={4}
+          placeholder="Outline roles, responsibilities, and any in-scope subsidiaries."
+        />
+      </FormField>
+    </div>
+  );
+}
+
+function BasStep() {
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext<OnboardingFormValues>();
+
+  return (
+    <div className="form-grid two-columns">
+      <FormField id="basFrequency" label="Filing frequency" error={errors.basFrequency?.message}>
+        <Select id="basFrequency" {...register('basFrequency')}>
+          <option value="Monthly">Monthly</option>
+          <option value="Quarterly">Quarterly</option>
+          <option value="Annually">Annually</option>
+        </Select>
+      </FormField>
+
+      <FormField id="basDay" label="Due day" error={errors.basDay?.message}>
+        <Input id="basDay" type="number" min={1} max={31} {...register('basDay')} />
+      </FormField>
+
+      <FormField
+        id="basTimezone"
+        label="Timezone"
+        description="Used when generating lodgement reminders"
+        error={errors.basTimezone?.message}
+      >
+        <Input id="basTimezone" {...register('basTimezone')} placeholder="Australia/Sydney" />
+      </FormField>
+    </div>
+  );
+}
+
+function ConnectorsStep() {
+  const {
+    register,
+    control,
+    formState: { errors }
+  } = useFormContext<OnboardingFormValues>();
+  const connectors = useWatch({ control, name: 'connectors' });
+  const connectorErrors = errors.connectors as
+    | Array<ConnectorFieldError | undefined>
+    | undefined;
+
+  return (
+    <div className="form-grid">
+      {connectors?.map((connector, index) => (
+        <ConnectorCard
+          key={`${connector.provider}-${index}`}
+          index={index}
+          status={connector.status}
+          register={register}
+          errors={connectorErrors?.[index]}
+        />
+      ))}
+
+      {typeof errors.connectors?.message === 'string' && (
+        <p role="alert" className="error-text">
+          {errors.connectors.message}
+        </p>
+      )}
+
+      <p className="muted">
+        Add additional connector stubs for payroll, payments, and ERP systems once integration briefs
+        are agreed.
+      </p>
+    </div>
+  );
+}
+
+type ConnectorFieldError = Partial<Record<'provider' | 'status', { message?: string }>>;
+
+interface ConnectorCardProps {
+  index: number;
+  status: string;
+  register: UseFormRegister<OnboardingFormValues>;
+  errors?: ConnectorFieldError;
+}
+
+function ConnectorCard({ index, status, register, errors }: ConnectorCardProps) {
+  const providerId = `connector-${index}-provider`;
+  const statusId = `connector-${index}-status`;
+
+  return (
+    <Card
+      header={<h3>Connector {index + 1}</h3>}
+      footer={<span className="badge">{status.replace('-', ' ')}</span>}
+    >
+      <FormField id={providerId} label="Provider" error={errors?.provider?.message}>
+        <Input {...register(`connectors.${index}.provider` as const)} placeholder="Xero Accounting" />
+      </FormField>
+
+      <FormField id={statusId} label="Status" error={errors?.status?.message}>
+        <Select {...register(`connectors.${index}.status` as const)}>
+          <option value="pending">Pending</option>
+          <option value="configured">Configured</option>
+          <option value="needs-approval">Needs approval</option>
+        </Select>
+      </FormField>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add router-driven console with onboarding wizard capturing organisation details, BAS schedule, and connector placeholders
- implement designated accounts, allocations & gates, reconciliation/audit, anomaly inbox, and settings screens backed by react-hook-form + zod validation
- introduce lightweight shadcn-style UI primitives, layout shell, and dashboard styling with accessible semantics and recharts visualisation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f31c65789c8327b1c1250d54f32d58