### PR TITLE
feat(api): add gate orchestrator mocks and api

### DIFF
--- a/apgms/apps/api/package.json
+++ b/apgms/apps/api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apgms/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/apps/api/src/index.ts
+++ b/apgms/apps/api/src/index.ts
@@ -1,0 +1,105 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+
+import { MockBecs, MockPayTo } from "./rails";
+import {
+  GateOrchestrator,
+  GateOrchestratorSnapshot,
+} from "./services/gate-orchestrator";
+
+const app = Fastify({ logger: true });
+
+const orchestrator = new GateOrchestrator({
+  pollIntervalMs: 400,
+  adapters: [new MockPayTo(), new MockBecs()],
+  gates: [
+    { id: "payto-gate", label: "PayTo instant gate", rail: "payto", initiallyOpen: true },
+    { id: "becs-gate", label: "BECS batch gate", rail: "becs", initiallyOpen: false },
+  ],
+});
+
+orchestrator.start();
+
+orchestrator.on("audit", (entry) => {
+  app.log.info({ audit: entry }, "audit");
+});
+
+await app.register(cors, { origin: true });
+
+app.get("/health", async () => ({ ok: true, service: "api" }));
+
+app.get("/status", async (): Promise<GateOrchestratorSnapshot> => orchestrator.getSnapshot());
+
+app.get("/gates", async () => ({ gates: orchestrator.getSnapshot().gates }));
+
+app.post<{ Params: { gateId: string } }>(
+  "/gates/:gateId/open",
+  async (request, reply) => {
+    try {
+      const gate = orchestrator.setGateOpen(request.params.gateId, true);
+      return reply.code(200).send({ gate });
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(404).send({ error: "gate_not_found" });
+    }
+  },
+);
+
+app.post<{ Params: { gateId: string } }>(
+  "/gates/:gateId/close",
+  async (request, reply) => {
+    try {
+      const gate = orchestrator.setGateOpen(request.params.gateId, false);
+      return reply.code(200).send({ gate });
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(404).send({ error: "gate_not_found" });
+    }
+  },
+);
+
+app.get("/remittances", async () => ({ remittances: orchestrator.getSnapshot().remittances }));
+
+app.post("/remittances", async (request, reply) => {
+  const body = request.body as Record<string, unknown> | undefined;
+  const gateId = typeof body?.gateId === "string" ? body.gateId : undefined;
+  const currency = typeof body?.currency === "string" ? body.currency : undefined;
+  const beneficiaryName =
+    typeof body?.beneficiaryName === "string" ? body.beneficiaryName : undefined;
+  const amount = typeof body?.amount === "number" ? body.amount : Number(body?.amount);
+  const description = typeof body?.description === "string" ? body.description : undefined;
+  const metadataValue = body?.metadata;
+  const metadata =
+    typeof metadataValue === "object" && metadataValue !== null && !Array.isArray(metadataValue)
+      ? (metadataValue as Record<string, unknown>)
+      : undefined;
+
+  if (!gateId || !currency || !beneficiaryName || !Number.isFinite(amount)) {
+    return reply.code(400).send({ error: "invalid_payload" });
+  }
+
+  try {
+    const remittance = orchestrator.createPendingRemittance({
+      gateId,
+      amount,
+      currency,
+      beneficiaryName,
+      description,
+      metadata,
+    });
+    return reply.code(201).send({ remittance });
+  } catch (error) {
+    request.log.error(error);
+    return reply.code(404).send({ error: "gate_not_found" });
+  }
+});
+
+app.get("/audits", async () => ({ audits: orchestrator.getAuditLog() }));
+
+const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((error) => {
+  app.log.error(error);
+  process.exit(1);
+});

--- a/apgms/apps/api/src/rails/index.ts
+++ b/apgms/apps/api/src/rails/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./mock-payto";
+export * from "./mock-becs";

