### PR TITLE
feat(api): add SBR dev client with audit logging

### DIFF
--- a/apgms/apps/api/package.json
+++ b/apgms/apps/api/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@apgms/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev:replay": "tsx src/dev/replay.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.1"
+  }
+}

--- a/apgms/apps/api/src/config.ts
+++ b/apgms/apps/api/src/config.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const booleanFromEnv = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) {
+    return fallback;
+  }
+  return /^(true|1|yes)$/i.test(value);
+};
+
+const configSchema = z.object({
+  nodeEnv: z.enum(["development", "test", "production"]).default("development"),
+  sbr: z.object({
+    endpoint: z.string().url(),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    fromPartyId: z.string().min(1),
+    toPartyId: z.string().min(1),
+    service: z.string().min(1),
+    action: z.string().min(1),
+    replyTo: z.string().url().optional(),
+    mockResponses: z.boolean(),
+  }),
+});
+
+export type AppConfig = z.infer<typeof configSchema>;
+export type SbrConfig = AppConfig["sbr"];
+
+export const loadConfig = (env: NodeJS.ProcessEnv = process.env): AppConfig => {
+  const nodeEnv = env.NODE_ENV ?? "development";
+  const isDevLike = nodeEnv === "development" || nodeEnv === "test";
+
+  const resolved = configSchema.parse({
+    nodeEnv,
+    sbr: {
+      endpoint: env.SBR_ENDPOINT ?? (isDevLike ? "https://sandbox.sbr.gov.au/as4" : undefined),
+      username: env.SBR_USERNAME ?? (isDevLike ? "dev-user" : undefined),
+      password: env.SBR_PASSWORD ?? (isDevLike ? "dev-password" : undefined),
+      fromPartyId: env.SBR_FROM_PARTY_ID ?? (isDevLike ? "DEV-FROM" : undefined),
+      toPartyId: env.SBR_TO_PARTY_ID ?? (isDevLike ? "DEV-TO" : undefined),
+      service: env.SBR_SERVICE ?? "SubmitDocument",
+      action: env.SBR_ACTION ?? "Submit",
+      replyTo: env.SBR_REPLY_TO,
+      mockResponses: booleanFromEnv(env.SBR_MOCK_RESPONSES, isDevLike),
+    },
+  });
+
+  return resolved;
+};
+
+export const config = loadConfig();

