### PR TITLE
Add AS4 BAS submission service with immutable audit artifacts

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm run build && node --test dist/test"
+  },
+  "dependencies": {
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/as4.ts
+++ b/apgms/services/sbr/src/as4.ts
@@ -1,0 +1,93 @@
+import { createHash, createSign, createVerify, randomUUID } from "node:crypto";
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export interface As4Envelope {
+  messageId: string;
+  createdAt: string;
+  payload: Record<string, JsonValue>;
+}
+
+export interface DetachedSignature {
+  algorithm: "RSA-SHA256";
+  value: string; // base64 encoded signature
+}
+
+export interface As4Receipt {
+  messageId: string;
+  receivedAt: string;
+  raw: Record<string, JsonValue>;
+}
+
+export interface As4Client {
+  send(envelope: As4Envelope, signature: DetachedSignature): Promise<As4Receipt>;
+}
+
+export function signEnvelope(
+  envelope: As4Envelope,
+  privateKeyPem: string
+): DetachedSignature {
+  const canonical = canonicaliseEnvelope(envelope);
+  const signer = createSign("RSA-SHA256");
+  signer.update(canonical);
+  signer.end();
+  const value = signer.sign(privateKeyPem, "base64");
+  return {
+    algorithm: "RSA-SHA256",
+    value,
+  };
+}
+
+export function verifyEnvelope(
+  envelope: As4Envelope,
+  signature: DetachedSignature,
+  publicKeyPem: string
+): boolean {
+  const canonical = canonicaliseEnvelope(envelope);
+  const verifier = createVerify(signature.algorithm);
+  verifier.update(canonical);
+  verifier.end();
+  return verifier.verify(publicKeyPem, signature.value, "base64");
+}
+
+export function canonicaliseEnvelope(envelope: As4Envelope): string {
+  const normalised = normalise(envelope);
+  return JSON.stringify(normalised);
+}
+
+function normalise(value: JsonValue | As4Envelope | Record<string, JsonValue>): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalise(entry as JsonValue));
+  }
+  if (value && typeof value === "object") {
+    const sortedKeys = Object.keys(value).sort();
+    const output: Record<string, JsonValue> = {};
+    for (const key of sortedKeys) {
+      output[key] = normalise((value as Record<string, JsonValue>)[key]);
+    }
+    return output;
+  }
+  return value as JsonValue;
+}
+
+export function createBasEnvelope(payload: Record<string, JsonValue>): As4Envelope {
+  return {
+    messageId: randomUUID(),
+    createdAt: new Date().toISOString(),
+    payload,
+  };
+}
+
+export function buildReceipt(envelope: As4Envelope): As4Receipt {
+  return {
+    messageId: envelope.messageId,
+    receivedAt: new Date().toISOString(),
+    raw: {
+      status: "ACCEPTED",
+      correlationId: envelope.messageId,
+      digest: createHash("sha256")
+        .update(JSON.stringify(normalise(envelope.payload)))
+        .digest("hex"),
+    },
+  };
+}