--- a/apgms/apps/api/src/rails/mock-becs.ts
+++ b/apgms/apps/api/src/rails/mock-becs.ts
@@ -1,0 +1,58 @@
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  RailAdapter,
+  RailLifecycleCallbacks,
+  RailCode,
+  RemittanceInstruction,
+} from "./types";
+
+export class MockBecs implements RailAdapter {
+  readonly id = "mock-becs";
+  readonly rail: RailCode = "becs";
+
+  constructor(
+    private readonly config: {
+      initiationDelayMs?: number;
+      settlementDelayMs?: number;
+      failureAmountThreshold?: number;
+    } = {},
+  ) {}
+
+  async initiate(
+    remittance: RemittanceInstruction,
+    callbacks: RailLifecycleCallbacks,
+  ): Promise<void> {
+    const initiationDelay = this.config.initiationDelayMs ?? 250;
+    const settlementDelay = this.config.settlementDelayMs ?? 1_200;
+    const failureThreshold = this.config.failureAmountThreshold ?? 75_000;
+
+    await delay(initiationDelay);
+
+    callbacks.onInitiated({
+      remittanceId: remittance.id,
+      initiatedAt: new Date(),
+      reference: `BECS-${remittance.id.slice(0, 6).toUpperCase()}`,
+      raw: {
+        rail: this.rail,
+        lodgementReference: remittance.description ?? "",
+      },
+    });
+
+    setTimeout(() => {
+      if (remittance.amount >= failureThreshold) {
+        callbacks.onFailed({
+          remittanceId: remittance.id,
+          failedAt: new Date(),
+          reason: `Amount ${remittance.amount.toFixed(2)} exceeds BECS mock limit`,
+        });
+        return;
+      }
+
+      callbacks.onSettled({
+        remittanceId: remittance.id,
+        settledAt: new Date(),
+        receipt: `BECS-RCT-${remittance.id.slice(-5).toUpperCase()}`,
+      });
+    }, settlementDelay);
+  }
+}

--- a/apgms/apps/api/src/rails/mock-payto.ts
+++ b/apgms/apps/api/src/rails/mock-payto.ts
@@ -1,0 +1,48 @@
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  RailAdapter,
+  RailLifecycleCallbacks,
+  RailCode,
+  RemittanceInstruction,
+} from "./types";
+
+export class MockPayTo implements RailAdapter {
+  readonly id = "mock-payto";
+  readonly rail: RailCode = "payto";
+
+  constructor(
+    private readonly config: {
+      initiationDelayMs?: number;
+      settlementDelayMs?: number;
+    } = {},
+  ) {}
+
+  async initiate(
+    remittance: RemittanceInstruction,
+    callbacks: RailLifecycleCallbacks,
+  ): Promise<void> {
+    const initiationDelay = this.config.initiationDelayMs ?? 75;
+    const settlementDelay = this.config.settlementDelayMs ?? 400;
+
+    await delay(initiationDelay);
+
+    callbacks.onInitiated({
+      remittanceId: remittance.id,
+      initiatedAt: new Date(),
+      reference: `PAYTO-${remittance.id.slice(0, 8).toUpperCase()}`,
+      raw: {
+        rail: this.rail,
+        beneficiaryName: remittance.beneficiaryName,
+        amount: remittance.amount,
+      },
+    });
+
+    setTimeout(() => {
+      callbacks.onSettled({
+        remittanceId: remittance.id,
+        settledAt: new Date(),
+        receipt: `PAYTO-RCPT-${remittance.id.slice(-6).toUpperCase()}`,
+      });
+    }, settlementDelay);
+  }
+}