--- a/apgms/apps/api/src/dev/replay.ts
+++ b/apgms/apps/api/src/dev/replay.ts
@@ -1,0 +1,24 @@
+import { SbrClient } from "../services/sbr-client";
+import { config } from "../config";
+
+const samplePayload = `<Ping>
+  <Message>Developer replay payload</Message>
+</Ping>`;
+
+async function main(): Promise<void> {
+  const client = new SbrClient();
+  const result = await client.submitDocument({ payload: samplePayload });
+
+  console.log("SBR dev replay complete:");
+  console.log(JSON.stringify({
+    endpoint: config.sbr.endpoint,
+    messageId: result.messageId,
+    conversationId: result.conversationId,
+    simulated: result.simulated,
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error("Replay failed", error);
+  process.exitCode = 1;
+});

--- a/apgms/apps/api/src/services/sbr-client.ts
+++ b/apgms/apps/api/src/services/sbr-client.ts
@@ -1,0 +1,270 @@
+import { randomUUID } from "node:crypto";
+import type { AppConfig, SbrConfig } from "../config";
+import { config as appConfig } from "../config";
+import { prisma } from "@apgms/shared/src/db";
+
+export type AuditBlobDirection = "request" | "response";
+
+export interface AuditBlobInput {
+  correlationId?: string;
+  direction: AuditBlobDirection;
+  endpoint: string;
+  messageId: string;
+  payload: string;
+  payloadType: string;
+}
+
+export interface AuditBlobRepository {
+  save(input: AuditBlobInput): Promise<void>;
+}
+
+export class PrismaAuditBlobRepository implements AuditBlobRepository {
+  async save(input: AuditBlobInput): Promise<void> {
+    await (prisma as unknown as { auditBlob: { create: (args: { data: unknown }) => Promise<void> } }).auditBlob.create({
+      data: {
+        correlationId: input.correlationId ?? null,
+        direction: input.direction,
+        endpoint: input.endpoint,
+        messageId: input.messageId,
+        payload: input.payload,
+        payloadType: input.payloadType,
+      },
+    });
+  }
+}
+
+export interface SubmitDocumentOptions {
+  payload: string;
+  correlationId?: string;
+  conversationId?: string;
+  documentType?: string;
+}
+
+export interface SubmitDocumentResult {
+  messageId: string;
+  conversationId: string;
+  receipt: string;
+  simulated: boolean;
+}
+
+export interface SbrClientDependencies {
+  auditRepository?: AuditBlobRepository;
+  fetchImpl?: typeof fetch;
+  clock?: () => Date;
+  uuid?: () => string;
+  config?: AppConfig;
+}
+
+const SOAP_ENV = "http://schemas.xmlsoap.org/soap/envelope/";
+const EBMS_NS = "http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/";
+const WSSE_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+const WSU_NS = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+
+const defaultConfig = appConfig;
+
+export class SbrClient {
+  private readonly auditRepository: AuditBlobRepository;
+  private readonly fetchImpl: typeof fetch;
+  private readonly clock: () => Date;
+  private readonly uuid: () => string;
+  private readonly config: AppConfig;
+
+  constructor(deps: SbrClientDependencies = {}) {
+    this.auditRepository = deps.auditRepository ?? new PrismaAuditBlobRepository();
+    this.fetchImpl = deps.fetchImpl ?? fetch.bind(globalThis);
+    this.clock = deps.clock ?? (() => new Date());
+    this.uuid = deps.uuid ?? (() => randomUUID());
+    this.config = deps.config ?? defaultConfig;
+  }
+
+  async submitDocument(options: SubmitDocumentOptions): Promise<SubmitDocumentResult> {
+    const messageId = this.uuid();
+    const conversationId = options.conversationId ?? messageId;
+    const timestamp = this.clock().toISOString();
+    const sbrConfig = this.config.sbr;
+
+    const envelope = buildAs4Envelope({
+      payload: options.payload,
+      messageId,
+      conversationId,
+      timestamp,
+      documentType: options.documentType ?? sbrConfig.service,
+      sbr: sbrConfig,
+    });
+
+    await this.auditRepository.save({
+      correlationId: options.correlationId ?? conversationId,
+      direction: "request",
+      endpoint: sbrConfig.endpoint,
+      messageId,
+      payload: envelope,
+      payloadType: "application/soap+xml",
+    });
+
+    if (sbrConfig.mockResponses) {
+      const simulated = buildSimulatedResponse({
+        conversationId,
+        messageId,
+        timestamp,
+        receiptId: this.uuid(),
+        sbr: sbrConfig,
+      });
+
+      await this.auditRepository.save({
+        correlationId: options.correlationId ?? conversationId,
+        direction: "response",
+        endpoint: sbrConfig.endpoint,
+        messageId,
+        payload: simulated.receipt,
+        payloadType: "application/soap+xml",
+      });
+
+      return { ...simulated, simulated: true };
+    }
+
+    const response = await this.fetchImpl(sbrConfig.endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/soap+xml; charset=utf-8",
+        Authorization: `Basic ${Buffer.from(`${sbrConfig.username}:${sbrConfig.password}`).toString("base64")}`,
+      },
+      body: envelope,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`SBR gateway responded with ${response.status}: ${text}`);
+    }
+
+    const receipt = await response.text();
+
+    await this.auditRepository.save({
+      correlationId: options.correlationId ?? conversationId,
+      direction: "response",
+      endpoint: sbrConfig.endpoint,
+      messageId,
+      payload: receipt,
+      payloadType: response.headers.get("content-type") ?? "application/soap+xml",
+    });
+
+    return {
+      messageId,
+      conversationId,
+      receipt,
+      simulated: false,
+    };
+  }
+}
+
+interface EnvelopeParams {
+  payload: string;
+  messageId: string;
+  conversationId: string;
+  timestamp: string;
+  documentType: string;
+  sbr: SbrConfig;
+}
+
+const escapeXml = (input: string): string =>
+  input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+
+const buildAs4Envelope = (params: EnvelopeParams): string => {
+  const { payload, messageId, conversationId, timestamp, documentType, sbr } = params;
+  const replyTo = sbr.replyTo ? `<eb:ReceiptReplyTo>${escapeXml(sbr.replyTo)}</eb:ReceiptReplyTo>` : "";
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="${SOAP_ENV}" xmlns:eb="${EBMS_NS}" xmlns:wsse="${WSSE_NS}" xmlns:wsu="${WSU_NS}">
+  <soap:Header>
+    <eb:Messaging soap:mustUnderstand="true">
+      <eb:UserMessage>
+        <eb:MessageInfo>
+          <eb:Timestamp>${timestamp}</eb:Timestamp>
+          <eb:MessageId>${messageId}</eb:MessageId>
+          <eb:RefToMessageId>${conversationId}</eb:RefToMessageId>
+        </eb:MessageInfo>
+        <eb:PartyInfo>
+          <eb:From>
+            <eb:PartyId>${escapeXml(sbr.fromPartyId)}</eb:PartyId>
+          </eb:From>
+          <eb:To>
+            <eb:PartyId>${escapeXml(sbr.toPartyId)}</eb:PartyId>
+          </eb:To>
+        </eb:PartyInfo>
+        <eb:CollaborationInfo>
+          <eb:Service>${escapeXml(documentType)}</eb:Service>
+          <eb:Action>${escapeXml(sbr.action)}</eb:Action>
+          <eb:ConversationId>${conversationId}</eb:ConversationId>
+        </eb:CollaborationInfo>
+        <eb:PayloadInfo>
+          <eb:PartInfo href="#payload">
+            <eb:PartProperties>
+              <eb:Property name="MimeType">application/xml</eb:Property>
+            </eb:PartProperties>
+          </eb:PartInfo>
+        </eb:PayloadInfo>
+        ${replyTo}
+      </eb:UserMessage>
+    </eb:Messaging>
+    <wsse:Security soap:mustUnderstand="true">
+      <wsu:Timestamp>
+        <wsu:Created>${timestamp}</wsu:Created>
+        <wsu:Expires>${new Date(new Date(timestamp).getTime() + 5 * 60_000).toISOString()}</wsu:Expires>
+      </wsu:Timestamp>
+    </wsse:Security>
+  </soap:Header>
+  <soap:Body>
+    <eb:PayloadData wsu:Id="payload">${payload}</eb:PayloadData>
+  </soap:Body>
+</soap:Envelope>`;
+};
+
+interface SimulatedResponseParams {
+  conversationId: string;
+  messageId: string;
+  timestamp: string;
+  receiptId: string;
+  sbr: SbrConfig;
+}
+
+const buildSimulatedResponse = (params: SimulatedResponseParams): SubmitDocumentResult => {
+  const { conversationId, messageId, timestamp, receiptId, sbr } = params;
+  const receipt = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="${SOAP_ENV}" xmlns:eb="${EBMS_NS}">
+  <soap:Header>
+    <eb:Messaging>
+      <eb:SignalMessage>
+        <eb:MessageInfo>
+          <eb:Timestamp>${timestamp}</eb:Timestamp>
+          <eb:MessageId>${receiptId}</eb:MessageId>
+          <eb:RefToMessageId>${messageId}</eb:RefToMessageId>
+        </eb:MessageInfo>
+        <eb:Receipt>
+          <eb:MessageId>${messageId}</eb:MessageId>
+          <eb:ConversationId>${conversationId}</eb:ConversationId>
+          <eb:Status>ACCEPTED</eb:Status>
+        </eb:Receipt>
+      </eb:SignalMessage>
+    </eb:Messaging>
+  </soap:Header>
+  <soap:Body>
+    <eb:ReceiptAcknowledgement>Simulated response for ${escapeXml(sbr.endpoint)}</eb:ReceiptAcknowledgement>
+  </soap:Body>
+</soap:Envelope>`;
+
+  return {
+    messageId,
+    conversationId,
+    receipt,
+    simulated: true,
+  };
+};
+
+export const __private__ = {
+  buildAs4Envelope,
+  buildSimulatedResponse,
+};