--- a/apgms/services/sbr/src/audit-blob.ts
+++ b/apgms/services/sbr/src/audit-blob.ts
@@ -1,0 +1,95 @@
+import { createHash, randomUUID } from "node:crypto";
+
+export type AuditBlobScope = "sbr.bas";
+export type AuditBlobKind = "request" | "receipt";
+
+export interface AuditBlobInput {
+  scope: AuditBlobScope;
+  referenceId: string;
+  kind: AuditBlobKind;
+  payload: string;
+}
+
+export interface AuditBlobRecord extends AuditBlobInput {
+  id: string;
+  sha256: string;
+  createdAt: Date;
+}
+
+export interface IntegrityReport {
+  ok: boolean;
+  expectedSha256: string;
+  actualSha256: string;
+}
+
+export class AuditBlobMutationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuditBlobMutationError";
+  }
+}
+
+export interface AuditBlobRepository {
+  create(input: AuditBlobInput): Promise<AuditBlobRecord>;
+  findById(id: string): Promise<AuditBlobRecord | null>;
+  findByReference(
+    scope: AuditBlobScope,
+    referenceId: string,
+    kind: AuditBlobKind
+  ): Promise<AuditBlobRecord | null>;
+}
+
+export class InMemoryAuditBlobRepository implements AuditBlobRepository {
+  private readonly records = new Map<string, AuditBlobRecord>();
+  private readonly referenceIndex = new Map<string, string>();
+
+  async create(input: AuditBlobInput): Promise<AuditBlobRecord> {
+    const key = this.referenceKey(input.scope, input.referenceId, input.kind);
+    if (this.referenceIndex.has(key)) {
+      throw new AuditBlobMutationError("Audit blob already exists for reference");
+    }
+    const sha256 = createHash("sha256").update(input.payload).digest("hex");
+    const record: AuditBlobRecord = {
+      ...input,
+      id: randomUUID(),
+      sha256,
+      createdAt: new Date(),
+    };
+    this.records.set(record.id, record);
+    this.referenceIndex.set(key, record.id);
+    return record;
+  }
+
+  async findById(id: string): Promise<AuditBlobRecord | null> {
+    return this.records.get(id) ?? null;
+  }
+
+  async findByReference(
+    scope: AuditBlobScope,
+    referenceId: string,
+    kind: AuditBlobKind
+  ): Promise<AuditBlobRecord | null> {
+    const key = this.referenceKey(scope, referenceId, kind);
+    const id = this.referenceIndex.get(key);
+    if (!id) return null;
+    return this.findById(id);
+  }
+
+  // Expose records map for tests to simulate corruption.
+  get unsafeRecords(): Map<string, AuditBlobRecord> {
+    return this.records;
+  }
+
+  private referenceKey(scope: string, referenceId: string, kind: string): string {
+    return `${scope}:${referenceId}:${kind}`;
+  }
+}
+
+export function evaluateIntegrity(record: AuditBlobRecord): IntegrityReport {
+  const actualSha256 = createHash("sha256").update(record.payload).digest("hex");
+  return {
+    ok: actualSha256 === record.sha256,
+    expectedSha256: record.sha256,
+    actualSha256,
+  };
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,4 @@
-﻿console.log('sbr service');
+export * from "./as4.js";
+export * from "./audit-blob.js";
+export * from "./service.js";
+export * from "./server.js";

--- a/apgms/services/sbr/src/server.ts
+++ b/apgms/services/sbr/src/server.ts
@@ -1,0 +1,43 @@
+import Fastify, { FastifyInstance } from "fastify";
+import { As4Client } from "./as4.js";
+import { AuditBlobRepository } from "./audit-blob.js";
+import { SbrService, SbrServiceDependencies } from "./service.js";
+
+export interface BuildServerOptions {
+  service?: SbrService;
+  signingKeyPem?: string;
+  auditRepo?: AuditBlobRepository;
+  as4Client?: As4Client;
+}
+
+export function buildServer(options: BuildServerOptions = {}): FastifyInstance {
+  const service = resolveService(options);
+  const app = Fastify({ logger: false });
+
+  app.get("/sbr/bas/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const submission = await service.getSubmissionDetail(id);
+    if (!submission) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+    return { submission };
+  });
+
+  return app;
+}
+
+function resolveService(options: BuildServerOptions): SbrService {
+  if (options.service) {
+    return options.service;
+  }
+  const { signingKeyPem, auditRepo, as4Client } = options;
+  if (!signingKeyPem) {
+    throw new Error("signingKeyPem is required when building the default service");
+  }
+  const deps: SbrServiceDependencies = {
+    signingKeyPem,
+    auditRepo,
+    as4Client,
+  };
+  return new SbrService(deps);
+}

