### PR TITLE
Add alert anomaly rules, persistence, and inbox UI

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,29 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/policy/anomalies.ts
+++ b/apgms/policy/anomalies.ts
@@ -1,0 +1,247 @@
+import { AlertSeverity } from "../shared/src/alerts";
+
+type PrimitiveRecord = Record<string, unknown>;
+
+export interface CandidateTransaction {
+  id: string;
+  orgId: string;
+  amount: number;
+  occurredAt: Date;
+  payee?: string;
+  description?: string;
+  bankLineId?: string;
+}
+
+export interface DetectionContext {
+  recentTransactions?: CandidateTransaction[];
+  watchlist?: string[];
+  baselines?: Record<string, { average: number; stdev?: number } | number>;
+}
+
+export interface RuleEvaluation {
+  triggered: boolean;
+  message?: string;
+  metadata?: PrimitiveRecord;
+}
+
+export interface RuleDefinition<TOptions extends PrimitiveRecord = PrimitiveRecord> {
+  id: string;
+  description: string;
+  severity: AlertSeverity;
+  defaultOptions: TOptions;
+  evaluate: (
+    candidate: CandidateTransaction,
+    context: DetectionContext,
+    options: TOptions
+  ) => RuleEvaluation;
+}
+
+export interface RuleConfiguration<TOptions extends PrimitiveRecord = PrimitiveRecord> {
+  id: string;
+  enabled?: boolean;
+  options?: Partial<TOptions>;
+  severity?: AlertSeverity;
+  summary?: string;
+}
+
+export interface AnomalyFinding extends RuleEvaluation {
+  ruleId: string;
+  candidateId: string;
+  summary: string;
+  severity: AlertSeverity;
+}
+
+const asArray = <T>(value: T | T[] | undefined): T[] => {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+};
+
+const minutesToMs = (minutes: number): number => Math.max(minutes, 0) * 60 * 1000;
+
+const normalizeWatchlist = (context: DetectionContext, options: PrimitiveRecord): Set<string> => {
+  const fromContext = context.watchlist ?? [];
+  const fromOptions = asArray<string>(options.watchlist as string[] | string | undefined);
+  return new Set([...fromContext, ...fromOptions].map((item) => item.toLowerCase()));
+};
+
+const absolute = (value: number): number => Math.abs(Number.isFinite(value) ? value : Number(value));
+
+const findBaseline = (
+  candidate: CandidateTransaction,
+  context: DetectionContext,
+  fallback: number
+): number | undefined => {
+  if (!candidate.payee) return undefined;
+  const baseline = context.baselines?.[candidate.payee] ?? context.baselines?.default ?? fallback;
+  if (baseline == null) return undefined;
+  if (typeof baseline === "number") return baseline;
+  if (typeof baseline === "object" && "average" in baseline) {
+    return Number((baseline as { average: number }).average);
+  }
+  return undefined;
+};
+
+const largeAmountRule: RuleDefinition<{ threshold: number }> = {
+  id: "large-amount",
+  description: "Amounts that exceed the configured threshold",
+  severity: "HIGH",
+  defaultOptions: {
+    threshold: 10_000,
+  },
+  evaluate: (candidate, _context, options) => {
+    const threshold = Number(options.threshold ?? 0);
+    const amount = absolute(candidate.amount);
+    if (!Number.isFinite(threshold) || threshold <= 0) {
+      return { triggered: false };
+    }
+    if (amount >= threshold) {
+      return {
+        triggered: true,
+        message: `Amount ${amount.toFixed(2)} exceeds threshold ${threshold.toFixed(2)}`,
+        metadata: { threshold, amount },
+      };
+    }
+    return { triggered: false };
+  },
+};
+
+const watchlistPayeeRule: RuleDefinition<{ watchlist?: string[] }> = {
+  id: "watchlist-payee",
+  description: "Transactions with a counterparty from the watchlist",
+  severity: "CRITICAL",
+  defaultOptions: {
+    watchlist: [],
+  },
+  evaluate: (candidate, context, options) => {
+    if (!candidate.payee) {
+      return { triggered: false };
+    }
+    const watchlist = normalizeWatchlist(context, options);
+    if (watchlist.size === 0) {
+      return { triggered: false };
+    }
+    const payee = candidate.payee.toLowerCase();
+    if (watchlist.has(payee)) {
+      return {
+        triggered: true,
+        message: `${candidate.payee} is on the watchlist`,
+        metadata: { payee: candidate.payee },
+      };
+    }
+    return { triggered: false };
+  },
+};
+
+const rapidRepeatRule: RuleDefinition<{ windowMinutes: number; maxPerPayee: number }> = {
+  id: "rapid-repeat",
+  description: "Multiple payments to the same counterparty in a short period",
+  severity: "MEDIUM",
+  defaultOptions: {
+    windowMinutes: 60,
+    maxPerPayee: 3,
+  },
+  evaluate: (candidate, context, options) => {
+    const { windowMinutes, maxPerPayee } = options;
+    if (!candidate.payee || !context.recentTransactions?.length) {
+      return { triggered: false };
+    }
+    const windowMs = minutesToMs(windowMinutes);
+    const windowStart = candidate.occurredAt.getTime() - windowMs;
+    const count = context.recentTransactions.filter((txn) => {
+      if (!txn.payee) return false;
+      return (
+        txn.payee.toLowerCase() === candidate.payee!.toLowerCase() &&
+        txn.occurredAt.getTime() >= windowStart &&
+        txn.occurredAt.getTime() <= candidate.occurredAt.getTime()
+      );
+    }).length + 1;
+    if (count > maxPerPayee) {
+      return {
+        triggered: true,
+        message: `${count} payments to ${candidate.payee} within ${windowMinutes} minutes`,
+        metadata: { count, windowMinutes, payee: candidate.payee },
+      };
+    }
+    return { triggered: false };
+  },
+};
+
+const deviationRule: RuleDefinition<{ multiplier: number; fallbackAverage: number }> = {
+  id: "average-deviation",
+  description: "Payments that deviate significantly from historic averages",
+  severity: "MEDIUM",
+  defaultOptions: {
+    multiplier: 3,
+    fallbackAverage: 5_000,
+  },
+  evaluate: (candidate, context, options) => {
+    const baseline = findBaseline(candidate, context, options.fallbackAverage);
+    if (!baseline) return { triggered: false };
+    const multiplier = Number(options.multiplier ?? 1);
+    if (multiplier <= 0) return { triggered: false };
+    const limit = baseline * multiplier;
+    const amount = absolute(candidate.amount);
+    if (amount > limit) {
+      return {
+        triggered: true,
+        message: `Amount ${amount.toFixed(2)} exceeds baseline ${baseline.toFixed(2)} by multiplier ${multiplier}`,
+        metadata: { amount, baseline, multiplier },
+      };
+    }
+    return { triggered: false };
+  },
+};
+
+export const defaultAnomalyRules: RuleDefinition[] = [
+  largeAmountRule,
+  watchlistPayeeRule,
+  rapidRepeatRule,
+  deviationRule,
+];
+
+export class AnomalyRuleEngine {
+  private readonly configById: Map<string, RuleConfiguration>;
+
+  constructor(private readonly rules: RuleDefinition[], configurations: RuleConfiguration[] = []) {
+    this.configById = new Map(configurations.map((cfg) => [cfg.id, cfg]));
+  }
+
+  withConfiguration(configurations: RuleConfiguration[]): AnomalyRuleEngine {
+    return new AnomalyRuleEngine(this.rules, configurations);
+  }
+
+  evaluate(candidate: CandidateTransaction, context: DetectionContext = {}): AnomalyFinding[] {
+    const findings: AnomalyFinding[] = [];
+    for (const rule of this.rules) {
+      const config = this.configById.get(rule.id);
+      if (config?.enabled === false) {
+        continue;
+      }
+      const mergedOptions = {
+        ...rule.defaultOptions,
+        ...(config?.options ?? {}),
+      } as PrimitiveRecord;
+      const evaluation = rule.evaluate(candidate, context, mergedOptions as any);
+      if (!evaluation.triggered) {
+        continue;
+      }
+      const severity = config?.severity ?? rule.severity;
+      const summary = config?.summary ?? rule.description;
+      findings.push({
+        ruleId: rule.id,
+        candidateId: candidate.id,
+        severity,
+        summary,
+        message: evaluation.message,
+        metadata: evaluation.metadata,
+        triggered: true,
+      });
+    }
+    return findings;
+  }
+}
+
+export const createRuleEngine = (
+  rules: RuleDefinition[] = defaultAnomalyRules,
+  configurations: RuleConfiguration[] = []
+): AnomalyRuleEngine => new AnomalyRuleEngine(rules, configurations);

