### PR TITLE
Add mock remittance scheduler with policy gates

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker",
+    "tests/*"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -75,6 +75,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  tests/scheduler: {}
+
   webapp: {}
 
   worker: {}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests/*
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/server/index.ts
+++ b/apgms/server/index.ts
@@ -1,0 +1,101 @@
+import { MockRail } from './rails/mockRail.js';
+import {
+  GateScheduler,
+  GateSchedulerOptions,
+  createBlockedAccountGate,
+  createMaxAmountGate,
+} from './scheduler/gates.js';
+
+export interface BootstrapOptions {
+  env?: NodeJS.ProcessEnv;
+  scheduler?: Partial<GateSchedulerOptions> & {
+    enabled?: boolean;
+    maxAmount?: number;
+    blockedAccounts?: string[];
+  };
+  logger?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+  };
+}
+
+export interface ServerContext {
+  rail: MockRail;
+  scheduler: GateScheduler;
+}
+
+const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const normalized = value.toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+};
+
+const parseNumber = (value: string | undefined, fallback: number): number => {
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const parseList = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+};
+
+export const bootstrapServer = (options: BootstrapOptions = {}): ServerContext => {
+  const env = options.env ?? process.env;
+  const logger = options.logger ?? console;
+
+  const schedulerEnabled =
+    options.scheduler?.enabled ?? parseBoolean(env.MOCK_RAIL_SCHEDULER_ENABLED, true);
+
+  const intervalMs =
+    options.scheduler?.intervalMs ?? parseNumber(env.MOCK_RAIL_SCHEDULER_INTERVAL_MS, 5_000);
+
+  const maxAmount =
+    options.scheduler?.maxAmount ?? parseNumber(env.MOCK_RAIL_MAX_AMOUNT, 100_000);
+
+  const blockedAccounts =
+    options.scheduler?.blockedAccounts ?? parseList(env.MOCK_RAIL_BLOCKED_ACCOUNTS);
+
+  const rail = new MockRail();
+
+  const scheduler = new GateScheduler(rail, {
+    ...options.scheduler,
+    intervalMs,
+    gates: [
+      createMaxAmountGate(maxAmount),
+      createBlockedAccountGate(blockedAccounts),
+      ...(options.scheduler?.gates ?? []),
+    ],
+    logger,
+  });
+
+  if (schedulerEnabled) {
+    scheduler.start();
+    logger.info?.('Mock rail scheduler started.');
+  } else {
+    logger.info?.('Mock rail scheduler disabled via configuration.');
+  }
+
+  return { rail, scheduler };
+};

--- a/apgms/server/rails/mockRail.ts
+++ b/apgms/server/rails/mockRail.ts
@@ -1,0 +1,74 @@
+export interface TransferRequest {
+  fromAccountId: string;
+  toAccountId: string;
+  amount: number;
+  currency: string;
+  reference?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type TransferStatus = 'settled' | 'failed';
+
+export interface TransferReceipt {
+  id: string;
+  status: TransferStatus;
+  requestedAt: Date;
+  completedAt: Date;
+  request: TransferRequest;
+  failureReason?: string;
+}
+
+export interface MockRailOptions {
+  latencyMs?: number;
+  clock?: () => Date;
+  idFactory?: (request: TransferRequest) => string;
+  onTransfer?: (receipt: TransferReceipt) => void;
+}
+
+const defaultIdFactory = () => `mock-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+
+const sleep = async (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export class MockRail {
+  private history: TransferReceipt[] = [];
+
+  constructor(private readonly options: MockRailOptions = {}) {}
+
+  public getTransfers(): TransferReceipt[] {
+    return [...this.history];
+  }
+
+  public reset(): void {
+    this.history = [];
+  }
+
+  public async transfer(request: TransferRequest): Promise<TransferReceipt> {
+    if (request.amount <= 0) {
+      throw new Error('Transfer amount must be greater than zero.');
+    }
+
+    const requestedAt = this.options.clock?.() ?? new Date();
+
+    if (this.options.latencyMs && this.options.latencyMs > 0) {
+      await sleep(this.options.latencyMs);
+    }
+
+    const completedAt = this.options.clock?.() ?? new Date();
+
+    const receipt: TransferReceipt = {
+      id: this.options.idFactory?.(request) ?? defaultIdFactory(),
+      status: 'settled',
+      requestedAt,
+      completedAt,
+      request: { ...request },
+    };
+
+    this.history.push(receipt);
+    this.options.onTransfer?.(receipt);
+
+    return receipt;
+  }
+}

--- a/apgms/server/scheduler/gates.ts
+++ b/apgms/server/scheduler/gates.ts
@@ -1,0 +1,155 @@
+import { MockRail, TransferReceipt, TransferRequest } from '../rails/mockRail.js';
+
+export type TransferGate = (request: TransferRequest) => void | Promise<void>;
+
+export interface ScheduledTransfer {
+  id: string;
+  request: TransferRequest;
+  runAt?: Date;
+}
+
+export interface TransferRejection {
+  job: ScheduledTransfer & { runAt: Date };
+  reason: string;
+}
+
+export interface TransferSettlement {
+  job: ScheduledTransfer & { runAt: Date };
+  receipt: TransferReceipt;
+}
+
+export interface ProcessingSummary {
+  settled: TransferSettlement[];
+  rejected: TransferRejection[];
+}
+
+export interface SchedulerLogger {
+  info?: (...args: unknown[]) => void;
+  warn?: (...args: unknown[]) => void;
+  error?: (...args: unknown[]) => void;
+  debug?: (...args: unknown[]) => void;
+}
+
+export interface GateSchedulerOptions {
+  gates?: TransferGate[];
+  intervalMs?: number;
+  clock?: () => Date;
+  logger?: SchedulerLogger;
+  onSettled?: (settlement: TransferSettlement) => void;
+  onRejected?: (rejection: TransferRejection) => void;
+}
+
+const defaultClock = () => new Date();
+
+export class GateScheduler {
+  private readonly gates: TransferGate[];
+  private readonly clock: () => Date;
+  private readonly logger: SchedulerLogger;
+  private queue: Array<ScheduledTransfer & { runAt: Date }> = [];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(
+    private readonly rail: MockRail,
+    private readonly options: GateSchedulerOptions = {}
+  ) {
+    this.gates = [...(options.gates ?? [])];
+    this.clock = options.clock ?? defaultClock;
+    this.logger = options.logger ?? console;
+  }
+
+  public registerGate(gate: TransferGate): void {
+    this.gates.push(gate);
+  }
+
+  public enqueue(job: ScheduledTransfer): void {
+    const runAt = job.runAt ?? this.clock();
+    this.queue.push({ ...job, runAt });
+    this.queue.sort((a, b) => a.runAt.getTime() - b.runAt.getTime());
+  }
+
+  public start(): void {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    const interval = this.options.intervalMs ?? 1_000;
+
+    this.timer = setInterval(() => {
+      void this.processDueJobs();
+    }, interval);
+
+    void this.processDueJobs();
+  }
+
+  public stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    this.running = false;
+  }
+
+  public async processDueJobs(now: Date = this.clock()): Promise<ProcessingSummary> {
+    const due: Array<ScheduledTransfer & { runAt: Date }> = [];
+    const remaining: Array<ScheduledTransfer & { runAt: Date }> = [];
+
+    for (const job of this.queue) {
+      if (job.runAt.getTime() <= now.getTime()) {
+        due.push(job);
+      } else {
+        remaining.push(job);
+      }
+    }
+
+    this.queue = remaining;
+
+    const summary: ProcessingSummary = { settled: [], rejected: [] };
+
+    for (const job of due) {
+      try {
+        for (const gate of this.gates) {
+          await gate(job.request);
+        }
+
+        const receipt = await this.rail.transfer(job.request);
+        const settlement: TransferSettlement = { job, receipt };
+        summary.settled.push(settlement);
+        this.options.onSettled?.(settlement);
+        this.logger.info?.(`Transfer ${job.id} settled.`);
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        const rejection: TransferRejection = { job, reason };
+        summary.rejected.push(rejection);
+        this.options.onRejected?.(rejection);
+        this.logger.warn?.(`Transfer ${job.id} rejected: ${reason}`);
+      }
+    }
+
+    return summary;
+  }
+}
+
+export const createMaxAmountGate = (limit: number): TransferGate => {
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new Error('Transfer amount limit must be a positive number.');
+  }
+
+  return (request) => {
+    if (request.amount > limit) {
+      throw new Error(`Transfer amount ${request.amount} exceeds limit of ${limit}.`);
+    }
+  };
+};
+
+export const createBlockedAccountGate = (blocked: Iterable<string>): TransferGate => {
+  const blockedSet = new Set(blocked);
+
+  return (request) => {
+    if (blockedSet.has(request.fromAccountId) || blockedSet.has(request.toAccountId)) {
+      throw new Error('Transfer involves a blocked account.');
+    }
+  };
+};

--- a/apgms/tests/scheduler/gateScheduler.test.ts
+++ b/apgms/tests/scheduler/gateScheduler.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { MockRail, TransferRequest } from '../../server/rails/mockRail.js';
+import {
+  GateScheduler,
+  ProcessingSummary,
+  ScheduledTransfer,
+  createBlockedAccountGate,
+  createMaxAmountGate,
+} from '../../server/scheduler/gates.js';
+
+const createTransfer = (overrides: Partial<TransferRequest> = {}): TransferRequest => ({
+  fromAccountId: 'payer-1',
+  toAccountId: 'beneficiary-1',
+  amount: 100,
+  currency: 'AUD',
+  ...overrides,
+});
+
+const now = new Date('2024-01-01T00:00:00.000Z');
+
+const createScheduler = () => {
+  const rail = new MockRail({ clock: () => now });
+  const scheduler = new GateScheduler(rail, {
+    clock: () => now,
+    gates: [
+      createMaxAmountGate(1_000),
+      createBlockedAccountGate(['fraudulent-account']),
+    ],
+  });
+
+  return { rail, scheduler };
+};
+
+const process = async (
+  scheduler: GateScheduler,
+  jobs: ScheduledTransfer[]
+): Promise<ProcessingSummary> => {
+  jobs.forEach((job) => scheduler.enqueue(job));
+  return scheduler.processDueJobs(now);
+};
+
+test('GateScheduler settles transfers that pass all gates', async () => {
+  const { rail, scheduler } = createScheduler();
+
+  const summary = await process(scheduler, [
+    { id: 'job-1', request: createTransfer(), runAt: now },
+  ]);
+
+  assert.equal(summary.settled.length, 1);
+  assert.equal(summary.rejected.length, 0);
+  assert.equal(rail.getTransfers().length, 1);
+  assert.equal(summary.settled[0]?.receipt.request.amount, 100);
+});
+
+test('GateScheduler rejects transfers that exceed the amount limit', async () => {
+  const { rail, scheduler } = createScheduler();
+
+  const summary = await process(scheduler, [
+    { id: 'job-2', request: createTransfer({ amount: 2_000 }), runAt: now },
+  ]);
+
+  assert.equal(summary.settled.length, 0);
+  assert.equal(summary.rejected.length, 1);
+  assert.match(summary.rejected[0]?.reason ?? '', /exceeds limit/);
+  assert.equal(rail.getTransfers().length, 0);
+});
+
+test('GateScheduler rejects transfers that involve blocked accounts', async () => {
+  const { rail, scheduler } = createScheduler();
+
+  const summary = await process(scheduler, [
+    {
+      id: 'job-3',
+      request: createTransfer({ toAccountId: 'fraudulent-account' }),
+      runAt: now,
+    },
+  ]);
+
+  assert.equal(summary.settled.length, 0);
+  assert.equal(summary.rejected.length, 1);
+  assert.match(summary.rejected[0]?.reason ?? '', /blocked account/);
+  assert.equal(rail.getTransfers().length, 0);
+});

--- a/apgms/tests/scheduler/package.json
+++ b/apgms/tests/scheduler/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@apgms/tests-scheduler",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --import tsx --test gateScheduler.test.ts"
+  }
+}

--- a/apgms/tests/scheduler/tsconfig.json
+++ b/apgms/tests/scheduler/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a mock remittance rail implementation that records simulated transfers
- introduce a gate-aware scheduler service and bootstrap wiring with config-driven toggles
- register a scheduler test workspace and provide unit tests for gate enforcement

## Testing
- pnpm --filter @apgms/tests-scheduler test

------
https://chatgpt.com/codex/tasks/task_e_68f31cf18ee8832786c4a30f5b9a999e