### PR TITLE
feat(webapp): build dashboard shell and bank line workflows

### DIFF
--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,27 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "clsx": "^1.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.0"
+  }
+}

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+@layer base {
+  html {
+    font-size: 16px;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    @apply m-0 bg-slate-100 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-50;
+  }
+
+  a {
+    color: inherit;
+  }
+}

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,149 @@
+export type ChartPoint = {
+  date: string;
+  value: number;
+};
+
+export type DashboardSummary = {
+  kpis: Array<{
+    id: string;
+    label: string;
+    value: number;
+    change: number;
+  }>;
+  chart: ChartPoint[];
+};
+
+export type BankLine = {
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  status: 'pending' | 'verified' | 'flagged';
+  counterparty: string;
+  rptExcerpt: string;
+};
+
+export type Paginated<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+};
+
+type FetchBankLinesParams = {
+  page: number;
+  pageSize: number;
+  signal?: AbortSignal;
+};
+
+const dashboardSummary: DashboardSummary = {
+  kpis: [
+    { id: 'operating', label: 'Operating', value: 482430.45, change: 3.8 },
+    { id: 'tax-buffer', label: 'Tax buffer', value: 128930.12, change: -1.6 },
+    { id: 'paygw', label: 'PAYGW', value: 80210.76, change: 0.4 },
+    { id: 'gst', label: 'GST', value: 55330.18, change: 1.1 }
+  ],
+  chart: generateChart()
+};
+
+const bankLineStore: BankLine[] = generateBankLines();
+
+export async function fetchDashboardSummary({ signal }: { signal?: AbortSignal } = {}): Promise<DashboardSummary> {
+  await delay(180, signal);
+  return JSON.parse(JSON.stringify(dashboardSummary));
+}
+
+export async function fetchBankLines({ page, pageSize, signal }: FetchBankLinesParams): Promise<Paginated<BankLine>> {
+  await delay(220, signal);
+  const start = page * pageSize;
+  const end = start + pageSize;
+  const items = bankLineStore.slice(start, end).map((item) => ({ ...item }));
+  return {
+    items,
+    page,
+    pageSize,
+    total: bankLineStore.length
+  };
+}
+
+export async function verifyBankLine(id: string, { signal }: { signal?: AbortSignal } = {}): Promise<BankLine> {
+  await delay(150, signal);
+  const line = bankLineStore.find((item) => item.id === id);
+  if (!line) {
+    throw new Error('Bank line not found');
+  }
+  line.status = 'verified';
+  return { ...line };
+}
+
+function delay(ms: number, signal?: AbortSignal) {
+  return new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+
+    function cleanup() {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    }
+
+    function onAbort() {
+      cleanup();
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      reject(abortError);
+    }
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort);
+    }
+  });
+}
+
+function generateChart(): ChartPoint[] {
+  const today = new Date();
+  const points: ChartPoint[] = [];
+  let base = 410000;
+  for (let i = 29; i >= 0; i -= 1) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - i);
+    base += Math.sin(i / 3) * 3000 + Math.random() * 1200 - 600;
+    points.push({ date: date.toISOString(), value: Math.max(base, 320000) });
+  }
+  return points;
+}
+
+function generateBankLines(): BankLine[] {
+  const statuses: BankLine['status'][] = ['pending', 'verified', 'flagged'];
+  const descriptions = [
+    'Investor disbursement',
+    'Birchal platform fee',
+    'ATO remittance',
+    'Custody provider invoice',
+    'Insurance premium',
+    'R&D rebate deposit',
+    'Regulatory filing fee'
+  ];
+  const lines: BankLine[] = [];
+  const today = new Date();
+  for (let i = 0; i < 64; i += 1) {
+    const date = new Date(today);
+    date.setDate(today.getDate() - i);
+    lines.push({
+      id: `line-${i + 1}`,
+      date: date.toISOString(),
+      description: descriptions[i % descriptions.length],
+      amount: Number((Math.random() * 18000 - 9000).toFixed(2)),
+      status: statuses[i % statuses.length],
+      counterparty: ['Birchal Nominees', 'ATO', 'Macquarie Bank'][i % 3],
+      rptExcerpt:
+        'Reference Payment Transaction (RPT) data indicates reconciliation with ledger entry \u2013 supporting documents attached.'
+    });
+  }
+  return lines;
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,63 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
+import DashboardRoute from './routes/index';
+import BankLinesRoute from './routes/bank-lines';
+import { AppSidebar } from './shell/Sidebar';
+import { AppHeader } from './shell/Header';
+import { ThemeProvider } from './shell/ThemeProvider';
+import { MobileSidebar } from './shell/MobileSidebar';
+import './index.css';
+
+const router = createBrowserRouter([
+  {
+    element: (
+      <AppLayout>
+        <Outlet />
+      </AppLayout>
+    ),
+    children: [
+      { index: true, element: <DashboardRoute /> },
+      { path: 'bank-lines', element: <BankLinesRoute /> }
+    ]
+  }
+]);
+
+function AppLayout({ children }: { children: React.ReactNode }) {
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
+
+  return (
+    <ThemeProvider>
+      <a
+        href="#main-content"
+        className="absolute left-4 top-4 z-50 -translate-y-16 rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white focus:translate-y-0 focus:outline-none"
+      >
+        Skip to main content
+      </a>
+      <div className="min-h-screen bg-slate-100 text-slate-900 dark:bg-slate-950 dark:text-slate-50">
+        <div className="flex min-h-screen">
+          <MobileSidebar open={mobileNavOpen} onClose={() => setMobileNavOpen(false)} />
+          <AppSidebar />
+          <div className="flex flex-1 flex-col">
+            <AppHeader onToggleMobileNav={() => setMobileNavOpen(true)} />
+            <main className="flex-1 overflow-y-auto p-4 sm:p-6" id="main-content">
+              {children}
+            </main>
+          </div>
+        </div>
+      </div>
+    </ThemeProvider>
+  );
+}
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element #root not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,317 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { BankLine, fetchBankLines, verifyBankLine } from '../lib/api';
+import { DateDisplay } from '../ui/DateDisplay';
+import { Money } from '../ui/Money';
+import { Skeleton } from '../ui/Skeleton';
+import { Drawer } from '../ui/Drawer';
+import { StatusBadge } from '../ui/StatusBadge';
+
+type LoadState = 'idle' | 'loading' | 'success' | 'error';
+
+type TableState = {
+  status: LoadState;
+  data?: {
+    items: BankLine[];
+    total: number;
+  };
+  error?: string;
+};
+
+const pageSize = 10;
+
+export default function BankLinesRoute() {
+  const [page, setPage] = useState(0);
+  const [state, setState] = useState<TableState>({ status: 'idle' });
+  const [selectedLine, setSelectedLine] = useState<BankLine | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [actionState, setActionState] = useState<'idle' | 'verifying' | 'error'>('idle');
+  const [actionError, setActionError] = useState<string | undefined>();
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: 'loading' });
+    fetchBankLines({ page, pageSize, signal: controller.signal })
+      .then((response) => {
+        setState({
+          status: 'success',
+          data: { items: response.items, total: response.total }
+        });
+      })
+      .catch((error: unknown) => {
+        if ((error as DOMException)?.name === 'AbortError') return;
+        setState({ status: 'error', error: error instanceof Error ? error.message : 'Unknown error' });
+      });
+    return () => controller.abort();
+  }, [page, reloadToken]);
+
+  const reloadPage = () => setReloadToken((value) => value + 1);
+
+  const totalPages = useMemo(() => {
+    if (!state.data) return 0;
+    return Math.ceil(state.data.total / pageSize);
+  }, [state.data]);
+
+  const openDrawer = (line: BankLine) => {
+    setSelectedLine(line);
+    setActionState('idle');
+    setActionError(undefined);
+    setDrawerOpen(true);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setSelectedLine(null);
+    setActionState('idle');
+    setActionError(undefined);
+  };
+
+  const handleVerify = async () => {
+    if (!selectedLine || selectedLine.status === 'verified') return;
+    setActionState('verifying');
+    setActionError(undefined);
+    try {
+      const updated = await verifyBankLine(selectedLine.id);
+      setSelectedLine(updated);
+      setState((previous) => {
+        if (!previous.data) return previous;
+        const updatedItems = previous.data.items.map((item) => (item.id === updated.id ? updated : item));
+        return {
+          status: 'success',
+          data: {
+            items: updatedItems,
+            total: previous.data.total
+          }
+        };
+      });
+      setActionState('idle');
+    } catch (error) {
+      setActionState('error');
+      setActionError(error instanceof Error ? error.message : 'Could not verify line');
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4 dark:border-slate-800">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">Bank statement lines</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Monitor ingested bank lines and reconcile with the ledger.
+            </p>
+          </div>
+          <p className="text-xs text-slate-500 dark:text-slate-400">Page {page + 1}</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm dark:divide-slate-800">
+            <caption className="sr-only">Bank statement lines</caption>
+            <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+              <tr>
+                <th scope="col" className="px-6 py-3 font-semibold">
+                  Date
+                </th>
+                <th scope="col" className="px-6 py-3 font-semibold">
+                  Description
+                </th>
+                <th scope="col" className="px-6 py-3 font-semibold">
+                  Counterparty
+                </th>
+                <th scope="col" className="px-6 py-3 font-semibold text-right">
+                  Amount
+                </th>
+                <th scope="col" className="px-6 py-3 font-semibold">
+                  Status
+                </th>
+                <th scope="col" className="px-6 py-3" aria-label="Actions" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              {state.status === 'loading' &&
+                Array.from({ length: pageSize }).map((_, index) => (
+                  <tr key={index} className="bg-white dark:bg-slate-900">
+                    <td className="px-6 py-4"><Skeleton className="h-4 w-24" /></td>
+                    <td className="px-6 py-4"><Skeleton className="h-4 w-40" /></td>
+                    <td className="px-6 py-4"><Skeleton className="h-4 w-32" /></td>
+                    <td className="px-6 py-4 text-right"><Skeleton className="ml-auto h-4 w-20" /></td>
+                    <td className="px-6 py-4"><Skeleton className="h-5 w-16" /></td>
+                    <td className="px-6 py-4"><Skeleton className="h-5 w-14" /></td>
+                  </tr>
+                ))}
+
+              {state.status === 'success' && state.data && state.data.items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-6 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
+                    No bank lines available for this period.
+                  </td>
+                </tr>
+              ) : null}
+
+              {state.status === 'success' && state.data
+                ? state.data.items.map((line) => (
+                    <tr key={line.id} className="bg-white transition hover:bg-indigo-50/50 dark:bg-slate-900 dark:hover:bg-slate-800">
+                      <td className="whitespace-nowrap px-6 py-4">
+                        <DateDisplay value={line.date} />
+                      </td>
+                      <td className="px-6 py-4">
+                        <div className="font-medium text-slate-900 dark:text-slate-100">{line.description}</div>
+                        <p className="text-xs text-slate-500 dark:text-slate-400">{line.id}</p>
+                      </td>
+                      <td className="px-6 py-4 text-slate-600 dark:text-slate-300">{line.counterparty}</td>
+                      <td className="px-6 py-4 text-right">
+                        <Money value={line.amount} />
+                      </td>
+                      <td className="px-6 py-4">
+                        <StatusBadge status={line.status} />
+                      </td>
+                      <td className="px-6 py-4 text-right">
+                        <button
+                          type="button"
+                          className="inline-flex items-center rounded-md border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 shadow-sm transition hover:border-indigo-200 hover:text-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:text-slate-200 dark:hover:border-indigo-500/50 dark:hover:text-indigo-200"
+                          onClick={() => openDrawer(line)}
+                        >
+                          Inspect
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                : null}
+
+              {state.status === 'error' ? (
+                <tr>
+                  <td colSpan={6} className="px-6 py-12 text-center text-sm text-rose-600 dark:text-rose-300">
+                    <div className="flex flex-col items-center gap-4">
+                      <p>{state.error}</p>
+                      <button
+                        type="button"
+                        className="inline-flex items-center rounded-md bg-rose-600 px-3 py-1.5 font-semibold text-white shadow-sm transition hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+                        onClick={reloadPage}
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+        <footer className="flex items-center justify-between border-t border-slate-200 px-6 py-4 text-sm dark:border-slate-800">
+          <div className="text-slate-500 dark:text-slate-400">
+            Showing {state.data?.items.length ?? 0} of {state.data?.total ?? 0} lines
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="rounded-md border border-slate-200 px-3 py-1.5 font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:text-slate-300 dark:hover:border-indigo-500/50 dark:hover:text-indigo-200"
+              onClick={() => setPage((current) => Math.max(current - 1, 0))}
+              disabled={page === 0 || state.status === 'loading'}
+            >
+              Previous
+            </button>
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Page {page + 1} of {totalPages || 1}
+            </span>
+            <button
+              type="button"
+              className="rounded-md border border-slate-200 px-3 py-1.5 font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:text-slate-300 dark:hover:border-indigo-500/50 dark:hover:text-indigo-200"
+              onClick={() => setPage((current) => (totalPages ? Math.min(current + 1, totalPages - 1) : current))}
+              disabled={state.status === 'loading' || !totalPages || page >= totalPages - 1}
+            >
+              Next
+            </button>
+          </div>
+        </footer>
+      </section>
+
+      <Drawer
+        title={selectedLine ? `RPT review for ${selectedLine.description}` : 'RPT review'}
+        description="Review the RPT data before verifying the bank line."
+        open={drawerOpen}
+        onClose={() => {
+          setDrawerOpen(false);
+        }}
+        footer={
+          <div className="flex items-center justify-between gap-4">
+            {actionState === 'error' && actionError ? (
+              <p className="text-sm text-rose-500" role="alert">
+                {actionError}
+              </p>
+            ) : (
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                Verification locks the line for downstream reconciliation.
+              </span>
+            )}
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="rounded-md border border-transparent px-4 py-2 text-sm font-semibold text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:text-slate-200"
+                onClick={closeDrawer}
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={handleVerify}
+                disabled={!selectedLine || selectedLine.status === 'verified' || actionState === 'verifying'}
+              >
+                {selectedLine?.status === 'verified' ? 'Verified' : actionState === 'verifying' ? 'Verifying…' : 'Verify'}
+              </button>
+            </div>
+          </div>
+        }
+      >
+        {selectedLine ? (
+          <div className="space-y-6">
+            <section aria-labelledby="line-summary-heading">
+              <h3 id="line-summary-heading" className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                Line summary
+              </h3>
+              <dl className="mt-3 grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">Date</dt>
+                  <dd className="mt-1 text-sm text-slate-700 dark:text-slate-200">
+                    <DateDisplay value={selectedLine.date} withTime />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">Amount</dt>
+                  <dd className="mt-1 text-sm text-slate-700 dark:text-slate-200">
+                    <Money value={selectedLine.amount} />
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">Counterparty</dt>
+                  <dd className="mt-1 text-sm text-slate-700 dark:text-slate-200">{selectedLine.counterparty}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-medium uppercase text-slate-500 dark:text-slate-400">Status</dt>
+                  <dd className="mt-1 text-sm text-slate-700 dark:text-slate-200">
+                    <StatusBadge status={selectedLine.status} />
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section aria-labelledby="rpt-heading">
+              <h3 id="rpt-heading" className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                RPT viewer
+              </h3>
+              <article className="mt-2 space-y-2 rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-950/40 dark:text-slate-300">
+                <p>
+                  {selectedLine.rptExcerpt}
+                </p>
+                <p className="font-mono text-xs text-slate-500 dark:text-slate-400">
+                  Ref: {selectedLine.id}
+                </p>
+              </article>
+            </section>
+          </div>
+        ) : (
+          <p className="text-sm text-slate-500">Select a bank line to view RPT data.</p>
+        )}
+      </Drawer>
+    </div>
+  );
+}

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import { fetchDashboardSummary, DashboardSummary } from '../lib/api';
+import { Money } from '../ui/Money';
+import { Skeleton } from '../ui/Skeleton';
+import { TrendChart } from '../ui/TrendChart';
+
+type LoadState = 'idle' | 'loading' | 'success' | 'error';
+
+type SummaryState = {
+  status: LoadState;
+  data?: DashboardSummary;
+  error?: string;
+};
+
+const initialState: SummaryState = {
+  status: 'idle'
+};
+
+export default function DashboardRoute() {
+  const [state, setState] = useState<SummaryState>(initialState);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: 'loading' });
+    fetchDashboardSummary({ signal: controller.signal })
+      .then((data) => {
+        setState({ status: 'success', data });
+      })
+      .catch((error: unknown) => {
+        if ((error as DOMException)?.name === 'AbortError') return;
+        setState({ status: 'error', error: error instanceof Error ? error.message : 'Unknown error' });
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (state.status === 'loading' || state.status === 'idle') {
+    return (
+      <div className="space-y-8" aria-busy="true">
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="rounded-lg border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900">
+              <Skeleton className="mb-3 h-4 w-24" />
+              <Skeleton className="h-8 w-32" />
+            </div>
+          ))}
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900">
+          <Skeleton className="mb-4 h-4 w-48" />
+          <Skeleton className="h-48 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <section className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-rose-800 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-200">
+        <h2 className="text-lg font-semibold">We could not load the dashboard.</h2>
+        <p className="mt-2 text-sm">{state.error}</p>
+        <button
+          type="button"
+          className="mt-4 inline-flex items-center rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-500"
+          onClick={() => {
+            setState({ status: 'loading' });
+            fetchDashboardSummary()
+              .then((data) => setState({ status: 'success', data }))
+              .catch((error: unknown) =>
+                setState({ status: 'error', error: error instanceof Error ? error.message : 'Unknown error' })
+              );
+          }}
+        >
+          Retry
+        </button>
+      </section>
+    );
+  }
+
+  const { data } = state;
+  if (!data) return null;
+
+  return (
+    <div className="space-y-8">
+      <section aria-labelledby="kpi-heading">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 id="kpi-heading" className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Core balances
+          </h2>
+        </div>
+        <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {data.kpis.map((kpi) => (
+            <div
+              key={kpi.id}
+              className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+            >
+              <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">{kpi.label}</dt>
+              <dd className="mt-3 flex items-baseline justify-between">
+                <Money value={kpi.value} className="text-2xl font-semibold" />
+                <ChangePill value={kpi.change} />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mb-4 flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900 dark:text-slate-50">Cash runway</h2>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Tracking the last 30 days of net cash movement.
+            </p>
+          </div>
+        </div>
+        <TrendChart data={data.chart} />
+      </section>
+    </div>
+  );
+}
+
+function ChangePill({ value }: { value: number }) {
+  const positive = value >= 0;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold ${
+        positive
+          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200'
+          : 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200'
+      }`}
+    >
+      <span aria-hidden="true" className="mr-1">
+        {positive ? '▲' : '▼'}
+      </span>
+      {Math.abs(value).toFixed(1)}%
+      <span className="sr-only"> {positive ? 'increase' : 'decrease'} since last period</span>
+    </span>
+  );
+}

--- a/apgms/webapp/src/shell/Header.tsx
+++ b/apgms/webapp/src/shell/Header.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import { useTheme } from './ThemeProvider';
+import { navigation } from './navigation';
+
+const routeTitles: Record<string, string> = Object.fromEntries(navigation.map((item) => [item.to, item.name]));
+
+type AppHeaderProps = {
+  onToggleMobileNav: () => void;
+};
+
+export function AppHeader({ onToggleMobileNav }: AppHeaderProps) {
+  const location = useLocation();
+  const { theme, toggleTheme } = useTheme();
+  const title = routeTitles[location.pathname] ?? 'Overview';
+
+  return (
+    <header
+      className="sticky top-0 z-20 flex items-center justify-between border-b border-slate-200 bg-white/80 px-4 py-3 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 sm:px-6"
+      role="banner"
+    >
+      <div className="flex items-center gap-4">
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-transparent text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:text-slate-300 dark:hover:text-white lg:hidden"
+          onClick={onToggleMobileNav}
+        >
+          <span className="sr-only">Open navigation</span>
+          <MenuIcon aria-hidden="true" className="h-5 w-5" />
+        </button>
+        <div>
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-50">{title}</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Real-time financial visibility for Birchal operations.
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-4">
+        <ThemeToggleButton theme={theme} onToggle={toggleTheme} />
+      </div>
+    </header>
+  );
+}
+
+function ThemeToggleButton({
+  theme,
+  onToggle
+}: {
+  theme: 'light' | 'dark';
+  onToggle: () => void;
+}) {
+  const label = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={theme === 'dark'}
+      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:bg-slate-700"
+    >
+      <span className="sr-only">{label}</span>
+      {theme === 'dark' ? (
+        <MoonIcon aria-hidden="true" className="h-5 w-5" />
+      ) : (
+        <SunIcon aria-hidden="true" className="h-5 w-5" />
+      )}
+      <span aria-hidden="true">{theme === 'dark' ? 'Dark' : 'Light'}</span>
+    </button>
+  );
+}
+
+function SunIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2m0 16v2m10-10h-2M4 12H2m16.95 6.95-1.41-1.41M6.46 6.46 5.05 5.05m12.9 0-1.41 1.41M6.46 17.54 5.05 18.95" />
+    </svg>
+  );
+}
+
+function MoonIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79z" />
+    </svg>
+  );
+}
+
+function MenuIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <path d="M4 6h16M4 12h16M4 18h16" />
+    </svg>
+  );
+}

--- a/apgms/webapp/src/shell/MobileSidebar.tsx
+++ b/apgms/webapp/src/shell/MobileSidebar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import clsx from 'clsx';
+import { Drawer } from '../ui/Drawer';
+import { navigation } from './navigation';
+
+type MobileSidebarProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function MobileSidebar({ open, onClose }: MobileSidebarProps) {
+  return (
+    <Drawer
+      title="Navigation"
+      description="Choose a destination."
+      open={open}
+      onClose={onClose}
+      side="left"
+    >
+      <nav aria-label="Mobile">
+        <ul className="space-y-2">
+          {navigation.map((item) => (
+            <li key={item.to}>
+              <NavLink
+                to={item.to}
+                className={({ isActive }) =>
+                  clsx(
+                    'block rounded-md px-3 py-2 text-base font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500',
+                    isActive
+                      ? 'bg-indigo-500 text-white'
+                      : 'text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800'
+                  )
+                }
+                onClick={onClose}
+              >
+                {item.name}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </Drawer>
+  );
+}

--- a/apgms/webapp/src/shell/Sidebar.tsx
+++ b/apgms/webapp/src/shell/Sidebar.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import clsx from 'clsx';
+import { navigation } from './navigation';
+
+export function AppSidebar() {
+  return (
+    <aside
+      className="hidden w-64 shrink-0 border-r border-slate-200 bg-white px-5 py-6 dark:border-slate-800 dark:bg-slate-900 lg:block"
+      aria-label="Primary"
+    >
+      <div className="mb-8 flex items-center gap-2">
+        <span className="flex h-9 w-9 items-center justify-center rounded-lg bg-indigo-600 font-semibold text-white">B</span>
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold text-slate-900 dark:text-slate-50">Birchal</span>
+          <span className="text-xs text-slate-500 dark:text-slate-400">Accounts platform</span>
+        </div>
+      </div>
+      <nav>
+        <ul className="space-y-1">
+          {navigation.map((item) => (
+            <li key={item.to}>
+              <NavLink
+                to={item.to}
+                end={item.to === '/'}
+                className={({ isActive }) =>
+                  clsx(
+                    'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500',
+                    isActive
+                      ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-200'
+                      : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white'
+                  )
+                }
+              >
+                <span>{item.name}</span>
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+}

--- a/apgms/webapp/src/shell/ThemeProvider.tsx
+++ b/apgms/webapp/src/shell/ThemeProvider.tsx
@@ -1,0 +1,56 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light';
+    const stored = window.localStorage.getItem('apgms-theme');
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    window.localStorage.setItem('apgms-theme', theme);
+  }, [theme]);
+
+  const setTheme = useCallback((value: Theme) => {
+    setThemeState(value);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((current) => (current === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme
+    }),
+    [theme, setTheme, toggleTheme]
+  );
+
+  return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const value = useContext(ThemeContext);
+  if (!value) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return value;
+}

--- a/apgms/webapp/src/shell/navigation.ts
+++ b/apgms/webapp/src/shell/navigation.ts
@@ -1,0 +1,9 @@
+export type NavItem = {
+  name: string;
+  to: string;
+};
+
+export const navigation: NavItem[] = [
+  { name: 'Dashboard', to: '/' },
+  { name: 'Bank lines', to: '/bank-lines' }
+];

--- a/apgms/webapp/src/ui/DateDisplay.tsx
+++ b/apgms/webapp/src/ui/DateDisplay.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type DateDisplayProps = {
+  value: string | Date;
+  className?: string;
+  withTime?: boolean;
+};
+
+const dateFormatter = new Intl.DateTimeFormat('en-AU', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric'
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat('en-AU', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit'
+});
+
+export function DateDisplay({ value, className, withTime = false }: DateDisplayProps) {
+  const date = typeof value === 'string' ? new Date(value) : value;
+  const formatted = (withTime ? dateTimeFormatter : dateFormatter).format(date);
+  return (
+    <time dateTime={date.toISOString()} className={clsx('tabular-nums text-slate-600 dark:text-slate-300', className)}>
+      {formatted}
+    </time>
+  );
+}

--- a/apgms/webapp/src/ui/Drawer.tsx
+++ b/apgms/webapp/src/ui/Drawer.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useId, useRef } from 'react';
+import clsx from 'clsx';
+
+type DrawerProps = {
+  side?: 'left' | 'right';
+  title: string;
+  description?: string;
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  footer?: React.ReactNode;
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+export function Drawer({ title, description, open, onClose, children, footer, side = 'right' }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descriptionId = description ? `${titleId}-description` : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+    const node = panelRef.current;
+    if (!node) return;
+
+    const focusable = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    (first ?? node).focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+      if (event.key === 'Tab' && focusable.length > 0) {
+        if (event.shiftKey && document.activeElement === (first ?? node)) {
+          event.preventDefault();
+          (last ?? node).focus();
+        } else if (!event.shiftKey && document.activeElement === (last ?? node)) {
+          event.preventDefault();
+          (first ?? node).focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div className={clsx('fixed inset-0 z-40 flex', side === 'right' ? 'justify-end' : 'justify-start')}>
+      <div
+        className="fixed inset-0 bg-slate-900/60"
+        aria-hidden="true"
+        onClick={onClose}
+        role="presentation"
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className={clsx(
+          'relative flex h-full w-full max-w-xl flex-col bg-white shadow-xl dark:bg-slate-900',
+          side === 'right'
+            ? 'border-l border-slate-200 dark:border-slate-800'
+            : 'border-r border-slate-200 dark:border-slate-800'
+        )}
+      >
+        <header className="flex items-start justify-between border-b border-slate-200 px-6 py-4 dark:border-slate-800">
+          <div>
+            <h2 id={titleId} className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+              {title}
+            </h2>
+            {description ? (
+              <p id={descriptionId} className="text-sm text-slate-500 dark:text-slate-400">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-transparent p-2 text-slate-500 transition hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            <span className="sr-only">Close drawer</span>
+            <CloseIcon aria-hidden="true" />
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto px-6 py-4 text-sm text-slate-600 dark:text-slate-300">{children}</div>
+        {footer ? <div className="border-t border-slate-200 px-6 py-4 dark:border-slate-800">{footer}</div> : null}
+      </div>
+    </div>
+  );
+}
+
+function CloseIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" {...props}>
+      <path d="m6 6 8 8m0-8-8 8" />
+    </svg>
+  );
+}

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type MoneyProps = {
+  value: number;
+  currency?: string;
+  minimumFractionDigits?: number;
+  className?: string;
+};
+
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+export function Money({ value, currency = 'AUD', minimumFractionDigits = 2, className }: MoneyProps) {
+  const key = `${currency}-${minimumFractionDigits}`;
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat('en-AU', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits,
+      maximumFractionDigits: minimumFractionDigits
+    });
+    formatterCache.set(key, formatter);
+  }
+
+  return (
+    <span
+      className={clsx(
+        'tabular-nums',
+        value < 0 ? 'text-rose-600 dark:text-rose-300' : 'text-emerald-600 dark:text-emerald-300',
+        className
+      )}
+    >
+      {formatter.format(value)}
+    </span>
+  );
+}

--- a/apgms/webapp/src/ui/Skeleton.tsx
+++ b/apgms/webapp/src/ui/Skeleton.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import clsx from 'clsx';
+
+type SkeletonProps = {
+  className?: string;
+};
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={clsx('animate-pulse rounded bg-slate-200 dark:bg-slate-700', className)} aria-hidden="true" />;
+}

--- a/apgms/webapp/src/ui/StatusBadge.tsx
+++ b/apgms/webapp/src/ui/StatusBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import clsx from 'clsx';
+
+const styles: Record<string, string> = {
+  pending: 'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-200',
+  verified: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-200',
+  flagged: 'bg-rose-100 text-rose-700 dark:bg-rose-500/20 dark:text-rose-200'
+};
+
+type StatusBadgeProps = {
+  status: 'pending' | 'verified' | 'flagged';
+};
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <span className={clsx('inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold', styles[status])}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}

--- a/apgms/webapp/src/ui/TrendChart.tsx
+++ b/apgms/webapp/src/ui/TrendChart.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ChartPoint } from '../lib/api';
+
+type TrendChartProps = {
+  data: ChartPoint[];
+  className?: string;
+};
+
+export function TrendChart({ data, className }: TrendChartProps) {
+  if (data.length === 0) {
+    return <p className="text-sm text-slate-500">No chart data available.</p>;
+  }
+
+  const values = data.map((point) => point.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const gradientId = React.useId();
+
+  const path = data
+    .map((point, index) => {
+      const x = (index / (data.length - 1)) * 100;
+      const y = 100 - ((point.value - min) / range) * 100;
+      return `${index === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+
+  const areaPath = `${path} L100,100 L0,100 Z`;
+
+  return (
+    <figure className={clsx('w-full', className)}>
+      <svg
+        viewBox="0 0 100 100"
+        role="img"
+        aria-label="Cash runway over the last 30 days"
+        preserveAspectRatio="none"
+        className="h-48 w-full overflow-visible rounded-lg bg-slate-100 text-indigo-500 dark:bg-slate-900"
+      >
+        <path d={areaPath} fill={`url(#${gradientId})`} />
+        <path d={path} fill="none" stroke="currentColor" strokeWidth="1.8" />
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="rgb(99 102 241)" stopOpacity="0.3" />
+            <stop offset="100%" stopColor="rgb(99 102 241)" stopOpacity="0" />
+          </linearGradient>
+        </defs>
+      </svg>
+      <figcaption className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+        30 days of daily balances.
+      </figcaption>
+    </figure>
+  );
+}

--- a/apgms/webapp/tailwind.config.cjs
+++ b/apgms/webapp/tailwind.config.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: [
+          'Inter',
+          'system-ui',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'sans-serif'
+        ]
+      }
+    }
+  },
+  plugins: []
+};

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true,
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- implement the web app shell with theme support, primary navigation, and mobile drawer navigation
- add the dashboard route with KPI cards, a 30-day trend chart, and resilient loading/error states
- build the bank lines workflow with server pagination, verification drawer, and shared UI utilities for currency and dates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f32c03776c8327a2e31170ffc80d6d