--- a/apgms/server/services/alerts.ts
+++ b/apgms/server/services/alerts.ts
@@ -1,0 +1,182 @@
+import { prisma } from "../../shared/src/db";
+import type {
+  AlertFilters,
+  AlertRecord,
+  AlertSeverity,
+  AlertStatus,
+  AlertStatusChange,
+} from "../../shared/src/alerts";
+
+export type PrismaAlertModel = {
+  id: string;
+  orgId: string;
+  ruleId: string;
+  summary: string;
+  details: string | null;
+  status: AlertStatus;
+  severity: AlertSeverity;
+  metadata: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+  readAt: Date | null;
+  bankLineId: string | null;
+};
+
+type AlertClient = {
+  create: (args: { data: Record<string, unknown> }) => Promise<PrismaAlertModel>;
+  findMany: (args: Record<string, unknown>) => Promise<PrismaAlertModel[]>;
+  update: (args: { where: { id: string }; data: Record<string, unknown> }) => Promise<PrismaAlertModel>;
+  updateMany: (
+    args: { where: Record<string, unknown>; data: Record<string, unknown> }
+  ) => Promise<{ count: number }>;
+  count: (args: Record<string, unknown>) => Promise<number>;
+};
+
+export interface AlertsRepository {
+  alert: AlertClient;
+}
+
+export interface CreateAlertInput {
+  orgId: string;
+  ruleId: string;
+  summary: string;
+  details?: string | null;
+  severity?: AlertSeverity;
+  status?: AlertStatus;
+  metadata?: Record<string, unknown> | null;
+  bankLineId?: string | null;
+  createdAt?: Date;
+}
+
+export interface ListAlertsOptions extends AlertFilters {
+  order?: "asc" | "desc";
+}
+
+const mapAlertRecord = (alert: PrismaAlertModel): AlertRecord => ({
+  id: alert.id,
+  orgId: alert.orgId,
+  ruleId: alert.ruleId,
+  summary: alert.summary,
+  details: alert.details,
+  status: alert.status,
+  severity: alert.severity,
+  metadata: alert.metadata,
+  createdAt: alert.createdAt,
+  updatedAt: alert.updatedAt,
+  readAt: alert.readAt,
+  bankLineId: alert.bankLineId,
+});
+
+const defaultClient = prisma as unknown as AlertsRepository;
+
+const buildWhereClause = (filters: AlertFilters): Record<string, unknown> => {
+  const where: Record<string, unknown> = {};
+  if (filters.orgId) {
+    where.orgId = filters.orgId;
+  }
+  if (filters.status && filters.status !== "ALL") {
+    where.status = filters.status;
+  }
+  if (filters.ruleIds?.length) {
+    where.ruleId = { in: filters.ruleIds };
+  }
+  if (filters.severity?.length) {
+    where.severity = { in: filters.severity };
+  }
+  if (filters.search) {
+    where.OR = [
+      { summary: { contains: filters.search, mode: "insensitive" } },
+      { details: { contains: filters.search, mode: "insensitive" } },
+    ];
+  }
+  return where;
+};
+
+export const createAlert = async (
+  input: CreateAlertInput,
+  client: AlertsRepository = defaultClient
+): Promise<AlertRecord> => {
+  const now = input.createdAt ?? new Date();
+  const result = await client.alert.create({
+    data: {
+      orgId: input.orgId,
+      ruleId: input.ruleId,
+      summary: input.summary,
+      details: input.details ?? null,
+      severity: input.severity ?? "MEDIUM",
+      status: input.status ?? "UNREAD",
+      metadata: input.metadata ?? null,
+      bankLineId: input.bankLineId ?? null,
+      createdAt: now,
+    },
+  });
+  return mapAlertRecord(result);
+};
+
+export const listAlerts = async (
+  filters: ListAlertsOptions = {},
+  client: AlertsRepository = defaultClient
+): Promise<AlertRecord[]> => {
+  const where = buildWhereClause(filters);
+  const take = Math.min(Math.max(filters.limit ?? 50, 1), 200);
+  const skip = Math.max(filters.offset ?? 0, 0);
+  const order = filters.order ?? "desc";
+  const records = await client.alert.findMany({
+    where,
+    orderBy: { createdAt: order },
+    take,
+    skip,
+  });
+  return records.map(mapAlertRecord);
+};
+
+export const markAlertStatus = async (
+  id: string,
+  status: AlertStatus,
+  client: AlertsRepository = defaultClient
+): Promise<AlertRecord> => {
+  const readAt = status === "READ" ? new Date() : null;
+  const updated = await client.alert.update({
+    where: { id },
+    data: {
+      status,
+      readAt,
+    },
+  });
+  return mapAlertRecord(updated);
+};
+
+export const markManyAlerts = async (
+  changes: AlertStatusChange[],
+  client: AlertsRepository = defaultClient
+): Promise<number> => {
+  if (!changes.length) return 0;
+  let total = 0;
+  for (const change of changes) {
+    const readAt = change.status === "READ" ? change.readAt ?? new Date() : null;
+    const result = await client.alert.update({
+      where: { id: change.id },
+      data: {
+        status: change.status,
+        readAt,
+      },
+    });
+    if (result) {
+      total += 1;
+    }
+  }
+  return total;
+};
+
+export const countUnreadAlerts = async (
+  orgId: string,
+  client: AlertsRepository = defaultClient
+): Promise<number> => {
+  const count = await client.alert.count({
+    where: {
+      orgId,
+      status: "UNREAD",
+    },
+  });
+  return count;
+};

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,9 +1,10 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
@@ -13,6 +14,7 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  alerts    Alert[]
 }
 
 model User {
@@ -33,4 +35,38 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+  alerts    Alert[]
+}
+
+model Alert {
+  id        String        @id @default(cuid())
+  org       Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  bankLine  BankLine?     @relation(fields: [bankLineId], references: [id], onDelete: SetNull)
+  bankLineId String?
+  ruleId    String
+  summary   String
+  details   String?
+  status    AlertStatus   @default(UNREAD)
+  severity  AlertSeverity @default(MEDIUM)
+  metadata  Json?
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+  readAt    DateTime?
+
+  @@index([orgId, status], map: "alerts_org_status_idx")
+  @@index([ruleId], map: "alerts_rule_idx")
+  @@index([bankLineId], map: "alerts_bank_line_idx")
+}
+
+enum AlertStatus {
+  UNREAD
+  READ
+}
+
+enum AlertSeverity {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
 }

