### PR TITLE
Add Fastify dashboard API with Prisma-backed services

### DIFF
--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests/*
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/server/app.ts
+++ b/apgms/server/app.ts
@@ -1,0 +1,29 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import {
+  allocationRoutes,
+  auditRoutes,
+  bankLinesRoutes,
+  dashboardRoutes,
+  policiesRoutes,
+  type RoutePluginOptions,
+} from "./routes";
+import { getDefaultPrisma, type PrismaService } from "./services";
+
+export interface AppOptions {
+  prisma?: PrismaService;
+  fastifyInstance?: FastifyInstance;
+}
+
+export const buildApp = (options: AppOptions = {}): FastifyInstance => {
+  const prismaClient = options.prisma ?? getDefaultPrisma();
+  const app = options.fastifyInstance ?? Fastify({ logger: false });
+  const routeOptions: RoutePluginOptions = { prisma: prismaClient };
+
+  app.register(dashboardRoutes, routeOptions);
+  app.register(bankLinesRoutes, routeOptions);
+  app.register(policiesRoutes, routeOptions);
+  app.register(auditRoutes, routeOptions);
+  app.register(allocationRoutes, routeOptions);
+
+  return app;
+};

--- a/apgms/server/routes/allocations.ts
+++ b/apgms/server/routes/allocations.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getAllocations, type AllocationItem } from "../services/allocations.service";
+import type { RoutePluginOptions } from "./types";
+import { orgQuerystringSchema } from "./types";
+
+const allocationItemSchema = {
+  type: "object",
+  required: ["id", "orgId", "portfolio", "amount", "currency", "updatedAt"],
+  properties: {
+    id: { type: "string" },
+    orgId: { type: "string" },
+    portfolio: { type: "string" },
+    amount: { type: "number" },
+    currency: { type: "string" },
+    updatedAt: { type: "string", format: "date-time" },
+  },
+} as const;
+
+const allocationsResponseSchema = {
+  type: "object",
+  required: ["items"],
+  properties: {
+    items: {
+      type: "array",
+      items: allocationItemSchema,
+    },
+  },
+} as const;
+
+export const allocationRoutes: FastifyPluginAsync<RoutePluginOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: { orgId: string }; Reply: { items: AllocationItem[] } }>(
+    "/allocations",
+    {
+      schema: {
+        querystring: orgQuerystringSchema,
+        response: {
+          200: allocationsResponseSchema,
+        },
+      },
+    },
+    async (request) => ({
+      items: await getAllocations(request.query.orgId, opts.prisma),
+    }),
+  );
+};

--- a/apgms/server/routes/audit.ts
+++ b/apgms/server/routes/audit.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getAuditLog, type AuditEntry } from "../services/audit.service";
+import type { RoutePluginOptions } from "./types";
+import { orgQuerystringSchema } from "./types";
+
+const auditEntrySchema = {
+  type: "object",
+  required: ["id", "orgId", "actor", "action", "createdAt"],
+  properties: {
+    id: { type: "string" },
+    orgId: { type: "string" },
+    actor: { type: "string" },
+    action: { type: "string" },
+    createdAt: { type: "string", format: "date-time" },
+    details: {},
+  },
+} as const;
+
+const auditResponseSchema = {
+  type: "object",
+  required: ["items"],
+  properties: {
+    items: {
+      type: "array",
+      items: auditEntrySchema,
+    },
+  },
+} as const;
+
+export const auditRoutes: FastifyPluginAsync<RoutePluginOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: { orgId: string }; Reply: { items: AuditEntry[] } }>(
+    "/audit",
+    {
+      schema: {
+        querystring: orgQuerystringSchema,
+        response: {
+          200: auditResponseSchema,
+        },
+      },
+    },
+    async (request) => ({
+      items: await getAuditLog(request.query.orgId, opts.prisma),
+    }),
+  );
+};

--- a/apgms/server/routes/bank-lines.ts
+++ b/apgms/server/routes/bank-lines.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getBankLines, type BankLineItem } from "../services/bank-lines.service";
+import type { RoutePluginOptions } from "./types";
+import { orgQuerystringSchema } from "./types";
+
+const bankLineItemSchema = {
+  type: "object",
+  required: ["id", "orgId", "date", "amount", "payee", "description"],
+  properties: {
+    id: { type: "string" },
+    orgId: { type: "string" },
+    date: { type: "string", format: "date-time" },
+    amount: { type: "number" },
+    payee: { type: "string" },
+    description: { type: "string" },
+  },
+} as const;
+
+const bankLinesResponseSchema = {
+  type: "object",
+  required: ["items"],
+  properties: {
+    items: {
+      type: "array",
+      items: bankLineItemSchema,
+    },
+  },
+} as const;
+
+export const bankLinesRoutes: FastifyPluginAsync<RoutePluginOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: { orgId: string }; Reply: { items: BankLineItem[] } }>(
+    "/bank-lines",
+    {
+      schema: {
+        querystring: orgQuerystringSchema,
+        response: {
+          200: bankLinesResponseSchema,
+        },
+      },
+    },
+    async (request) => ({
+      items: await getBankLines(request.query.orgId, opts.prisma),
+    }),
+  );
+};

--- a/apgms/server/routes/dashboard.ts
+++ b/apgms/server/routes/dashboard.ts
@@ -1,0 +1,56 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getDashboardSummary, type DashboardSummary } from "../services/dashboard.service";
+import type { RoutePluginOptions } from "./types";
+import { orgQuerystringSchema } from "./types";
+
+const dashboardResponseSchema = {
+  type: "object",
+  required: ["org", "metrics", "latestAudit"],
+  properties: {
+    org: {
+      type: ["object", "null"],
+      properties: {
+        id: { type: "string" },
+        name: { type: "string" },
+      },
+      required: ["id", "name"],
+    },
+    metrics: {
+      type: "object",
+      required: ["userCount", "bankLineTotal", "policyCount", "allocationTotal"],
+      properties: {
+        userCount: { type: "integer", minimum: 0 },
+        bankLineTotal: { type: "number" },
+        policyCount: { type: "integer", minimum: 0 },
+        allocationTotal: { type: "number" },
+      },
+    },
+    latestAudit: {
+      type: ["object", "null"],
+      properties: {
+        id: { type: "string" },
+        actor: { type: "string" },
+        action: { type: "string" },
+        createdAt: { type: "string", format: "date-time" },
+      },
+      required: ["id", "actor", "action", "createdAt"],
+    },
+  },
+} as const;
+
+export const dashboardRoutes: FastifyPluginAsync<RoutePluginOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: { orgId: string }; Reply: DashboardSummary }>(
+    "/dashboard",
+    {
+      schema: {
+        querystring: orgQuerystringSchema,
+        response: {
+          200: dashboardResponseSchema,
+        },
+      },
+    },
+    async (request) => {
+      return getDashboardSummary(request.query.orgId, opts.prisma);
+    },
+  );
+};

--- a/apgms/server/routes/index.ts
+++ b/apgms/server/routes/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export * from "./dashboard";
+export * from "./bank-lines";
+export * from "./policies";
+export * from "./audit";
+export * from "./allocations";

--- a/apgms/server/routes/policies.ts
+++ b/apgms/server/routes/policies.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsync } from "fastify";
+import { getPolicies, type PolicyItem } from "../services/policies.service";
+import type { RoutePluginOptions } from "./types";
+import { orgQuerystringSchema } from "./types";
+
+const policyItemSchema = {
+  type: "object",
+  required: ["id", "orgId", "name", "status", "premium", "effectiveDate"],
+  properties: {
+    id: { type: "string" },
+    orgId: { type: "string" },
+    name: { type: "string" },
+    status: { type: "string" },
+    premium: { type: "number" },
+    effectiveDate: { type: "string", format: "date-time" },
+  },
+} as const;
+
+const policiesResponseSchema = {
+  type: "object",
+  required: ["items"],
+  properties: {
+    items: {
+      type: "array",
+      items: policyItemSchema,
+    },
+  },
+} as const;
+
+export const policiesRoutes: FastifyPluginAsync<RoutePluginOptions> = async (fastify, opts) => {
+  fastify.get<{ Querystring: { orgId: string }; Reply: { items: PolicyItem[] } }>(
+    "/policies",
+    {
+      schema: {
+        querystring: orgQuerystringSchema,
+        response: {
+          200: policiesResponseSchema,
+        },
+      },
+    },
+    async (request) => ({
+      items: await getPolicies(request.query.orgId, opts.prisma),
+    }),
+  );
+};

--- a/apgms/server/routes/types.ts
+++ b/apgms/server/routes/types.ts
@@ -1,0 +1,13 @@
+import type { PrismaService } from "../services";
+
+export interface RoutePluginOptions {
+  prisma: PrismaService;
+}
+
+export const orgQuerystringSchema = {
+  type: "object",
+  required: ["orgId"],
+  properties: {
+    orgId: { type: "string", minLength: 1 },
+  },
+} as const;

--- a/apgms/server/services/allocations.service.ts
+++ b/apgms/server/services/allocations.service.ts
@@ -1,0 +1,29 @@
+import { getDefaultPrisma, toNumber, type PrismaService } from "./types";
+
+export interface AllocationItem {
+  id: string;
+  orgId: string;
+  portfolio: string;
+  amount: number;
+  currency: string;
+  updatedAt: string;
+}
+
+export const getAllocations = async (
+  orgId: string,
+  prismaClient: PrismaService = getDefaultPrisma(),
+): Promise<AllocationItem[]> => {
+  const allocations = await prismaClient.allocation.findMany({
+    where: { orgId },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return allocations.map((allocation) => ({
+    id: allocation.id,
+    orgId: allocation.orgId,
+    portfolio: allocation.portfolio,
+    amount: toNumber(allocation.amount),
+    currency: allocation.currency,
+    updatedAt: allocation.updatedAt.toISOString(),
+  }));
+};

--- a/apgms/server/services/audit.service.ts
+++ b/apgms/server/services/audit.service.ts
@@ -1,0 +1,30 @@
+import { getDefaultPrisma, type PrismaService } from "./types";
+
+export interface AuditEntry {
+  id: string;
+  orgId: string;
+  actor: string;
+  action: string;
+  createdAt: string;
+  details?: unknown;
+}
+
+export const getAuditLog = async (
+  orgId: string,
+  prismaClient: PrismaService = getDefaultPrisma(),
+): Promise<AuditEntry[]> => {
+  const entries = await prismaClient.auditLog.findMany({
+    where: { orgId },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  return entries.map((entry) => ({
+    id: entry.id,
+    orgId: entry.orgId,
+    actor: entry.actor,
+    action: entry.action,
+    createdAt: entry.createdAt.toISOString(),
+    details: entry.details ?? undefined,
+  }));
+};

--- a/apgms/server/services/bank-lines.service.ts
+++ b/apgms/server/services/bank-lines.service.ts
@@ -1,0 +1,29 @@
+import { getDefaultPrisma, toNumber, type PrismaService } from "./types";
+
+export interface BankLineItem {
+  id: string;
+  orgId: string;
+  date: string;
+  amount: number;
+  payee: string;
+  description: string;
+}
+
+export const getBankLines = async (
+  orgId: string,
+  prismaClient: PrismaService = getDefaultPrisma(),
+): Promise<BankLineItem[]> => {
+  const lines = await prismaClient.bankLine.findMany({
+    where: { orgId },
+    orderBy: { date: "desc" },
+  });
+
+  return lines.map((line) => ({
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amount: toNumber(line.amount),
+    payee: line.payee,
+    description: line.desc,
+  }));
+};

--- a/apgms/server/services/dashboard.service.ts
+++ b/apgms/server/services/dashboard.service.ts
@@ -1,0 +1,57 @@
+import { getDefaultPrisma, toNumber, type PrismaService } from "./types";
+
+export interface DashboardSummary {
+  org: { id: string; name: string } | null;
+  metrics: {
+    userCount: number;
+    bankLineTotal: number;
+    policyCount: number;
+    allocationTotal: number;
+  };
+  latestAudit: { id: string; actor: string; action: string; createdAt: string } | null;
+}
+
+export const getDashboardSummary = async (
+  orgId: string,
+  prismaClient: PrismaService = getDefaultPrisma(),
+): Promise<DashboardSummary> => {
+  const [org, userCount, bankLineAggregate, policyCount, allocationAggregate, latestAudit] =
+    await Promise.all([
+      prismaClient.org.findUnique({
+        where: { id: orgId },
+        select: { id: true, name: true },
+      }),
+      prismaClient.user.count({ where: { orgId } }),
+      prismaClient.bankLine.aggregate({
+        where: { orgId },
+        _sum: { amount: true },
+      }),
+      prismaClient.policy.count({ where: { orgId } }),
+      prismaClient.allocation.aggregate({
+        where: { orgId },
+        _sum: { amount: true },
+      }),
+      prismaClient.auditLog.findFirst({
+        where: { orgId },
+        orderBy: { createdAt: "desc" },
+      }),
+    ]);
+
+  return {
+    org,
+    metrics: {
+      userCount,
+      bankLineTotal: toNumber(bankLineAggregate._sum.amount),
+      policyCount,
+      allocationTotal: toNumber(allocationAggregate._sum.amount),
+    },
+    latestAudit: latestAudit
+      ? {
+          id: latestAudit.id,
+          actor: latestAudit.actor,
+          action: latestAudit.action,
+          createdAt: latestAudit.createdAt.toISOString(),
+        }
+      : null,
+  };
+};

--- a/apgms/server/services/index.ts
+++ b/apgms/server/services/index.ts
@@ -1,0 +1,6 @@
+export * from "./types";
+export * from "./dashboard.service";
+export * from "./bank-lines.service";
+export * from "./policies.service";
+export * from "./audit.service";
+export * from "./allocations.service";

--- a/apgms/server/services/policies.service.ts
+++ b/apgms/server/services/policies.service.ts
@@ -1,0 +1,29 @@
+import { getDefaultPrisma, toNumber, type PrismaService } from "./types";
+
+export interface PolicyItem {
+  id: string;
+  orgId: string;
+  name: string;
+  status: string;
+  premium: number;
+  effectiveDate: string;
+}
+
+export const getPolicies = async (
+  orgId: string,
+  prismaClient: PrismaService = getDefaultPrisma(),
+): Promise<PolicyItem[]> => {
+  const policies = await prismaClient.policy.findMany({
+    where: { orgId },
+    orderBy: { effectiveDate: "desc" },
+  });
+
+  return policies.map((policy) => ({
+    id: policy.id,
+    orgId: policy.orgId,
+    name: policy.name,
+    status: policy.status,
+    premium: toNumber(policy.premium),
+    effectiveDate: policy.effectiveDate.toISOString(),
+  }));
+};

--- a/apgms/server/services/types.ts
+++ b/apgms/server/services/types.ts
@@ -1,0 +1,136 @@
+import { createRequire } from "node:module";
+import type { Prisma } from "@prisma/client";
+
+export type DecimalLike = Prisma.Decimal | number | null | undefined;
+
+export interface PrismaService {
+  org: {
+    findUnique(args: {
+      where: { id: string };
+      select?: { id?: boolean; name?: boolean };
+    }): Promise<{ id: string; name: string } | null>;
+  };
+  user: {
+    count(args: { where: { orgId: string } }): Promise<number>;
+  };
+  bankLine: {
+    findMany(args: {
+      where: { orgId: string };
+      orderBy?: { date?: "asc" | "desc" };
+    }): Promise<
+      Array<{
+        id: string;
+        orgId: string;
+        date: Date;
+        amount: Prisma.Decimal | number;
+        payee: string;
+        desc: string;
+      }>
+    >;
+    aggregate(args: {
+      where: { orgId: string };
+      _sum: { amount: true };
+    }): Promise<{ _sum: { amount: Prisma.Decimal | number | null } }>;
+  };
+  policy: {
+    findMany(args: {
+      where: { orgId: string };
+      orderBy?: { effectiveDate?: "asc" | "desc" };
+    }): Promise<
+      Array<{
+        id: string;
+        orgId: string;
+        name: string;
+        status: string;
+        premium: Prisma.Decimal | number;
+        effectiveDate: Date;
+      }>
+    >;
+    count(args: { where: { orgId: string } }): Promise<number>;
+  };
+  auditLog: {
+    findMany(args: {
+      where: { orgId: string };
+      orderBy?: { createdAt?: "asc" | "desc" };
+      take?: number;
+    }): Promise<
+      Array<{
+        id: string;
+        orgId: string;
+        actor: string;
+        action: string;
+        createdAt: Date;
+        details?: unknown;
+      }>
+    >;
+    findFirst(args: {
+      where: { orgId: string };
+      orderBy: { createdAt: "desc" };
+    }): Promise<
+      | {
+          id: string;
+          orgId: string;
+          actor: string;
+          action: string;
+          createdAt: Date;
+          details?: unknown;
+        }
+      | null
+    >;
+  };
+  allocation: {
+    findMany(args: {
+      where: { orgId: string };
+      orderBy?: { updatedAt?: "asc" | "desc" };
+    }): Promise<
+      Array<{
+        id: string;
+        orgId: string;
+        portfolio: string;
+        amount: Prisma.Decimal | number;
+        currency: string;
+        updatedAt: Date;
+      }>
+    >;
+    aggregate(args: {
+      where: { orgId: string };
+      _sum: { amount: true };
+    }): Promise<{ _sum: { amount: Prisma.Decimal | number | null } }>;
+  };
+}
+
+const require = createRequire(import.meta.url);
+
+let cachedPrisma: PrismaService | undefined;
+let prismaError: unknown;
+
+export const getDefaultPrisma = (): PrismaService => {
+  if (cachedPrisma) {
+    return cachedPrisma;
+  }
+
+  if (prismaError) {
+    throw prismaError;
+  }
+
+  try {
+    const { prisma } = require("../../shared/src/db") as { prisma: unknown };
+    cachedPrisma = prisma as PrismaService;
+    return cachedPrisma;
+  } catch (error) {
+    prismaError = error;
+    throw error;
+  }
+};
+
+export const toNumber = (value: DecimalLike): number => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+
+  if (typeof value === "number") {
+    return value;
+  }
+
+  return value.toNumber();
+};

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -34,3 +34,41 @@ model BankLine {
   desc      String
   createdAt DateTime @default(now())
 }
+
+model Policy {
+  id            String       @id @default(cuid())
+  org           Org          @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  name          String
+  status        PolicyStatus
+  premium       Decimal
+  effectiveDate DateTime
+  createdAt     DateTime     @default(now())
+}
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  actor     String
+  action    String
+  createdAt DateTime @default(now())
+  details   Json?
+}
+
+model Allocation {
+  id         String   @id @default(cuid())
+  org        Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  portfolio  String
+  amount     Decimal
+  currency   String   @default("AUD")
+  updatedAt  DateTime @default(now())
+  createdAt  DateTime @default(now())
+}
+
+enum PolicyStatus {
+  ACTIVE
+  LAPSED
+  PENDING
+}

--- a/apgms/tests/server/app.test.ts
+++ b/apgms/tests/server/app.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildApp } from "../../server/app";
+import type { PrismaService } from "../../server/services";
+
+const ORG_ID = "org-1";
+
+const bankLineRecords = [
+  {
+    id: "line-1",
+    orgId: ORG_ID,
+    date: new Date("2024-02-01T10:00:00Z"),
+    amount: 1500,
+    payee: "Supplier A",
+    desc: "Invoice 1001",
+  },
+  {
+    id: "line-2",
+    orgId: ORG_ID,
+    date: new Date("2024-01-15T09:30:00Z"),
+    amount: 2750,
+    payee: "Utilities B",
+    desc: "Power bill",
+  },
+];
+
+const policyRecords = [
+  {
+    id: "policy-1",
+    orgId: ORG_ID,
+    name: "Cyber insurance",
+    status: "ACTIVE",
+    premium: 1200,
+    effectiveDate: new Date("2024-01-01T00:00:00Z"),
+  },
+  {
+    id: "policy-2",
+    orgId: ORG_ID,
+    name: "Management liability",
+    status: "PENDING",
+    premium: 800,
+    effectiveDate: new Date("2024-03-01T00:00:00Z"),
+  },
+];
+
+const auditRecords = [
+  {
+    id: "audit-1",
+    orgId: ORG_ID,
+    actor: "jane@example.com",
+    action: "Updated policy",
+    createdAt: new Date("2024-03-02T12:00:00Z"),
+    details: { policyId: "policy-2" },
+  },
+  {
+    id: "audit-2",
+    orgId: ORG_ID,
+    actor: "john@example.com",
+    action: "Created bank line",
+    createdAt: new Date("2024-02-01T10:05:00Z"),
+    details: { bankLineId: "line-1" },
+  },
+];
+
+const allocationRecords = [
+  {
+    id: "allocation-1",
+    orgId: ORG_ID,
+    portfolio: "Cash reserve",
+    amount: 5000,
+    currency: "AUD",
+    updatedAt: new Date("2024-03-04T09:00:00Z"),
+  },
+  {
+    id: "allocation-2",
+    orgId: ORG_ID,
+    portfolio: "Growth",
+    amount: 3250,
+    currency: "AUD",
+    updatedAt: new Date("2024-02-10T08:30:00Z"),
+  },
+];
+
+const prismaStub: PrismaService = {
+  org: {
+    findUnique: async ({ where }) =>
+      where.id === ORG_ID ? { id: ORG_ID, name: "Birchal Holdings" } : null,
+  },
+  user: {
+    count: async () => 5,
+  },
+  bankLine: {
+    findMany: async ({ where, orderBy }) => {
+      const filtered = bankLineRecords.filter((line) => line.orgId === where.orgId);
+      if (orderBy?.date === "desc") {
+        filtered.sort((a, b) => b.date.getTime() - a.date.getTime());
+      } else if (orderBy?.date === "asc") {
+        filtered.sort((a, b) => a.date.getTime() - b.date.getTime());
+      }
+      return filtered;
+    },
+    aggregate: async ({ where }) => ({
+      _sum: {
+        amount: bankLineRecords
+          .filter((line) => line.orgId === where.orgId)
+          .reduce((total, line) => total + Number(line.amount), 0),
+      },
+    }),
+  },
+  policy: {
+    findMany: async ({ where, orderBy }) => {
+      const filtered = policyRecords.filter((policy) => policy.orgId === where.orgId);
+      if (orderBy?.effectiveDate === "desc") {
+        filtered.sort((a, b) => b.effectiveDate.getTime() - a.effectiveDate.getTime());
+      } else if (orderBy?.effectiveDate === "asc") {
+        filtered.sort((a, b) => a.effectiveDate.getTime() - b.effectiveDate.getTime());
+      }
+      return filtered;
+    },
+    count: async ({ where }) => policyRecords.filter((policy) => policy.orgId === where.orgId).length,
+  },
+  auditLog: {
+    findMany: async ({ where, orderBy, take }) => {
+      const filtered = auditRecords
+        .filter((entry) => entry.orgId === where.orgId)
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      if (orderBy?.createdAt === "asc") {
+        filtered.reverse();
+      }
+      return typeof take === "number" ? filtered.slice(0, take) : filtered;
+    },
+    findFirst: async ({ where }) => {
+      const sorted = auditRecords
+        .filter((entry) => entry.orgId === where.orgId)
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      return sorted[0] ?? null;
+    },
+  },
+  allocation: {
+    findMany: async ({ where, orderBy }) => {
+      const filtered = allocationRecords.filter((allocation) => allocation.orgId === where.orgId);
+      if (orderBy?.updatedAt === "desc") {
+        filtered.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+      } else if (orderBy?.updatedAt === "asc") {
+        filtered.sort((a, b) => a.updatedAt.getTime() - b.updatedAt.getTime());
+      }
+      return filtered;
+    },
+    aggregate: async ({ where }) => ({
+      _sum: {
+        amount: allocationRecords
+          .filter((allocation) => allocation.orgId === where.orgId)
+          .reduce((total, allocation) => total + Number(allocation.amount), 0),
+      },
+    }),
+  },
+};
+
+test("GET /dashboard returns aggregated summary", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/dashboard",
+    query: { orgId: ORG_ID },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    org: { id: ORG_ID, name: "Birchal Holdings" },
+    metrics: {
+      userCount: 5,
+      bankLineTotal: 4250,
+      policyCount: 2,
+      allocationTotal: 8250,
+    },
+    latestAudit: {
+      id: "audit-1",
+      actor: "jane@example.com",
+      action: "Updated policy",
+      createdAt: auditRecords[0].createdAt.toISOString(),
+    },
+  });
+});
+
+test("GET /bank-lines returns the org bank lines", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+    query: { orgId: ORG_ID },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.items[0].id, "line-1");
+  assert.equal(payload.items[1].id, "line-2");
+});
+
+test("GET /policies returns the org policies", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/policies",
+    query: { orgId: ORG_ID },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.items[0].id, "policy-2");
+  assert.equal(payload.items[1].id, "policy-1");
+});
+
+test("GET /audit returns the audit log", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/audit",
+    query: { orgId: ORG_ID },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.items[0].id, "audit-1");
+});
+
+test("GET /allocations returns the portfolio allocations", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/allocations",
+    query: { orgId: ORG_ID },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.items.length, 2);
+  assert.equal(payload.items[0].id, "allocation-1");
+  assert.equal(payload.items[1].id, "allocation-2");
+});
+
+test("Routes enforce the orgId query parameter", async (t) => {
+  const app = buildApp({ prisma: prismaStub });
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(response.statusCode, 400);
+});

--- a/apgms/tests/server/package.json
+++ b/apgms/tests/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@apgms/server-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "tsx --test app.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}


### PR DESCRIPTION
## Summary
- extend the Prisma schema to cover policies, audit logs, and allocations
- add Fastify route handlers and service functions for dashboard, bank line, policy, audit, and allocation data
- cover the new endpoints with integration tests exercised through Fastify's inject API

## Testing
- pnpm --filter @apgms/server-tests test

------
https://chatgpt.com/codex/tasks/task_e_68f31ced1a0483278128881340656685