### PR TITLE
Add policy governance schema and tests

### DIFF
--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,5 +1,124 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 const prisma = new PrismaClient();
+
+async function seedGates() {
+  const gates = [
+    {
+      id: "gate-kyc",
+      key: "kyc-verification",
+      name: "KYC Verification",
+      description: "Ensures all investor identities are verified before approval.",
+    },
+    {
+      id: "gate-aml",
+      key: "aml-screening",
+      name: "AML Screening",
+      description: "Flags transactions against AML rule sets.",
+    },
+    {
+      id: "gate-risk",
+      key: "risk-threshold",
+      name: "Risk Threshold",
+      description: "Applies portfolio exposure limits before reconciliation.",
+    },
+  ];
+
+  await Promise.all(
+    gates.map((gate) =>
+      prisma.gate.upsert({
+        where: { key: gate.key },
+        update: {
+          name: gate.name,
+          description: gate.description,
+        },
+        create: {
+          id: gate.id,
+          key: gate.key,
+          name: gate.name,
+          description: gate.description,
+        },
+      })
+    )
+  );
+}
+
+async function attachGatesToPolicy(policyId: string, gateKeys: string[]) {
+  const gates = await prisma.gate.findMany({ where: { key: { in: gateKeys } } });
+  const order = new Map(gateKeys.map((key, index) => [key, index] as const));
+  const sorted = gates.sort((a, b) => (order.get(a.key) ?? 0) - (order.get(b.key) ?? 0));
+
+  await Promise.all(
+    sorted.map((gate, index) =>
+      prisma.policyGate.upsert({
+        where: { id: `${policyId}-${gate.id}` },
+        update: { sequence: index },
+        create: {
+          id: `${policyId}-${gate.id}`,
+          policyId,
+          gateId: gate.id,
+          sequence: index,
+        },
+      })
+    )
+  );
+}
+
+async function seedPolicies(orgId: string) {
+  const policy = await prisma.policy.upsert({
+    where: { id: "policy-standard-recon" },
+    update: {
+      name: "Standard Reconciliation",
+      description: "Default control gates applied to nightly reconciliations.",
+      isActive: true,
+    },
+    create: {
+      id: "policy-standard-recon",
+      orgId,
+      name: "Standard Reconciliation",
+      description: "Default control gates applied to nightly reconciliations.",
+      isActive: true,
+    },
+  });
+
+  await attachGatesToPolicy(policy.id, ["kyc-verification", "aml-screening", "risk-threshold"]);
+
+  await prisma.reconciliationPassToken.upsert({
+    where: { token: "demo-pass-token" },
+    update: {
+      policyId: policy.id,
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+    },
+    create: {
+      id: "token-demo",
+      policyId: policy.id,
+      token: "demo-pass-token",
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60 * 24 * 7),
+    },
+  });
+
+  await prisma.auditTrail.upsert({
+    where: { id: "audit-policy-standard-recon" },
+    update: {
+      entityType: "Policy",
+      entityId: policy.id,
+      action: "SEED_SYNC",
+      metadata: {
+        note: "Policy refreshed during seed",
+      },
+    },
+    create: {
+      id: "audit-policy-standard-recon",
+      orgId,
+      entityType: "Policy",
+      entityId: policy.id,
+      action: "SEED_CREATE",
+      metadata: {
+        note: "Policy created during initial seed",
+      },
+    },
+  });
+}
 
 async function main() {
   const org = await prisma.org.upsert({
@@ -17,15 +136,24 @@ async function main() {
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
+      { orgId: org.id, date: today, amount: 5000.0, payee: "Birchal", desc: "Investment received" },
     ],
     skipDuplicates: true,
   });
 
+  await seedGates();
+  await seedPolicies(org.id);
+
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/shared/prisma/migrations/20251020120000_policy_gate_audit/migration.sql
+++ b/apgms/shared/prisma/migrations/20251020120000_policy_gate_audit/migration.sql
@@ -1,0 +1,104 @@
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT TRUE,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Gate" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Gate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PolicyGate" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "gateId" TEXT NOT NULL,
+    "sequence" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PolicyGate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ReconciliationPassToken" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReconciliationPassToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditTrail" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT,
+    "userId" TEXT,
+    "entityType" TEXT NOT NULL,
+    "entityId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "changes" JSONB,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditTrail_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Policy_orgId_idx" ON "Policy"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Gate_key_key" ON "Gate"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PolicyGate_policyId_gateId_key" ON "PolicyGate"("policyId", "gateId");
+
+-- CreateIndex
+CREATE INDEX "PolicyGate_policyId_idx" ON "PolicyGate"("policyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReconciliationPassToken_token_key" ON "ReconciliationPassToken"("token");
+
+-- CreateIndex
+CREATE INDEX "ReconciliationPassToken_policyId_idx" ON "ReconciliationPassToken"("policyId");
+
+-- CreateIndex
+CREATE INDEX "AuditTrail_orgId_idx" ON "AuditTrail"("orgId");
+
+-- CreateIndex
+CREATE INDEX "AuditTrail_entityType_entityId_idx" ON "AuditTrail"("entityType", "entityId");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PolicyGate" ADD CONSTRAINT "PolicyGate_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PolicyGate" ADD CONSTRAINT "PolicyGate_gateId_fkey" FOREIGN KEY ("gateId") REFERENCES "Gate"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReconciliationPassToken" ADD CONSTRAINT "ReconciliationPassToken_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditTrail" ADD CONSTRAINT "AuditTrail_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditTrail" ADD CONSTRAINT "AuditTrail_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,27 +1,31 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model Org {
-  id        String   @id @default(cuid())
+  id        String    @id @default(cuid())
   name      String
-  createdAt DateTime @default(now())
+  createdAt DateTime  @default(now())
   users     User[]
   lines     BankLine[]
+  policies  Policy[]
+  audits    AuditTrail[]
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
+  id        String    @id @default(cuid())
+  email     String    @unique
   password  String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  createdAt DateTime  @default(now())
+  org       Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
+  audits    AuditTrail[]
 }
 
 model BankLine {
@@ -33,4 +37,71 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+}
+
+model Policy {
+  id          String                    @id @default(cuid())
+  org         Org                       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  name        String
+  description String?
+  isActive    Boolean                   @default(true)
+  createdAt   DateTime                  @default(now())
+  updatedAt   DateTime                  @updatedAt
+  gates       PolicyGate[]
+  tokens      ReconciliationPassToken[]
+
+  @@index([orgId])
+}
+
+model Gate {
+  id          String       @id @default(cuid())
+  key         String       @unique
+  name        String
+  description String?
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  policies    PolicyGate[]
+}
+
+model PolicyGate {
+  id        String   @id @default(cuid())
+  policy    Policy   @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId  String
+  gate      Gate     @relation(fields: [gateId], references: [id], onDelete: Cascade)
+  gateId    String
+  sequence  Int      @default(0)
+  createdAt DateTime @default(now())
+
+  @@unique([policyId, gateId])
+  @@index([policyId])
+}
+
+model ReconciliationPassToken {
+  id        String   @id @default(cuid())
+  policy    Policy   @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId  String
+  token     String   @unique
+  expiresAt DateTime?
+  usedAt    DateTime?
+  createdAt DateTime @default(now())
+
+  @@index([policyId])
+}
+
+model AuditTrail {
+  id         String   @id @default(cuid())
+  org        Org?     @relation(fields: [orgId], references: [id], onDelete: SetNull)
+  orgId      String?
+  user       User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId     String?
+  entityType String
+  entityId   String
+  action     String
+  changes    Json?
+  metadata   Json?
+  createdAt  DateTime @default(now())
+
+  @@index([orgId])
+  @@index([entityType, entityId])
 }

--- a/apgms/tests/db/schema.test.mjs
+++ b/apgms/tests/db/schema.test.mjs
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const schemaPath = resolve(__dirname, "../../shared/prisma/schema.prisma");
+const schema = readFileSync(schemaPath, "utf8");
+
+function getModelBlock(modelName) {
+  const lines = schema.split(/\r?\n/);
+  const startPattern = new RegExp(`^model\\s+${modelName}\\s+\\{`);
+  let depth = 0;
+  let collecting = false;
+  const buffer = [];
+
+  for (const line of lines) {
+    if (!collecting && startPattern.test(line.trim())) {
+      collecting = true;
+    }
+
+    if (collecting) {
+      if (line.includes("{")) depth += (line.match(/\{/g) ?? []).length;
+      if (line.includes("}")) depth -= (line.match(/\}/g) ?? []).length;
+      buffer.push(line);
+      if (collecting && depth === 0) {
+        break;
+      }
+    }
+  }
+
+  return buffer.join("\n");
+}
+
+test("Policy model includes required relations and index", () => {
+  const block = getModelBlock("Policy");
+  assert.ok(block.includes("gates       PolicyGate[]"), "Policy should expose gates relation");
+  assert.ok(block.includes("tokens      ReconciliationPassToken[]"), "Policy should expose reconciliation tokens");
+  assert.ok(block.includes("org         Org"), "Policy should relate to Org");
+  assert.ok(block.includes("@@index([orgId])"), "Policy should be indexed by orgId");
+});
+
+test("Gate model exposes unique key and metadata", () => {
+  const block = getModelBlock("Gate");
+  assert.ok(block.includes("key         String       @unique"), "Gate should enforce unique key");
+  assert.ok(block.includes("description String?"), "Gate should allow optional description");
+});
+
+test("PolicyGate join enforces composite uniqueness and sequence", () => {
+  const block = getModelBlock("PolicyGate");
+  assert.ok(block.includes("policy    Policy   @relation"), "PolicyGate should relate to Policy");
+  assert.ok(block.includes("gate      Gate     @relation"), "PolicyGate should relate to Gate");
+  assert.ok(block.includes("sequence  Int      @default(0)"), "PolicyGate should capture sequence");
+  assert.ok(block.includes("@@unique([policyId, gateId])"), "PolicyGate should enforce composite uniqueness");
+  assert.ok(block.includes("@@index([policyId])"), "PolicyGate should index policyId");
+});
+
+test("ReconciliationPassToken enforces uniqueness and relationships", () => {
+  const block = getModelBlock("ReconciliationPassToken");
+  assert.ok(block.includes("policy    Policy   @relation"), "Tokens should belong to a policy");
+  assert.ok(block.includes("token     String   @unique"), "Tokens should be unique");
+  assert.ok(block.includes("@@index([policyId])"), "Tokens should index policyId");
+});
+
+test("AuditTrail keeps optional org and user relations", () => {
+  const block = getModelBlock("AuditTrail");
+  assert.ok(block.includes("org        Org?"), "AuditTrail should allow optional org relation");
+  assert.ok(block.includes("user       User?"), "AuditTrail should allow optional user relation");
+  assert.ok(block.includes("metadata   Json?"), "AuditTrail should store metadata JSON");
+  assert.ok(block.includes("@@index([entityType, entityId])"), "AuditTrail should index entity references");
+});

--- a/apgms/tests/package.json
+++ b/apgms/tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@apgms/tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test db"
+  },
+  "dependencies": {
+    "@prisma/client": "6.17.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add migrations for policy, gate, reconciliation token, and audit trail tables with supporting indexes
- expand the Prisma schema plus workspace configuration to expose the new models
- seed demo data for the new entities and add schema integrity tests under the db test suite

## Testing
- pnpm --filter @apgms/tests test

------
https://chatgpt.com/codex/tasks/task_e_68f31ced03e88327978a5626455d8d11