### PR TITLE
Add OWDA/BAS policy and ledger Prisma models

### DIFF
--- a/apgms/shared/prisma/migrations/20251010140000_add_policy_ledgers/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010140000_add_policy_ledgers/migration.sql
@@ -1,0 +1,174 @@
+-- CreateEnum
+CREATE TYPE "PolicyProgram" AS ENUM ('OWDA', 'BAS');
+
+-- CreateEnum
+CREATE TYPE "PolicyStatus" AS ENUM ('DRAFT', 'ACTIVE', 'SUSPENDED', 'TERMINATED');
+
+-- CreateEnum
+CREATE TYPE "AllocationRuleStatus" AS ENUM ('DRAFT', 'ACTIVE', 'RETIRED');
+
+-- CreateEnum
+CREATE TYPE "AllocationRuleType" AS ENUM ('FIXED', 'PERCENTAGE', 'THRESHOLD');
+
+-- CreateEnum
+CREATE TYPE "LedgerEntryType" AS ENUM ('CREDIT', 'DEBIT', 'ADJUSTMENT');
+
+-- CreateEnum
+CREATE TYPE "LedgerEntrySource" AS ENUM ('BANK_LINE', 'MANUAL', 'SYSTEM');
+
+-- CreateEnum
+CREATE TYPE "GateEventType" AS ENUM ('POLICY_ACTIVATED', 'POLICY_DEACTIVATED', 'RULE_TRIGGERED', 'REMITTANCE_CREATED', 'REMITTANCE_SETTLED');
+
+-- CreateEnum
+CREATE TYPE "GateEventStatus" AS ENUM ('PENDING', 'PROCESSED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "RptTokenKind" AS ENUM ('ACCESS', 'REFRESH');
+
+-- CreateEnum
+CREATE TYPE "PendingRemittanceStatus" AS ENUM ('PREPARED', 'SUBMITTED', 'SETTLED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "externalRef" TEXT,
+    "name" TEXT NOT NULL,
+    "program" "PolicyProgram" NOT NULL,
+    "status" "PolicyStatus" NOT NULL DEFAULT 'DRAFT',
+    "coverageStart" TIMESTAMP(3) NOT NULL,
+    "coverageEnd" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AllocationRuleSet" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "status" "AllocationRuleStatus" NOT NULL DEFAULT 'DRAFT',
+    "ruleType" "AllocationRuleType" NOT NULL,
+    "definition" JSONB NOT NULL,
+    "effectiveFrom" TIMESTAMP(3) NOT NULL,
+    "effectiveTo" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AllocationRuleSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GateEvent" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "allocationSetId" TEXT,
+    "eventType" "GateEventType" NOT NULL,
+    "status" "GateEventStatus" NOT NULL DEFAULT 'PENDING',
+    "payload" JSONB,
+    "triggeredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GateEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LedgerEntry" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "allocationRuleSetId" TEXT,
+    "bankLineId" TEXT,
+    "gateEventId" TEXT,
+    "entryType" "LedgerEntryType" NOT NULL,
+    "source" "LedgerEntrySource" NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "memo" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LedgerEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RptToken" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "kind" "RptTokenKind" NOT NULL DEFAULT 'ACCESS',
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RptToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PendingRemittance" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "ledgerEntryId" TEXT,
+    "status" "PendingRemittanceStatus" NOT NULL DEFAULT 'PREPARED',
+    "amount" DECIMAL(65,30) NOT NULL,
+    "scheduledFor" TIMESTAMP(3) NOT NULL,
+    "submittedAt" TIMESTAMP(3),
+    "settledAt" TIMESTAMP(3),
+    "settlementRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PendingRemittance_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Policy_externalRef_key" ON "Policy"("externalRef");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AllocationRuleSet_policyId_version_key" ON "AllocationRuleSet"("policyId", "version");
+
+-- CreateIndex
+CREATE INDEX "LedgerEntry_policyId_occurredAt_idx" ON "LedgerEntry"("policyId", "occurredAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RptToken_token_key" ON "RptToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PendingRemittance_ledgerEntryId_key" ON "PendingRemittance"("ledgerEntryId");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AllocationRuleSet" ADD CONSTRAINT "AllocationRuleSet_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_allocationSetId_fkey" FOREIGN KEY ("allocationSetId") REFERENCES "AllocationRuleSet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_allocationRuleSetId_fkey" FOREIGN KEY ("allocationRuleSetId") REFERENCES "AllocationRuleSet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_bankLineId_fkey" FOREIGN KEY ("bankLineId") REFERENCES "BankLine"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_gateEventId_fkey" FOREIGN KEY ("gateEventId") REFERENCES "GateEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PendingRemittance" ADD CONSTRAINT "PendingRemittance_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PendingRemittance" ADD CONSTRAINT "PendingRemittance_ledgerEntryId_fkey" FOREIGN KEY ("ledgerEntryId") REFERENCES "LedgerEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,9 +1,10 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
@@ -13,6 +14,7 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  policies  Policy[]
 }
 
 model User {
@@ -25,12 +27,178 @@ model User {
 }
 
 model BankLine {
-  id        String   @id @default(cuid())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
-  date      DateTime
-  amount    Decimal
-  payee     String
-  desc      String
-  createdAt DateTime @default(now())
+  id         String        @id @default(cuid())
+  org        Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  date       DateTime
+  amount     Decimal
+  payee      String
+  desc       String
+  createdAt  DateTime      @default(now())
+  ledgerRefs LedgerEntry[]
+}
+
+model Policy {
+  id            String                 @id @default(cuid())
+  org           Org                    @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  externalRef   String?                @unique
+  name          String
+  program       PolicyProgram
+  status        PolicyStatus           @default(DRAFT)
+  coverageStart DateTime
+  coverageEnd   DateTime?
+  allocationSets AllocationRuleSet[]
+  ledgerEntries  LedgerEntry[]
+  gateEvents     GateEvent[]
+  rptTokens      RptToken[]
+  remittances    PendingRemittance[]
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+}
+
+model AllocationRuleSet {
+  id            String             @id @default(cuid())
+  policy        Policy             @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId      String
+  label         String
+  version       Int
+  status        AllocationRuleStatus @default(DRAFT)
+  ruleType      AllocationRuleType
+  definition    Json
+  effectiveFrom DateTime
+  effectiveTo   DateTime?
+  gateEvents    GateEvent[]
+  ledgerEntries LedgerEntry[]
+  createdAt     DateTime            @default(now())
+  updatedAt     DateTime            @updatedAt
+
+  @@unique([policyId, version])
+}
+
+model LedgerEntry {
+  id                 String             @id @default(cuid())
+  policy             Policy             @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId           String
+  allocationRuleSet  AllocationRuleSet? @relation(fields: [allocationRuleSetId], references: [id])
+  allocationRuleSetId String?
+  bankLine           BankLine?          @relation(fields: [bankLineId], references: [id])
+  bankLineId         String?
+  gateEvent          GateEvent?         @relation(fields: [gateEventId], references: [id])
+  gateEventId        String?
+  entryType          LedgerEntryType
+  source             LedgerEntrySource
+  amount             Decimal
+  occurredAt         DateTime
+  memo               String?
+  remittance         PendingRemittance? @relation("LedgerEntryRemittance")
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+
+  @@index([policyId, occurredAt])
+}
+
+model GateEvent {
+  id              String             @id @default(cuid())
+  policy          Policy             @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId        String
+  allocationSet   AllocationRuleSet? @relation(fields: [allocationSetId], references: [id])
+  allocationSetId String?
+  eventType       GateEventType
+  status          GateEventStatus    @default(PENDING)
+  payload         Json?
+  triggeredAt     DateTime            @default(now())
+  processedAt     DateTime?
+  ledgerEntries   LedgerEntry[]
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+}
+
+model RptToken {
+  id         String      @id @default(cuid())
+  policy     Policy      @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId   String
+  token      String      @unique
+  kind       RptTokenKind @default(ACCESS)
+  expiresAt  DateTime
+  lastUsedAt DateTime?
+  createdAt  DateTime    @default(now())
+}
+
+model PendingRemittance {
+  id            String                  @id @default(cuid())
+  policy        Policy                  @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId      String
+  ledgerEntry   LedgerEntry?            @relation("LedgerEntryRemittance", fields: [ledgerEntryId], references: [id])
+  ledgerEntryId String?                 @unique
+  status        PendingRemittanceStatus @default(PREPARED)
+  amount        Decimal
+  scheduledFor  DateTime
+  submittedAt   DateTime?
+  settledAt     DateTime?
+  settlementRef String?
+  createdAt     DateTime               @default(now())
+  updatedAt     DateTime               @updatedAt
+}
+
+enum PolicyProgram {
+  OWDA
+  BAS
+}
+
+enum PolicyStatus {
+  DRAFT
+  ACTIVE
+  SUSPENDED
+  TERMINATED
+}
+
+enum AllocationRuleStatus {
+  DRAFT
+  ACTIVE
+  RETIRED
+}
+
+enum AllocationRuleType {
+  FIXED
+  PERCENTAGE
+  THRESHOLD
+}
+
+enum LedgerEntryType {
+  CREDIT
+  DEBIT
+  ADJUSTMENT
+}
+
+enum LedgerEntrySource {
+  BANK_LINE
+  MANUAL
+  SYSTEM
+}
+
+enum GateEventType {
+  POLICY_ACTIVATED
+  POLICY_DEACTIVATED
+  RULE_TRIGGERED
+  REMITTANCE_CREATED
+  REMITTANCE_SETTLED
+}
+
+enum GateEventStatus {
+  PENDING
+  PROCESSED
+  FAILED
+}
+
+enum RptTokenKind {
+  ACCESS
+  REFRESH
+}
+
+enum PendingRemittanceStatus {
+  PREPARED
+  SUBMITTED
+  SETTLED
+  REJECTED
 }


### PR DESCRIPTION
## Summary
- introduce policy, allocation rule set, ledger entry, gate event, reporting token, and pending remittance Prisma models for OWDA/BAS processing
- add supporting enums and relations plus a migration to create the new tables and constraints

## Testing
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/apgms?schema=public" SHADOW_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/apgms_shadow?schema=public" pnpm prisma migrate dev --name add-policy-ledger-models --create-only *(fails: Prisma engines download blocked by 403)*
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/apgms?schema=public" pnpm prisma generate *(fails: Prisma engines download blocked by 403)*
- pnpm exec tsc --noEmit *(fails: @prisma/client not generated because prisma generate failed)*

------
https://chatgpt.com/codex/tasks/task_e_68f31c717fb88327a316a97341a60d27