### PR TITLE
Add anomaly detection engine and alerts inbox

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,7 +9,15 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { Prisma } from "@prisma/client";
+import {
+  AnomalyEngine,
+  DetectionContext,
+  TransactionSample,
+  prisma,
+} from "../../../shared/src";
+
+const engine = new AnomalyEngine();
 
 const app = Fastify({ logger: true });
 
@@ -48,6 +56,7 @@ app.post("/bank-lines", async (req, rep) => {
       amount: number | string;
       payee: string;
       desc: string;
+      category?: string | null;
     };
     const created = await prisma.bankLine.create({
       data: {
@@ -56,12 +65,159 @@ app.post("/bank-lines", async (req, rep) => {
         amount: body.amount as any,
         payee: body.payee,
         desc: body.desc,
+        category: body.category ?? null,
       },
     });
     return rep.code(201).send(created);
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+const toSample = (line: { id: string; orgId: string; date: Date; amount: Prisma.Decimal; payee: string; desc: string; category: string | null; }): TransactionSample => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date,
+  amount: line.amount.toNumber(),
+  payee: line.payee,
+  desc: line.desc,
+  category: line.category,
+});
+
+const serializeCounterExamples = (
+  counterExamples: { transaction: TransactionSample; reason: string }[]
+) =>
+  counterExamples.map((example) => ({
+    reason: example.reason,
+    transaction: {
+      ...example.transaction,
+      date: example.transaction.date.toISOString(),
+    },
+  }));
+
+app.get("/alerts", async (req) => {
+  const query = req.query as {
+    status?: string;
+    ruleId?: string;
+    orgId?: string;
+    severity?: string;
+  };
+  const where: Prisma.AlertWhereInput = {};
+  if (query.status) {
+    where.status = query.status as any;
+  }
+  if (query.ruleId) {
+    where.ruleId = query.ruleId;
+  }
+  if (query.orgId) {
+    where.orgId = query.orgId;
+  }
+  if (query.severity) {
+    where.severity = query.severity as any;
+  }
+  const alerts = await prisma.alert.findMany({
+    where,
+    orderBy: { detectedAt: "desc" },
+  });
+  return { alerts };
+});
+
+app.post("/alerts", async (req, rep) => {
+  try {
+    const body = req.body as {
+      transaction: {
+        id?: string;
+        orgId: string;
+        date: string;
+        amount: number;
+        payee: string;
+        desc: string;
+        category?: string | null;
+      };
+      policy?: DetectionContext["policy"];
+    };
+
+    const txnDate = new Date(body.transaction.date);
+    const history = await prisma.bankLine.findMany({
+      where: {
+        orgId: body.transaction.orgId,
+        date: { lt: txnDate },
+      },
+      orderBy: { date: "desc" },
+      take: 365,
+    });
+
+    const findings = engine.evaluate(
+      {
+        id: body.transaction.id ?? `txn-${Date.now()}`,
+        orgId: body.transaction.orgId,
+        date: txnDate,
+        amount: body.transaction.amount,
+        payee: body.transaction.payee,
+        desc: body.transaction.desc,
+        category: body.transaction.category ?? null,
+      },
+      history.map(toSample),
+      { policy: body.policy }
+    );
+
+    const createdAlerts = await Promise.all(
+      findings.map((finding) =>
+        prisma.alert.create({
+          data: {
+            orgId: body.transaction.orgId,
+            ruleId: finding.ruleId,
+            severity: finding.severity,
+            summary: finding.summary,
+            transactionRef: body.transaction.id ?? null,
+            context: finding.context,
+            counterExample: serializeCounterExamples(finding.counterExamples),
+          },
+        })
+      )
+    );
+
+    if (createdAlerts.length === 0) {
+      return rep.code(204).send();
+    }
+
+    return rep.code(201).send({ alerts: createdAlerts });
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+app.post("/alerts/:id/ack", async (req, rep) => {
+  try {
+    const updated = await prisma.alert.update({
+      where: { id: (req.params as { id: string }).id },
+      data: {
+        status: "ACKNOWLEDGED",
+        acknowledgedAt: new Date(),
+      },
+    });
+    return updated;
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(404).send({ error: "not_found" });
+  }
+});
+
+app.post("/alerts/:id/escalate", async (req, rep) => {
+  try {
+    const updated = await prisma.alert.update({
+      where: { id: (req.params as { id: string }).id },
+      data: {
+        status: "ESCALATED",
+        escalatedAt: new Date(),
+      },
+    });
+    return updated;
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(404).send({ error: "not_found" });
   }
 });
 

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
-    "build": "echo building shared"
+    "build": "echo building shared",
+    "test": "tsx --test test/**/*.ts"
   },
   "dependencies": {
     "@prisma/client": "6.17.1"

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -32,5 +32,36 @@ model BankLine {
   amount    Decimal
   payee     String
   desc      String
+  category  String?
   createdAt DateTime @default(now())
+}
+
+model Alert {
+  id             String      @id @default(cuid())
+  org            Org         @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId          String
+  ruleId         String
+  status         AlertStatus @default(OPEN)
+  severity       AlertSeverity
+  summary        String
+  detectedAt     DateTime    @default(now())
+  transactionRef String?
+  context        Json
+  counterExample Json
+  acknowledgedAt DateTime?
+  escalatedAt    DateTime?
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
+}
+
+enum AlertStatus {
+  OPEN
+  ACKNOWLEDGED
+  ESCALATED
+}
+
+enum AlertSeverity {
+  LOW
+  MEDIUM
+  HIGH
 }

--- a/apgms/shared/src/anomaly/engine.ts
+++ b/apgms/shared/src/anomaly/engine.ts
@@ -1,0 +1,36 @@
+import { DEFAULT_RULES } from "./rules";
+import {
+  AnomalyFinding,
+  DetectionContext,
+  EngineOptions,
+  TransactionSample,
+} from "./types";
+
+export class AnomalyEngine {
+  private readonly rules;
+
+  constructor(options?: EngineOptions) {
+    this.rules = options?.rules ?? [...DEFAULT_RULES];
+  }
+
+  evaluate(
+    candidate: TransactionSample,
+    history: readonly TransactionSample[],
+    context: DetectionContext = {}
+  ): AnomalyFinding[] {
+    const findings: AnomalyFinding[] = [];
+    for (const rule of this.rules) {
+      const result = rule.evaluate(candidate, history, context);
+      if (result) {
+        findings.push(result);
+      }
+    }
+    return findings;
+  }
+}
+
+export const evaluateWithDefaults = (
+  candidate: TransactionSample,
+  history: readonly TransactionSample[],
+  context: DetectionContext = {}
+) => new AnomalyEngine().evaluate(candidate, history, context);

--- a/apgms/shared/src/anomaly/rules.ts
+++ b/apgms/shared/src/anomaly/rules.ts
@@ -1,0 +1,232 @@
+import {
+  AllocationPolicy,
+  AnomalyFinding,
+  AnomalyRule,
+  CounterExample,
+  DetectionContext,
+  TransactionSample,
+} from "./types";
+
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+const differenceInCalendarDays = (later: Date, earlier: Date) => {
+  const diff = later.getTime() - earlier.getTime();
+  return Math.floor(diff / MS_IN_DAY);
+};
+
+const DEFAULT_POLICY: AllocationPolicy = {
+  windowDays: 30,
+  categories: {
+    Operations: { target: 0.45, tolerance: 0.15 },
+    Payroll: { target: 0.35, tolerance: 0.1 },
+    Marketing: { target: 0.2, tolerance: 0.1 },
+  },
+};
+
+const toWindow = (
+  history: readonly TransactionSample[],
+  candidate: TransactionSample,
+  days: number
+) =>
+  history.filter(
+    (txn) =>
+      txn.orgId === candidate.orgId &&
+      differenceInCalendarDays(candidate.date, txn.date) >= 0 &&
+      differenceInCalendarDays(candidate.date, txn.date) <= days
+  );
+
+const mean = (values: readonly number[]): number => {
+  if (!values.length) {
+    return 0;
+  }
+  return values.reduce((acc, value) => acc + value, 0) / values.length;
+};
+
+const pickNearestByAmount = (
+  window: readonly TransactionSample[],
+  target: number
+): CounterExample | null => {
+  if (!window.length) {
+    return null;
+  }
+  const sorted = [...window].sort(
+    (a, b) => Math.abs(target - Math.abs(a.amount)) - Math.abs(target - Math.abs(b.amount))
+  );
+  const sample = sorted[0];
+  return {
+    transaction: sample,
+    reason: "Representative transaction used for baseline velocity",
+  };
+};
+
+const velocitySpikeRule: AnomalyRule = {
+  id: "velocity_spike",
+  evaluate(candidate, history) {
+    const last30 = toWindow(history, candidate, 30);
+    const last90 = toWindow(history, candidate, 90);
+    if (last30.length < 5 || last90.length < 12) {
+      return null;
+    }
+    const baseline = Math.max(
+      mean(last30.map((txn) => Math.abs(txn.amount))),
+      mean(last90.map((txn) => Math.abs(txn.amount)))
+    );
+    if (baseline === 0) {
+      return null;
+    }
+    const deviation = Math.abs(candidate.amount) / baseline;
+    if (deviation < 3) {
+      return null;
+    }
+    const counterExample = pickNearestByAmount(last90, baseline);
+    if (!counterExample) {
+      return null;
+    }
+    return {
+      ruleId: this.id,
+      severity: deviation > 6 ? "HIGH" : deviation > 4 ? "MEDIUM" : "LOW",
+      summary: `Velocity spike: ${candidate.payee} amount ${candidate.amount.toFixed(
+        2
+      )} vs baseline ${baseline.toFixed(2)}`,
+      context: {
+        deviation,
+        baseline,
+        last30Count: last30.length,
+        last90Count: last90.length,
+      },
+      counterExamples: [counterExample],
+    } satisfies AnomalyFinding;
+  },
+};
+
+const novelCounterpartyRule: AnomalyRule = {
+  id: "novel_counterparty",
+  evaluate(candidate, history) {
+    const lookback = toWindow(history, candidate, 180);
+    if (lookback.length < 8) {
+      return null;
+    }
+    const seen = new Set(lookback.map((txn) => txn.payee.toLowerCase()));
+    const current = candidate.payee.toLowerCase();
+    if (seen.has(current)) {
+      return null;
+    }
+    const freq = new Map<string, { count: number; sample: TransactionSample }>();
+    for (const txn of lookback) {
+      const key = txn.payee.toLowerCase();
+      const record = freq.get(key) ?? { count: 0, sample: txn };
+      record.count += 1;
+      record.sample = txn;
+      freq.set(key, record);
+    }
+    const [counterExample] = [...freq.values()].sort((a, b) => b.count - a.count);
+    if (!counterExample) {
+      return null;
+    }
+    return {
+      ruleId: this.id,
+      severity: "MEDIUM",
+      summary: `Novel counterparty: ${candidate.payee} not seen in the last ${lookback.length} payments`,
+      context: {
+        knownCounterparties: freq.size,
+        sampleCounterparty: counterExample.sample.payee,
+      },
+      counterExamples: [
+        {
+          transaction: counterExample.sample,
+          reason: "Most common historical counterparty",
+        },
+      ],
+    } satisfies AnomalyFinding;
+  },
+};
+
+const allocationDriftRule: AnomalyRule = {
+  id: "allocation_drift",
+  evaluate(candidate, history, context) {
+    const policy = context.policy ?? DEFAULT_POLICY;
+    if (!candidate.category) {
+      return null;
+    }
+    const window = toWindow(history, candidate, policy.windowDays);
+    const relevant = window.filter((txn) => Boolean(txn.category));
+    if (relevant.length < 10) {
+      return null;
+    }
+    const totals = new Map<string, number>();
+    for (const txn of relevant) {
+      const key = txn.category as string;
+      totals.set(key, (totals.get(key) ?? 0) + Math.max(Math.abs(txn.amount), 0));
+    }
+    const candidateCategory = candidate.category as string;
+    totals.set(
+      candidateCategory,
+      (totals.get(candidateCategory) ?? 0) + Math.max(Math.abs(candidate.amount), 0)
+    );
+    const grandTotal = [...totals.values()].reduce((acc, value) => acc + value, 0);
+    if (!grandTotal) {
+      return null;
+    }
+    const breaches: Array<{ category: string; share: number; band: AllocationPolicy["categories"][string] }>
+      = [];
+    for (const [category, band] of Object.entries(policy.categories)) {
+      const share = (totals.get(category) ?? 0) / grandTotal;
+      if (Math.abs(share - band.target) > band.tolerance) {
+        breaches.push({ category, share, band });
+      }
+    }
+    if (!breaches.length) {
+      return null;
+    }
+    let counterExample: CounterExample | null = null;
+    if (totals.size > 1) {
+      const sorted = [...relevant].sort((a, b) => (a.amount ?? 0) - (b.amount ?? 0));
+      for (const txn of sorted) {
+        const band = policy.categories[txn.category as string];
+        if (!band) {
+          continue;
+        }
+        const share = (totals.get(txn.category as string) ?? 0) / grandTotal;
+        if (Math.abs(share - band.target) <= band.tolerance) {
+          counterExample = {
+            transaction: txn,
+            reason: "Category operating within policy band",
+          };
+          break;
+        }
+      }
+    }
+    if (!counterExample) {
+      return null;
+    }
+    const strongest = breaches.sort((a, b) => Math.abs(b.share - b.band.target) - Math.abs(a.share - a.band.target))[0];
+    return {
+      ruleId: this.id,
+      severity: "MEDIUM",
+      summary: `Allocation drift: ${strongest.category} at ${(strongest.share * 100).toFixed(1)}% vs target ${(strongest.band.target * 100).toFixed(1)}%±${(strongest.band.tolerance * 100).toFixed(1)}%`,
+      context: {
+        breaches: breaches.map((entry) => ({
+          category: entry.category,
+          share: entry.share,
+          target: entry.band.target,
+          tolerance: entry.band.tolerance,
+        })),
+        grandTotal,
+        windowDays: policy.windowDays,
+      },
+      counterExamples: [counterExample],
+    } satisfies AnomalyFinding;
+  },
+};
+
+export const DEFAULT_RULES: readonly AnomalyRule[] = [
+  velocitySpikeRule,
+  novelCounterpartyRule,
+  allocationDriftRule,
+];
+
+export const ALL_RULES = {
+  velocitySpikeRule,
+  novelCounterpartyRule,
+  allocationDriftRule,
+};

--- a/apgms/shared/src/anomaly/types.ts
+++ b/apgms/shared/src/anomaly/types.ts
@@ -1,0 +1,50 @@
+export type AllocationBand = {
+  target: number;
+  tolerance: number;
+};
+
+export type AllocationPolicy = {
+  windowDays: number;
+  categories: Record<string, AllocationBand>;
+};
+
+export type TransactionSample = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  category?: string | null;
+};
+
+export type DetectionContext = {
+  policy?: AllocationPolicy;
+  now?: Date;
+};
+
+export type CounterExample = {
+  transaction: TransactionSample;
+  reason: string;
+};
+
+export type AnomalyFinding = {
+  ruleId: string;
+  severity: "LOW" | "MEDIUM" | "HIGH";
+  summary: string;
+  context: Record<string, unknown>;
+  counterExamples: CounterExample[];
+};
+
+export interface AnomalyRule {
+  id: string;
+  evaluate(
+    candidate: TransactionSample,
+    history: readonly TransactionSample[],
+    context: DetectionContext
+  ): AnomalyFinding | null;
+}
+
+export type EngineOptions = {
+  rules?: AnomalyRule[];
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,4 @@
-﻿// shared
+export * from "./db";
+export * from "./anomaly/engine";
+export * from "./anomaly/types";
+export { DEFAULT_RULES, ALL_RULES } from "./anomaly/rules";

--- a/apgms/shared/test/anomaly.test.ts
+++ b/apgms/shared/test/anomaly.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AnomalyEngine } from "../src/anomaly/engine";
+import { anomalyFixtures } from "./fixtures/transactions";
+
+test("rules emit counter examples and control false positives", () => {
+  const engine = new AnomalyEngine();
+  const workingHistory = [...anomalyFixtures.history];
+  let falsePositives = 0;
+  let normalEvaluations = 0;
+
+  for (const entry of anomalyFixtures.stream) {
+    workingHistory.sort((a, b) => a.date.getTime() - b.date.getTime());
+    const findings = engine.evaluate(entry.transaction, workingHistory, {
+      policy: anomalyFixtures.policy,
+    });
+    const actualRuleIds = findings.map((finding) => finding.ruleId).sort();
+    const expectedRuleIds = [...entry.expectedRules].sort();
+
+    for (const finding of findings) {
+      assert.ok(
+        finding.counterExamples.length > 0,
+        `${finding.ruleId} should include at least one counter example`
+      );
+    }
+
+    for (const expected of expectedRuleIds) {
+      assert.ok(
+        actualRuleIds.includes(expected),
+        `${entry.note} should trigger ${expected}`
+      );
+    }
+
+    if (expectedRuleIds.length === 0) {
+      normalEvaluations += 1;
+      if (actualRuleIds.length > 0) {
+        falsePositives += 1;
+      }
+    } else {
+      assert.ok(
+        actualRuleIds.length >= expectedRuleIds.length,
+        `${entry.note} expected at least ${expectedRuleIds.length} rules`
+      );
+    }
+
+    workingHistory.push(entry.transaction);
+  }
+
+  assert.ok(normalEvaluations > 0, "fixtures should include normal traffic");
+  const falsePositiveRate = falsePositives / normalEvaluations;
+  assert.ok(
+    falsePositiveRate <= 0.2,
+    `false positive rate ${falsePositiveRate.toFixed(2)} exceeds threshold`
+  );
+});

--- a/apgms/shared/test/fixtures/transactions.ts
+++ b/apgms/shared/test/fixtures/transactions.ts
@@ -1,0 +1,197 @@
+import { AllocationPolicy, TransactionSample } from "../../src/anomaly/types";
+
+export type LabeledCandidate = {
+  transaction: TransactionSample;
+  expectedRules: string[];
+  note: string;
+};
+
+const basePolicy: AllocationPolicy = {
+  windowDays: 30,
+  categories: {
+    Operations: { target: 0.45, tolerance: 0.15 },
+    Payroll: { target: 0.35, tolerance: 0.1 },
+    Marketing: { target: 0.2, tolerance: 0.1 },
+  },
+};
+
+const mkTxn = (overrides: Partial<TransactionSample> & { id: string }): TransactionSample => ({
+  id: overrides.id,
+  orgId: overrides.orgId ?? "org-1",
+  date: overrides.date ?? new Date("2024-04-01T00:00:00.000Z"),
+  amount: overrides.amount ?? 0,
+  payee: overrides.payee ?? "",
+  desc: overrides.desc ?? "",
+  category: overrides.category ?? "Operations",
+});
+
+const startDate = new Date("2024-01-01T00:00:00.000Z");
+
+const baselineHistory = (): TransactionSample[] => {
+  const entries: TransactionSample[] = [];
+  for (let week = 0; week < 12; week += 1) {
+    const base = new Date(startDate.getTime() + week * 7 * 24 * 60 * 60 * 1000);
+    entries.push(
+      mkTxn({
+        id: `ops-${week}`,
+        date: new Date(base.getTime()),
+        amount: 4800 + (week % 3) * 120,
+        payee: "City Utilities",
+        desc: "Operational spend",
+        category: "Operations",
+      })
+    );
+    entries.push(
+      mkTxn({
+        id: `payroll-${week}`,
+        date: new Date(base.getTime() + 1 * 24 * 60 * 60 * 1000),
+        amount: 3600 + (week % 2) * 80,
+        payee: "Birchal Payroll",
+        desc: "Monthly payroll",
+        category: "Payroll",
+      })
+    );
+    entries.push(
+      mkTxn({
+        id: `marketing-${week}`,
+        date: new Date(base.getTime() + 2 * 24 * 60 * 60 * 1000),
+        amount: 1900 + (week % 4) * 60,
+        payee: "Northwind Media",
+        desc: "Campaign spend",
+        category: "Marketing",
+      })
+    );
+  }
+  return entries;
+};
+
+const baseHistory = baselineHistory();
+
+const candidateStream: LabeledCandidate[] = [
+  {
+    transaction: mkTxn({
+      id: "stream-1",
+      date: new Date("2024-04-05T00:00:00.000Z"),
+      amount: 5100,
+      payee: "City Utilities",
+      desc: "Operational spend",
+      category: "Operations",
+    }),
+    expectedRules: [],
+    note: "Baseline operational payment",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-2",
+      date: new Date("2024-04-06T00:00:00.000Z"),
+      amount: 34950,
+      payee: "Rapid Freight",
+      desc: "Emergency logistics",
+      category: "Operations",
+    }),
+    expectedRules: ["velocity_spike"],
+    note: "Large spike against normal operations velocity",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-3",
+      date: new Date("2024-04-07T00:00:00.000Z"),
+      amount: 3550,
+      payee: "Birchal Payroll",
+      desc: "Monthly payroll",
+      category: "Payroll",
+    }),
+    expectedRules: [],
+    note: "Payroll within established range",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-4",
+      date: new Date("2024-04-08T00:00:00.000Z"),
+      amount: 4100,
+      payee: "Zed Ventures",
+      desc: "Ad-hoc consulting",
+      category: "Operations",
+    }),
+    expectedRules: ["novel_counterparty"],
+    note: "New counterparty compared to historical vendors",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-5",
+      date: new Date("2024-04-09T00:00:00.000Z"),
+      amount: 2200,
+      payee: "Northwind Media",
+      desc: "Campaign",
+      category: "Marketing",
+    }),
+    expectedRules: [],
+    note: "Marketing spend still compliant",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-6",
+      date: new Date("2024-04-10T00:00:00.000Z"),
+      amount: 9800,
+      payee: "Launch Partners",
+      desc: "Product launch activation",
+      category: "Marketing",
+    }),
+    expectedRules: ["allocation_drift"],
+    note: "Marketing allocation surge that should breach policy",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-7",
+      date: new Date("2024-04-11T00:00:00.000Z"),
+      amount: 3600,
+      payee: "Birchal Payroll",
+      desc: "Payroll",
+      category: "Payroll",
+    }),
+    expectedRules: [],
+    note: "Payroll normal",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-8",
+      date: new Date("2024-04-12T00:00:00.000Z"),
+      amount: 5200,
+      payee: "City Utilities",
+      desc: "Operations",
+      category: "Operations",
+    }),
+    expectedRules: [],
+    note: "Operations slightly above average but not anomalous",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-9",
+      date: new Date("2024-04-13T00:00:00.000Z"),
+      amount: 1500,
+      payee: "Riverside Cafe",
+      desc: "Team event",
+      category: "Operations",
+    }),
+    expectedRules: ["novel_counterparty"],
+    note: "Another new vendor to ensure rule remains stable",
+  },
+  {
+    transaction: mkTxn({
+      id: "stream-10",
+      date: new Date("2024-04-14T00:00:00.000Z"),
+      amount: 3400,
+      payee: "Birchal Payroll",
+      desc: "Payroll",
+      category: "Payroll",
+    }),
+    expectedRules: [],
+    note: "Payroll trending down, still within tolerance",
+  },
+];
+
+export const anomalyFixtures = {
+  history: baseHistory,
+  stream: candidateStream,
+  policy: basePolicy,
+};

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,420 @@
-﻿console.log('webapp');
+type AlertRecord = {
+  id: string;
+  orgId: string;
+  ruleId: string;
+  severity: "LOW" | "MEDIUM" | "HIGH";
+  status: "OPEN" | "ACKNOWLEDGED" | "ESCALATED";
+  summary: string;
+  detectedAt: string;
+  counterExample?: Array<{
+    reason: string;
+    transaction: {
+      payee: string;
+      amount: number;
+      date: string;
+      category?: string | null;
+    };
+  }>;
+};
+
+type FilterState = {
+  status: string;
+  ruleId: string;
+  severity: string;
+  orgId: string;
+};
+
+type TransitionAction = "ack" | "escalate";
+
+const STATUS_OPTIONS: AlertRecord["status"][] = ["OPEN", "ACKNOWLEDGED", "ESCALATED"];
+const RULE_OPTIONS = ["velocity_spike", "novel_counterparty", "allocation_drift"];
+const SEVERITY_OPTIONS: AlertRecord["severity"][] = ["LOW", "MEDIUM", "HIGH"];
+
+const state: {
+  alerts: AlertRecord[];
+  filters: FilterState;
+  selected: Set<string>;
+  loading: boolean;
+  error: string | null;
+} = {
+  alerts: [],
+  filters: { status: "OPEN", ruleId: "all", severity: "all", orgId: "all" },
+  selected: new Set(),
+  loading: false,
+  error: null,
+};
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Missing root container");
+}
+
+const layout = document.createElement("div");
+layout.style.padding = "1.5rem";
+layout.style.fontFamily = "Inter, system-ui, sans-serif";
+layout.style.display = "flex";
+layout.style.flexDirection = "column";
+layout.style.gap = "1rem";
+
+const header = document.createElement("header");
+header.style.display = "flex";
+header.style.alignItems = "center";
+header.style.gap = "1rem";
+
+const title = document.createElement("h1");
+title.textContent = "Alerts inbox";
+title.style.margin = "0";
+header.appendChild(title);
+
+const refreshButton = document.createElement("button");
+refreshButton.textContent = "Refresh";
+refreshButton.addEventListener("click", () => fetchAlerts());
+header.appendChild(refreshButton);
+
+const filtersContainer = document.createElement("section");
+filtersContainer.style.display = "flex";
+filtersContainer.style.flexWrap = "wrap";
+filtersContainer.style.gap = "1rem";
+filtersContainer.style.background = "#f7f7f9";
+filtersContainer.style.padding = "1rem";
+filtersContainer.style.borderRadius = "0.5rem";
+filtersContainer.style.fontSize = "0.9rem";
+
+const statusSelect = document.createElement("select");
+const ruleSelect = document.createElement("select");
+const severitySelect = document.createElement("select");
+const orgInput = document.createElement("input");
+
+const messageArea = document.createElement("div");
+const tableContainer = document.createElement("section");
+const bulkActions = document.createElement("section");
+
+layout.appendChild(header);
+layout.appendChild(filtersContainer);
+layout.appendChild(messageArea);
+layout.appendChild(tableContainer);
+layout.appendChild(bulkActions);
+root.appendChild(layout);
+
+const createLabel = (text: string) => {
+  const label = document.createElement("label");
+  label.style.display = "flex";
+  label.style.flexDirection = "column";
+  label.style.gap = "0.25rem";
+  const span = document.createElement("span");
+  span.textContent = text;
+  label.appendChild(span);
+  return label;
+};
+
+const buildSelectOptions = (select: HTMLSelectElement, values: string[], includeAll = true) => {
+  select.innerHTML = "";
+  if (includeAll) {
+    const opt = document.createElement("option");
+    opt.value = "all";
+    opt.textContent = `All ${select.dataset.label ?? "items"}`;
+    select.appendChild(opt);
+  }
+  for (const value of values) {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = value;
+    select.appendChild(opt);
+  }
+};
+
+const syncFiltersUI = () => {
+  statusSelect.value = state.filters.status;
+  ruleSelect.value = state.filters.ruleId;
+  severitySelect.value = state.filters.severity;
+  orgInput.value = state.filters.orgId === "all" ? "" : state.filters.orgId;
+};
+
+const renderMessage = () => {
+  messageArea.innerHTML = "";
+  if (state.error) {
+    const errorDiv = document.createElement("div");
+    errorDiv.textContent = `Error: ${state.error}`;
+    errorDiv.style.color = "#b00020";
+    messageArea.appendChild(errorDiv);
+  } else if (state.loading) {
+    const loadingDiv = document.createElement("div");
+    loadingDiv.textContent = "Loading alerts…";
+    messageArea.appendChild(loadingDiv);
+  }
+};
+
+const renderTable = () => {
+  tableContainer.innerHTML = "";
+  const table = document.createElement("table");
+  table.style.width = "100%";
+  table.style.borderCollapse = "collapse";
+  const thead = document.createElement("thead");
+  const headerRow = document.createElement("tr");
+  headerRow.style.borderBottom = "1px solid #ddd";
+  const headings = ["", "Rule", "Severity", "Summary", "Detected", "Counter example", "Status", "Actions"];
+  for (const heading of headings) {
+    const th = document.createElement("th");
+    th.textContent = heading;
+    th.style.textAlign = "left";
+    th.style.padding = "0.5rem";
+    headerRow.appendChild(th);
+  }
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement("tbody");
+  for (const alert of state.alerts) {
+    const row = document.createElement("tr");
+    row.style.borderBottom = "1px solid #f0f0f0";
+
+    const selectCell = document.createElement("td");
+    selectCell.style.padding = "0.5rem";
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = state.selected.has(alert.id);
+    checkbox.addEventListener("change", () => toggleSelection(alert.id));
+    selectCell.appendChild(checkbox);
+    row.appendChild(selectCell);
+
+    const ruleCell = document.createElement("td");
+    ruleCell.textContent = alert.ruleId;
+    ruleCell.style.padding = "0.5rem";
+    ruleCell.style.fontFamily = "monospace";
+    row.appendChild(ruleCell);
+
+    const severityCell = document.createElement("td");
+    severityCell.textContent = alert.severity;
+    severityCell.style.padding = "0.5rem";
+    severityCell.style.fontWeight = "600";
+    if (alert.severity === "HIGH") {
+      severityCell.style.color = "#b00020";
+    } else if (alert.severity === "MEDIUM") {
+      severityCell.style.color = "#c17d00";
+    } else {
+      severityCell.style.color = "#2b7a0b";
+    }
+    row.appendChild(severityCell);
+
+    const summaryCell = document.createElement("td");
+    summaryCell.textContent = alert.summary;
+    summaryCell.style.padding = "0.5rem";
+    row.appendChild(summaryCell);
+
+    const detectedCell = document.createElement("td");
+    detectedCell.textContent = new Date(alert.detectedAt).toLocaleString();
+    detectedCell.style.padding = "0.5rem";
+    row.appendChild(detectedCell);
+
+    const counterCell = document.createElement("td");
+    counterCell.style.padding = "0.5rem";
+    counterCell.style.fontSize = "0.85rem";
+    counterCell.style.color = "#444";
+    const counter = alert.counterExample?.[0];
+    if (counter) {
+      const reason = document.createElement("div");
+      reason.textContent = counter.reason;
+      reason.style.fontWeight = "600";
+      const detail = document.createElement("div");
+      detail.textContent = `${counter.transaction.payee} on ${new Date(counter.transaction.date).toLocaleDateString()} for $${counter.transaction.amount.toFixed(2)}`;
+      counterCell.appendChild(reason);
+      counterCell.appendChild(detail);
+    } else {
+      counterCell.textContent = "—";
+    }
+    row.appendChild(counterCell);
+
+    const statusCell = document.createElement("td");
+    statusCell.textContent = alert.status;
+    statusCell.style.padding = "0.5rem";
+    row.appendChild(statusCell);
+
+    const actionsCell = document.createElement("td");
+    actionsCell.style.padding = "0.5rem";
+    actionsCell.style.display = "flex";
+    actionsCell.style.gap = "0.5rem";
+
+    const ackButton = document.createElement("button");
+    ackButton.textContent = "Ack";
+    ackButton.disabled = alert.status !== "OPEN";
+    ackButton.addEventListener("click", () => transitionAlert(alert.id, "ack"));
+    actionsCell.appendChild(ackButton);
+
+    const escalateButton = document.createElement("button");
+    escalateButton.textContent = "Escalate";
+    escalateButton.disabled = alert.status === "ESCALATED";
+    escalateButton.addEventListener("click", () => transitionAlert(alert.id, "escalate"));
+    actionsCell.appendChild(escalateButton);
+
+    row.appendChild(actionsCell);
+
+    tbody.appendChild(row);
+  }
+
+  table.appendChild(tbody);
+
+  const selectAllHeader = headerRow.firstElementChild as HTMLTableCellElement;
+  selectAllHeader.innerHTML = "";
+  const selectAll = document.createElement("input");
+  selectAll.type = "checkbox";
+  selectAll.checked = state.alerts.length > 0 && state.selected.size === state.alerts.length;
+  selectAll.addEventListener("change", (event) => toggleAll((event.target as HTMLInputElement).checked));
+  selectAllHeader.appendChild(selectAll);
+
+  tableContainer.appendChild(table);
+};
+
+const renderBulkActions = () => {
+  bulkActions.innerHTML = "";
+  bulkActions.style.display = "flex";
+  bulkActions.style.gap = "0.5rem";
+  bulkActions.style.alignItems = "center";
+
+  const ackSelected = document.createElement("button");
+  ackSelected.textContent = "Ack selected";
+  ackSelected.disabled = state.selected.size === 0;
+  ackSelected.addEventListener("click", () => transitionAlertBulk("ack"));
+  bulkActions.appendChild(ackSelected);
+
+  const escalateSelected = document.createElement("button");
+  escalateSelected.textContent = "Escalate selected";
+  escalateSelected.disabled = state.selected.size === 0;
+  escalateSelected.addEventListener("click", () => transitionAlertBulk("escalate"));
+  bulkActions.appendChild(escalateSelected);
+
+  const summary = document.createElement("span");
+  summary.textContent = `${state.selected.size} selected`;
+  summary.style.marginLeft = "auto";
+  summary.style.fontSize = "0.85rem";
+  summary.style.color = "#555";
+  bulkActions.appendChild(summary);
+};
+
+const renderFilters = () => {
+  filtersContainer.innerHTML = "";
+
+  statusSelect.dataset.label = "statuses";
+  ruleSelect.dataset.label = "rules";
+  severitySelect.dataset.label = "severities";
+
+  buildSelectOptions(statusSelect, STATUS_OPTIONS, true);
+  buildSelectOptions(ruleSelect, RULE_OPTIONS, true);
+  buildSelectOptions(severitySelect, SEVERITY_OPTIONS, true);
+
+  statusSelect.addEventListener("change", () => {
+    state.filters.status = statusSelect.value;
+    fetchAlerts();
+  });
+  ruleSelect.addEventListener("change", () => {
+    state.filters.ruleId = ruleSelect.value;
+    fetchAlerts();
+  });
+  severitySelect.addEventListener("change", () => {
+    state.filters.severity = severitySelect.value;
+    fetchAlerts();
+  });
+  orgInput.placeholder = "Org ID contains";
+  orgInput.addEventListener("input", () => {
+    state.filters.orgId = orgInput.value.trim() ? orgInput.value.trim() : "all";
+    fetchAlerts();
+  });
+
+  syncFiltersUI();
+
+  const statusLabel = createLabel("Status");
+  statusLabel.appendChild(statusSelect);
+  filtersContainer.appendChild(statusLabel);
+
+  const ruleLabel = createLabel("Rule");
+  ruleLabel.appendChild(ruleSelect);
+  filtersContainer.appendChild(ruleLabel);
+
+  const severityLabel = createLabel("Severity");
+  severityLabel.appendChild(severitySelect);
+  filtersContainer.appendChild(severityLabel);
+
+  const orgLabel = createLabel("Org");
+  orgLabel.appendChild(orgInput);
+  filtersContainer.appendChild(orgLabel);
+};
+
+const toggleSelection = (id: string) => {
+  if (state.selected.has(id)) {
+    state.selected.delete(id);
+  } else {
+    state.selected.add(id);
+  }
+  renderTable();
+  renderBulkActions();
+};
+
+const toggleAll = (nextState: boolean) => {
+  if (!nextState) {
+    state.selected.clear();
+  } else {
+    state.selected = new Set(state.alerts.map((alert) => alert.id));
+  }
+  renderTable();
+  renderBulkActions();
+};
+
+const transitionAlert = async (id: string, action: TransitionAction) => {
+  await fetch(`/alerts/${id}/${action === "ack" ? "ack" : "escalate"}`, {
+    method: "POST",
+  });
+  await fetchAlerts();
+};
+
+const transitionAlertBulk = async (action: TransitionAction) => {
+  const ids = Array.from(state.selected);
+  if (ids.length === 0) {
+    return;
+  }
+  await Promise.all(ids.map((id) => fetch(`/alerts/${id}/${action === "ack" ? "ack" : "escalate"}`, { method: "POST" })));
+  state.selected.clear();
+  await fetchAlerts();
+};
+
+const fetchAlerts = async () => {
+  state.loading = true;
+  state.error = null;
+  renderMessage();
+  try {
+    const params = new URLSearchParams();
+    if (state.filters.status !== "all") {
+      params.set("status", state.filters.status);
+    }
+    if (state.filters.ruleId !== "all") {
+      params.set("ruleId", state.filters.ruleId);
+    }
+    if (state.filters.severity !== "all") {
+      params.set("severity", state.filters.severity);
+    }
+    if (state.filters.orgId !== "all") {
+      params.set("orgId", state.filters.orgId);
+    }
+    const query = params.toString();
+    const response = await fetch(`/alerts${query ? `?${query}` : ""}`);
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    const payload = (await response.json()) as { alerts: AlertRecord[] };
+    state.alerts = payload.alerts ?? [];
+    state.selected = new Set(Array.from(state.selected).filter((id) => state.alerts.some((alert) => alert.id === id)));
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : "Unknown error";
+  } finally {
+    state.loading = false;
+    syncFiltersUI();
+    renderMessage();
+    renderTable();
+    renderBulkActions();
+  }
+};
+
+renderFilters();
+renderMessage();
+renderTable();
+renderBulkActions();
+
+fetchAlerts();


### PR DESCRIPTION
## Summary
- add anomaly detection engine with velocity, novel counterparty, and allocation drift rules that emit counter examples
- persist alerts via new Prisma model and Fastify endpoints for ingest, listing, and status transitions
- build a simple alerts inbox UI with filters and bulk acknowledgements and add fixtures to bound false positives

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f32c2af138832795a7a0607e595413