### PR TITLE
feat(web): add resilient data list with theme tokens

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "web",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - services/*
   - webapp
+  - web
   - shared
   - worker
 

--- a/apgms/web/package.json
+++ b/apgms/web/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@apgms/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "axe-core": "^4.10.0",
+    "jest-axe": "^9.0.0",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.3"
+  }
+}

--- a/apgms/web/src/components/DataList.tsx
+++ b/apgms/web/src/components/DataList.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useId } from 'react';
+import { ErrorBoundary } from './ErrorBoundary.js';
+import { Skeleton } from './Skeleton.js';
+import { StatusMessage } from './StatusMessage.js';
+import { injectComponentStyles } from './styles.js';
+
+export interface DataListProps<T> {
+  items: T[];
+  isLoading?: boolean;
+  error?: Error | null;
+  emptyMessage?: {
+    title: string;
+    description?: string;
+    actionLabel?: string;
+    onAction?: () => void;
+  };
+  loadingSkeletonCount?: number;
+  renderItem: (item: T, index: number) => React.ReactNode;
+  getKey?: (item: T, index: number) => React.Key;
+  ariaLabel?: string;
+  onRetry?: () => void;
+}
+
+const LoadingState: React.FC<{ count: number; labelledBy: string; id?: string }> = ({
+  count,
+  labelledBy,
+  id,
+}) => (
+  <div id={id} role="status" aria-labelledby={labelledBy} aria-live="polite" aria-busy="true">
+    {Array.from({ length: count }).map((_, index) => (
+      <Skeleton key={index} height="3rem" style={{ marginBottom: 'var(--apgms-spacing-sm)' }} />
+    ))}
+  </div>
+);
+
+const EmptyState: React.FC<{
+  messageId: string;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}> = ({ messageId, title, description, actionLabel, onAction }) => (
+  <StatusMessage
+    id={messageId}
+    title={title}
+    description={description}
+    action={
+      actionLabel ? (
+        <button type="button" onClick={onAction}>
+          {actionLabel}
+        </button>
+      ) : undefined
+    }
+  />
+);
+
+const ErrorState: React.FC<{ messageId: string; error: Error; onRetry?: () => void }> = ({
+  messageId,
+  error,
+  onRetry,
+}) => (
+  <StatusMessage
+    id={messageId}
+    variant="error"
+    title="We could not load your data"
+    description={error.message}
+    action={
+      onRetry ? (
+        <button type="button" onClick={onRetry}>
+          Try again
+        </button>
+      ) : undefined
+    }
+  />
+);
+
+export function DataList<T>({
+  items,
+  isLoading = false,
+  error = null,
+  emptyMessage = {
+    title: 'No items to show',
+    description: 'Once data is available, it will appear here.',
+  },
+  loadingSkeletonCount = 3,
+  renderItem,
+  getKey,
+  ariaLabel,
+  onRetry,
+}: DataListProps<T>) {
+  const headingId = useId();
+  const emptyMessageId = useId();
+  const errorMessageId = useId();
+  const loadingMessageId = useId();
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      injectComponentStyles();
+    }
+  }, []);
+
+  const describedBy = isLoading
+    ? loadingMessageId
+    : error
+      ? errorMessageId
+      : items.length === 0
+        ? emptyMessageId
+        : undefined;
+
+  return (
+    <section
+      className="apgms-card"
+      aria-busy={isLoading ? 'true' : undefined}
+      aria-live="polite"
+      aria-labelledby={headingId}
+      aria-describedby={describedBy}
+      aria-label={ariaLabel}
+    >
+      <h2 id={headingId}>Latest activity</h2>
+      <ErrorBoundary
+        fallback={
+          <StatusMessage
+            id={errorMessageId}
+            variant="error"
+            title="We could not load your data"
+            description="An unexpected error occurred while rendering this list."
+            action={
+              onRetry ? (
+                <button type="button" onClick={onRetry}>
+                  Try again
+                </button>
+              ) : undefined
+            }
+          />
+        }
+        resetKeys={[items, isLoading, error]}
+      >
+        {isLoading ? (
+          <LoadingState id={loadingMessageId} count={loadingSkeletonCount} labelledBy={headingId} />
+        ) : error ? (
+          <ErrorState messageId={errorMessageId} error={error} onRetry={onRetry} />
+        ) : items.length === 0 ? (
+          <EmptyState
+            messageId={emptyMessageId}
+            title={emptyMessage.title}
+            description={emptyMessage.description}
+            actionLabel={emptyMessage.actionLabel}
+            onAction={emptyMessage.onAction}
+          />
+        ) : (
+          <ul className="apgms-data-list" role="list">
+            {items.map((item, index) => (
+              <li key={getKey?.(item, index) ?? index}>{renderItem(item, index)}</li>
+            ))}
+          </ul>
+        )}
+      </ErrorBoundary>
+    </section>
+  );
+}

--- a/apgms/web/src/components/ErrorBoundary.tsx
+++ b/apgms/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { StatusMessage } from './StatusMessage.js';
+
+type ErrorBoundaryState = { hasError: boolean; error?: Error };
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  onReset?: () => void;
+  resetKeys?: React.DependencyList;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    const { resetKeys } = this.props;
+    if (!resetKeys) return;
+
+    const hasChanged = resetKeys.some((key, index) => !Object.is(key, prevProps.resetKeys?.[index]));
+    if (hasChanged && this.state.hasError) {
+      this.reset();
+    }
+  }
+
+  reset() {
+    this.setState({ hasError: false, error: undefined });
+    this.props.onReset?.();
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <StatusMessage
+            variant="error"
+            title="Something went wrong"
+            description={this.state.error?.message ?? 'An unexpected error occurred.'}
+            action={
+              <button type="button" onClick={() => this.reset()}>
+                Try again
+              </button>
+            }
+          />
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apgms/web/src/components/Skeleton.tsx
+++ b/apgms/web/src/components/Skeleton.tsx
@@ -1,0 +1,32 @@
+import type { HTMLAttributes } from 'react';
+import React from 'react';
+
+export type SkeletonProps = HTMLAttributes<HTMLDivElement> & {
+  width?: string | number;
+  height?: string | number;
+  radius?: string | number;
+};
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  width = '100%',
+  height = '1rem',
+  radius = 'var(--apgms-radius-sm)',
+  style,
+  className,
+  ...rest
+}) => (
+  <div
+    role="presentation"
+    aria-hidden="true"
+    className={`apgms-skeleton ${className ?? ''}`.trim()}
+    style={{
+      background: 'linear-gradient(90deg, rgba(148, 163, 184, 0.1) 0%, rgba(148, 163, 184, 0.35) 50%, rgba(148, 163, 184, 0.1) 100%)',
+      borderRadius: radius,
+      width,
+      height,
+      animation: 'apgms-skeleton 1.6s ease-in-out infinite',
+      ...style,
+    }}
+    {...rest}
+  />
+);

--- a/apgms/web/src/components/StatusMessage.tsx
+++ b/apgms/web/src/components/StatusMessage.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+
+export type StatusMessageVariant = 'empty' | 'error';
+
+export interface StatusMessageProps {
+  icon?: ReactNode;
+  title: string;
+  description?: ReactNode;
+  action?: ReactNode;
+  variant?: StatusMessageVariant;
+  id?: string;
+}
+
+export const StatusMessage: React.FC<StatusMessageProps> = ({
+  icon,
+  title,
+  description,
+  action,
+  variant = 'empty',
+  id,
+}) => (
+  <div
+    role={variant === 'error' ? 'alert' : 'status'}
+    aria-live={variant === 'error' ? 'assertive' : 'polite'}
+    className="apgms-status-message"
+    data-variant={variant}
+    id={id}
+  >
+    {icon ? <span aria-hidden="true">{icon}</span> : null}
+    <div>
+      <p style={{
+        margin: 0,
+        fontWeight: 'var(--apgms-typography-weight-semibold)',
+        fontSize: 'var(--apgms-typography-size-md)',
+      }}>
+        {title}
+      </p>
+      {description ? (
+        <p
+          style={{
+            margin: 'var(--apgms-spacing-xs) 0 0 0',
+            color: 'var(--apgms-color-text-secondary)',
+          }}
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+    {action}
+  </div>
+);

--- a/apgms/web/src/components/__tests__/DataList.test.tsx
+++ b/apgms/web/src/components/__tests__/DataList.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { DataList } from '../DataList.js';
+
+const items = [
+  { id: '1', label: 'First event' },
+  { id: '2', label: 'Second event' },
+];
+
+describe('DataList', () => {
+  it('renders skeletons while loading', () => {
+    render(
+      <DataList
+        items={[]}
+        isLoading
+        renderItem={(item) => <span>{item as string}</span>}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getAllByRole('presentation').length).toBeGreaterThan(0);
+  });
+
+  it('renders empty state when no items are available', () => {
+    render(
+      <DataList
+        items={[]}
+        renderItem={(item) => <span>{item as string}</span>}
+        emptyMessage={{
+          title: 'No transactions yet',
+          description: 'Start by connecting an account.',
+        }}
+      />,
+    );
+
+    expect(screen.getByRole('status', { name: /no transactions yet/i })).toBeInTheDocument();
+    expect(screen.getByText(/start by connecting an account/i)).toBeVisible();
+  });
+
+  it('renders provided items', () => {
+    render(
+      <DataList
+        items={items}
+        getKey={(item) => item.id}
+        renderItem={(item) => <span>{item.label}</span>}
+      />,
+    );
+
+    items.forEach((item) => {
+      expect(screen.getByText(item.label)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an accessible error message when renderItem throws', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      render(
+        <DataList
+          items={items}
+          getKey={(item) => item.id}
+          renderItem={() => {
+            throw new Error('boom');
+          }}
+        />,
+      );
+
+      expect(
+        screen.getByText(/an unexpected error occurred while rendering this list/i),
+      ).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('passes axe accessibility checks', async () => {
+    const { container } = render(
+      <DataList
+        items={items}
+        getKey={(item) => item.id}
+        renderItem={(item) => <span>{item.label}</span>}
+      />,
+    );
+
+    const results = await axe(container);
+    await waitFor(() => expect(results).toHaveNoViolations());
+  });
+});

--- a/apgms/web/src/components/index.ts
+++ b/apgms/web/src/components/index.ts
@@ -1,0 +1,9 @@
+export { DataList } from './DataList.js';
+export type { DataListProps } from './DataList.js';
+export { ErrorBoundary } from './ErrorBoundary.js';
+export type { ErrorBoundaryProps } from './ErrorBoundary.js';
+export { Skeleton } from './Skeleton.js';
+export type { SkeletonProps } from './Skeleton.js';
+export { StatusMessage } from './StatusMessage.js';
+export type { StatusMessageProps, StatusMessageVariant } from './StatusMessage.js';
+export { injectComponentStyles } from './styles.js';

--- a/apgms/web/src/components/styles.ts
+++ b/apgms/web/src/components/styles.ts
@@ -1,0 +1,87 @@
+const styles = `
+@keyframes apgms-skeleton {
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+}
+
+.apgms-card {
+  background-color: var(--apgms-color-surface);
+  border-radius: var(--apgms-radius-md);
+  border: 1px solid var(--apgms-color-border);
+  box-shadow: var(--apgms-shadow-sm);
+  padding: var(--apgms-spacing-lg);
+  color: var(--apgms-color-text-primary);
+  font-family: var(--apgms-typography-font-family);
+}
+
+.apgms-card h2 {
+  font-size: var(--apgms-typography-size-lg);
+  line-height: var(--apgms-typography-line-height-tight);
+  font-weight: var(--apgms-typography-weight-semibold);
+  margin-bottom: var(--apgms-spacing-md);
+}
+
+.apgms-status-message {
+  display: grid;
+  gap: var(--apgms-spacing-sm);
+  justify-items: flex-start;
+  padding: var(--apgms-spacing-lg);
+  border-radius: var(--apgms-radius-md);
+  background-color: var(--apgms-color-surface-muted);
+  border: 1px dashed var(--apgms-color-border);
+}
+
+.apgms-status-message[data-variant='error'] {
+  border-color: var(--apgms-color-destructive);
+  color: var(--apgms-color-destructive);
+}
+
+.apgms-status-message button {
+  padding: var(--apgms-spacing-xs) var(--apgms-spacing-md);
+  border-radius: var(--apgms-radius-sm);
+  border: none;
+  background-color: var(--apgms-color-accent);
+  color: var(--apgms-color-text-inverted);
+  font-weight: var(--apgms-typography-weight-medium);
+  cursor: pointer;
+}
+
+.apgms-status-message button:focus-visible {
+  outline: 3px solid var(--apgms-color-focus);
+  outline-offset: 2px;
+}
+
+.apgms-data-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--apgms-spacing-sm);
+}
+
+.apgms-skeleton {
+  background-size: 200px 100%;
+  position: relative;
+  overflow: hidden;
+}
+`;
+
+export const injectComponentStyles = (doc: Document = document) => {
+  const existing = doc.getElementById('apgms-component-styles');
+  if (existing) {
+    existing.textContent = styles;
+    return existing as HTMLStyleElement;
+  }
+
+  const style = doc.createElement('style');
+  style.id = 'apgms-component-styles';
+  style.textContent = styles;
+  doc.head.appendChild(style);
+  return style;
+};
+
+export { styles as componentStyles };

--- a/apgms/web/src/index.ts
+++ b/apgms/web/src/index.ts
@@ -1,0 +1,2 @@
+export * from './components/index.js';
+export { applyTheme, injectThemeStyles, themeCssText, themeTokens, themeVariableMap } from './theme/index.js';

--- a/apgms/web/src/theme/__tests__/theme.test.ts
+++ b/apgms/web/src/theme/__tests__/theme.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { applyTheme, injectThemeStyles, themeCssText, themeTokens, themeVariableMap } from '../index.js';
+
+describe('theme exports', () => {
+  it('exposes a stable map of css variables', () => {
+    expect(themeVariableMap['--apgms-color-background']).toBe(themeTokens.color.background);
+    expect(themeCssText).toContain('--apgms-spacing-md');
+  });
+
+  it('injects theme styles into the document head', () => {
+    const doc = document.implementation.createHTMLDocument();
+    const styleElement = injectThemeStyles(doc);
+
+    expect(styleElement.id).toBe('apgms-theme');
+    expect(doc.head.querySelectorAll('style#apgms-theme')).toHaveLength(1);
+    expect(styleElement.textContent).toBe(themeCssText);
+  });
+
+  it('applies token overrides to a target element', () => {
+    const element = document.createElement('div');
+    applyTheme(element, {
+      color: {
+        accent: '#ff0000',
+      },
+    });
+
+    expect(element.style.getPropertyValue('--apgms-color-accent')).toBe('#ff0000');
+  });
+});

--- a/apgms/web/src/theme/index.ts
+++ b/apgms/web/src/theme/index.ts
@@ -1,0 +1,81 @@
+import type { ThemeTokens } from './tokens';
+import { themeTokens } from './tokens';
+
+type FlatTokenMap = Record<string, string | number>;
+type TokenRecord = Record<string, unknown>;
+
+const VARIABLE_PREFIX = '--apgms';
+
+const toCssVarName = (segments: string[]) => [VARIABLE_PREFIX, ...segments].join('-');
+
+const isPlainObject = (value: unknown): value is TokenRecord =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const flattenTokens = (tokens: TokenRecord, path: string[] = []): FlatTokenMap => {
+  const entries: FlatTokenMap = {};
+
+  Object.entries(tokens).forEach(([key, value]) => {
+    const normalizedKey = key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+    const nextPath = [...path, normalizedKey];
+
+    if (isPlainObject(value)) {
+      Object.assign(entries, flattenTokens(value, nextPath));
+      return;
+    }
+
+    entries[toCssVarName(nextPath)] = String(value);
+  });
+
+  return entries;
+};
+
+const mergeTokens = (base: TokenRecord, overrides?: TokenRecord): TokenRecord => {
+  if (!overrides) {
+    return { ...base };
+  }
+
+  return Object.entries(base).reduce<TokenRecord>((acc, [key, value]) => {
+    if (isPlainObject(value)) {
+      acc[key] = mergeTokens(value, isPlainObject(overrides[key]) ? (overrides[key] as TokenRecord) : undefined);
+      return acc;
+    }
+
+    acc[key] = value;
+    return acc;
+  }, { ...overrides });
+};
+
+export const themeVariableMap = flattenTokens(themeTokens as TokenRecord);
+
+export const themeCssText = `:root {\n${Object.entries(themeVariableMap)
+  .map(([name, value]) => `  ${name}: ${value};`)
+  .join('\n')}\n}`;
+
+export const injectThemeStyles = (doc: Document = document) => {
+  const existing = doc.getElementById('apgms-theme');
+  if (existing) {
+    existing.textContent = themeCssText;
+    return existing as HTMLStyleElement;
+  }
+
+  const style = doc.createElement('style');
+  style.id = 'apgms-theme';
+  style.textContent = themeCssText;
+  doc.head.appendChild(style);
+  return style;
+};
+
+export const applyTheme = (
+  target: HTMLElement = document.documentElement,
+  tokens: Partial<ThemeTokens> = {},
+) => {
+  const merged = mergeTokens(themeTokens as TokenRecord, tokens as TokenRecord);
+  const resolved = flattenTokens(merged);
+  Object.entries(resolved).forEach(([name, value]) => {
+    target.style.setProperty(name, String(value));
+  });
+
+  return target;
+};
+
+export { themeTokens };

--- a/apgms/web/src/theme/tokens.ts
+++ b/apgms/web/src/theme/tokens.ts
@@ -1,0 +1,56 @@
+export type ThemeTokens = typeof themeTokens;
+
+export const themeTokens = {
+  color: {
+    background: '#0f172a',
+    surface: '#ffffff',
+    surfaceMuted: '#f8fafc',
+    border: '#e2e8f0',
+    accent: '#2563eb',
+    accentMuted: '#60a5fa',
+    destructive: '#dc2626',
+    text: {
+      primary: '#0f172a',
+      secondary: '#475569',
+      inverted: '#ffffff',
+      subtle: '#64748b',
+    },
+    focus: '#fbbf24',
+  },
+  spacing: {
+    xs: '0.25rem',
+    sm: '0.5rem',
+    md: '0.75rem',
+    lg: '1rem',
+    xl: '1.5rem',
+  },
+  radius: {
+    sm: '0.375rem',
+    md: '0.75rem',
+    full: '9999px',
+  },
+  typography: {
+    fontFamily: '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    lineHeight: {
+      tight: 1.2,
+      normal: 1.5,
+      relaxed: 1.7,
+    },
+    size: {
+      xs: '0.75rem',
+      sm: '0.875rem',
+      md: '1rem',
+      lg: '1.125rem',
+      xl: '1.25rem',
+    },
+    weight: {
+      regular: 400,
+      medium: 500,
+      semibold: 600,
+    },
+  },
+  shadow: {
+    sm: '0 1px 2px rgba(15, 23, 42, 0.08)',
+    md: '0 10px 30px rgba(15, 23, 42, 0.12)',
+  },
+} as const;

--- a/apgms/web/tsconfig.json
+++ b/apgms/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src", "vitest.setup.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apgms/web/vitest.config.ts
+++ b/apgms/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+});

--- a/apgms/web/vitest.setup.ts
+++ b/apgms/web/vitest.setup.ts
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom/vitest';
+import { toHaveNoViolations } from 'jest-axe';
+import { expect } from 'vitest';
+
+expect.extend(toHaveNoViolations);


### PR DESCRIPTION
## Summary
- add a new @apgms/web workspace with shared UI components and theming helpers
- implement a resilient DataList with loading skeletons, empty state messaging, and error boundaries
- define CSS-variable based design tokens and injectors, plus regression tests covering new UI states and accessibility

## Testing
- pnpm --filter @apgms/web test *(fails: vitest binary not available because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f31cf505b0832797c04ee9f2ed3d50