### PR TITLE
feat: expand seed data and add smoke tests

### DIFF
--- a/apgms/README.md
+++ b/apgms/README.md
@@ -4,5 +4,8 @@ Quickstart:
 pnpm i
 pnpm -r build
 docker compose up -d
+export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+pnpm dlx prisma db push --schema shared/prisma/schema.prisma
+pnpm tsx scripts/seed.ts
 pnpm -r test
 pnpm -w exec playwright test

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests/*
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/scripts/seed-data/helpers.ts
+++ b/apgms/scripts/seed-data/helpers.ts
@@ -1,0 +1,47 @@
+export type RandomGenerator = () => number;
+
+export const createSeedRandom = (seed: string): RandomGenerator => {
+  let h = 2166136261 ^ seed.length;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return () => {
+    h += h << 13;
+    h ^= h >>> 7;
+    h += h << 3;
+    h ^= h >>> 17;
+    h += h << 5;
+    return ((h >>> 0) % 1000000) / 1000000;
+  };
+};
+
+export const randomInt = (min: number, max: number, rng: RandomGenerator): number => {
+  return Math.floor(rng() * (max - min + 1)) + min;
+};
+
+export const randomNumber = (min: number, max: number, rng: RandomGenerator): number => {
+  return rng() * (max - min) + min;
+};
+
+export const randomPick = <T>(values: readonly T[], rng: RandomGenerator): T => {
+  return values[randomInt(0, values.length - 1, rng)];
+};
+
+export const randomPastDate = (daysBack: number, rng: RandomGenerator): Date => {
+  const now = new Date();
+  const offsetDays = randomInt(0, daysBack, rng);
+  const date = new Date(now);
+  date.setDate(now.getDate() - offsetDays);
+  date.setHours(randomInt(7, 18, rng), randomInt(0, 59, rng), 0, 0);
+  return date;
+};
+
+export const toCurrency = (value: number): string => value.toFixed(2);
+
+export const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+

--- a/apgms/scripts/seed-data/index.ts
+++ b/apgms/scripts/seed-data/index.ts
@@ -1,0 +1,343 @@
+import {
+  RandomGenerator,
+  createSeedRandom,
+  randomInt,
+  randomNumber,
+  randomPastDate,
+  randomPick,
+  slugify,
+  toCurrency,
+} from "./helpers";
+
+export type PolicyStatus = "ACTIVE" | "INACTIVE" | "ARCHIVED";
+
+export interface PolicySeed {
+  id: string;
+  orgId: string;
+  name: string;
+  description: string;
+  status: PolicyStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface PolicyGateSeed {
+  id: string;
+  policyId: string;
+  name: string;
+  type: string;
+  config: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface BankLineSeed {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: string;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}
+
+export interface AllocationSeed {
+  id: string;
+  bankLineId: string;
+  category: string;
+  amount: string;
+  notes?: string;
+  createdAt: Date;
+}
+
+export interface AuditEventSeed {
+  id: string;
+  orgId: string;
+  actor: string;
+  actorType: string;
+  action: string;
+  entityType: "policy" | "allocation" | "bank_line";
+  entityId: string;
+  metadata: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface SeedData {
+  policies: PolicySeed[];
+  gates: PolicyGateSeed[];
+  bankLines: BankLineSeed[];
+  allocations: AllocationSeed[];
+  auditEvents: AuditEventSeed[];
+}
+
+const POLICY_TEMPLATES = [
+  {
+    name: "Spending Guardrails",
+    description: "Escalate review on large supplier and unusual weekend spend.",
+    gateTemplates: [
+      { type: "amount_threshold", name: "Large amount review", min: 3500, max: 7500 },
+      { type: "weekend_block", name: "Weekend payments", min: 0, max: 0 },
+    ],
+  },
+  {
+    name: "Vendor Risk Checks",
+    description: "Require due diligence for new or offshore vendors.",
+    gateTemplates: [
+      { type: "vendor_history", name: "First time vendor", min: 0, max: 0 },
+      { type: "jurisdiction", name: "Foreign jurisdiction", min: 0, max: 0 },
+    ],
+  },
+];
+
+const PAYEES = [
+  "Acme Fabrication",
+  "Skyline Cloud",
+  "Birchal Capital",
+  "Southbank Studios",
+  "Office Collective",
+  "Metro Utilities",
+  "Courier & Co",
+  "Brightline Consulting",
+  "Harbour Events",
+];
+
+const EXPENSE_DESCRIPTIONS = [
+  "Software subscription",
+  "Office rent",
+  "Digital marketing campaign",
+  "Equipment purchase",
+  "Professional services",
+  "Travel reimbursement",
+  "Insurance premium",
+];
+
+const INCOME_DESCRIPTIONS = [
+  "Investor funds received",
+  "Client project milestone",
+  "Platform revenue share",
+];
+
+const CATEGORIES = [
+  "Operations",
+  "Marketing",
+  "Technology",
+  "People",
+  "Compliance",
+  "Capital",
+];
+
+const ALLOCATION_NOTES = [
+  "Approved by finance",
+  "Split across teams",
+  "Pending reconciliation",
+  "Auto categorised",
+  "Adjusted for FX",
+];
+
+const ACTORS = [
+  { actor: "system", actorType: "SYSTEM" },
+  { actor: "jane.cfo@demo.org", actorType: "USER" },
+  { actor: "alex.controller@demo.org", actorType: "USER" },
+];
+
+const AUDIT_ACTIONS = [
+  "POLICY_ACTIVATED",
+  "POLICY_GATE_TRIGGERED",
+  "ALLOCATION_CREATED",
+  "BANK_LINE_IMPORTED",
+  "ALLOCATION_CONFIRMED",
+];
+
+const ensurePolicyStatus = (rng: RandomGenerator): PolicyStatus => {
+  const statuses: PolicyStatus[] = ["ACTIVE", "ACTIVE", "INACTIVE"];
+  return randomPick(statuses, rng);
+};
+
+const buildPolicies = (orgId: string, rng: RandomGenerator) => {
+  const policies: PolicySeed[] = [];
+  const gates: PolicyGateSeed[] = [];
+
+  POLICY_TEMPLATES.forEach((template) => {
+    const policyId = `${orgId}-policy-${slugify(template.name)}`;
+    const createdAt = randomPastDate(45, rng);
+    policies.push({
+      id: policyId,
+      orgId,
+      name: template.name,
+      description: template.description,
+      status: ensurePolicyStatus(rng),
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    template.gateTemplates.forEach((gateTemplate, gateIndex) => {
+      // Randomly decide if the gate is enabled, keep at least one per policy
+      const includeGate = gateIndex === 0 || rng() > 0.25;
+      if (!includeGate) return;
+
+      const gateId = `${policyId}-gate-${gateIndex + 1}-${slugify(gateTemplate.name)}`;
+      const config = {
+        threshold: gateTemplate.max > gateTemplate.min ? Number(toCurrency(randomNumber(gateTemplate.min, gateTemplate.max, rng))) : undefined,
+        windowDays: randomInt(3, 14, rng),
+      } satisfies Record<string, unknown>;
+
+      gates.push({
+        id: gateId,
+        policyId,
+        name: gateTemplate.name,
+        type: gateTemplate.type,
+        config,
+        createdAt: randomPastDate(30, rng),
+      });
+    });
+  });
+
+  return { policies, gates };
+};
+
+const buildBankLines = (orgId: string, rng: RandomGenerator) => {
+  const lines: BankLineSeed[] = [];
+
+  const lineCount = randomInt(8, 12, rng);
+  for (let index = 0; index < lineCount; index += 1) {
+    const payee = randomPick(PAYEES, rng);
+    const isIncome = rng() > 0.7;
+    const description = isIncome ? randomPick(INCOME_DESCRIPTIONS, rng) : randomPick(EXPENSE_DESCRIPTIONS, rng);
+    const amountBase = isIncome ? randomNumber(4000, 15000, rng) : randomNumber(120, 4200, rng);
+    const amount = isIncome ? amountBase : -amountBase;
+    const date = randomPastDate(20, rng);
+    const id = `${orgId}-line-${index + 1}-${slugify(payee)}`;
+
+    lines.push({
+      id,
+      orgId,
+      date,
+      amount: toCurrency(amount),
+      payee,
+      desc: description,
+      createdAt: date,
+    });
+  }
+
+  return lines;
+};
+
+const buildAllocations = (
+  bankLines: BankLineSeed[],
+  rng: RandomGenerator,
+): AllocationSeed[] => {
+  const allocations: AllocationSeed[] = [];
+
+  bankLines.forEach((line) => {
+    const allocationCount = randomInt(1, 3, rng);
+    const total = Math.abs(Number(line.amount));
+    const weights = Array.from({ length: allocationCount }, () => randomNumber(0.4, 1.25, rng));
+    const weightTotal = weights.reduce((acc, value) => acc + value, 0);
+    let allocated = 0;
+
+    weights.forEach((weight, index) => {
+      const isLast = index === allocationCount - 1;
+      const proportional = (total * weight) / weightTotal;
+      const amountValue = isLast ? total - allocated : Number(toCurrency(proportional));
+      allocated = Number(toCurrency(allocated + amountValue));
+      const signedAmount = Number(toCurrency(amountValue)) * Math.sign(Number(line.amount));
+
+      allocations.push({
+        id: `${line.id}-alloc-${index + 1}`,
+        bankLineId: line.id,
+        category: randomPick(CATEGORIES, rng),
+        amount: toCurrency(signedAmount),
+        notes: rng() > 0.5 ? randomPick(ALLOCATION_NOTES, rng) : undefined,
+        createdAt: randomPastDate(10, rng),
+      });
+    });
+  });
+
+  return allocations;
+};
+
+const buildAuditEvents = (
+  orgId: string,
+  policies: PolicySeed[],
+  bankLines: BankLineSeed[],
+  allocations: AllocationSeed[],
+  rng: RandomGenerator,
+): AuditEventSeed[] => {
+  const events: AuditEventSeed[] = [];
+
+  const relatedAllocations = allocations.slice(0, Math.min(allocations.length, 8));
+  const policyEvents = policies.map((policy) => {
+    const { actor, actorType } = randomPick(ACTORS, rng);
+    return {
+      id: `${policy.id}-audit-${slugify(actor)}`,
+      orgId,
+      actor,
+      actorType,
+      action: randomPick(AUDIT_ACTIONS, rng),
+      entityType: "policy",
+      entityId: policy.id,
+      metadata: {
+        name: policy.name,
+        status: policy.status,
+      },
+      createdAt: randomPastDate(15, rng),
+    } satisfies AuditEventSeed;
+  });
+  events.push(...policyEvents);
+
+  relatedAllocations.forEach((allocation) => {
+    const { actor, actorType } = randomPick(ACTORS, rng);
+    events.push({
+      id: `${allocation.id}-audit`,
+      orgId,
+      actor,
+      actorType,
+      action: "ALLOCATION_CREATED",
+      entityType: "allocation",
+      entityId: allocation.id,
+      metadata: {
+        bankLineId: allocation.bankLineId,
+        category: allocation.category,
+        amount: allocation.amount,
+      },
+      createdAt: randomPastDate(7, rng),
+    });
+  });
+
+  bankLines.slice(0, 3).forEach((line) => {
+    const { actor, actorType } = randomPick(ACTORS, rng);
+    events.push({
+      id: `${line.id}-audit`,
+      orgId,
+      actor,
+      actorType,
+      action: "BANK_LINE_IMPORTED",
+      entityType: "bank_line",
+      entityId: line.id,
+      metadata: {
+        payee: line.payee,
+        desc: line.desc,
+        amount: line.amount,
+      },
+      createdAt: randomPastDate(3, rng),
+    });
+  });
+
+  return events;
+};
+
+export const generateSeedData = (orgId: string): SeedData => {
+  const rng = createSeedRandom(orgId);
+  const { policies, gates } = buildPolicies(orgId, rng);
+  const bankLines = buildBankLines(orgId, rng);
+  const allocations = buildAllocations(bankLines, rng);
+  const auditEvents = buildAuditEvents(orgId, policies, bankLines, allocations, rng);
+
+  return {
+    policies,
+    gates,
+    bankLines,
+    allocations,
+    auditEvents,
+  };
+};
+

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,31 +1,107 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import { generateSeedData } from "./seed-data";
+
 const prisma = new PrismaClient();
 
 async function main() {
   const org = await prisma.org.upsert({
     where: { id: "demo-org" },
-    update: {},
+    update: {
+      name: "Demo Org",
+    },
     create: { id: "demo-org", name: "Demo Org" },
   });
 
   await prisma.user.upsert({
     where: { email: "founder@example.com" },
-    update: {},
+    update: {
+      orgId: org.id,
+    },
     create: { email: "founder@example.com", password: "password123", orgId: org.id },
   });
 
-  const today = new Date();
-  await prisma.bankLine.createMany({
-    data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
-    ],
-    skipDuplicates: true,
+  const seed = generateSeedData(org.id);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe(`DELETE FROM "AuditEvent" WHERE "orgId" = $1`, org.id);
+    await tx.$executeRawUnsafe(
+      `DELETE FROM "PolicyGate" USING "Policy" WHERE "PolicyGate"."policyId" = "Policy"."id" AND "Policy"."orgId" = $1`,
+      org.id,
+    );
+    await tx.$executeRawUnsafe(`DELETE FROM "Policy" WHERE "orgId" = $1`, org.id);
+    await tx.$executeRawUnsafe(
+      `DELETE FROM "Allocation" USING "BankLine" WHERE "Allocation"."bankLineId" = "BankLine"."id" AND "BankLine"."orgId" = $1`,
+      org.id,
+    );
+    await tx.bankLine.deleteMany({ where: { orgId: org.id } });
+
+    if (seed.bankLines.length > 0) {
+      await tx.bankLine.createMany({ data: seed.bankLines });
+    }
+
+    for (const allocation of seed.allocations) {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO "Allocation" ("id", "bankLineId", "category", "amount", "notes", "createdAt") VALUES ($1, $2, $3, $4, $5, $6)`,
+        allocation.id,
+        allocation.bankLineId,
+        allocation.category,
+        allocation.amount,
+        allocation.notes ?? null,
+        allocation.createdAt,
+      );
+    }
+
+    for (const policy of seed.policies) {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO "Policy" ("id", "orgId", "name", "description", "status", "createdAt", "updatedAt") VALUES ($1, $2, $3, $4, $5::"PolicyStatus", $6, $7)`,
+        policy.id,
+        policy.orgId,
+        policy.name,
+        policy.description,
+        policy.status,
+        policy.createdAt,
+        policy.updatedAt,
+      );
+    }
+
+    for (const gate of seed.gates) {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO "PolicyGate" ("id", "policyId", "name", "type", "config", "createdAt") VALUES ($1, $2, $3, $4, $5::jsonb, $6)`,
+        gate.id,
+        gate.policyId,
+        gate.name,
+        gate.type,
+        JSON.stringify(gate.config),
+        gate.createdAt,
+      );
+    }
+
+    for (const event of seed.auditEvents) {
+      await tx.$executeRawUnsafe(
+        `INSERT INTO "AuditEvent" ("id", "orgId", "actor", "actorType", "action", "entityType", "entityId", "metadata", "createdAt") VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)`,
+        event.id,
+        event.orgId,
+        event.actor,
+        event.actorType,
+        event.action,
+        event.entityType,
+        event.entityId,
+        JSON.stringify(event.metadata),
+        event.createdAt,
+      );
+    }
   });
 
-  console.log("Seed OK");
+  console.log(
+    `Seeded ${seed.policies.length} policies, ${seed.gates.length} gates, ${seed.bankLines.length} bank lines, ${seed.allocations.length} allocations, and ${seed.auditEvents.length} audit events for ${org.name}.`,
+  );
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((error) => {
+    console.error("Failed seeding database", error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -13,6 +13,8 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  policies  Policy[]
+  auditLog  AuditEvent[]
 }
 
 model User {
@@ -33,4 +35,56 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+  allocations Allocation[]
+}
+
+model Policy {
+  id          String        @id @default(cuid())
+  org         Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  name        String
+  description String
+  status      PolicyStatus  @default(ACTIVE)
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  gates       PolicyGate[]
+}
+
+model PolicyGate {
+  id        String   @id @default(cuid())
+  policy    Policy   @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId  String
+  name      String
+  type      String
+  config    Json
+  createdAt DateTime @default(now())
+}
+
+model Allocation {
+  id         String   @id @default(cuid())
+  bankLine   BankLine @relation(fields: [bankLineId], references: [id], onDelete: Cascade)
+  bankLineId String
+  category   String
+  amount     Decimal
+  notes      String?
+  createdAt  DateTime @default(now())
+}
+
+model AuditEvent {
+  id         String   @id @default(cuid())
+  org        Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  actor      String
+  actorType  String
+  action     String
+  entityType String
+  entityId   String
+  metadata   Json
+  createdAt  DateTime @default(now())
+}
+
+enum PolicyStatus {
+  ACTIVE
+  INACTIVE
+  ARCHIVED
 }

--- a/apgms/tests/seed/package.json
+++ b/apgms/tests/seed/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@apgms/seed-tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.3",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/tests/seed/seed-data.test.ts
+++ b/apgms/tests/seed/seed-data.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { PolicyStatus, generateSeedData } from "../../scripts/seed-data";
+
+describe("generateSeedData", () => {
+  const data = generateSeedData("test-org");
+
+  it("creates policies with at least one gate", () => {
+    expect(data.policies.length).toBeGreaterThan(0);
+    const gatePolicyIds = new Set(data.gates.map((gate) => gate.policyId));
+    const statuses: PolicyStatus[] = ["ACTIVE", "INACTIVE", "ARCHIVED"];
+    data.policies.forEach((policy) => {
+      expect(statuses).toContain(policy.status);
+      expect(gatePolicyIds.has(policy.id)).toBe(true);
+    });
+  });
+
+  it("splits bank lines into allocations that sum to the line amount", () => {
+    const lineLookup = new Map(data.bankLines.map((line) => [line.id, line]));
+    expect(lineLookup.size).toBeGreaterThan(0);
+
+    const allocationsByLine = new Map<string, number>();
+    data.allocations.forEach((allocation) => {
+      const amount = Number(allocation.amount);
+      const existing = allocationsByLine.get(allocation.bankLineId) ?? 0;
+      allocationsByLine.set(allocation.bankLineId, Number((existing + amount).toFixed(2)));
+    });
+
+    allocationsByLine.forEach((allocatedTotal, bankLineId) => {
+      const sourceLine = lineLookup.get(bankLineId);
+      expect(sourceLine).toBeDefined();
+      const lineAmount = Number(sourceLine!.amount);
+      expect(Math.abs(allocatedTotal - lineAmount)).toBeLessThanOrEqual(0.02);
+    });
+  });
+
+  it("produces audit events tied to known entities", () => {
+    expect(data.auditEvents.length).toBeGreaterThan(0);
+    const policyIds = new Set(data.policies.map((policy) => policy.id));
+    const allocationIds = new Set(data.allocations.map((allocation) => allocation.id));
+    const bankLineIds = new Set(data.bankLines.map((line) => line.id));
+
+    const entityCoverage = { policy: 0, allocation: 0, bank_line: 0 };
+
+    data.auditEvents.forEach((event) => {
+      switch (event.entityType) {
+        case "policy":
+          expect(policyIds.has(event.entityId)).toBe(true);
+          entityCoverage.policy += 1;
+          break;
+        case "allocation":
+          expect(allocationIds.has(event.entityId)).toBe(true);
+          entityCoverage.allocation += 1;
+          break;
+        case "bank_line":
+          expect(bankLineIds.has(event.entityId)).toBe(true);
+          entityCoverage.bank_line += 1;
+          break;
+        default:
+          throw new Error(`Unexpected entity type ${event.entityType}`);
+      }
+    });
+
+    expect(entityCoverage.policy).toBeGreaterThan(0);
+    expect(entityCoverage.allocation).toBeGreaterThan(0);
+    expect(entityCoverage.bank_line).toBeGreaterThan(0);
+  });
+});
+

--- a/apgms/tests/seed/tsconfig.json
+++ b/apgms/tests/seed/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"]
+}
+


### PR DESCRIPTION
## Summary
- extend the shared Prisma schema with policies, gates, allocations, and audit events
- add reusable seed data generators and update the seed script to populate the richer dataset
- document the seed command and add smoke tests that assert the generated data shapes

## Testing
- pnpm --filter @apgms/seed-tests test *(fails: vitest binary is unavailable in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68f31cf005748327bcd45c4b77dbb859