--- a/apgms/services/sbr/src/service.ts
+++ b/apgms/services/sbr/src/service.ts
@@ -1,0 +1,162 @@
+import { randomUUID } from "node:crypto";
+import {
+  As4Client,
+  As4Envelope,
+  DetachedSignature,
+  createBasEnvelope,
+  signEnvelope,
+} from "./as4.js";
+import {
+  AuditBlobKind,
+  AuditBlobRepository,
+  AuditBlobScope,
+  AuditBlobRecord,
+  InMemoryAuditBlobRepository,
+  evaluateIntegrity,
+} from "./audit-blob.js";
+
+type BasArtifactKind = Extract<AuditBlobKind, "request" | "receipt">;
+
+const BAS_SCOPE: AuditBlobScope = "sbr.bas";
+
+export interface BasSubmissionRecord {
+  id: string;
+  orgId: string;
+  period: string;
+  requestBlobId: string;
+  receiptBlobId: string;
+  createdAt: Date;
+  envelope: As4Envelope;
+  signature: DetachedSignature;
+}
+
+export interface BasArtifactView {
+  kind: BasArtifactKind;
+  blobId: string;
+  payload: string;
+  sha256: string;
+  integrity: ReturnType<typeof evaluateIntegrity>;
+}
+
+export interface BasSubmissionDetail {
+  id: string;
+  orgId: string;
+  period: string;
+  createdAt: Date;
+  artifacts: Record<BasArtifactKind, BasArtifactView>;
+}
+
+export interface SubmitBasOptions {
+  orgId: string;
+  period: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface SbrServiceDependencies {
+  auditRepo?: AuditBlobRepository;
+  as4Client?: As4Client;
+  signingKeyPem: string;
+}
+
+export class SbrService {
+  private readonly auditRepo: AuditBlobRepository;
+  private readonly as4Client: As4Client;
+  private readonly signingKeyPem: string;
+  private readonly submissions = new Map<string, BasSubmissionRecord>();
+
+  constructor(deps: SbrServiceDependencies) {
+    this.auditRepo = deps.auditRepo ?? new InMemoryAuditBlobRepository();
+    this.as4Client =
+      deps.as4Client ??
+      new (class implements As4Client {
+        async send(envelope: As4Envelope, signature: DetachedSignature) {
+          return {
+            messageId: envelope.messageId,
+            receivedAt: new Date().toISOString(),
+            raw: {
+              status: "ACCEPTED",
+              echoSignature: signature.value,
+            },
+          };
+        }
+      })();
+    this.signingKeyPem = deps.signingKeyPem;
+  }
+
+  async submitBAS(options: SubmitBasOptions): Promise<BasSubmissionRecord> {
+    const submissionId = randomUUID();
+    const envelopePayload = {
+      formType: "BAS",
+      orgId: options.orgId,
+      period: options.period,
+      ...(options.payload ?? {}),
+    };
+    const envelope = createBasEnvelope(envelopePayload);
+    const signature = signEnvelope(envelope, this.signingKeyPem);
+
+    const requestPayload = JSON.stringify({ envelope, signature });
+    const requestBlob = await this.auditRepo.create({
+      scope: BAS_SCOPE,
+      referenceId: submissionId,
+      kind: "request",
+      payload: requestPayload,
+    });
+
+    const receipt = await this.as4Client.send(envelope, signature);
+    const receiptPayload = JSON.stringify(receipt);
+    const receiptBlob = await this.auditRepo.create({
+      scope: BAS_SCOPE,
+      referenceId: submissionId,
+      kind: "receipt",
+      payload: receiptPayload,
+    });
+
+    const record: BasSubmissionRecord = {
+      id: submissionId,
+      orgId: options.orgId,
+      period: options.period,
+      requestBlobId: requestBlob.id,
+      receiptBlobId: receiptBlob.id,
+      createdAt: new Date(),
+      envelope,
+      signature,
+    };
+    this.submissions.set(record.id, record);
+    return record;
+  }
+
+  async getSubmissionDetail(id: string): Promise<BasSubmissionDetail | null> {
+    const record = this.submissions.get(id);
+    if (!record) {
+      return null;
+    }
+    const [requestBlob, receiptBlob] = await Promise.all([
+      this.auditRepo.findById(record.requestBlobId),
+      this.auditRepo.findById(record.receiptBlobId),
+    ]);
+    if (!requestBlob || !receiptBlob) {
+      throw new Error("Submission artifacts missing");
+    }
+
+    return {
+      id: record.id,
+      orgId: record.orgId,
+      period: record.period,
+      createdAt: record.createdAt,
+      artifacts: {
+        request: this.toArtifactView("request", requestBlob),
+        receipt: this.toArtifactView("receipt", receiptBlob),
+      },
+    };
+  }
+
+  private toArtifactView(kind: BasArtifactKind, blob: AuditBlobRecord): BasArtifactView {
+    return {
+      kind,
+      blobId: blob.id,
+      payload: blob.payload,
+      sha256: blob.sha256,
+      integrity: evaluateIntegrity(blob),
+    };
+  }
+}

--- a/apgms/services/sbr/test/service.test.ts
+++ b/apgms/services/sbr/test/service.test.ts
@@ -1,0 +1,150 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildServer } from "../src/server.js";
+import {
+  AuditBlobMutationError,
+  AuditBlobScope,
+  InMemoryAuditBlobRepository,
+} from "../src/audit-blob.js";
+import { As4Client, As4Envelope, DetachedSignature } from "../src/as4.js";
+import { SbrService } from "../src/service.js";
+
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDk3LPBVRPAEFve
+e10R0JGqTZR8zRRKVtwSrc6X4o/8tuZewtmur4/Y/vlRadlF03UGsbSG+M1GF8tF
+VntP2MAxHqLGufEy1ZEPWoLyr9dBq1Dd161ls8NURm0CSYolYWtwyaqN5dD72Hte
+J21BmEFGkhAOwTHDMoJq4yv8BI71LqpRf3NCNWvwVe3f36GkEFIeNDSMZfQpaxGL
+Rf8hbQ9v9eL+Cabq9iMKLW7XXjRna6+JmsTJyC+qgw3pVsjARe7RjkYehxMqjlMY
+AUxj4iCONHUGgu7D7pTnmhKdeZoZ0Org++I/hlay0Gd5d3PpcFDIl1a+x/y8SMmc
+9NsH4qknAgMBAAECggEAAM1Ti4PM5CZcvgeWCKMCv24ushFVnd6d/0nWhhzKL0Dm
+Ak6bvRdHCMdy/hwYgFQRZrG6TsZ6Yc/H0Az2+Cj1nHR9E6xigNP7Hf59CphKlKGs
+twvLJYsg+0zjswilIPkdpRPGvrurd8d3aY330XQ3aDGFxgW9rRLxRcm7WRljDVUw
+k3E/idOkIiGzOgpwJx1KMDQ1ix3qz5Exk/8AW1JXQE5/+7o7NZdJVRHVgKu5oweb
+oPRn1nfaCPn2luVkZEJWSWty4QKLTlKiAkbFZt1OhfsguPfRsp6vzg/J8SO4h9JS
+BKsygLrmMDJU/ODkUPYFIdbsPuSal32WnzlMe7iDQQKBgQD1ErwZtoQ2klaeAWtU
+24t8kTsRvrQ+0fcxHIzNIOSxtEH5JgJXGliqaMDoRIVLjnE6XnXhM2KPMDiS1k8u
+D4J7TfLM1J8KAj+to7hg4ZaEd0589j7cVM9v9Svq3sqndlRaHSzfQbHACOhLcQ17
+termAlLl7S2kxibtv2LxSM9iBwKBgQDvEO8vFwHDFw3DOED70Az+WAGhoCaIC71u
+7N5bFpz9r84ilvzae1XGoi6EBZY4wV4J4cO4eziIdN/GB65jo+V21mZ62jJhMDqo
+1KBjuiCzxpbjSyXjGMy0Rk6q9ETcnc4pdhgyLXcAPTFL8wtwfF4Ymq9QW4CCn3R4
+wSz/rII34QKBgQDKlOgEYUk9Sw5qokW06Z6OJAcuDfQ1EZ9Ca5VAY3ZoJtd6Op8o
+nVC53MnJtgpxgJe8ZiUPOUi5kGTTjG/7ZTq47qBMDV5CCcXVpUZeX1vquCybQ3qG
+61xl8caR6gSfFUN5EjDrhASI91P+OL+qiaBY7YbVJY/bayj20oPZbBRxtQKBgEwA
+gzniQ5IlKx/sK2Si0O6vRd1/T6CisteoAEzPFJvmH0+J1tsSqMNcXhNkv0xN1Tqp
+BpMIwYFIPrfzSzKsMVAlezEFW0zgi1WPO2pZCvp8YQ3jnyjignmxfGMHAzlsBdXS
+kICrSZDO43Q00Wcycqu5yZBvdpyQWvPk3gxuaHuhAoGAKEI0J7iIQZQ+2SUAGYug
+gIinqGQox3vR4DIh09tHgv4eYi2TBDYrYST80jvieJobtjA408fb6jn5Gv+HLyqj
+uYvnwObAAg7HZskFz6JvfqOx3Mr9sNLU6i9GJGmZ1VZ1paRXeSYwr0V9v4mov+S0
+ERiDf/iqoZMxq+zI0PfLpN8=
+-----END PRIVATE KEY-----`;
+
+class EchoAs4Client implements As4Client {
+  async send(envelope: As4Envelope, signature: DetachedSignature) {
+    return {
+      messageId: envelope.messageId,
+      receivedAt: "2024-01-01T00:00:00.000Z",
+      raw: {
+        acknowledged: true,
+        signature: signature.value,
+      },
+    };
+  }
+}
+
+test("persists request and receipt as immutable audit blobs", async () => {
+  const auditRepo = new InMemoryAuditBlobRepository();
+  const service = new SbrService({
+    auditRepo,
+    signingKeyPem: PRIVATE_KEY,
+    as4Client: new EchoAs4Client(),
+  });
+
+  const submission = await service.submitBAS({ orgId: "org-123", period: "2024-09" });
+  assert.ok(submission.requestBlobId);
+  assert.ok(submission.receiptBlobId);
+
+  const detail = await service.getSubmissionDetail(submission.id);
+  assert.ok(detail);
+  assert.equal(detail!.artifacts.request.integrity.ok, true);
+  assert.equal(detail!.artifacts.receipt.integrity.ok, true);
+  assert.match(detail!.artifacts.request.sha256, /^[a-f0-9]{64}$/);
+});
+
+test("denies updates to an existing audit blob", async () => {
+  const auditRepo = new InMemoryAuditBlobRepository();
+  await auditRepo.create({
+    scope: "sbr.bas" satisfies AuditBlobScope,
+    referenceId: "submission-1",
+    kind: "request",
+    payload: "initial",
+  });
+
+  await assert.rejects(
+    auditRepo.create({
+      scope: "sbr.bas",
+      referenceId: "submission-1",
+      kind: "request",
+      payload: "second",
+    }),
+    AuditBlobMutationError
+  );
+});
+
+test("serves audit artifacts with integrity status", async () => {
+  const auditRepo = new InMemoryAuditBlobRepository();
+  const service = new SbrService({
+    auditRepo,
+    signingKeyPem: PRIVATE_KEY,
+    as4Client: new EchoAs4Client(),
+  });
+  const submission = await service.submitBAS({ orgId: "org-456", period: "2024-10" });
+  const app = buildServer({ service });
+
+  const response = await app.inject({
+    method: "GET",
+    url: `/sbr/bas/${submission.id}`,
+  });
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as {
+    submission: {
+      artifacts: {
+        request: { integrity: { ok: boolean } };
+        receipt: { integrity: { ok: boolean } };
+      };
+    };
+  };
+  assert.equal(body.submission.artifacts.request.integrity.ok, true);
+  assert.equal(body.submission.artifacts.receipt.integrity.ok, true);
+});
+
+test("reports hash mismatches", async () => {
+  const auditRepo = new InMemoryAuditBlobRepository();
+  const service = new SbrService({
+    auditRepo,
+    signingKeyPem: PRIVATE_KEY,
+    as4Client: new EchoAs4Client(),
+  });
+  const submission = await service.submitBAS({ orgId: "org-789", period: "2024-11" });
+
+  const tampered = auditRepo.unsafeRecords.get(submission.requestBlobId);
+  if (!tampered) {
+    throw new Error("expected audit blob");
+  }
+  tampered.payload = `${tampered.payload} corrupted`;
+
+  const app = buildServer({ service });
+  const response = await app.inject({ method: "GET", url: `/sbr/bas/${submission.id}` });
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as {
+    submission: {
+      artifacts: {
+        request: { integrity: { ok: boolean; expectedSha256: string; actualSha256: string } };
+      };
+    };
+  };
+  assert.equal(body.submission.artifacts.request.integrity.ok, false);
+  assert.notEqual(
+    body.submission.artifacts.request.integrity.actualSha256,
+    body.submission.artifacts.request.integrity.expectedSha256
+  );
+});

--- a/apgms/services/sbr/test/signing.test.ts
+++ b/apgms/services/sbr/test/signing.test.ts
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { As4Envelope, signEnvelope, verifyEnvelope } from "../src/as4.js";
+
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDk3LPBVRPAEFve
+e10R0JGqTZR8zRRKVtwSrc6X4o/8tuZewtmur4/Y/vlRadlF03UGsbSG+M1GF8tF
+VntP2MAxHqLGufEy1ZEPWoLyr9dBq1Dd161ls8NURm0CSYolYWtwyaqN5dD72Hte
+J21BmEFGkhAOwTHDMoJq4yv8BI71LqpRf3NCNWvwVe3f36GkEFIeNDSMZfQpaxGL
+Rf8hbQ9v9eL+Cabq9iMKLW7XXjRna6+JmsTJyC+qgw3pVsjARe7RjkYehxMqjlMY
+AUxj4iCONHUGgu7D7pTnmhKdeZoZ0Org++I/hlay0Gd5d3PpcFDIl1a+x/y8SMmc
+9NsH4qknAgMBAAECggEAAM1Ti4PM5CZcvgeWCKMCv24ushFVnd6d/0nWhhzKL0Dm
+Ak6bvRdHCMdy/hwYgFQRZrG6TsZ6Yc/H0Az2+Cj1nHR9E6xigNP7Hf59CphKlKGs
+twvLJYsg+0zjswilIPkdpRPGvrurd8d3aY330XQ3aDGFxgW9rRLxRcm7WRljDVUw
+k3E/idOkIiGzOgpwJx1KMDQ1ix3qz5Exk/8AW1JXQE5/+7o7NZdJVRHVgKu5oweb
+oPRn1nfaCPn2luVkZEJWSWty4QKLTlKiAkbFZt1OhfsguPfRsp6vzg/J8SO4h9JS
+BKsygLrmMDJU/ODkUPYFIdbsPuSal32WnzlMe7iDQQKBgQD1ErwZtoQ2klaeAWtU
+24t8kTsRvrQ+0fcxHIzNIOSxtEH5JgJXGliqaMDoRIVLjnE6XnXhM2KPMDiS1k8u
+D4J7TfLM1J8KAj+to7hg4ZaEd0589j7cVM9v9Svq3sqndlRaHSzfQbHACOhLcQ17
+termAlLl7S2kxibtv2LxSM9iBwKBgQDvEO8vFwHDFw3DOED70Az+WAGhoCaIC71u
+7N5bFpz9r84ilvzae1XGoi6EBZY4wV4J4cO4eziIdN/GB65jo+V21mZ62jJhMDqo
+1KBjuiCzxpbjSyXjGMy0Rk6q9ETcnc4pdhgyLXcAPTFL8wtwfF4Ymq9QW4CCn3R4
+wSz/rII34QKBgQDKlOgEYUk9Sw5qokW06Z6OJAcuDfQ1EZ9Ca5VAY3ZoJtd6Op8o
+nVC53MnJtgpxgJe8ZiUPOUi5kGTTjG/7ZTq47qBMDV5CCcXVpUZeX1vquCybQ3qG
+61xl8caR6gSfFUN5EjDrhASI91P+OL+qiaBY7YbVJY/bayj20oPZbBRxtQKBgEwA
+gzniQ5IlKx/sK2Si0O6vRd1/T6CisteoAEzPFJvmH0+J1tsSqMNcXhNkv0xN1Tqp
+BpMIwYFIPrfzSzKsMVAlezEFW0zgi1WPO2pZCvp8YQ3jnyjignmxfGMHAzlsBdXS
+kICrSZDO43Q00Wcycqu5yZBvdpyQWvPk3gxuaHuhAoGAKEI0J7iIQZQ+2SUAGYug
+gIinqGQox3vR4DIh09tHgv4eYi2TBDYrYST80jvieJobtjA408fb6jn5Gv+HLyqj
+uYvnwObAAg7HZskFz6JvfqOx3Mr9sNLU6i9GJGmZ1VZ1paRXeSYwr0V9v4mov+S0
+ERiDf/iqoZMxq+zI0PfLpN8=
+-----END PRIVATE KEY-----`;
+
+const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5NyzwVUTwBBb3ntdEdCR
+qk2UfM0USlbcEq3Ol+KP/LbmXsLZrq+P2P75UWnZRdN1BrG0hvjNRhfLRVZ7T9jA
+MR6ixrnxMtWRD1qC8q/XQatQ3detZbPDVEZtAkmKJWFrcMmqjeXQ+9h7XidtQZhB
+RpIQDsExwzKCauMr/ASO9S6qUX9zQjVr8FXt39+hpBBSHjQ0jGX0KWsRi0X/IW0P
+b/Xi/gmm6vYjCi1u1140Z2uviZrEycgvqoMN6VbIwEXu0Y5GHocTKo5TGAFMY+Ig
+jjR1BoLuw+6U55oSnXmaGdDq4PviP4ZWstBneXdz6XBQyJdWvsf8vEjJnPTbB+Kp
+JwIDAQAB
+-----END PUBLIC KEY-----`;
+
+const ENVELOPE: As4Envelope = {
+  messageId: "11111111-1111-1111-1111-111111111111",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  payload: {
+    formType: "BAS",
+    orgId: "org-123",
+    period: "2024-09",
+    totals: {
+      payable: 12345,
+      refundable: 23456,
+    },
+  },
+};
+
+test("creates deterministic detached signature", () => {
+  const signature = signEnvelope(ENVELOPE, PRIVATE_KEY);
+  assert.deepStrictEqual(signature, {
+    algorithm: "RSA-SHA256",
+    value:
+      "Gqd59jFly20WH1IG7p6VzAnpRg0NqgTtSljuI+/XrIgsg9NLxUQUgJtbNsyMsc1EBWmQh1qtm1jHik9Q/YmOA4f/9LV+77DQCj++yeDGKq5lLUPonkfD+oES0kAr2lm1lcU6AimCNQythb5/30GOvEK1+LRdpoiCsvqODk+vaNA+WFk8A18g/b+PB+r/5DfEzyHdwIX/12+SiNBpab3eKwjEFUHFwan0Ll/qO1Pj1c9rWrGPhGnfN+yd5DCr5FrKl3bKOtOBjFpxUbybHZOTqAc9ujTnFoIRogzoXjh9H9B3mTo60RxLTOSIkJgfzpNeHeCJ5HbJUDBs06crCwWHpQ==",
+  });
+});
+
+test("verifies the detached signature", () => {
+  const signature = signEnvelope(ENVELOPE, PRIVATE_KEY);
+  assert.equal(verifyEnvelope(ENVELOPE, signature, PUBLIC_KEY), true);
+});
+
+test("detects tampering", () => {
+  const signature = signEnvelope(ENVELOPE, PRIVATE_KEY);
+  const tampered: As4Envelope = {
+    ...ENVELOPE,
+    payload: { ...ENVELOPE.payload, period: "2024-12" },
+  };
+  assert.equal(verifyEnvelope(tampered, signature, PUBLIC_KEY), false);
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "baseUrl": "../../",
+    "paths": {
+      "@apgms/shared/*": ["shared/src/*"]
+    },
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- implement AS4 envelope utilities and a WORM audit blob repository for BAS submissions
- add a BAS submission service that signs envelopes, persists request/receipt artifacts, and exposes them via a Fastify endpoint with integrity reports
- cover the AS4 signing flow and artifact storage integrity with node:test suites

## Testing
- pnpm --filter @apgms/sbr test
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f32bf434a483279e376d336a403002