--- a/apgms/apps/api/test/sbr-client.test.ts
+++ b/apgms/apps/api/test/sbr-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { SbrClient } from "../src/services/sbr-client";
+import type { AuditBlobInput, AuditBlobRepository } from "../src/services/sbr-client";
+import type { AppConfig } from "../src/config";
+
+class InMemoryAuditRepository implements AuditBlobRepository {
+  public readonly entries: AuditBlobInput[] = [];
+
+  async save(input: AuditBlobInput): Promise<void> {
+    this.entries.push(input);
+  }
+}
+
+describe("SbrClient (development replay)", () => {
+  const baseConfig: AppConfig = {
+    nodeEnv: "development",
+    sbr: {
+      endpoint: "https://sandbox.sbr.gov.au/mock",
+      username: "dev-user",
+      password: "dev-password",
+      fromPartyId: "FROM",
+      toPartyId: "TO",
+      service: "SubmitDocument",
+      action: "Submit",
+      replyTo: "https://listener.example.com/reply",
+      mockResponses: true,
+    },
+  };
+
+  it("persists request and simulated response payloads", async () => {
+    const repo = new InMemoryAuditRepository();
+    const ids = ["MSG-001", "RCPT-001"];
+    const uuid = () => ids.shift() ?? "overflow";
+    const clock = () => new Date("2024-07-09T05:00:00.000Z");
+
+    const client = new SbrClient({
+      auditRepository: repo,
+      uuid,
+      clock,
+      config: baseConfig,
+    });
+
+    const result = await client.submitDocument({
+      payload: "<Invoice>42</Invoice>",
+    });
+
+    expect(result.simulated).toBe(true);
+    expect(result.messageId).toBe("MSG-001");
+    expect(result.conversationId).toBe("MSG-001");
+    expect(result.receipt).toContain("Simulated response for https://sandbox.sbr.gov.au/mock");
+
+    expect(repo.entries).toHaveLength(2);
+
+    const [request, response] = repo.entries;
+    expect(request.direction).toBe("request");
+    expect(request.payloadType).toBe("application/soap+xml");
+    expect(request.payload).toContain("<Invoice>42</Invoice>");
+    expect(request.payload).toContain("<eb:MessageId>MSG-001</eb:MessageId>");
+    expect(request.payload).toContain("<eb:ReceiptReplyTo>https://listener.example.com/reply</eb:ReceiptReplyTo>");
+
+    expect(response.direction).toBe("response");
+    expect(response.payloadType).toBe("application/soap+xml");
+    expect(response.payload).toContain("<eb:Status>ACCEPTED</eb:Status>");
+    expect(response.payload).toContain("<eb:RefToMessageId>MSG-001</eb:RefToMessageId>");
+  });
+});

--- a/apgms/apps/api/tsconfig.json
+++ b/apgms/apps/api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src", "test"]
+}

--- a/apgms/apps/api/vitest.config.ts
+++ b/apgms/apps/api/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "json", "html"]
+    }
+  }
+});

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - services/*
+  - apps/*
   - webapp
   - shared
   - worker

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -34,3 +34,19 @@ model BankLine {
   desc      String
   createdAt DateTime @default(now())
 }
+
+model AuditBlob {
+  id            String            @id @default(cuid())
+  createdAt     DateTime          @default(now())
+  direction     AuditBlobDirection
+  endpoint      String
+  messageId     String
+  correlationId String?
+  payloadType   String
+  payload       String
+}
+
+enum AuditBlobDirection {
+  request
+  response
+}


### PR DESCRIPTION
## Summary
- add an SBR AS4 client that builds envelopes and logs request/response payloads through Prisma
- introduce validated configuration surfaces for SBR credentials and endpoints
- wire up a dev replay harness and vitest coverage to exercise envelope construction and audit persistence

## Testing
- pnpm install *(fails: registry returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f31c67e880832792c74fac229c7869