--- a/apgms/shared/src/alerts.ts
+++ b/apgms/shared/src/alerts.ts
@@ -1,0 +1,33 @@
+export type AlertStatus = "UNREAD" | "READ";
+export type AlertSeverity = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export interface AlertRecord {
+  id: string;
+  orgId: string;
+  ruleId: string;
+  summary: string;
+  details?: string | null;
+  status: AlertStatus;
+  severity: AlertSeverity;
+  metadata?: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+  readAt?: Date | null;
+  bankLineId?: string | null;
+}
+
+export interface AlertFilters {
+  orgId?: string;
+  status?: AlertStatus | "ALL";
+  ruleIds?: string[];
+  severity?: AlertSeverity[];
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface AlertStatusChange {
+  id: string;
+  status: AlertStatus;
+  readAt?: Date | null;
+}

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./alerts";
+export * from "./db";

--- a/apgms/tests/package.json
+++ b/apgms/tests/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@apgms/tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "tsx --test \"src/**/*.test.ts?(x)\""
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.0.0",
+    "jsdom": "^24.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/apgms/tests/src/policy/anomalies.test.ts
+++ b/apgms/tests/src/policy/anomalies.test.ts
@@ -1,0 +1,95 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AnomalyRuleEngine,
+  CandidateTransaction,
+  DetectionContext,
+  createRuleEngine,
+  defaultAnomalyRules,
+} from "../../../policy/anomalies";
+
+const baseCandidate: CandidateTransaction = {
+  id: "txn-1",
+  orgId: "org-1",
+  amount: 12_500,
+  occurredAt: new Date("2024-01-01T10:00:00Z"),
+  payee: "Acme Corp",
+  description: "Consulting",
+};
+
+describe("policy/anomalies", () => {
+  it("triggers configurable threshold rule", () => {
+    const engine = createRuleEngine(defaultAnomalyRules, [
+      { id: "large-amount", options: { threshold: 5_000 }, summary: "Large payment" },
+    ]);
+    const results = engine.evaluate(baseCandidate, {});
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.ruleId, "large-amount");
+    assert.equal(results[0]?.summary, "Large payment");
+    assert.equal(results[0]?.severity, "HIGH");
+    assert.ok(results[0]?.message?.includes("12500"));
+  });
+
+  it("merges contextual watchlists with configuration", () => {
+    const engine = new AnomalyRuleEngine(defaultAnomalyRules, [
+      { id: "watchlist-payee", options: { watchlist: ["Acme Corp"] } },
+    ]);
+    const context: DetectionContext = {
+      watchlist: ["Bad Actors"],
+    };
+    const configured = engine.evaluate(baseCandidate, context);
+    assert.equal(configured.length, 1);
+    assert.equal(configured[0]?.ruleId, "watchlist-payee");
+
+    const contextOnlyCandidate = { ...baseCandidate, id: "txn-2", payee: "Bad Actors" };
+    const contextual = engine.evaluate(contextOnlyCandidate, context);
+    assert.equal(contextual.length, 1);
+    assert.equal(contextual[0]?.ruleId, "watchlist-payee");
+    assert.equal(contextual[0]?.severity, "CRITICAL");
+  });
+
+  it("respects disabled rules in configuration", () => {
+    const engine = createRuleEngine(defaultAnomalyRules, [
+      { id: "large-amount", enabled: false },
+    ]);
+    const results = engine.evaluate(baseCandidate, {});
+    assert.equal(results.length, 0);
+  });
+
+  it("detects rapid repeat activity within the configured window", () => {
+    const context: DetectionContext = {
+      recentTransactions: [
+        { ...baseCandidate, id: "txn-0", occurredAt: new Date("2024-01-01T09:15:00Z") },
+        { ...baseCandidate, id: "txn-00", occurredAt: new Date("2024-01-01T09:45:00Z") },
+        { ...baseCandidate, id: "txn-000", occurredAt: new Date("2024-01-01T09:50:00Z") },
+      ],
+    };
+    const engine = createRuleEngine(defaultAnomalyRules, [
+      { id: "rapid-repeat", options: { windowMinutes: 90, maxPerPayee: 3 } },
+    ]);
+    const results = engine.evaluate(baseCandidate, context);
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.ruleId, "rapid-repeat");
+    assert.equal(results[0]?.metadata?.count, 4);
+  });
+
+  it("falls back to baseline deviation rule when defaults apply", () => {
+    const candidate: CandidateTransaction = {
+      ...baseCandidate,
+      amount: 30_000,
+      payee: "Future Goods",
+    };
+    const context: DetectionContext = {
+      baselines: {
+        "Future Goods": { average: 4_000 },
+      },
+    };
+    const engine = createRuleEngine();
+    const results = engine.evaluate(candidate, context);
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.ruleId, "average-deviation");
+    assert.equal(results[0]?.severity, "MEDIUM");
+    assert.ok(results[0]?.message?.includes("average"));
+  });
+});

