### PR TITLE
Add SBR AS4 stub integration and storage helpers

### DIFF
--- a/apgms/__init__.py
+++ b/apgms/__init__.py
@@ -1,0 +1,13 @@
+"""APGMS Python package.
+
+This package hosts Python utilities that support local development tools
+within the APGMS monorepo.  The modules added in this change provide a mock
+SBR/AS4 integration layer that can be exercised from the command line and in
+unit tests without relying on external infrastructure.
+"""
+
+__all__ = [
+    "integrations",
+    "storage",
+]
+

--- a/apgms/integrations/__init__.py
+++ b/apgms/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Integration stubs and helpers."""
+
+from . import sbr
+
+__all__ = ["sbr"]
+

--- a/apgms/integrations/sbr/__init__.py
+++ b/apgms/integrations/sbr/__init__.py
@@ -1,0 +1,13 @@
+"""Mock SBR/AS4 integration helpers."""
+
+from .messages import generate_as4_message
+from .receipts import build_receipt, parse_receipt
+from .stub import SBRStubClient
+
+__all__ = [
+    "SBRStubClient",
+    "build_receipt",
+    "generate_as4_message",
+    "parse_receipt",
+]
+

--- a/apgms/integrations/sbr/cli.py
+++ b/apgms/integrations/sbr/cli.py
@@ -1,0 +1,66 @@
+"""Command line interface for interacting with the SBR stub."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from .stub import SBRStubClient
+
+
+def _load_json_from_file(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _write_json(data: Dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _list_interactions(interactions: Iterable[str]) -> None:
+    for interaction in sorted(interactions):
+        print(interaction)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Interact with the SBR stub")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser(
+        "generate", help="Generate an AS4 payload and receipt"
+    )
+    generate_parser.add_argument("payload", type=Path, help="Path to a JSON payload file")
+
+    parse_parser = subparsers.add_parser("parse", help="Parse a receipt file")
+    parse_parser.add_argument("receipt", type=Path, help="Path to a stored receipt")
+
+    subparsers.add_parser("list", help="List stored interaction identifiers")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    client = SBRStubClient()
+
+    if args.command == "generate":
+        payload = _load_json_from_file(args.payload)
+        receipt = client.submit_payload(payload)
+        _write_json(receipt.to_dict())
+    elif args.command == "parse":
+        raw = args.receipt.read_text(encoding="utf-8")
+        receipt = client.parse_receipt(raw)
+        _write_json(receipt.to_dict())
+    elif args.command == "list":
+        _list_interactions(client.list_interactions())
+    else:  # pragma: no cover - defensive
+        parser.error(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()
+

--- a/apgms/integrations/sbr/messages.py
+++ b/apgms/integrations/sbr/messages.py
@@ -1,0 +1,82 @@
+"""Utilities for generating mock AS4 payloads."""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+def _now_iso() -> str:
+    """Return an ISO-8601 timestamp in UTC."""
+
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class AS4Message:
+    """Representation of a simplified AS4 message."""
+
+    message_id: str
+    conversation_id: str
+    payload: Dict[str, Any]
+    attachments: Dict[str, str] = field(default_factory=dict)
+    created_at: str = field(default_factory=_now_iso)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the message to a serialisable dictionary."""
+
+        return {
+            "message_id": self.message_id,
+            "conversation_id": self.conversation_id,
+            "payload": self.payload,
+            "attachments": self.attachments,
+            "created_at": self.created_at,
+        }
+
+    def to_json(self) -> str:
+        """Return the message as a JSON string."""
+
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+def generate_as4_message(
+    payload: Dict[str, Any],
+    *,
+    message_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
+    attachments: Optional[Dict[str, bytes]] = None,
+) -> AS4Message:
+    """Generate a mock AS4 message ready to persist.
+
+    Args:
+        payload: JSON serialisable payload that mimics the business document.
+        message_id: Optional pre-determined message identifier. When omitted a
+            random UUID is generated.
+        conversation_id: Optional conversation identifier used to correlate
+            multi-message exchanges.
+        attachments: Optional mapping of attachment name to raw bytes. Binary
+            content is base64 encoded to simplify storage.
+
+    Returns:
+        AS4Message: A dataclass instance capturing the AS4 envelope.
+    """
+
+    generated_message_id = message_id or str(uuid.uuid4())
+    generated_conversation_id = conversation_id or str(uuid.uuid4())
+
+    encoded_attachments: Dict[str, str] = {}
+    if attachments:
+        for name, content in attachments.items():
+            encoded_attachments[name] = base64.b64encode(content).decode()
+
+    return AS4Message(
+        message_id=generated_message_id,
+        conversation_id=generated_conversation_id,
+        payload=payload,
+        attachments=encoded_attachments,
+    )
+

--- a/apgms/integrations/sbr/receipts.py
+++ b/apgms/integrations/sbr/receipts.py
@@ -1,0 +1,75 @@
+"""Receipt builders and parsers for the SBR AS4 stub."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class Receipt:
+    """Simple acknowledgement format returned by the stub."""
+
+    message_id: str
+    conversation_id: str
+    status: str = "ACCEPTED"
+    received_at: str = field(default_factory=_now_iso)
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "message_id": self.message_id,
+            "conversation_id": self.conversation_id,
+            "status": self.status,
+            "received_at": self.received_at,
+            "details": self.details,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True)
+
+
+def build_receipt(
+    message_id: str,
+    conversation_id: str,
+    *,
+    status: str = "ACCEPTED",
+    details: Dict[str, Any] | None = None,
+) -> Receipt:
+    """Construct a receipt for the supplied identifiers."""
+
+    return Receipt(
+        message_id=message_id,
+        conversation_id=conversation_id,
+        status=status,
+        details=details or {},
+    )
+
+
+def parse_receipt(raw_receipt: str | bytes | Dict[str, Any]) -> Receipt:
+    """Parse a receipt representation back into a :class:`Receipt`."""
+
+    if isinstance(raw_receipt, Receipt):  # type: ignore[unreachable]
+        return raw_receipt
+
+    if isinstance(raw_receipt, bytes):
+        data: Dict[str, Any] = json.loads(raw_receipt.decode())
+    elif isinstance(raw_receipt, str):
+        data = json.loads(raw_receipt)
+    else:
+        data = raw_receipt
+
+    return Receipt(
+        message_id=data["message_id"],
+        conversation_id=data["conversation_id"],
+        status=data.get("status", "ACCEPTED"),
+        received_at=data.get("received_at", _now_iso()),
+        details=data.get("details", {}),
+    )
+

--- a/apgms/integrations/sbr/stub.py
+++ b/apgms/integrations/sbr/stub.py
@@ -1,0 +1,120 @@
+"""High level façade for working with the SBR AS4 stub."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from apgms.storage import StorageManager
+
+from .messages import AS4Message, generate_as4_message
+from .receipts import Receipt, build_receipt, parse_receipt
+
+
+class SBRStubClient:
+    """Client that mimics the behaviour of the SBR AS4 gateway.
+
+    The client focuses on developer ergonomics rather than protocol accuracy.
+    It allows payload generation, persistence of message artefacts, and receipt
+    parsing so developers can exercise integration flows locally.
+    """
+
+    def __init__(self, storage: Optional[StorageManager] = None) -> None:
+        self.storage = storage or StorageManager(app_subdir="sbr")
+
+    # ------------------------------------------------------------------
+    # Message helpers
+    # ------------------------------------------------------------------
+    def create_message(
+        self,
+        payload: Dict[str, Any],
+        *,
+        message_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        attachments: Optional[Dict[str, bytes]] = None,
+    ) -> AS4Message:
+        """Generate and persist an AS4 message for the supplied payload."""
+
+        message = generate_as4_message(
+            payload,
+            message_id=message_id,
+            conversation_id=conversation_id,
+            attachments=attachments,
+        )
+
+        self._persist_artifact(message.message_id, "payload.json", message.to_dict())
+        return message
+
+    def submit_payload(
+        self,
+        payload: Dict[str, Any],
+        *,
+        message_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        attachments: Optional[Dict[str, bytes]] = None,
+        receipt_status: str = "ACCEPTED",
+    ) -> Receipt:
+        """Create a payload, persist it, and return a receipt.
+
+        This method mirrors what a full integration would perform while keeping
+        the implementation deliberately simple.
+        """
+
+        message = self.create_message(
+            payload,
+            message_id=message_id,
+            conversation_id=conversation_id,
+            attachments=attachments,
+        )
+
+        receipt = build_receipt(
+            message.message_id,
+            message.conversation_id,
+            status=receipt_status,
+            details={"payload_checksum": self._checksum_payload(payload)},
+        )
+
+        self._persist_artifact(message.message_id, "receipt.json", receipt.to_dict())
+        return receipt
+
+    # ------------------------------------------------------------------
+    # Receipt helpers
+    # ------------------------------------------------------------------
+    def parse_receipt(self, raw_receipt: str | bytes | Dict[str, Any]) -> Receipt:
+        """Parse a stored or inline receipt representation."""
+
+        return parse_receipt(raw_receipt)
+
+    # ------------------------------------------------------------------
+    # Storage helpers
+    # ------------------------------------------------------------------
+    def list_interactions(self) -> Iterable[str]:
+        """Return the set of interaction identifiers stored on disk."""
+
+        return self.storage.list_interactions()
+
+    def load_payload(self, message_id: str) -> Dict[str, Any]:
+        """Load the stored payload for a given message identifier."""
+
+        return self.storage.load_json(message_id, "payload.json")
+
+    def load_receipt(self, message_id: str) -> Receipt:
+        """Load and parse the stored receipt for a given message identifier."""
+
+        data = self.storage.load_json(message_id, "receipt.json")
+        return parse_receipt(data)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+    def _persist_artifact(self, message_id: str, name: str, content: Any) -> Path:
+        return self.storage.save_artifact(message_id, name, content)
+
+    @staticmethod
+    def _checksum_payload(payload: Dict[str, Any]) -> str:
+        """Generate a reproducible checksum string for diagnostics."""
+
+        normalised = json.dumps(payload, sort_keys=True)
+        return f"sha256-mock-{abs(hash(normalised)) % 10 ** 12:012d}"
+

--- a/apgms/storage/.gitignore
+++ b/apgms/storage/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/apgms/storage/__init__.py
+++ b/apgms/storage/__init__.py
@@ -1,0 +1,6 @@
+"""Storage helpers for integration artefacts."""
+
+from .manager import StorageManager
+
+__all__ = ["StorageManager"]
+

--- a/apgms/storage/manager.py
+++ b/apgms/storage/manager.py
@@ -1,0 +1,59 @@
+"""Filesystem backed storage for generated artefacts."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+
+class StorageManager:
+    """Persist integration artefacts to a local directory."""
+
+    def __init__(self, base_dir: str | Path | None = None, *, app_subdir: str | None = None) -> None:
+        env_dir = os.environ.get("APGMS_STORAGE_DIR")
+        base_path = Path(base_dir or env_dir or Path(__file__).resolve().parent / "artifacts")
+
+        if app_subdir:
+            base_path = base_path / app_subdir
+
+        self.base_path = base_path
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Directory helpers
+    # ------------------------------------------------------------------
+    def interaction_path(self, interaction_id: str) -> Path:
+        path = self.base_path / interaction_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def list_interactions(self) -> Iterable[str]:
+        for child in self.base_path.iterdir():
+            if child.is_dir():
+                yield child.name
+
+    # ------------------------------------------------------------------
+    # Persist & load helpers
+    # ------------------------------------------------------------------
+    def save_artifact(self, interaction_id: str, name: str, content: Any) -> Path:
+        target = self.interaction_path(interaction_id) / name
+
+        if isinstance(content, (dict, list)):
+            target.write_text(json.dumps(content, indent=2, sort_keys=True), encoding="utf-8")
+        elif isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(str(content), encoding="utf-8")
+
+        return target
+
+    def load_text(self, interaction_id: str, name: str) -> str:
+        path = self.interaction_path(interaction_id) / name
+        return path.read_text(encoding="utf-8")
+
+    def load_json(self, interaction_id: str, name: str) -> Dict[str, Any]:
+        raw = self.load_text(interaction_id, name)
+        return json.loads(raw)
+

--- a/apgms/tests/__init__.py
+++ b/apgms/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Python test suite for APGMS utilities."""
+

--- a/apgms/tests/integrations/__init__.py
+++ b/apgms/tests/integrations/__init__.py
@@ -1,0 +1,2 @@
+"""Integration related tests."""
+

--- a/apgms/tests/integrations/test_sbr_stub.py
+++ b/apgms/tests/integrations/test_sbr_stub.py
@@ -1,0 +1,72 @@
+"""Tests for the SBR stub integration helpers."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from apgms.integrations.sbr import SBRStubClient, build_receipt
+from apgms.storage import StorageManager
+
+
+class SBRStubClientTests(unittest.TestCase):
+    def setUp(self) -> None:  # noqa: D401 - standard unittest hook
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.temp_path = Path(self._tmp.name)
+
+    def _create_client(self) -> SBRStubClient:
+        storage = StorageManager(base_dir=self.temp_path)
+        return SBRStubClient(storage=storage)
+
+    def test_submit_payload_persists_artifacts(self) -> None:
+        client = self._create_client()
+        payload = {"type": "test", "value": 42}
+
+        receipt = client.submit_payload(
+            payload,
+            message_id="msg-123",
+            conversation_id="conv-abc",
+        )
+
+        self.assertEqual(receipt.message_id, "msg-123")
+        self.assertEqual(receipt.conversation_id, "conv-abc")
+        self.assertEqual(receipt.status, "ACCEPTED")
+
+        interaction_dir = self.temp_path / "msg-123"
+        self.assertTrue(interaction_dir.exists())
+        payload_path = interaction_dir / "payload.json"
+        receipt_path = interaction_dir / "receipt.json"
+        self.assertTrue(payload_path.exists())
+        self.assertTrue(receipt_path.exists())
+
+        stored_payload = json.loads(payload_path.read_text(encoding="utf-8"))
+        self.assertEqual(stored_payload["payload"], payload)
+
+        stored_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        self.assertEqual(stored_receipt["message_id"], "msg-123")
+
+        interactions = list(client.list_interactions())
+        self.assertIn("msg-123", interactions)
+
+    def test_parse_receipt_from_string(self) -> None:
+        client = self._create_client()
+        receipt = build_receipt(
+            "msg-999",
+            "conv-999",
+            status="REJECTED",
+            details={"error": "invalid data"},
+        )
+
+        parsed = client.parse_receipt(receipt.to_json())
+
+        self.assertEqual(parsed.message_id, "msg-999")
+        self.assertEqual(parsed.status, "REJECTED")
+        self.assertEqual(parsed.details["error"], "invalid data")
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience
+    unittest.main()
+

--- a/docs/sbr-as4.md
+++ b/docs/sbr-as4.md
@@ -1,0 +1,53 @@
+# SBR / AS4 Stub
+
+The SBR integration in APGMS is under active development. To support local
+testing without depending on the external ATO gateway, this repository
+includes a lightweight stub that simulates the minimum message generation and
+acknowledgement flows. The stub focuses on developer productivity rather than
+protocol fidelity.
+
+## Storage layout
+
+Generated artefacts are written to `apgms/storage/artifacts/sbr` by default.
+The base directory can be customised by setting the `APGMS_STORAGE_DIR`
+environment variable. Each interaction creates a directory named after the
+AS4 message identifier and contains the following files:
+
+- `payload.json` – the submitted payload and envelope metadata.
+- `receipt.json` – a mock SBR receipt acknowledging the payload.
+
+These artefacts are ignored by git to keep the repository clean.
+
+## Command line usage
+
+The CLI is implemented in `apgms/integrations/sbr/cli.py` and can be executed
+using the module runner. Example:
+
+```bash
+python -m apgms.integrations.sbr.cli generate example-payload.json
+```
+
+Commands:
+
+- `generate <payload.json>` – create an AS4 message, persist the artefacts and
+  print the receipt to stdout.
+- `parse <receipt.json>` – parse a stored receipt and print the normalised
+  representation.
+- `list` – list the stored interaction/message identifiers.
+
+## Programmatic usage
+
+The `SBRStubClient` class offers a thin API for composing messages, persisting
+them, and working with receipts. Example:
+
+```python
+from apgms.integrations.sbr import SBRStubClient
+
+client = SBRStubClient()
+receipt = client.submit_payload({"submission": "example"})
+print(receipt.message_id)
+```
+
+The stub is intentionally deterministic and returns predictable receipts to
+make assertions straightforward in unit tests.
+


### PR DESCRIPTION
## Summary
- add a mock SBR/AS4 integration client that generates payloads, receipts, and a CLI for local testing
- implement a filesystem-backed storage manager to persist integration artefacts
- document usage and cover the new functionality with unit tests

## Testing
- python -m unittest discover -s apgms/tests/integrations -p 'test_*.py'

------
https://chatgpt.com/codex/tasks/task_e_68f31cf2a53483279825816c554e0da1