### PR TITLE
Add reverse-engineered architecture and API documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,114 @@
+# HTTP API Reference
+
+## API Gateway (`services/api-gateway`)
+
+### GET `/health`
+- Description: Returns service liveness.
+- Authentication: None.
+- Request: no parameters.
+- Response 200 body schema:
+```json
+{
+  "type": "object",
+  "required": ["ok", "service"],
+  "properties": {
+    "ok": { "type": "boolean", "const": true },
+    "service": { "type": "string", "const": "api-gateway" }
+  }
+}
+```
+
+### GET `/users`
+- Description: Lists users with creation timestamps and organisation linkage.
+- Authentication: None.
+- Request query parameters: none.
+- Response 200 body schema:
+```json
+{
+  "type": "object",
+  "required": ["users"],
+  "properties": {
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["email", "orgId", "createdAt"],
+        "properties": {
+          "email": { "type": "string", "format": "email" },
+          "orgId": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}
+```
+
+### GET `/bank-lines`
+- Description: Lists bank statement lines ordered by descending date.
+- Authentication: None.
+- Request query parameters:
+  - `take` (optional, integer, min 1, max 200) — number of records to return; defaults to 20.
+- Response 200 body schema:
+```json
+{
+  "type": "object",
+  "required": ["lines"],
+  "properties": {
+    "lines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "orgId", "date", "amount", "payee", "desc", "createdAt"],
+        "properties": {
+          "id": { "type": "string" },
+          "orgId": { "type": "string" },
+          "date": { "type": "string", "format": "date-time" },
+          "amount": { "type": "string" },
+          "payee": { "type": "string" },
+          "desc": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}
+```
+
+### POST `/bank-lines`
+- Description: Creates a bank statement line for the specified organisation.
+- Authentication: None.
+- Request body schema:
+```json
+{
+  "type": "object",
+  "required": ["orgId", "date", "amount", "payee", "desc"],
+  "properties": {
+    "orgId": { "type": "string" },
+    "date": { "type": "string", "format": "date-time" },
+    "amount": { "type": ["number", "string"] },
+    "payee": { "type": "string" },
+    "desc": { "type": "string" }
+  }
+}
+```
+- Responses:
+  - 201 Created — returns the persisted bank line object (schema matches `GET /bank-lines` items).
+  - 400 Bad Request — returns `{ "error": "bad_request" }` when validation or persistence fails.
+
+## Tax Engine (`services/tax-engine`)
+
+### GET `/health`
+- Description: Returns service liveness.
+- Authentication: None.
+- Request: no parameters.
+- Response 200 body schema:
+```json
+{
+  "type": "object",
+  "required": ["ok"],
+  "properties": {
+    "ok": { "type": "boolean", "const": true }
+  }
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,35 @@
+# Architecture Overview
+
+## Monorepo layout
+- `apgms/package.json` defines a PNPM workspace that groups service packages (`services/*`), the React webapp, shared libraries, and the background worker.
+- Shared database access is provided via `shared/src/db.ts`, which instantiates a singleton Prisma client for reuse across services.
+
+## Runtime components
+| Component | Runtime | Entry point | Responsibilities |
+| --- | --- | --- | --- |
+| API Gateway | Node.js (Fastify) | `services/api-gateway/src/index.ts` | Hosts HTTP routes for health checks, user listing, and bank line CRUD. Loads configuration from `.env`, enables permissive CORS, and talks to Postgres through Prisma. |
+| Tax Engine | Python (FastAPI) | `services/tax-engine/app/main.py` | Exposes a `/health` endpoint; business logic is TBD. |
+| Audit, CDR, Connectors, Payments, Recon, Registries, SBR services | Node.js | `services/<name>/src/index.ts` | Currently log a startup message only; implementation TBD. |
+| Worker | Node.js | `worker/src/index.ts` | Placeholder worker process; currently logs "worker" only. |
+| Webapp | React/Vite | `webapp/src/main.tsx` | Placeholder SPA entry point logging "webapp" only; UI TBD. |
+
+## Data layer
+- Prisma models `Org`, `User`, and `BankLine` are defined in `shared/prisma/schema.prisma`, establishing relationships between organisations, their users, and imported bank statement lines.
+- All services that need database access rely on the shared Prisma client; currently only the API Gateway issues queries.
+
+## Infrastructure
+- `docker-compose.yml` provisions Postgres 15 and Redis 7 containers for local development; no application services are orchestrated yet.
+- Environment variables (e.g., `DATABASE_URL`) are expected in a repo-level `.env` file that the API Gateway loads on startup.
+
+## Inter-service interactions
+- Presently, only the API Gateway interacts with the database; there is no implemented messaging or RPC between services.
+- Placeholder services and the worker emit console logs but expose no network interfaces or job handlers yet, so integration points remain TBD.
+
+## Observability
+- The API Gateway enables Fastify's default logger, emitting structured logs for requests and errors; no metrics or tracing integrations are present.
+
+## Security surface
+- No authentication or authorization checks are implemented in any exposed endpoint; API Gateway routes are publicly accessible.
+- Requests accept JSON bodies without schema validation beyond Prisma constraints; input sanitisation is minimal (simple try/catch around `/bank-lines` insert).
+- CORS is configured to allow any origin, widening exposure for browser clients.
+- No rate limiting, request signing, or CSRF protections are present.

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,0 +1,32 @@
+# Entity-Relationship Diagram
+
+## Current entities
+
+### Org
+- **Table**: `Org`
+- **Primary key**: `id` (string, `cuid()`)
+- **Attributes**: `name` (string), `createdAt` (timestamp default `now()`)
+- **Relations**:
+  - One-to-many with `User` via `Org.id` → `User.orgId` (cascade delete).
+  - One-to-many with `BankLine` via `Org.id` → `BankLine.orgId` (cascade delete).
+
+### User
+- **Table**: `User`
+- **Primary key**: `id` (string, `cuid()`)
+- **Attributes**: `email` (unique string), `password` (string), `createdAt` (timestamp default `now()`), `orgId` (string FK).
+- **Relations**: Many-to-one to `Org`.
+
+### BankLine
+- **Table**: `BankLine`
+- **Primary key**: `id` (string, `cuid()`)
+- **Attributes**: `orgId` (string FK), `date` (timestamp), `amount` (decimal), `payee` (string), `desc` (string), `createdAt` (timestamp default `now()`).
+- **Relations**: Many-to-one to `Org`.
+
+## Missing domains
+The repository has no schema definitions or migrations for the requested domains below. Each item requires a new model/table design, migrations, and related repositories/services.
+
+- **POLICY**: TBD — no existing models reference policy management.
+- **GATE**: TBD — no existing models define gateway/entitlement data.
+- **LEDGER**: TBD — no general ledger tables exist beyond `BankLine` placeholders.
+- **RPT**: TBD — no reporting tables or materialized views are present.
+- **AUDIT_BLOB**: TBD — no blob storage or audit trail tables are implemented.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -1,0 +1,27 @@
+# Gap Analysis
+
+## Jobs, queues, and webhooks
+- No job scheduler or message queue integrations are implemented. `docker-compose.yml` provisions Redis, but no code consumes it for background processing.
+- Idempotency strategy is undefined; POST endpoints (e.g., `/bank-lines`) accept duplicate submissions without checks (`services/api-gateway/src/index.ts`).
+
+## Security and validation
+- Every public route lacks authentication and authorization, leaving data exposed (`services/api-gateway/src/index.ts`).
+- Request validation is minimal: `/bank-lines` trusts the inbound payload apart from a try/catch. Schema validation (e.g., via Zod) is not enforced despite the dependency being available.
+- CORS allows any origin, potentially exposing the API to CSRF-like risks when combined with missing auth (`services/api-gateway/src/index.ts`).
+- Password handling for users is undefined; passwords are stored as plain strings in Prisma schema (`shared/prisma/schema.prisma`).
+
+## Data model completeness
+- Domain tables for POLICY, GATE, LEDGER, RPT, and AUDIT_BLOB are missing; Prisma schema currently models only organisations, users, and bank lines (`shared/prisma/schema.prisma`).
+- Prisma migrations are absent; schema changes rely on manual generation.
+
+## Service implementation gaps
+- `services/audit`, `services/cdr`, `services/connectors`, `services/payments`, `services/recon`, `services/registries`, and `services/sbr` contain only placeholder console logs — real business logic, transport layers, and persistence are TBD.
+- `services/tax-engine` exposes only a health check; taxation logic, data access, and integration points remain TBD (`services/tax-engine/app/main.py`).
+- `worker/src/index.ts` is a stub that logs "worker" and should be replaced with actual queue/message consumers.
+
+## Web application
+- `webapp/src/main.tsx` merely logs "webapp"; routing, pages, authentication flows, and API integrations are unimplemented.
+
+## Documentation and operations
+- `.env` loading is assumed but no sample configuration is committed; onboarding documentation should specify required variables for each service.
+- Monitoring, metrics, and alerting are absent across services.


### PR DESCRIPTION
## Summary
- document monorepo architecture, runtime components, and security posture
- record available HTTP routes with JSON schemas and health endpoints
- capture current data model along with gap analysis for missing domains and systems

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f32b873e108327aaeee3ae3788b010