### PR TITLE
feat(web): scaffold dashboard and bank lines ui

### DIFF
--- a/apgms/web/src/App.tsx
+++ b/apgms/web/src/App.tsx
@@ -1,0 +1,112 @@
+import React, { useMemo, useState } from 'react';
+import { Layout, Navigation, Header, RPTDrawer } from './components';
+import { BankLineSummary } from './components/RPTDrawer';
+import { DashboardPage, BankLinesPage } from './pages';
+import { ThemeProvider } from './theme/ThemeProvider';
+import { defaultTheme } from './theme/theme';
+
+type PageId = 'dashboard' | 'bank-lines';
+
+type PageDefinition = {
+  id: PageId;
+  label: string;
+  subtitle: string;
+  icon: string;
+};
+
+const pages: PageDefinition[] = [
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    subtitle: 'Liquidity runway and counterparty health at a glance',
+    icon: '📊',
+  },
+  {
+    id: 'bank-lines',
+    label: 'Bank Lines',
+    subtitle: 'Risk participation terms, utilisation and next actions',
+    icon: '🏦',
+  },
+];
+
+export const App = () => {
+  const [activePage, setActivePage] = useState<PageId>('dashboard');
+  const [selectedLine, setSelectedLine] = useState<BankLineSummary | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const currentPage = useMemo(
+    () => pages.find((page) => page.id === activePage) ?? pages[0],
+    [activePage]
+  );
+
+  const navigationItems = useMemo(
+    () =>
+      pages.map((page) => ({
+        id: page.id,
+        label: page.label,
+        icon: page.icon,
+        badge: page.id === 'bank-lines' ? 'Live' : undefined,
+      })),
+    []
+  );
+
+  const renderPage = () => {
+    if (activePage === 'dashboard') {
+      return <DashboardPage />;
+    }
+
+    return (
+      <BankLinesPage
+        onSelectLine={(line) => {
+          setSelectedLine(line);
+          setDrawerOpen(true);
+        }}
+      />
+    );
+  };
+
+  return (
+    <ThemeProvider>
+      <Layout
+        navigation={
+          <Navigation
+            items={navigationItems}
+            activeItemId={activePage}
+            onSelect={(id) => {
+              setActivePage(id as PageId);
+              setDrawerOpen(false);
+            }}
+          />
+        }
+        header={
+          <Header
+            title={currentPage.label}
+            subtitle={currentPage.subtitle}
+            actions={
+              <button
+                type="button"
+                onClick={() => setDrawerOpen(true)}
+                style={{
+                  padding: '8px 16px',
+                  borderRadius: 999,
+                  border: 'none',
+                  background: defaultTheme.colors.primary,
+                  color: '#02040B',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              >
+                Create brief
+              </button>
+            }
+          />
+        }
+        drawer={<RPTDrawer bankLine={selectedLine} onClose={() => setDrawerOpen(false)} />}
+        isDrawerOpen={drawerOpen}
+        onCloseDrawer={() => setDrawerOpen(false)}
+      >
+        {renderPage()}
+      </Layout>
+    </ThemeProvider>
+  );
+};

--- a/apgms/web/src/__tests__/Layout.test.tsx
+++ b/apgms/web/src/__tests__/Layout.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Layout, Navigation, Header, RPTDrawer } from '../components';
+import { ThemeProvider } from '../theme/ThemeProvider';
+
+describe('Layout', () => {
+  const renderLayout = () =>
+    render(
+      <ThemeProvider>
+        <Layout
+          navigation={
+            <Navigation
+              items={[
+                { id: 'dashboard', label: 'Dashboard', icon: '📊' },
+                { id: 'bank-lines', label: 'Bank Lines', icon: '🏦' },
+              ]}
+              activeItemId="dashboard"
+              onSelect={() => undefined}
+            />
+          }
+          header={<Header title="Dashboard" subtitle="Liquidity overview" />}
+          drawer={<RPTDrawer bankLine={null} onClose={() => undefined} />}
+          isDrawerOpen
+          onCloseDrawer={() => undefined}
+        >
+          <div>Content</div>
+        </Layout>
+      </ThemeProvider>
+    );
+
+  it('renders navigation items and content', () => {
+    renderLayout();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Bank Lines')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('shows the drawer headline', () => {
+    renderLayout();
+    fireEvent.click(screen.getByText('Close'));
+    expect(screen.getByText('RPT Insights')).toBeInTheDocument();
+  });
+});

--- a/apgms/web/src/components/Card.tsx
+++ b/apgms/web/src/components/Card.tsx
@@ -1,0 +1,56 @@
+import React, { ReactNode } from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+type CardProps = {
+  title?: string;
+  subtitle?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+export const Card = ({ title, subtitle, children, footer }: CardProps) => {
+  const theme = useTheme();
+
+  return (
+    <section
+      style={{
+        background: theme.colors.surface,
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.radii.lg,
+        padding: theme.spacing.lg,
+        display: 'grid',
+        gap: theme.spacing.md,
+        boxShadow: theme.shadows.raised,
+      }}
+    >
+      {(title || subtitle) && (
+        <header style={{ display: 'grid', gap: theme.spacing.xs }}>
+          {title && (
+            <h2
+              style={{
+                margin: 0,
+                fontSize: theme.typography.headings.h3.size,
+                fontWeight: theme.typography.headings.h3.weight,
+              }}
+            >
+              {title}
+            </h2>
+          )}
+          {subtitle && (
+            <p
+              style={{
+                margin: 0,
+                color: theme.colors.textSecondary,
+                fontSize: theme.typography.body.md.size,
+              }}
+            >
+              {subtitle}
+            </p>
+          )}
+        </header>
+      )}
+      <div>{children}</div>
+      {footer && <footer>{footer}</footer>}
+    </section>
+  );
+};

--- a/apgms/web/src/components/Header.tsx
+++ b/apgms/web/src/components/Header.tsx
@@ -1,0 +1,47 @@
+import React, { ReactNode } from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+type HeaderProps = {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+};
+
+export const Header = ({ title, subtitle, actions }: HeaderProps) => {
+  const theme = useTheme();
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: theme.spacing.lg,
+      }}
+    >
+      <div style={{ display: 'grid', gap: theme.spacing.xs }}>
+        <h1
+          style={{
+            margin: 0,
+            fontSize: theme.typography.headings.h1.size,
+            fontWeight: theme.typography.headings.h1.weight,
+          }}
+        >
+          {title}
+        </h1>
+        {subtitle && (
+          <p
+            style={{
+              margin: 0,
+              color: theme.colors.textSecondary,
+              fontSize: theme.typography.body.lg.size,
+            }}
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
+      {actions && <div style={{ display: 'flex', gap: theme.spacing.sm }}>{actions}</div>}
+    </div>
+  );
+};

--- a/apgms/web/src/components/Layout.tsx
+++ b/apgms/web/src/components/Layout.tsx
@@ -1,0 +1,131 @@
+import React, { ReactNode } from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+type LayoutProps = {
+  navigation: ReactNode;
+  header: ReactNode;
+  children: ReactNode;
+  drawer?: ReactNode;
+  isDrawerOpen?: boolean;
+  onCloseDrawer?: () => void;
+};
+
+export const Layout = ({
+  navigation,
+  header,
+  children,
+  drawer,
+  isDrawerOpen,
+  onCloseDrawer,
+}: LayoutProps) => {
+  const theme = useTheme();
+
+  return (
+    <div
+      style={{
+        backgroundColor: theme.colors.background,
+        color: theme.colors.textPrimary,
+        fontFamily: theme.typography.fontFamily,
+        minHeight: '100vh',
+        display: 'grid',
+        gridTemplateColumns: '260px 1fr',
+      }}
+    >
+      <aside
+        style={{
+          borderRight: `1px solid ${theme.colors.border}`,
+          padding: theme.spacing.lg,
+          background: theme.colors.surface,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: theme.spacing.lg,
+        }}
+      >
+        <div
+          style={{
+            fontSize: theme.typography.headings.h3.size,
+            fontWeight: theme.typography.headings.h3.weight,
+            letterSpacing: '0.06em',
+            textTransform: 'uppercase',
+            color: theme.colors.textSecondary,
+          }}
+        >
+          APGMS
+        </div>
+        {navigation}
+      </aside>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: '100vh',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <header
+          style={{
+            padding: `${theme.spacing.lg}px ${theme.spacing.xl}px`,
+            borderBottom: `1px solid ${theme.colors.border}`,
+            background: theme.colors.surface,
+            position: 'sticky',
+            top: 0,
+            zIndex: 2,
+          }}
+        >
+          {header}
+        </header>
+        <main
+          style={{
+            flex: 1,
+            padding: theme.spacing.xl,
+            background: theme.colors.surfaceAlt,
+          }}
+        >
+          {children}
+        </main>
+      </div>
+
+      {drawer && (
+        <div
+          aria-hidden={!isDrawerOpen}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            pointerEvents: isDrawerOpen ? 'auto' : 'none',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            zIndex: 3,
+          }}
+        >
+          <div
+            role="presentation"
+            onClick={onCloseDrawer}
+            style={{
+              flex: 1,
+              backgroundColor: 'rgba(4, 7, 21, 0.6)',
+              opacity: isDrawerOpen ? 1 : 0,
+              transition: 'opacity 180ms ease',
+            }}
+          />
+          <aside
+            style={{
+              width: 400,
+              maxWidth: '90vw',
+              background: theme.colors.surface,
+              borderLeft: `1px solid ${theme.colors.border}`,
+              transform: isDrawerOpen ? 'translateX(0)' : 'translateX(100%)',
+              transition: 'transform 180ms ease',
+              boxShadow: theme.shadows.raised,
+              height: '100%',
+              overflowY: 'auto',
+            }}
+          >
+            {drawer}
+          </aside>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apgms/web/src/components/MetricTile.tsx
+++ b/apgms/web/src/components/MetricTile.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+type MetricTileProps = {
+  label: string;
+  value: string;
+  delta?: string;
+  trend?: 'up' | 'down' | 'flat';
+};
+
+export const MetricTile = ({ label, value, delta, trend = 'flat' }: MetricTileProps) => {
+  const theme = useTheme();
+
+  const trendColor =
+    trend === 'up'
+      ? theme.colors.success
+      : trend === 'down'
+      ? theme.colors.danger
+      : theme.colors.textSecondary;
+
+  const trendSymbol = trend === 'up' ? '▲' : trend === 'down' ? '▼' : '◆';
+
+  return (
+    <div
+      style={{
+        borderRadius: theme.radii.lg,
+        padding: theme.spacing.lg,
+        border: `1px solid ${theme.colors.border}`,
+        background: theme.colors.surface,
+        display: 'grid',
+        gap: theme.spacing.sm,
+      }}
+    >
+      <span
+        style={{
+          textTransform: 'uppercase',
+          letterSpacing: '0.08em',
+          fontSize: theme.typography.body.sm.size,
+          color: theme.colors.textSecondary,
+        }}
+      >
+        {label}
+      </span>
+      <strong
+        style={{
+          fontSize: 28,
+          fontWeight: 600,
+          lineHeight: 1,
+        }}
+      >
+        {value}
+      </strong>
+      {delta && (
+        <span style={{ color: trendColor, fontSize: theme.typography.body.md.size }}>
+          {trendSymbol} {delta}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/apgms/web/src/components/Navigation.tsx
+++ b/apgms/web/src/components/Navigation.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+type NavigationItem = {
+  id: string;
+  label: string;
+  icon?: string;
+  badge?: string;
+};
+
+type NavigationProps = {
+  items: NavigationItem[];
+  activeItemId: string;
+  onSelect: (id: string) => void;
+};
+
+export const Navigation = ({ items, activeItemId, onSelect }: NavigationProps) => {
+  const theme = useTheme();
+
+  return (
+    <nav
+      aria-label="Primary navigation"
+      style={{ display: 'grid', gap: theme.spacing.sm }}
+    >
+      {items.map((item) => {
+        const isActive = activeItemId === item.id;
+        return (
+          <button
+            key={item.id}
+            onClick={() => onSelect(item.id)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              justifyContent: 'space-between',
+              padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+              background: isActive ? theme.colors.surfaceAlt : 'transparent',
+              border: `1px solid ${isActive ? theme.colors.primary : theme.colors.border}`,
+              borderRadius: theme.radii.md,
+              color: isActive ? theme.colors.textPrimary : theme.colors.textSecondary,
+              cursor: 'pointer',
+              transition: 'all 160ms ease',
+            }}
+          >
+            <span style={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+              {item.icon && <span aria-hidden>{item.icon}</span>}
+              <span>{item.label}</span>
+            </span>
+            {item.badge && (
+              <span
+                style={{
+                  fontSize: theme.typography.body.sm.size,
+                  padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+                  background: theme.colors.primary,
+                  color: '#02040B',
+                  borderRadius: theme.radii.pill,
+                  fontWeight: 600,
+                }}
+              >
+                {item.badge}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </nav>
+  );
+};

--- a/apgms/web/src/components/RPTDrawer.tsx
+++ b/apgms/web/src/components/RPTDrawer.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeProvider';
+
+export type BankLineSummary = {
+  id: string;
+  provider: string;
+  currency: string;
+  limit: number;
+  utilised: number;
+  renewalDate: string;
+  relationshipManager: string;
+};
+
+type RPTDrawerProps = {
+  bankLine?: BankLineSummary | null;
+  onClose: () => void;
+};
+
+export const RPTDrawer = ({ bankLine, onClose }: RPTDrawerProps) => {
+  const theme = useTheme();
+
+  if (!bankLine) {
+    return (
+      <div style={{ padding: theme.spacing.xl }}>
+        <header style={{ marginBottom: theme.spacing.lg }}>
+          <h2 style={{ margin: 0 }}>RPT Insights</h2>
+          <p style={{ color: theme.colors.textSecondary }}>
+            Select a bank line to review risk participation terms and exposures.
+          </p>
+        </header>
+      </div>
+    );
+  }
+
+  const utilisation = ((bankLine.utilised / bankLine.limit) * 100).toFixed(1);
+  const remaining = bankLine.limit - bankLine.utilised;
+
+  return (
+    <div style={{ padding: theme.spacing.xl, display: 'grid', gap: theme.spacing.lg }}>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <h2 style={{ margin: 0 }}>{bankLine.provider}</h2>
+          <p style={{ margin: 0, color: theme.colors.textSecondary }}>Line ID · {bankLine.id}</p>
+        </div>
+        <button
+          onClick={onClose}
+          style={{
+            background: 'transparent',
+            border: `1px solid ${theme.colors.border}`,
+            borderRadius: theme.radii.md,
+            color: theme.colors.textSecondary,
+            padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+            cursor: 'pointer',
+          }}
+        >
+          Close
+        </button>
+      </header>
+      <section
+        style={{
+          display: 'grid',
+          gap: theme.spacing.md,
+          border: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.radii.md,
+          padding: theme.spacing.lg,
+          background: theme.colors.surfaceAlt,
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: theme.colors.textSecondary }}>Currency</span>
+          <strong>{bankLine.currency}</strong>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: theme.colors.textSecondary }}>Committed limit</span>
+          <strong>{bankLine.limit.toLocaleString()}</strong>
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <span style={{ color: theme.colors.textSecondary }}>Utilised</span>
+          <strong>{bankLine.utilised.toLocaleString()}</strong>
+        </div>
+        <div
+          style={{
+            height: 6,
+            background: 'rgba(255,255,255,0.08)',
+            borderRadius: theme.radii.pill,
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${utilisation}%`,
+              background: theme.colors.primary,
+              height: '100%',
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', color: theme.colors.textSecondary }}>
+          <span>{utilisation}% utilised</span>
+          <span>{remaining.toLocaleString()} remaining</span>
+        </div>
+      </section>
+      <section
+        style={{
+          border: `1px solid ${theme.colors.border}`,
+          borderRadius: theme.radii.md,
+          padding: theme.spacing.lg,
+          display: 'grid',
+          gap: theme.spacing.md,
+        }}
+      >
+        <div>
+          <h3 style={{ margin: 0 }}>Relationship</h3>
+          <p style={{ margin: 0, color: theme.colors.textSecondary }}>{bankLine.relationshipManager}</p>
+        </div>
+        <div>
+          <h3 style={{ margin: 0 }}>Renewal</h3>
+          <p style={{ margin: 0, color: theme.colors.warning }}>{bankLine.renewalDate}</p>
+        </div>
+        <button
+          style={{
+            padding: `${theme.spacing.sm}px ${theme.spacing.md}px`,
+            borderRadius: theme.radii.md,
+            border: 'none',
+            background: theme.colors.primary,
+            color: '#02040B',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          Generate latest RPT
+        </button>
+      </section>
+    </div>
+  );
+};

--- a/apgms/web/src/components/index.ts
+++ b/apgms/web/src/components/index.ts
@@ -1,0 +1,6 @@
+export * from './Layout';
+export * from './Navigation';
+export * from './Header';
+export * from './Card';
+export * from './MetricTile';
+export * from './RPTDrawer';

--- a/apgms/web/src/index.tsx
+++ b/apgms/web/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+
+const container = document.getElementById('root');
+
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
+}

--- a/apgms/web/src/pages/BankLines.tsx
+++ b/apgms/web/src/pages/BankLines.tsx
@@ -1,0 +1,146 @@
+import React, { CSSProperties } from 'react';
+import { Card } from '../components';
+import { BankLineSummary } from '../components/RPTDrawer';
+import { useTheme } from '../theme/ThemeProvider';
+
+type BankLinesPageProps = {
+  onSelectLine: (line: BankLineSummary) => void;
+};
+
+const visuallyHidden: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+const bankLines: BankLineSummary[] = [
+  {
+    id: 'BL-2034',
+    provider: 'Silicon Valley Bank UK',
+    currency: 'GBP',
+    limit: 45000000,
+    utilised: 31200000,
+    renewalDate: '30 Jun 2024',
+    relationshipManager: 'Sophie Martins',
+  },
+  {
+    id: 'BL-2078',
+    provider: 'HSBC Innovation',
+    currency: 'USD',
+    limit: 60000000,
+    utilised: 22400000,
+    renewalDate: '12 Sep 2024',
+    relationshipManager: 'Daniel Bryant',
+  },
+  {
+    id: 'BL-2101',
+    provider: 'Judo Bank',
+    currency: 'AUD',
+    limit: 32000000,
+    utilised: 28400000,
+    renewalDate: '05 Nov 2024',
+    relationshipManager: 'Amelia Stone',
+  },
+];
+
+export const BankLinesPage = ({ onSelectLine }: BankLinesPageProps) => {
+  const theme = useTheme();
+
+  return (
+    <div style={{ display: 'grid', gap: theme.spacing.xl }}>
+      <Card title="Risk participation overview" subtitle="Monitor active and proposed bank partnerships">
+        <table
+          style={{
+            width: '100%',
+            borderCollapse: 'collapse',
+            fontSize: theme.typography.body.lg.size,
+          }}
+        >
+          <thead>
+            <tr style={{ color: theme.colors.textSecondary, textAlign: 'left' }}>
+              <th style={{ paddingBottom: theme.spacing.sm }}>Provider</th>
+              <th style={{ paddingBottom: theme.spacing.sm }}>Currency</th>
+              <th style={{ paddingBottom: theme.spacing.sm }}>Committed</th>
+              <th style={{ paddingBottom: theme.spacing.sm }}>Utilised</th>
+              <th style={{ paddingBottom: theme.spacing.sm }}>Renewal</th>
+              <th style={{ paddingBottom: theme.spacing.sm }}>
+                <span style={visuallyHidden}>Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {bankLines.map((line) => {
+              const utilisation = Math.round((line.utilised / line.limit) * 100);
+              return (
+                <tr key={line.id} style={{ borderTop: `1px solid ${theme.colors.border}` }}>
+                  <td style={{ padding: `${theme.spacing.sm}px 0` }}>
+                    <div style={{ display: 'grid', gap: 4 }}>
+                      <strong>{line.provider}</strong>
+                      <span style={{ color: theme.colors.textSecondary }}>{line.id}</span>
+                    </div>
+                  </td>
+                  <td style={{ padding: `${theme.spacing.sm}px 0` }}>{line.currency}</td>
+                  <td style={{ padding: `${theme.spacing.sm}px 0` }}>{line.limit.toLocaleString()}</td>
+                  <td style={{ padding: `${theme.spacing.sm}px 0` }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+                      <span>{line.utilised.toLocaleString()}</span>
+                      <div
+                        aria-hidden
+                        style={{
+                          flex: 1,
+                          height: 6,
+                          background: 'rgba(255, 255, 255, 0.08)',
+                          borderRadius: theme.radii.pill,
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <div
+                          style={{
+                            width: `${utilisation}%`,
+                            background: utilisation > 85 ? theme.colors.warning : theme.colors.primary,
+                            height: '100%',
+                          }}
+                        />
+                      </div>
+                      <span style={{ color: theme.colors.textSecondary }}>{utilisation}%</span>
+                    </div>
+                  </td>
+                  <td style={{ padding: `${theme.spacing.sm}px 0` }}>{line.renewalDate}</td>
+                  <td style={{ padding: `${theme.spacing.sm}px 0`, textAlign: 'right' }}>
+                    <button
+                      onClick={() => onSelectLine(line)}
+                      style={{
+                        padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
+                        borderRadius: theme.radii.md,
+                        border: 'none',
+                        background: theme.colors.primary,
+                        color: '#02040B',
+                        fontWeight: 600,
+                        cursor: 'pointer',
+                      }}
+                    >
+                      View RPT
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Card>
+      <Card title="Playbook" subtitle="Suggested actions based on utilisation thresholds">
+        <ol style={{ margin: 0, paddingLeft: theme.spacing.xl, display: 'grid', gap: theme.spacing.sm }}>
+          <li>Engage SVB UK for upsized tranche before end of Q2.</li>
+          <li>Confirm HSBC Innovation renewal clauses with treasury counsel.</li>
+          <li>Review AUD hedging posture with Judo Bank relationship team.</li>
+        </ol>
+      </Card>
+    </div>
+  );
+};

--- a/apgms/web/src/pages/Dashboard.tsx
+++ b/apgms/web/src/pages/Dashboard.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Card, MetricTile } from '../components';
+import { useTheme } from '../theme/ThemeProvider';
+
+type ActivityItem = {
+  id: string;
+  label: string;
+  timestamp: string;
+  actor: string;
+};
+
+const activityFeed: ActivityItem[] = [
+  {
+    id: 'act-1',
+    label: 'Syndicated RPT approved for Series B',
+    timestamp: '2 hours ago',
+    actor: 'J. Cole · Risk',
+  },
+  {
+    id: 'act-2',
+    label: 'Updated liquidity waterfall for FY24',
+    timestamp: 'Yesterday',
+    actor: 'M. Byrne · Treasury',
+  },
+  {
+    id: 'act-3',
+    label: 'Bank line utilisation nudged to 78%',
+    timestamp: 'Monday',
+    actor: 'System alert',
+  },
+];
+
+const metrics = [
+  { id: 'm1', label: 'Total runway', value: '21.4 months', delta: '+3.2 months', trend: 'up' as const },
+  { id: 'm2', label: 'Cash on hand', value: '$84.2m', delta: '+$5.1m', trend: 'up' as const },
+  { id: 'm3', label: 'Burn multiple', value: '0.7×', delta: '-0.1', trend: 'down' as const },
+  { id: 'm4', label: 'Counterparty exposure', value: '32%', delta: 'Stable', trend: 'flat' as const },
+];
+
+export const DashboardPage = () => {
+  const theme = useTheme();
+
+  return (
+    <div style={{ display: 'grid', gap: theme.spacing.xl }}>
+      <section
+        style={{
+          display: 'grid',
+          gap: theme.spacing.lg,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+        }}
+      >
+        {metrics.map((metric) => (
+          <MetricTile key={metric.id} label={metric.label} value={metric.value} delta={metric.delta} trend={metric.trend} />
+        ))}
+      </section>
+
+      <Card title="Liquidity plan" subtitle="Consolidated targets across all managed entities">
+        <div
+          style={{
+            display: 'grid',
+            gap: theme.spacing.md,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+          }}
+        >
+          <div>
+            <p style={{ color: theme.colors.textSecondary, marginBottom: theme.spacing.xs }}>Target coverage</p>
+            <strong style={{ fontSize: 24 }}>18 months</strong>
+          </div>
+          <div>
+            <p style={{ color: theme.colors.textSecondary, marginBottom: theme.spacing.xs }}>Scenario stress</p>
+            <strong style={{ fontSize: 24 }}>-12%</strong>
+          </div>
+          <div>
+            <p style={{ color: theme.colors.textSecondary, marginBottom: theme.spacing.xs }}>Mitigation toolkit</p>
+            <strong style={{ fontSize: 24 }}>5 playbooks</strong>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="Latest activity" subtitle="Keep an eye on risk participation events and comments">
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'grid', gap: theme.spacing.md }}>
+          {activityFeed.map((item) => (
+            <li key={item.id} style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <div style={{ display: 'grid', gap: theme.spacing.xs }}>
+                <span style={{ fontWeight: 500 }}>{item.label}</span>
+                <span style={{ color: theme.colors.textSecondary }}>{item.actor}</span>
+              </div>
+              <span style={{ color: theme.colors.textSecondary }}>{item.timestamp}</span>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </div>
+  );
+};

--- a/apgms/web/src/pages/index.ts
+++ b/apgms/web/src/pages/index.ts
@@ -1,0 +1,2 @@
+export * from './Dashboard';
+export * from './BankLines';

--- a/apgms/web/src/theme/ThemeProvider.tsx
+++ b/apgms/web/src/theme/ThemeProvider.tsx
@@ -1,0 +1,30 @@
+import React, { createContext, ReactNode, useContext, useMemo } from 'react';
+import { defaultTheme, Theme } from './theme';
+
+type ThemeContextValue = Theme;
+
+const ThemeContext = createContext<ThemeContextValue>(defaultTheme);
+
+export type ThemeProviderProps = {
+  theme?: Partial<Theme>;
+  children: ReactNode;
+};
+
+export const ThemeProvider = ({ theme, children }: ThemeProviderProps) => {
+  const mergedTheme = useMemo<Theme>(
+    () => ({
+      ...defaultTheme,
+      ...theme,
+      colors: { ...defaultTheme.colors, ...(theme?.colors ?? {}) },
+      spacing: { ...defaultTheme.spacing, ...(theme?.spacing ?? {}) },
+      typography: { ...defaultTheme.typography, ...(theme?.typography ?? {}) },
+      radii: { ...defaultTheme.radii, ...(theme?.radii ?? {}) },
+      shadows: { ...defaultTheme.shadows, ...(theme?.shadows ?? {}) },
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={mergedTheme}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/apgms/web/src/theme/theme.ts
+++ b/apgms/web/src/theme/theme.ts
@@ -1,0 +1,17 @@
+import { colors, spacing, typography, radii, shadows } from './tokens';
+
+export type Theme = {
+  colors: typeof colors;
+  spacing: typeof spacing;
+  typography: typeof typography;
+  radii: typeof radii;
+  shadows: typeof shadows;
+};
+
+export const defaultTheme: Theme = {
+  colors,
+  spacing,
+  typography,
+  radii,
+  shadows,
+};

--- a/apgms/web/src/theme/tokens.ts
+++ b/apgms/web/src/theme/tokens.ts
@@ -1,0 +1,50 @@
+export const colors = {
+  background: '#0B0D17',
+  surface: '#151B2B',
+  surfaceAlt: '#1E2538',
+  primary: '#00E0B8',
+  primaryMuted: '#6EF7D9',
+  textPrimary: '#FFFFFF',
+  textSecondary: '#A5B4D4',
+  border: 'rgba(255, 255, 255, 0.08)',
+  accent: '#2A5EE8',
+  warning: '#FFB74D',
+  success: '#4CAF50',
+  danger: '#F44336',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+  xl: 32,
+  xxl: 48,
+};
+
+export const typography = {
+  fontFamily: "'Inter', 'IBM Plex Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  headings: {
+    h1: { size: 32, weight: 600 },
+    h2: { size: 24, weight: 600 },
+    h3: { size: 18, weight: 600 },
+    h4: { size: 16, weight: 500 },
+  },
+  body: {
+    sm: { size: 12, weight: 400 },
+    md: { size: 14, weight: 400 },
+    lg: { size: 16, weight: 400 },
+  },
+};
+
+export const radii = {
+  sm: 6,
+  md: 12,
+  lg: 18,
+  pill: 999,
+};
+
+export const shadows = {
+  focus: '0 0 0 2px rgba(0, 224, 184, 0.4)',
+  raised: '0 18px 45px rgba(12, 14, 35, 0.45)',
+};


### PR DESCRIPTION
## Summary
- scaffold a new web shell under `apgms/web/src` with themed layout, navigation, and shared UI components
- add dashboard and bank lines pages including the RPT drawer interaction and sample data
- introduce a component test to exercise the layout structure and drawer affordance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f31cf0c1948327b149e87f7fe00a60