### PR TITLE
Implement security hardening and audit export tooling

### DIFF
--- a/apgms/cli/audit-export.ts
+++ b/apgms/cli/audit-export.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { prisma, getDailyAuditBundle, formatAnchorDate } from "@apgms/shared";
+
+interface ExportResult {
+  jsonlPath: string;
+  pdfPath: string;
+  records: number;
+  anchor: string;
+}
+
+function parseDate(input?: string): Date {
+  if (!input) {
+    return new Date();
+  }
+  const parsed = new Date(input);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${input}`);
+  }
+  return parsed;
+}
+
+function escapePdf(text: string): string {
+  return text.replace(/[\\()]/g, (match) => `\\${match}`);
+}
+
+function createPdf(lines: string[]): Buffer {
+  const escaped = lines.map(escapePdf);
+  const textBody = escaped
+    .map((line, index) => (index === 0 ? `(${line}) Tj` : `0 -16 Td\n(${line}) Tj`))
+    .join("\n");
+  const content = `BT\n/F1 12 Tf\n72 720 Td\n${textBody}\nET\n`;
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [0];
+  let objectCount = 0;
+
+  const appendObject = (body: string) => {
+    objectCount += 1;
+    const offset = Buffer.byteLength(pdf, "utf8");
+    offsets.push(offset);
+    pdf += `${objectCount} 0 obj\n${body}\nendobj\n`;
+  };
+
+  appendObject("<< /Type /Catalog /Pages 2 0 R >>");
+  appendObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+  appendObject(
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+  );
+  appendObject(`<< /Length ${Buffer.byteLength(content, "utf8")} >>\nstream\n${content}\nendstream`);
+  appendObject("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+  const xrefOffset = Buffer.byteLength(pdf, "utf8");
+  pdf += `xref\n0 ${objectCount + 1}\n0000000000 65535 f \n`;
+  for (let i = 1; i <= objectCount; i += 1) {
+    pdf += `${offsets[i].toString().padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objectCount + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+  return Buffer.from(pdf, "utf8");
+}
+
+async function writeJsonl(filePath: string, records: unknown[]): Promise<void> {
+  const body = records.map((record) => JSON.stringify(record)).join("\n");
+  await fs.writeFile(filePath, body ? `${body}\n` : body, "utf8");
+}
+
+async function run(dateInput?: string): Promise<ExportResult> {
+  const targetDate = parseDate(dateInput);
+  const { anchorDate, anchor, records } = await getDailyAuditBundle(prisma, targetDate);
+  if (!anchor) {
+    throw new Error(`No audit anchor found for ${formatAnchorDate(anchorDate)}`);
+  }
+  const isoDate = formatAnchorDate(anchorDate);
+  const baseDir = path.resolve(process.cwd(), "exports", isoDate);
+  await fs.mkdir(baseDir, { recursive: true });
+  const jsonlPath = path.join(baseDir, `audit-${isoDate}.jsonl`);
+  const pdfPath = path.join(baseDir, `audit-${isoDate}.pdf`);
+  await writeJsonl(jsonlPath, records);
+  const lines = [
+    `Audit export for ${isoDate}`,
+    `Entries: ${records.length}`,
+    `Anchor hash: ${(anchor as any).hash}`,
+    `Generated at: ${new Date().toISOString()}`,
+  ];
+  const pdf = createPdf(lines);
+  await fs.writeFile(pdfPath, pdf);
+  return { jsonlPath, pdfPath, records: records.length, anchor: (anchor as any).hash };
+}
+
+async function main() {
+  try {
+    const [, , dateInput] = process.argv;
+    const result = await run(dateInput);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exitCode = 1;
+  } finally {
+    if (prisma.$disconnect) {
+      await prisma.$disconnect();
+    }
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}
+
+export { run };

--- a/apgms/cli/kms-rotate.ts
+++ b/apgms/cli/kms-rotate.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { createFileKMS } from "../shared/crypto/kms";
+
+async function main() {
+  const [, , statePathArg] = process.argv;
+  const statePath = statePathArg ? path.resolve(statePathArg) : path.resolve(process.cwd(), "kms-state.json");
+  const kms = await createFileKMS(statePath);
+  const metadata = await kms.rotate();
+  console.log(JSON.stringify({ rotatedKey: metadata, statePath }, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}
+
+export { main };

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,121 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { createFileKMS, type KeyManagementService } from "../../../shared/crypto/kms";
+import { prisma as defaultPrisma, type PrismaClientLike, appendAuditLog } from "@apgms/shared";
+import { registerSecurity, type Role } from "./security";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export interface AppOptions {
+  prisma?: PrismaClientLike;
+  kms?: KeyManagementService;
+  roleTokens?: Partial<Record<Role, string>>;
+  rateLimit?: {
+    max: number;
+    intervalMs: number;
+  };
+}
+
+function resolveRoleTokens(overrides?: Partial<Record<Role, string>>): Record<Role, string> {
+  return {
+    admin: overrides?.admin ?? process.env.ADMIN_TOKEN ?? "admin-token",
+    operator: overrides?.operator ?? process.env.OPERATOR_TOKEN ?? "operator-token",
+    auditor: overrides?.auditor ?? process.env.AUDITOR_TOKEN ?? "auditor-token",
+  };
+}
+
+export async function buildApp(options: AppOptions = {}) {
+  const app = Fastify({ logger: true });
+  await app.register(cors, { origin: true });
+
+  const kms = options.kms ?? (await createFileKMS(path.resolve(__dirname, "../../../kms-state.json")));
+  const prisma = options.prisma ?? defaultPrisma;
+  const rateLimit = options.rateLimit ?? {
+    max: Number(process.env.RATE_LIMIT_MAX ?? 60),
+    intervalMs: Number(process.env.RATE_LIMIT_INTERVAL_MS ?? 60_000),
+  };
+
+  registerSecurity(app, {
+    kms,
+    roleTokens: resolveRoleTokens(options.roleTokens),
+    rateLimit,
+  });
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get(
+    "/users",
+    {
+      preHandler: [app.requireRole(["admin", "auditor"])] as any,
+    },
+    async () => {
+      const users = await prisma.user.findMany({
+        select: { email: true, orgId: true, createdAt: true },
+        orderBy: { createdAt: "desc" },
+      });
+      return { users };
+    },
+  );
+
+  app.get(
+    "/bank-lines",
+    {
+      preHandler: [app.requireRole(["admin", "operator", "auditor"])] as any,
+    },
+    async (req) => {
+      const take = Number((req.query as any)?.take ?? 20);
+      const lines = await prisma.bankLine.findMany({
+        orderBy: { date: "desc" },
+        take: Math.min(Math.max(take, 1), 200),
+      });
+      return { lines };
+    },
+  );
+
+  app.post(
+    "/bank-lines",
+    {
+      preHandler: [app.requireRole(["admin", "operator"]), app.requireCsrf()] as any,
+    },
+    async (req, rep) => {
+      try {
+        const body = req.body as {
+          orgId: string;
+          date: string;
+          amount: number | string;
+          payee: string;
+          desc: string;
+        };
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: body.orgId,
+            date: new Date(body.date),
+            amount: body.amount as any,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+        if (req.auth) {
+          await appendAuditLog(prisma, {
+            actorRole: req.auth.role,
+            action: "bank_line:create",
+            resource: created.id,
+            metadata: { orgId: body.orgId, amount: body.amount },
+          });
+        }
+        return rep.code(201).send(created);
+      } catch (err) {
+        req.log.error(err);
+        return rep.code(400).send({ error: "bad_request" });
+      }
+    },
+  );
+
+  app.decorate("prisma", prisma);
+  app.decorate("kms", kms);
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,65 +7,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { buildApp } from "./app";
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
+const app = await buildApp();
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });

--- a/apgms/services/api-gateway/src/security.ts
+++ b/apgms/services/api-gateway/src/security.ts
@@ -1,0 +1,165 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { deserializeEnvelope, type KeyManagementService, serializeEnvelope } from "../../../shared/crypto/kms";
+
+export type Role = "admin" | "operator" | "auditor";
+
+export interface SecurityOptions {
+  kms: KeyManagementService;
+  roleTokens: Record<Role, string>;
+  rateLimit: {
+    max: number;
+    intervalMs: number;
+  };
+  csrfTtlMs?: number;
+}
+
+interface RateLimitState {
+  count: number;
+  resetAt: number;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    auth?: {
+      role: Role;
+      token: string;
+    };
+  }
+
+  interface FastifyInstance {
+    requireRole(roles: Role[]): (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    requireCsrf(): (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    issueCsrfToken(sessionId: string): Promise<string>;
+  }
+}
+
+const CSRF_HEADER = "x-csrf-token";
+const SESSION_HEADER = "x-session-id";
+
+function normalizeRoles(roleTokens: Record<Role, string>): Map<string, Role> {
+  const entries = Object.entries(roleTokens) as [Role, string][];
+  return new Map(entries.map(([role, token]) => [token, role]));
+}
+
+function getAuthToken(request: FastifyRequest): string | null {
+  const header = request.headers["authorization"];
+  if (typeof header !== "string") {
+    return null;
+  }
+  const [scheme, token] = header.split(" ");
+  if (scheme?.toLowerCase() !== "bearer" || !token) {
+    return null;
+  }
+  return token.trim();
+}
+
+async function handleRateLimit(
+  state: Map<string, RateLimitState>,
+  key: string,
+  options: SecurityOptions,
+  reply: FastifyReply,
+): Promise<boolean> {
+  const now = Date.now();
+  const existing = state.get(key);
+  if (!existing || existing.resetAt <= now) {
+    state.set(key, { count: 1, resetAt: now + options.rateLimit.intervalMs });
+    return true;
+  }
+  if (existing.count >= options.rateLimit.max) {
+    await reply.code(429).send({ error: "rate_limited" });
+    return false;
+  }
+  existing.count += 1;
+  return true;
+}
+
+function decodeCsrfToken(token: string) {
+  try {
+    return deserializeEnvelope(token);
+  } catch (err) {
+    throw new Error("invalid_csrf_token");
+  }
+}
+
+async function verifyCsrf(
+  kms: KeyManagementService,
+  sessionId: string,
+  token: string,
+  ttlMs: number,
+): Promise<boolean> {
+  try {
+    const envelope = decodeCsrfToken(token);
+    const payload = await kms.decrypt(envelope);
+    const parsed = JSON.parse(payload) as { sessionId: string; issuedAt: string };
+    if (parsed.sessionId !== sessionId) {
+      return false;
+    }
+    const issuedAt = Date.parse(parsed.issuedAt);
+    if (Number.isNaN(issuedAt)) {
+      return false;
+    }
+    return Date.now() - issuedAt <= ttlMs;
+  } catch {
+    return false;
+  }
+}
+
+export function registerSecurity(app: FastifyInstance, options: SecurityOptions) {
+  const tokenToRole = normalizeRoles(options.roleTokens);
+  const rateState = new Map<string, RateLimitState>();
+  const csrfTtlMs = options.csrfTtlMs ?? 15 * 60 * 1000;
+
+  app.decorate("issueCsrfToken", async (sessionId: string) => {
+    const payload = JSON.stringify({ sessionId, issuedAt: new Date().toISOString() });
+    const envelope = await options.kms.encrypt(payload);
+    return serializeEnvelope(envelope);
+  });
+
+  app.decorate("requireRole", (roles: Role[]) => {
+    return async (req: FastifyRequest, reply: FastifyReply) => {
+      const auth = req.auth;
+      if (!auth || !roles.includes(auth.role)) {
+        await reply.code(403).send({ error: "forbidden" });
+        return;
+      }
+    };
+  });
+
+  app.decorate("requireCsrf", () => {
+    return async (req: FastifyRequest, reply: FastifyReply) => {
+      const sessionId = req.headers[SESSION_HEADER];
+      const token = req.headers[CSRF_HEADER];
+      if (typeof sessionId !== "string" || typeof token !== "string") {
+        await reply.code(403).send({ error: "csrf_required" });
+        return;
+      }
+      const valid = await verifyCsrf(options.kms, sessionId, token, csrfTtlMs);
+      if (!valid) {
+        await reply.code(403).send({ error: "csrf_invalid" });
+        return;
+      }
+    };
+  });
+
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.raw.url === "/health" && request.method === "GET") {
+      return;
+    }
+    const token = getAuthToken(request);
+    if (!token) {
+      await reply.code(401).send({ error: "unauthorized" });
+      return;
+    }
+    const rateKey = token || request.ip;
+    const allowed = await handleRateLimit(rateState, rateKey, options, reply);
+    if (!allowed) {
+      return;
+    }
+    const role = tokenToRole.get(token);
+    if (!role) {
+      await reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+    request.auth = { role, token };
+  });
+}

--- a/apgms/services/api-gateway/test/security.test.ts
+++ b/apgms/services/api-gateway/test/security.test.ts
@@ -1,0 +1,121 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { InMemoryPrismaClient } from "@apgms/shared";
+import { MockKMS } from "../../../shared/crypto/kms";
+import { buildApp } from "../src/app";
+
+const TOKENS = {
+  admin: "admin-secret",
+  operator: "operator-secret",
+  auditor: "auditor-secret",
+};
+
+test("Permission matrix enforced", async (t) => {
+  const prisma = new InMemoryPrismaClient();
+  const kms = new MockKMS();
+  const app = await buildApp({
+    prisma,
+    kms,
+    roleTokens: TOKENS,
+    rateLimit: { max: 100, intervalMs: 1_000 },
+  });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  await prisma.user.create({
+    data: {
+      email: "audited@example.com",
+      password: "secret",
+      orgId: "org-1",
+    },
+  });
+
+  await prisma.bankLine.create({
+    data: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 100,
+      payee: "Example",
+      desc: "Seed",
+    },
+  });
+
+  const adminRes = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { authorization: `Bearer ${TOKENS.admin}` },
+  });
+  assert.equal(adminRes.statusCode, 200);
+
+  const operatorUsers = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { authorization: `Bearer ${TOKENS.operator}` },
+  });
+  assert.equal(operatorUsers.statusCode, 403);
+
+  const auditorLines = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+    headers: { authorization: `Bearer ${TOKENS.auditor}` },
+  });
+  assert.equal(auditorLines.statusCode, 200);
+
+  const sessionId = "session-1";
+  const csrfToken = await app.issueCsrfToken(sessionId);
+  const createRes = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: {
+      authorization: `Bearer ${TOKENS.operator}`,
+      "x-session-id": sessionId,
+      "x-csrf-token": csrfToken,
+    },
+    payload: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 42,
+      payee: "Vendor",
+      desc: "Compliant",
+    },
+  });
+  assert.equal(createRes.statusCode, 201);
+
+  const missingCsrf = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: {
+      authorization: `Bearer ${TOKENS.operator}`,
+      "x-session-id": sessionId,
+    },
+    payload: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 10,
+      payee: "Vendor",
+      desc: "Missing token",
+    },
+  });
+  assert.equal(missingCsrf.statusCode, 403);
+
+  const auditorCsrf = await app.issueCsrfToken("aud-session");
+  const auditorCreate = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: {
+      authorization: `Bearer ${TOKENS.auditor}`,
+      "x-session-id": "aud-session",
+      "x-csrf-token": auditorCsrf,
+    },
+    payload: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 10,
+      payee: "Vendor",
+      desc: "Denied",
+    },
+  });
+  assert.equal(auditorCreate.statusCode, 403);
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/crypto/kms.ts
+++ b/apgms/shared/crypto/kms.ts
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface KMSKeyMetadata {
+  id: string;
+  createdAt: string;
+}
+
+export interface KMSEnvelope {
+  keyId: string;
+  iv: string;
+  authTag: string;
+  ciphertext: string;
+  aad?: string;
+}
+
+interface KMSKeyRecord extends KMSKeyMetadata {
+  material: string;
+}
+
+interface KMSState {
+  activeKeyId: string;
+  keys: Record<string, KMSKeyRecord>;
+}
+
+export interface KeyManagementService {
+  encrypt(plaintext: string | Buffer, aad?: string | Buffer): Promise<KMSEnvelope>;
+  decrypt(payload: KMSEnvelope, aad?: string | Buffer): Promise<string>;
+  rotate(): Promise<KMSKeyMetadata>;
+  getActiveKey(): KMSKeyMetadata;
+  listKeys(): KMSKeyMetadata[];
+}
+
+function createInitialState(): KMSState {
+  const id = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  const material = crypto.randomBytes(32).toString("base64");
+  return {
+    activeKeyId: id,
+    keys: {
+      [id]: { id, createdAt, material },
+    },
+  };
+}
+
+function toBuffer(value: string | Buffer | undefined): Buffer | undefined {
+  if (!value) return undefined;
+  if (Buffer.isBuffer(value)) return value;
+  return Buffer.from(value);
+}
+
+export function serializeEnvelope(envelope: KMSEnvelope): string {
+  return Buffer.from(JSON.stringify(envelope), "utf8").toString("base64url");
+}
+
+export function deserializeEnvelope(serialized: string): KMSEnvelope {
+  return JSON.parse(Buffer.from(serialized, "base64url").toString("utf8")) as KMSEnvelope;
+}
+
+export class MockKMS implements KeyManagementService {
+  protected state: KMSState;
+
+  constructor(state?: KMSState) {
+    this.state = state ?? createInitialState();
+  }
+
+  protected getKey(keyId?: string): KMSKeyRecord {
+    const id = keyId ?? this.state.activeKeyId;
+    const key = this.state.keys[id];
+    if (!key) {
+      throw new Error(`Unknown key: ${id}`);
+    }
+    return key;
+  }
+
+  async encrypt(plaintext: string | Buffer, aad?: string | Buffer): Promise<KMSEnvelope> {
+    const key = this.getKey();
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", Buffer.from(key.material, "base64"), iv);
+    const aadBuffer = toBuffer(aad);
+    if (aadBuffer) {
+      cipher.setAAD(aadBuffer);
+    }
+    const ciphertext = Buffer.concat([cipher.update(toBuffer(plaintext) ?? Buffer.alloc(0)), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    return {
+      keyId: key.id,
+      iv: iv.toString("base64url"),
+      authTag: authTag.toString("base64url"),
+      ciphertext: ciphertext.toString("base64url"),
+      aad: aadBuffer ? aadBuffer.toString("base64url") : undefined,
+    };
+  }
+
+  async decrypt(payload: KMSEnvelope, aad?: string | Buffer): Promise<string> {
+    const key = this.getKey(payload.keyId);
+    const decipher = crypto.createDecipheriv(
+      "aes-256-gcm",
+      Buffer.from(key.material, "base64"),
+      Buffer.from(payload.iv, "base64url"),
+    );
+    const aadBuffer = toBuffer(aad) ?? (payload.aad ? Buffer.from(payload.aad, "base64url") : undefined);
+    if (aadBuffer) {
+      decipher.setAAD(aadBuffer);
+    }
+    decipher.setAuthTag(Buffer.from(payload.authTag, "base64url"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(payload.ciphertext, "base64url")),
+      decipher.final(),
+    ]);
+    return plaintext.toString("utf8");
+  }
+
+  async rotate(): Promise<KMSKeyMetadata> {
+    const id = crypto.randomUUID();
+    const createdAt = new Date().toISOString();
+    const material = crypto.randomBytes(32).toString("base64");
+    this.state.keys[id] = { id, createdAt, material };
+    this.state.activeKeyId = id;
+    return { id, createdAt };
+  }
+
+  getActiveKey(): KMSKeyMetadata {
+    const key = this.getKey();
+    return { id: key.id, createdAt: key.createdAt };
+  }
+
+  listKeys(): KMSKeyMetadata[] {
+    return Object.values(this.state.keys)
+      .map(({ id, createdAt }) => ({ id, createdAt }))
+      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
+  exportState(): KMSState {
+    return JSON.parse(JSON.stringify(this.state)) as KMSState;
+  }
+}
+
+async function loadState(filePath: string): Promise<KMSState> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const data = JSON.parse(raw) as KMSState;
+    if (!data.activeKeyId || !data.keys || !data.keys[data.activeKeyId]) {
+      throw new Error("Invalid KMS state");
+    }
+    return data;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return createInitialState();
+    }
+    throw err;
+  }
+}
+
+export class FileKMS extends MockKMS {
+  #filePath: string;
+
+  private constructor(filePath: string, state: KMSState) {
+    super(state);
+    this.#filePath = filePath;
+  }
+
+  static async create(filePath: string): Promise<FileKMS> {
+    const resolved = path.resolve(filePath);
+    const state = await loadState(resolved);
+    const kms = new FileKMS(resolved, state);
+    await kms.persist();
+    return kms;
+  }
+
+  private async persist(): Promise<void> {
+    const state = this.exportState();
+    await fs.mkdir(path.dirname(this.#filePath), { recursive: true });
+    await fs.writeFile(this.#filePath, JSON.stringify(state, null, 2), "utf8");
+  }
+
+  override async rotate(): Promise<KMSKeyMetadata> {
+    const metadata = await super.rotate();
+    await this.persist();
+    return metadata;
+  }
+}
+
+export async function createFileKMS(filePath?: string): Promise<FileKMS> {
+  const resolved = filePath ?? path.resolve(process.cwd(), "kms-state.json");
+  return FileKMS.create(resolved);
+}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "tsx --test test"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -34,3 +34,21 @@ model BankLine {
   desc      String
   createdAt DateTime @default(now())
 }
+
+model AuditLog {
+  id         String   @id @default(cuid())
+  createdAt  DateTime @default(now())
+  actorRole  String
+  action     String
+  resource   String
+  metadata   Json
+  prevHash   String?
+  hash       String
+  anchorDate DateTime
+}
+
+model AuditAnchor {
+  date      DateTime @id
+  hash      String
+  createdAt DateTime @default(now())
+}

--- a/apgms/shared/src/audit.ts
+++ b/apgms/shared/src/audit.ts
@@ -1,0 +1,72 @@
+import crypto from "node:crypto";
+import type { PrismaClientLike } from "./db";
+
+export interface AuditEvent {
+  actorRole: string;
+  action: string;
+  resource: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: Date;
+}
+
+function toAnchorDate(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function computeHash(payload: string, previous?: string | null): string {
+  const hash = crypto.createHash("sha256");
+  hash.update(payload);
+  if (previous) {
+    hash.update(previous);
+  }
+  return hash.digest("hex");
+}
+
+export async function appendAuditLog(prisma: PrismaClientLike, event: AuditEvent) {
+  const timestamp = event.timestamp ? new Date(event.timestamp) : new Date();
+  const anchorDate = toAnchorDate(timestamp);
+  const [last] = await prisma.auditLog.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 1,
+  });
+  const prevHash = last?.hash ?? null;
+  const payload = JSON.stringify({
+    timestamp: timestamp.toISOString(),
+    actorRole: event.actorRole,
+    action: event.action,
+    resource: event.resource,
+    metadata: event.metadata ?? {},
+  });
+  const hash = computeHash(payload, prevHash);
+  const record = await prisma.auditLog.create({
+    data: {
+      actorRole: event.actorRole,
+      action: event.action,
+      resource: event.resource,
+      metadata: event.metadata ?? {},
+      createdAt: timestamp,
+      prevHash,
+      hash,
+      anchorDate,
+    },
+  });
+  await prisma.auditAnchor.upsert({
+    where: { date: anchorDate },
+    create: { date: anchorDate, hash },
+    update: { hash },
+  });
+  return record;
+}
+
+export async function getDailyAuditBundle(prisma: PrismaClientLike, date: Date) {
+  const anchorDate = toAnchorDate(date);
+  const [anchor, records] = await Promise.all([
+    prisma.auditAnchor.findUnique({ where: { date: anchorDate } }),
+    prisma.auditLog.findMany({ where: { anchorDate }, orderBy: { createdAt: "asc" } }),
+  ]);
+  return { anchorDate, anchor, records };
+}
+
+export function formatAnchorDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,251 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { randomUUID } from "node:crypto";
+import { PrismaClient } from "@prisma/client";
+
+export interface PrismaClientLike {
+  user: {
+    findMany: (...args: any[]) => Promise<any[]>;
+    create: (...args: any[]) => Promise<any>;
+  };
+  bankLine: {
+    findMany: (...args: any[]) => Promise<any[]>;
+    create: (...args: any[]) => Promise<any>;
+  };
+  auditLog: {
+    findMany: (...args: any[]) => Promise<any[]>;
+    create: (...args: any[]) => Promise<any>;
+  };
+  auditAnchor: {
+    findUnique: (...args: any[]) => Promise<any | null>;
+    upsert: (...args: any[]) => Promise<any>;
+  };
+  $disconnect?: () => Promise<void>;
+}
+
+interface InMemoryUser {
+  id: string;
+  email: string;
+  password: string;
+  orgId: string;
+  createdAt: Date;
+}
+
+interface InMemoryBankLine {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+interface InMemoryAuditLog {
+  id: string;
+  actorRole: string;
+  action: string;
+  resource: string;
+  metadata: JsonValue;
+  createdAt: Date;
+  prevHash: string | null;
+  hash: string;
+  anchorDate: Date;
+}
+
+interface InMemoryAuditAnchor {
+  date: Date;
+  hash: string;
+  createdAt: Date;
+}
+
+export class InMemoryPrismaClient implements PrismaClientLike {
+  #users: InMemoryUser[] = [];
+  #bankLines: InMemoryBankLine[] = [];
+  #auditLogs: InMemoryAuditLog[] = [];
+  #anchors = new Map<string, InMemoryAuditAnchor>();
+
+  user = {
+    findMany: async (args: any = {}) => {
+      const select = args.select as Record<string, boolean> | undefined;
+      const orderBy = args.orderBy as { createdAt?: "asc" | "desc" } | undefined;
+      const take = typeof args.take === "number" ? args.take : undefined;
+      let result = [...this.#users];
+      if (orderBy?.createdAt === "desc") {
+        result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      } else if (orderBy?.createdAt === "asc") {
+        result.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      }
+      if (typeof take === "number") {
+        result = result.slice(0, take);
+      }
+      if (!select) {
+        return result.map((user) => ({ ...user }));
+      }
+      return result.map((user) => {
+        const picked: Record<string, unknown> = {};
+        for (const key of Object.keys(select)) {
+          if (select[key as keyof InMemoryUser]) {
+            const value = user[key as keyof InMemoryUser];
+            picked[key] = value instanceof Date ? value.toISOString() : value;
+          }
+        }
+        return picked;
+      });
+    },
+    create: async ({ data }: { data: Partial<InMemoryUser> }) => {
+      const created: InMemoryUser = {
+        id: data.id ?? randomUUID(),
+        email: data.email ?? "user@example.com",
+        password: data.password ?? "password",
+        orgId: data.orgId ?? randomUUID(),
+        createdAt: data.createdAt ? new Date(data.createdAt) : new Date(),
+      };
+      this.#users.push(created);
+      return { ...created, createdAt: created.createdAt.toISOString() };
+    },
+  };
+
+  bankLine = {
+    findMany: async (args: any = {}) => {
+      const orderBy = args.orderBy as { date?: "asc" | "desc" } | undefined;
+      const take = typeof args.take === "number" ? args.take : undefined;
+      let result = [...this.#bankLines];
+      if (orderBy?.date === "desc") {
+        result.sort((a, b) => b.date.getTime() - a.date.getTime());
+      } else if (orderBy?.date === "asc") {
+        result.sort((a, b) => a.date.getTime() - b.date.getTime());
+      }
+      if (typeof take === "number") {
+        result = result.slice(0, take);
+      }
+      return result.map((line) => ({
+        ...line,
+        date: line.date.toISOString(),
+        createdAt: line.createdAt.toISOString(),
+      }));
+    },
+    create: async ({ data }: { data: Partial<InMemoryBankLine> }) => {
+      const created: InMemoryBankLine = {
+        id: data.id ?? randomUUID(),
+        orgId: data.orgId ?? randomUUID(),
+        date: data.date ? new Date(data.date as unknown as string) : new Date(),
+        amount: typeof data.amount === "number" ? data.amount : Number(data.amount ?? 0),
+        payee: data.payee ?? "",
+        desc: data.desc ?? "",
+        createdAt: data.createdAt ? new Date(data.createdAt) : new Date(),
+      };
+      this.#bankLines.push(created);
+      return {
+        ...created,
+        date: created.date.toISOString(),
+        createdAt: created.createdAt.toISOString(),
+      };
+    },
+  };
+
+  auditLog = {
+    findMany: async (args: any = {}) => {
+      const where = args.where as { anchorDate?: Date } | undefined;
+      const orderBy = args.orderBy as { createdAt?: "asc" | "desc" } | undefined;
+      const take = typeof args.take === "number" ? args.take : undefined;
+      let result = [...this.#auditLogs];
+      if (where?.anchorDate) {
+        const target = where.anchorDate;
+        const targetTime = target instanceof Date ? target.getTime() : new Date(target).getTime();
+        result = result.filter((log) => log.anchorDate.getTime() === targetTime);
+      }
+      if (orderBy?.createdAt === "asc") {
+        result.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+      } else if (orderBy?.createdAt === "desc") {
+        result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+      }
+      if (typeof take === "number") {
+        result = result.slice(0, take);
+      }
+      return result.map((log) => ({
+        ...log,
+        createdAt: log.createdAt.toISOString(),
+        anchorDate: log.anchorDate.toISOString(),
+      }));
+    },
+    create: async ({ data }: { data: Partial<InMemoryAuditLog> }) => {
+      const created: InMemoryAuditLog = {
+        id: data.id ?? randomUUID(),
+        actorRole: data.actorRole ?? "unknown",
+        action: data.action ?? "unknown",
+        resource: data.resource ?? "unknown",
+        metadata: data.metadata ?? {},
+        createdAt: data.createdAt ? new Date(data.createdAt) : new Date(),
+        prevHash: data.prevHash ?? null,
+        hash: data.hash ?? "",
+        anchorDate: data.anchorDate ? new Date(data.anchorDate) : new Date(),
+      };
+      this.#auditLogs.push(created);
+      return {
+        ...created,
+        createdAt: created.createdAt.toISOString(),
+        anchorDate: created.anchorDate.toISOString(),
+      };
+    },
+  };
+
+  auditAnchor = {
+    findUnique: async ({ where }: { where: { date: Date } }) => {
+      const key = where.date.toISOString();
+      const anchor = this.#anchors.get(key);
+      if (!anchor) {
+        return null;
+      }
+      return {
+        ...anchor,
+        date: anchor.date.toISOString(),
+        createdAt: anchor.createdAt.toISOString(),
+      };
+    },
+    upsert: async ({ where, create, update }: any) => {
+      const key = where.date.toISOString();
+      const existing = this.#anchors.get(key);
+      if (existing) {
+        const next: InMemoryAuditAnchor = {
+          date: existing.date,
+          hash: update.hash ?? existing.hash,
+          createdAt: existing.createdAt,
+        };
+        this.#anchors.set(key, next);
+        return {
+          ...next,
+          date: next.date.toISOString(),
+          createdAt: next.createdAt.toISOString(),
+        };
+      }
+      const created: InMemoryAuditAnchor = {
+        date: new Date(create.date),
+        hash: create.hash,
+        createdAt: create.createdAt ? new Date(create.createdAt) : new Date(),
+      };
+      this.#anchors.set(key, created);
+      return {
+        ...created,
+        date: created.date.toISOString(),
+        createdAt: created.createdAt.toISOString(),
+      };
+    },
+  };
+}
+
+function shouldUseInMemory(): boolean {
+  return process.env.NODE_ENV === "test" || process.env.USE_PRISMA_MOCK === "true";
+}
+
+const prisma: PrismaClientLike = shouldUseInMemory()
+  ? new InMemoryPrismaClient()
+  : (new PrismaClient() as unknown as PrismaClientLike);
+
+export { prisma };

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./audit";

--- a/apgms/shared/test/kms.test.ts
+++ b/apgms/shared/test/kms.test.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import { MockKMS, serializeEnvelope, deserializeEnvelope } from "../crypto/kms";
+
+test("Backward verification survives rotation", async () => {
+  const kms = new MockKMS();
+  const payload = "sensitive-payload";
+  const envelope = await kms.encrypt(payload);
+  const firstKey = kms.getActiveKey();
+  await kms.rotate();
+  const afterRotate = kms.getActiveKey();
+  assert.notEqual(afterRotate.id, firstKey.id);
+  const decrypted = await kms.decrypt(envelope);
+  assert.equal(decrypted, payload);
+  const serialized = serializeEnvelope(envelope);
+  const roundTrip = deserializeEnvelope(serialized);
+  assert.deepEqual(roundTrip, envelope);
+});


### PR DESCRIPTION
## Summary
- introduce a KMS abstraction with rotation support and replace local secrets usage
- add role-aware security middleware with rate limiting and CSRF enforcement for the API gateway
- record immutable audit entries with daily anchors and provide a CLI to export JSONL and PDF bundles

## Testing
- NODE_ENV=test pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f32c5392a4832780ef8ea83ceb617c