--- a/apgms/tests/src/setup/dom.ts
+++ b/apgms/tests/src/setup/dom.ts
@@ -1,0 +1,21 @@
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", { url: "http://localhost" });
+
+const { window } = dom;
+
+const copyProps = (target: Record<string, unknown>, source: Record<string, unknown>) => {
+  for (const key of Reflect.ownKeys(source)) {
+    if (key in target) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(source, key as keyof typeof source);
+    if (descriptor) {
+      Object.defineProperty(target, key, descriptor);
+    }
+  }
+};
+
+(globalThis as unknown as Record<string, unknown>).window = window as unknown as Window;
+(globalThis as unknown as Record<string, unknown>).document = window.document as unknown as Document;
+(globalThis as unknown as Record<string, unknown>).navigator = window.navigator as unknown as Navigator;
+
+copyProps(globalThis as unknown as Record<string, unknown>, window as unknown as Record<string, unknown>);

--- a/apgms/tests/src/web/alertsInbox.test.tsx
+++ b/apgms/tests/src/web/alertsInbox.test.tsx
@@ -1,0 +1,96 @@
+import "../setup/dom";
+
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+
+import type { AlertRecord } from "../../../shared/src/alerts";
+import { AlertsInbox } from "../../../webapp/src/pages/Alerts/AlertsInbox";
+
+const buildAlert = (overrides: Partial<AlertRecord>): AlertRecord => ({
+  id: overrides.id ?? "alert-1",
+  orgId: overrides.orgId ?? "org-1",
+  ruleId: overrides.ruleId ?? "large-amount",
+  summary: overrides.summary ?? "Large amount detected",
+  details: overrides.details ?? "",
+  status: overrides.status ?? "UNREAD",
+  severity: overrides.severity ?? "HIGH",
+  metadata: overrides.metadata ?? null,
+  createdAt: overrides.createdAt ?? new Date("2024-01-01T12:00:00Z"),
+  updatedAt: overrides.updatedAt ?? new Date("2024-01-01T12:00:00Z"),
+  readAt: overrides.readAt ?? null,
+  bankLineId: overrides.bankLineId ?? null,
+});
+
+afterEach(() => cleanup());
+
+describe("web/AlertsInbox", () => {
+  it("renders unread counts and allows toggling read state", () => {
+    const alerts: AlertRecord[] = [
+      buildAlert({ id: "a1", summary: "Large amount detected" }),
+      buildAlert({ id: "a2", summary: "Watchlist hit", severity: "CRITICAL" }),
+    ];
+    render(<AlertsInbox alerts={alerts} />);
+
+    const unreadIndicator = screen.getByText(/Unread:/);
+    assert.match(unreadIndicator.textContent ?? "", /2$/);
+
+    const firstAlert = screen.getByText("Large amount detected").closest("li");
+    assert.ok(firstAlert);
+    assert.ok(firstAlert?.className.includes("alerts-inbox__item--unread"));
+
+    const toggleButton = within(firstAlert as HTMLElement).getByRole("button", { name: "Mark read" });
+    fireEvent.click(toggleButton);
+
+    assert.ok((firstAlert as HTMLElement).className.includes("alerts-inbox__item--read"));
+    assert.equal(within(firstAlert as HTMLElement).getByText("Read").textContent, "Read");
+
+    const updatedUnread = screen.getByText(/Unread:/);
+    assert.match(updatedUnread.textContent ?? "", /1$/);
+  });
+
+  it("filters alerts by status, severity, and search term", () => {
+    const alerts: AlertRecord[] = [
+      buildAlert({ id: "a1", summary: "Large amount detected", status: "UNREAD", severity: "HIGH" }),
+      buildAlert({
+        id: "a2",
+        summary: "Rapid repeat payment",
+        status: "READ",
+        severity: "MEDIUM",
+        ruleId: "rapid-repeat",
+        details: "Multiple payments to same vendor",
+      }),
+      buildAlert({
+        id: "a3",
+        summary: "Watchlist hit",
+        status: "UNREAD",
+        severity: "CRITICAL",
+        ruleId: "watchlist-payee",
+      }),
+    ];
+
+    render(<AlertsInbox alerts={alerts} initialFilters={{ status: "ALL" }} />);
+
+    // Apply severity filter
+    const severityToggle = screen.getByLabelText("High");
+    fireEvent.click(severityToggle);
+
+    // After toggling high severity, only the high severity alert remains
+    const visibleSummaries = screen.getAllByRole("listitem").map((item) =>
+      within(item).getByText(/Large amount detected|Watchlist hit|Rapid repeat payment/).textContent
+    );
+    assert.deepEqual(visibleSummaries.filter(Boolean), ["Large amount detected"]);
+
+    // Switch to unread status filter
+    fireEvent.click(screen.getByRole("button", { name: "Unread" }));
+
+    // Clear severity filter and apply search
+    fireEvent.click(severityToggle);
+    const searchInput = screen.getByPlaceholderText("Search alerts");
+    fireEvent.change(searchInput, { target: { value: "watchlist" } });
+
+    const listItems = screen.getAllByRole("listitem");
+    assert.equal(listItems.length, 1);
+    assert.equal(within(listItems[0]).getByText("Watchlist hit").textContent, "Watchlist hit");
+  });
+});