--- a/apgms/apps/api/src/rails/types.ts
+++ b/apgms/apps/api/src/rails/types.ts
@@ -1,0 +1,48 @@
+export type RailCode = "payto" | "becs";
+
+export interface RemittanceInstruction {
+  id: string;
+  gateId: string;
+  rail: RailCode;
+  amount: number;
+  currency: string;
+  beneficiaryName: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface RemittanceInitiatedEvent {
+  remittanceId: string;
+  initiatedAt: Date;
+  reference: string;
+  raw?: Record<string, unknown>;
+}
+
+export interface RemittanceSettledEvent {
+  remittanceId: string;
+  settledAt: Date;
+  receipt?: string;
+}
+
+export interface RemittanceFailedEvent {
+  remittanceId: string;
+  failedAt: Date;
+  reason: string;
+}
+
+export interface RailLifecycleCallbacks {
+  onInitiated: (event: RemittanceInitiatedEvent) => void;
+  onSettled: (event: RemittanceSettledEvent) => void;
+  onFailed: (event: RemittanceFailedEvent) => void;
+}
+
+export interface RailAdapter {
+  readonly id: string;
+  readonly rail: RailCode;
+  initiate: (
+    remittance: RemittanceInstruction,
+    callbacks: RailLifecycleCallbacks,
+  ) => Promise<void>;
+  cancel?: (remittanceId: string) => Promise<void>;
+}

--- a/apgms/apps/api/src/services/gate-orchestrator.ts
+++ b/apgms/apps/api/src/services/gate-orchestrator.ts
@@ -1,0 +1,409 @@
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import {
+  RailAdapter,
+  RailCode,
+  RailLifecycleCallbacks,
+  RemittanceInstruction,
+} from "../rails";
+
+export type RemittanceStatus =
+  | "pending"
+  | "initiating"
+  | "initiated"
+  | "settled"
+  | "failed";
+
+export interface RemittanceHistoryEntry {
+  status: RemittanceStatus;
+  at: Date;
+  note?: string;
+}
+
+export interface RemittanceRecord extends RemittanceInstruction {
+  status: RemittanceStatus;
+  updatedAt: Date;
+  reference?: string;
+  receipt?: string;
+  failureReason?: string;
+  history: RemittanceHistoryEntry[];
+}
+
+export interface GateConfig {
+  id: string;
+  label: string;
+  rail: RailCode;
+  initiallyOpen?: boolean;
+}
+
+export interface GateState extends GateConfig {
+  isOpen: boolean;
+  lastChangedAt: Date;
+}
+
+export type AuditEntryType =
+  | "gate.opened"
+  | "gate.closed"
+  | "remittance.created"
+  | "remittance.initiated"
+  | "remittance.settled"
+  | "remittance.failed";
+
+export interface AuditEntry {
+  id: string;
+  occurredAt: Date;
+  type: AuditEntryType;
+  message: string;
+  gateId?: string;
+  remittanceId?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface GateOrchestratorOptions {
+  gates: GateConfig[];
+  adapters: RailAdapter[];
+  pollIntervalMs?: number;
+}
+
+export interface CreateRemittanceInput {
+  gateId: string;
+  amount: number;
+  currency: string;
+  beneficiaryName: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GateOrchestratorSnapshot {
+  gates: GateState[];
+  remittances: RemittanceRecord[];
+  audits: AuditEntry[];
+}
+
+type GateOrchestratorEvents = {
+  audit: (entry: AuditEntry) => void;
+  "remittance:updated": (record: RemittanceRecord) => void;
+};
+
+type EventKeys = keyof GateOrchestratorEvents;
+
+export class GateOrchestrator extends EventEmitter {
+  private readonly gates = new Map<string, GateState>();
+  private readonly remittances = new Map<string, RemittanceRecord>();
+  private readonly adapters = new Map<RailCode, RailAdapter>();
+  private readonly auditLog: AuditEntry[] = [];
+  private readonly pollIntervalMs: number;
+  private timer?: NodeJS.Timeout;
+
+  constructor(options: GateOrchestratorOptions) {
+    super();
+    this.pollIntervalMs = options.pollIntervalMs ?? 500;
+
+    for (const adapter of options.adapters) {
+      this.adapters.set(adapter.rail, adapter);
+    }
+
+    const now = new Date();
+    for (const gate of options.gates) {
+      const state: GateState = {
+        ...gate,
+        isOpen: Boolean(gate.initiallyOpen),
+        lastChangedAt: now,
+      };
+      this.gates.set(gate.id, state);
+    }
+  }
+
+  override on<T extends EventKeys>(eventName: T, listener: GateOrchestratorEvents[T]): this {
+    return super.on(eventName, listener as any);
+  }
+
+  override once<T extends EventKeys>(eventName: T, listener: GateOrchestratorEvents[T]): this {
+    return super.once(eventName, listener as any);
+  }
+
+  override off<T extends EventKeys>(eventName: T, listener: GateOrchestratorEvents[T]): this {
+    return super.off(eventName, listener as any);
+  }
+
+  start(): void {
+    if (!this.timer) {
+      this.timer = setInterval(() => {
+        void this.tick();
+      }, this.pollIntervalMs);
+    }
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  createPendingRemittance(input: CreateRemittanceInput): RemittanceRecord {
+    const gate = this.getGateOrThrow(input.gateId);
+    const id = randomUUID();
+    const createdAt = new Date();
+    const remittance: RemittanceRecord = {
+      id,
+      gateId: gate.id,
+      rail: gate.rail,
+      amount: input.amount,
+      currency: input.currency,
+      beneficiaryName: input.beneficiaryName,
+      description: input.description,
+      metadata: input.metadata,
+      createdAt,
+      status: "pending",
+      updatedAt: createdAt,
+      history: [
+        {
+          status: "pending",
+          at: createdAt,
+          note: "remittance enqueued",
+        },
+      ],
+    };
+
+    this.remittances.set(remittance.id, remittance);
+    this.recordAudit("remittance.created", `Pending remittance ${remittance.id} created`, {
+      remittanceId: remittance.id,
+      gateId: gate.id,
+      amount: remittance.amount,
+      currency: remittance.currency,
+    });
+
+    void this.triggerIfOpen(remittance);
+
+    return cloneRemittance(remittance);
+  }
+
+  setGateOpen(gateId: string, open: boolean): GateState {
+    const gate = this.getGateOrThrow(gateId);
+    if (gate.isOpen === open) {
+      return cloneGate(gate);
+    }
+
+    gate.isOpen = open;
+    gate.lastChangedAt = new Date();
+    this.recordAudit(open ? "gate.opened" : "gate.closed", `${gate.label} gate ${open ? "opened" : "closed"}`, {
+      gateId: gate.id,
+    });
+
+    if (open) {
+      for (const remittance of this.remittances.values()) {
+        if (remittance.gateId === gate.id && remittance.status === "pending") {
+          void this.triggerIfOpen(remittance);
+        }
+      }
+    }
+
+    return cloneGate(gate);
+  }
+
+  getGateState(gateId: string): GateState {
+    return cloneGate(this.getGateOrThrow(gateId));
+  }
+
+  getSnapshot(): GateOrchestratorSnapshot {
+    return {
+      gates: Array.from(this.gates.values()).map((gate) => cloneGate(gate)),
+      remittances: Array.from(this.remittances.values()).map((remittance) =>
+        cloneRemittance(remittance),
+      ),
+      audits: [...this.auditLog],
+    };
+  }
+
+  getAuditLog(): AuditEntry[] {
+    return [...this.auditLog];
+  }
+
+  private async tick(): Promise<void> {
+    for (const gate of this.gates.values()) {
+      if (!gate.isOpen) {
+        continue;
+      }
+
+      for (const remittance of this.remittances.values()) {
+        if (remittance.gateId !== gate.id) {
+          continue;
+        }
+        if (remittance.status !== "pending") {
+          continue;
+        }
+        await this.triggerIfOpen(remittance);
+      }
+    }
+  }
+
+  private async triggerIfOpen(remittance: RemittanceRecord): Promise<void> {
+    const gate = this.getGateOrThrow(remittance.gateId);
+    if (!gate.isOpen) {
+      return;
+    }
+
+    if (remittance.status !== "pending") {
+      return;
+    }
+
+    const adapter = this.adapters.get(gate.rail);
+    if (!adapter) {
+      this.failRemittance(remittance.id, "No adapter is registered for the gate's rail");
+      return;
+    }
+
+    this.updateRemittance(remittance.id, "initiating", {
+      note: `Sending remittance to ${adapter.id}`,
+    });
+
+    try {
+      await adapter.initiate(remittance, this.createLifecycleCallbacks(remittance.id));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "Unknown adapter error";
+      this.failRemittance(remittance.id, reason);
+    }
+  }
+
+  private createLifecycleCallbacks(remittanceId: string): RailLifecycleCallbacks {
+    return {
+      onInitiated: (event) => {
+        this.updateRemittance(remittanceId, "initiated", {
+          note: `Rail reference ${event.reference}`,
+          extra: { reference: event.reference, initiatedAt: event.initiatedAt },
+          at: event.initiatedAt,
+        });
+        const remittance = this.remittances.get(remittanceId);
+        if (remittance) {
+          remittance.reference = event.reference;
+        }
+        this.recordAudit(
+          "remittance.initiated",
+          `Remittance ${remittanceId} initiated on rail ${event.reference}`,
+          {
+            remittanceId,
+            reference: event.reference,
+          },
+        );
+      },
+      onSettled: (event) => {
+        this.updateRemittance(remittanceId, "settled", {
+          note: "Rail marked remittance as settled",
+          extra: { settledAt: event.settledAt, receipt: event.receipt },
+          at: event.settledAt,
+        });
+        const settledRemittance = this.remittances.get(remittanceId);
+        if (settledRemittance) {
+          settledRemittance.receipt = event.receipt;
+        }
+        this.recordAudit("remittance.settled", `Remittance ${remittanceId} settled`, {
+          remittanceId,
+          receipt: event.receipt,
+        });
+      },
+      onFailed: (event) => {
+        this.updateRemittance(remittanceId, "failed", {
+          note: "Rail reported remittance failure",
+          extra: { reason: event.reason, failedAt: event.failedAt },
+          at: event.failedAt,
+        });
+        const failedRemittance = this.remittances.get(remittanceId);
+        if (failedRemittance) {
+          failedRemittance.failureReason = event.reason;
+        }
+        this.recordAudit("remittance.failed", `Remittance ${remittanceId} failed`, {
+          remittanceId,
+          reason: event.reason,
+        });
+      },
+    };
+  }
+
+  private updateRemittance(
+    remittanceId: string,
+    status: RemittanceStatus,
+    options: { note?: string; extra?: Record<string, unknown>; at?: Date } = {},
+  ): void {
+    const remittance = this.remittances.get(remittanceId);
+    if (!remittance) {
+      return;
+    }
+
+    const eventTime = options.at ?? new Date();
+    remittance.status = status;
+    remittance.updatedAt = eventTime;
+    remittance.history.push({ status, at: eventTime, note: options.note });
+    if (options.extra) {
+      remittance.metadata = {
+        ...(remittance.metadata ?? {}),
+        ...options.extra,
+      };
+    }
+
+    this.emit("remittance:updated", cloneRemittance(remittance));
+  }
+
+  private failRemittance(remittanceId: string, reason: string): void {
+    const remittance = this.remittances.get(remittanceId);
+    if (!remittance) {
+      return;
+    }
+    remittance.failureReason = reason;
+    this.updateRemittance(remittanceId, "failed", {
+      note: "Adapter rejected remittance",
+      extra: { reason },
+    });
+    this.recordAudit("remittance.failed", `Remittance ${remittanceId} failed`, {
+      remittanceId,
+      reason,
+    });
+  }
+
+  private recordAudit(
+    type: AuditEntryType,
+    message: string,
+    details?: Record<string, unknown>,
+  ): void {
+    const normalizedDetails = details ? { ...details } : undefined;
+    const entry: AuditEntry = {
+      id: randomUUID(),
+      occurredAt: new Date(),
+      type,
+      message,
+      gateId: (normalizedDetails?.gateId as string | undefined) ?? undefined,
+      remittanceId: (normalizedDetails?.remittanceId as string | undefined) ?? undefined,
+      details: normalizedDetails,
+    };
+    this.auditLog.push(entry);
+    this.emit("audit", { ...entry });
+  }
+
+  private getGateOrThrow(gateId: string): GateState {
+    const gate = this.gates.get(gateId);
+    if (!gate) {
+      throw new Error(`Gate ${gateId} is not registered`);
+    }
+    return gate;
+  }
+}
+
+function cloneGate(gate: GateState): GateState {
+  return {
+    ...gate,
+    lastChangedAt: new Date(gate.lastChangedAt),
+  };
+}
+
+function cloneRemittance(remittance: RemittanceRecord): RemittanceRecord {
+  return {
+    ...remittance,
+    createdAt: new Date(remittance.createdAt),
+    updatedAt: new Date(remittance.updatedAt),
+    history: remittance.history.map((entry) => ({
+      ...entry,
+      at: new Date(entry.at),
+    })),
+    metadata: remittance.metadata ? { ...remittance.metadata } : undefined,
+  };
+}

--- a/apgms/apps/api/tsconfig.json
+++ b/apgms/apps/api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "baseUrl": "../../",
+    "paths": {
+      "@apgms/shared/*": ["shared/src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,22 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "apps/*", "webapp", "shared", "worker"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - services/*
+  - apps/*
   - webapp
   - shared
   - worker


### PR DESCRIPTION
## Summary
- register the new apps workspace and scaffold the API package
- add mock PayTo and BECS rail adapters plus a gate orchestrator service with audit hooks
- expose Fastify endpoints for gate control, remittance scheduling, and status/audit inspection

## Testing
- pnpm --filter @apgms/api exec tsc --noEmit


------
https://chatgpt.com/codex/tasks/task_e_68f31c6ae6a08327bf555ac8dfe3d130