--- a/apgms/tests/tsconfig.json
+++ b/apgms/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/apgms/tsconfig.json
+++ b/apgms/tsconfig.json
@@ -9,6 +9,8 @@
     "resolveJsonModule": true,
     "outDir": "dist",
     "baseUrl": ".",
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM"],
     "paths": {
       "@apgms/shared/*": ["shared/src/*"]
     }

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,14 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/apgms/webapp/src/pages/Alerts/AlertsInbox.tsx
+++ b/apgms/webapp/src/pages/Alerts/AlertsInbox.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  AlertFilters,
+  AlertRecord,
+  AlertSeverity,
+  AlertStatus,
+  AlertStatusChange,
+} from "../../../../shared/src/alerts";
+
+type StatusFilter = AlertStatus | "ALL";
+
+type InitialFilters = Pick<AlertFilters, "ruleIds" | "severity" | "search"> & {
+  status?: StatusFilter;
+};
+
+export interface AlertsInboxProps {
+  alerts: AlertRecord[];
+  initialFilters?: InitialFilters;
+  onAlertStatusChange?: (change: AlertStatusChange) => void;
+}
+
+type AlertState = AlertRecord & { isLocal?: boolean };
+
+const normalizeAlert = (alert: AlertRecord): AlertState => ({
+  ...alert,
+  createdAt: alert.createdAt instanceof Date ? alert.createdAt : new Date(alert.createdAt),
+  updatedAt: alert.updatedAt instanceof Date ? alert.updatedAt : new Date(alert.updatedAt),
+  readAt:
+    alert.readAt == null
+      ? null
+      : alert.readAt instanceof Date
+      ? alert.readAt
+      : new Date(alert.readAt),
+});
+
+const normalizeAlerts = (alerts: AlertRecord[]): AlertState[] => alerts.map((alert) => normalizeAlert(alert));
+
+const mergeAlerts = (existing: AlertState[], incoming: AlertRecord[]): AlertState[] => {
+  const merged = new Map(existing.map((alert) => [alert.id, alert]));
+  for (const alert of incoming) {
+    const current = merged.get(alert.id);
+    merged.set(alert.id, { ...(current ?? {}), ...normalizeAlert(alert) });
+  }
+  return Array.from(merged.values());
+};
+
+const computeUnreadCount = (alerts: AlertState[]): number =>
+  alerts.filter((alert) => alert.status === "UNREAD").length;
+
+const severityOrder: AlertSeverity[] = ["CRITICAL", "HIGH", "MEDIUM", "LOW"];
+
+const formatDate = (value: Date): string =>
+  value.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+const statusLabel: Record<AlertStatus, string> = {
+  READ: "Read",
+  UNREAD: "Unread",
+};
+
+const severityLabel: Record<AlertSeverity, string> = {
+  CRITICAL: "Critical",
+  HIGH: "High",
+  MEDIUM: "Medium",
+  LOW: "Low",
+};
+
+export const AlertsInbox = ({
+  alerts,
+  initialFilters,
+  onAlertStatusChange,
+}: AlertsInboxProps) => {
+  const [items, setItems] = useState<AlertState[]>(() => normalizeAlerts(alerts));
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>(initialFilters?.status ?? "ALL");
+  const [ruleFilter, setRuleFilter] = useState<string | "ALL">(
+    initialFilters?.ruleIds?.[0] ?? "ALL"
+  );
+  const [severityFilter, setSeverityFilter] = useState<Set<AlertSeverity>>(
+    new Set(initialFilters?.severity ?? [])
+  );
+  const [searchTerm, setSearchTerm] = useState(initialFilters?.search ?? "");
+
+  useEffect(() => {
+    setItems((prev) => mergeAlerts(prev, alerts));
+  }, [alerts]);
+
+  const unreadCount = useMemo(() => computeUnreadCount(items), [items]);
+
+  const ruleOptions = useMemo(() => {
+    const unique = new Map<string, string>();
+    for (const alert of items) {
+      unique.set(alert.ruleId, alert.ruleId);
+    }
+    return Array.from(unique.keys()).sort();
+  }, [items]);
+
+  const toggleSeverity = (severity: AlertSeverity) => {
+    setSeverityFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(severity)) {
+        next.delete(severity);
+      } else {
+        next.add(severity);
+      }
+      return next;
+    });
+  };
+
+  const filteredAlerts = useMemo(() => {
+    return items
+      .filter((alert) => {
+        if (statusFilter !== "ALL" && alert.status !== statusFilter) {
+          return false;
+        }
+        if (ruleFilter !== "ALL" && alert.ruleId !== ruleFilter) {
+          return false;
+        }
+        if (severityFilter.size > 0 && !severityFilter.has(alert.severity)) {
+          return false;
+        }
+        if (searchTerm.trim()) {
+          const query = searchTerm.trim().toLowerCase();
+          const haystack = `${alert.summary} ${alert.details ?? ""}`.toLowerCase();
+          if (!haystack.includes(query)) {
+            return false;
+          }
+        }
+        return true;
+      })
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  }, [items, statusFilter, ruleFilter, severityFilter, searchTerm]);
+
+  const handleToggleStatus = (alert: AlertState) => {
+    setItems((prev) =>
+      prev.map((item) => {
+        if (item.id !== alert.id) return item;
+        const nextStatus: AlertStatus = item.status === "READ" ? "UNREAD" : "READ";
+        const readAt = nextStatus === "READ" ? new Date() : null;
+        const nextItem: AlertState = { ...item, status: nextStatus, readAt, isLocal: true };
+        onAlertStatusChange?.({ id: item.id, status: nextStatus, readAt: readAt ?? undefined });
+        return nextItem;
+      })
+    );
+  };
+
+  return (
+    <div className="alerts-inbox" aria-live="polite">
+      <header className="alerts-inbox__header">
+        <div>
+          <h2>Alerts Inbox</h2>
+          <p aria-label="Unread alerts">Unread: {unreadCount}</p>
+        </div>
+        <div className="alerts-inbox__filters">
+          <div className="alerts-inbox__filter-group" role="group" aria-label="Status filter">
+            {(["ALL", "UNREAD", "READ"] as StatusFilter[]).map((status) => (
+              <button
+                key={status}
+                type="button"
+                className={`alerts-inbox__filter-button${statusFilter === status ? " alerts-inbox__filter-button--active" : ""}`}
+                aria-pressed={statusFilter === status}
+                onClick={() => setStatusFilter(status)}
+              >
+                {status === "ALL" ? "All" : statusLabel[status]}
+              </button>
+            ))}
+          </div>
+          <label className="alerts-inbox__filter">
+            <span>Rule</span>
+            <select value={ruleFilter} onChange={(event) => setRuleFilter(event.target.value as any)}>
+              <option value="ALL">All rules</option>
+              {ruleOptions.map((ruleId) => (
+                <option key={ruleId} value={ruleId}>
+                  {ruleId}
+                </option>
+              ))}
+            </select>
+          </label>
+          <fieldset className="alerts-inbox__filter" aria-label="Severity filter">
+            <legend>Severity</legend>
+            <div className="alerts-inbox__severity-options">
+              {severityOrder.map((severity) => (
+                <label key={severity}>
+                  <input
+                    type="checkbox"
+                    checked={severityFilter.has(severity)}
+                    onChange={() => toggleSeverity(severity)}
+                  />
+                  {severityLabel[severity]}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <label className="alerts-inbox__filter alerts-inbox__search">
+            <span className="visually-hidden">Search alerts</span>
+            <input
+              type="search"
+              placeholder="Search alerts"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+            />
+          </label>
+        </div>
+      </header>
+      <section className="alerts-inbox__list" aria-live="polite">
+        {filteredAlerts.length === 0 ? (
+          <p className="alerts-inbox__empty">No alerts match the selected filters.</p>
+        ) : (
+          <ul>
+            {filteredAlerts.map((alert) => (
+              <li
+                key={alert.id}
+                className={`alerts-inbox__item alerts-inbox__item--${alert.status.toLowerCase()}`}
+              >
+                <div className="alerts-inbox__item-header">
+                  <span className="alerts-inbox__summary">{alert.summary}</span>
+                  <span className={`alerts-inbox__badge alerts-inbox__badge--${alert.severity.toLowerCase()}`}>
+                    {severityLabel[alert.severity]}
+                  </span>
+                </div>
+                {alert.details ? <p className="alerts-inbox__details">{alert.details}</p> : null}
+                <dl className="alerts-inbox__meta">
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{statusLabel[alert.status]}</dd>
+                  </div>
+                  <div>
+                    <dt>Rule</dt>
+                    <dd>{alert.ruleId}</dd>
+                  </div>
+                  <div>
+                    <dt>Created</dt>
+                    <dd>{formatDate(alert.createdAt)}</dd>
+                  </div>
+                </dl>
+                <button type="button" onClick={() => handleToggleStatus(alert)}>
+                  {alert.status === "READ" ? "Mark unread" : "Mark read"}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default AlertsInbox;

--- a/apgms/webapp/src/pages/Alerts/index.ts
+++ b/apgms/webapp/src/pages/Alerts/index.ts
@@ -1,0 +1,1 @@
+export * from "./AlertsInbox";


### PR DESCRIPTION
## Summary
- add a configurable anomaly rule engine with default detection rules
- extend the Prisma schema and add an alerts service for persistence operations
- build an alerts inbox view with filtering plus accompanying policy and UI tests

## Testing
- `pnpm test` *(fails: workspace dependencies missing in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f31cf40df48327809aa93252f66a16