### PR TITLE
feat: add mock remittance scheduler and payments API

### DIFF
--- a/apgms/services/payments/package.json
+++ b/apgms/services/payments/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@apgms/payments",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "tsx test/index.test.ts"
+  }
+}

--- a/apgms/services/payments/src/adapters.ts
+++ b/apgms/services/payments/src/adapters.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from 'node:crypto';
+
+import type { PaymentAdapter, PaymentAdapterContext, Remittance } from './types.js';
+
+interface TransferRecord {
+  status: 'INITIATED' | 'SETTLED';
+  remittanceId: string;
+  correlationId: string;
+}
+
+abstract class BaseMockAdapter implements PaymentAdapter {
+  protected readonly transfers = new Map<string, TransferRecord>();
+  createCalls = 0;
+  statusCalls = 0;
+  cancelCalls = 0;
+
+  constructor(private readonly prefix: string) {}
+
+  async create(remittance: Remittance, context: PaymentAdapterContext): Promise<{ transferId: string }> {
+    this.createCalls += 1;
+    const transferId = `${this.prefix}-${randomUUID()}`;
+    this.transfers.set(transferId, {
+      status: 'INITIATED',
+      remittanceId: remittance.id,
+      correlationId: context.correlationId,
+    });
+
+    return { transferId };
+  }
+
+  async status(transferId: string, context: PaymentAdapterContext): Promise<'INITIATED' | 'SETTLED'> {
+    this.statusCalls += 1;
+    const existing = this.transfers.get(transferId);
+    if (!existing) {
+      throw new Error(`Unknown transfer ${transferId}`);
+    }
+
+    // Mark the transfer as settled after the first status check to simulate downstream completion.
+    existing.status = 'SETTLED';
+    existing.correlationId = context.correlationId;
+    return existing.status;
+  }
+
+  async cancel(transferId: string, context: PaymentAdapterContext): Promise<void> {
+    this.cancelCalls += 1;
+    if (this.transfers.has(transferId)) {
+      this.transfers.delete(transferId);
+    }
+  }
+}
+
+export class MockPayToAdapter extends BaseMockAdapter {
+  constructor() {
+    super('payto');
+  }
+}
+
+export class MockBECSAdapter extends BaseMockAdapter {
+  constructor() {
+    super('becs');
+  }
+}

--- a/apgms/services/payments/src/gate.ts
+++ b/apgms/services/payments/src/gate.ts
@@ -1,0 +1,21 @@
+export type GateState = 'OPEN' | 'CLOSED';
+
+export class Gate {
+  private state: GateState;
+
+  constructor(initial: GateState = 'OPEN') {
+    this.state = initial;
+  }
+
+  open(): void {
+    this.state = 'OPEN';
+  }
+
+  close(): void {
+    this.state = 'CLOSED';
+  }
+
+  isOpen(): boolean {
+    return this.state === 'OPEN';
+  }
+}

--- a/apgms/services/payments/src/index.ts
+++ b/apgms/services/payments/src/index.ts
@@ -1,1 +1,8 @@
-﻿console.log('payments service');
+export * from './adapters.js';
+export * from './gate.js';
+export * from './logger.js';
+export * from './metrics.js';
+export * from './queue.js';
+export * from './server.js';
+export * from './store.js';
+export * from './types.js';

--- a/apgms/services/payments/src/logger.ts
+++ b/apgms/services/payments/src/logger.ts
@@ -1,0 +1,24 @@
+export interface LogContext {
+  readonly correlationId?: string;
+  readonly [key: string]: unknown;
+}
+
+export interface Logger {
+  info(context: LogContext, message: string): void;
+  error(context: LogContext, message: string): void;
+}
+
+export class ConsoleLogger implements Logger {
+  info(context: LogContext, message: string): void {
+    console.log(formatMessage('INFO', context, message));
+  }
+
+  error(context: LogContext, message: string): void {
+    console.error(formatMessage('ERROR', context, message));
+  }
+}
+
+function formatMessage(level: string, context: LogContext, message: string): string {
+  const meta = JSON.stringify(context);
+  return `[${level}] ${message} ${meta}`;
+}

--- a/apgms/services/payments/src/metrics.ts
+++ b/apgms/services/payments/src/metrics.ts
@@ -1,0 +1,51 @@
+class CounterMetric {
+  private value = 0;
+
+  constructor(
+    private readonly name: string,
+    private readonly help: string,
+  ) {}
+
+  inc(amount = 1): void {
+    this.value += amount;
+  }
+
+  render(): string {
+    return [
+      `# HELP ${this.name} ${this.help}`,
+      `# TYPE ${this.name} counter`,
+      `${this.name} ${this.value}`,
+    ].join('\n');
+  }
+}
+
+export class PaymentsMetrics {
+  readonly remittanceEnqueued = new CounterMetric(
+    'payments_remittance_enqueued_total',
+    'Total number of remittances enqueued',
+  );
+
+  readonly remittanceInitiated = new CounterMetric(
+    'payments_remittance_initiated_total',
+    'Total number of remittances initiated',
+  );
+
+  readonly remittanceSettled = new CounterMetric(
+    'payments_remittance_settled_total',
+    'Total number of remittances settled',
+  );
+
+  readonly remittanceRetries = new CounterMetric(
+    'payments_remittance_retry_total',
+    'Number of remittances retried after failure',
+  );
+
+  metrics(): string {
+    return [
+      this.remittanceEnqueued.render(),
+      this.remittanceInitiated.render(),
+      this.remittanceSettled.render(),
+      this.remittanceRetries.render(),
+    ].join('\n');
+  }
+}

--- a/apgms/services/payments/src/queue.ts
+++ b/apgms/services/payments/src/queue.ts
@@ -1,0 +1,140 @@
+import { Gate } from './gate.js';
+
+export interface RemittanceJob {
+  readonly id: string;
+  readonly attempt: number;
+}
+
+interface LeaseRecord {
+  readonly owner: string;
+  readonly expiresAt: number;
+  readonly job: RemittanceJob;
+}
+
+export interface LeaseOptions {
+  readonly owner: string;
+  readonly ttlMs?: number;
+}
+
+export interface ReleaseOptions {
+  readonly requeue?: boolean;
+  readonly delayMs?: number;
+}
+
+type Clock = () => number;
+
+export class InMemoryRemittanceQueue {
+  private readonly order: string[] = [];
+  private readonly pending = new Map<string, RemittanceJob>();
+  private readonly leased = new Map<string, LeaseRecord>();
+
+  constructor(
+    private readonly gate: Gate,
+    private readonly defaultTtlMs: number = 5_000,
+    private readonly clock: Clock = () => Date.now(),
+  ) {}
+
+  enqueue(id: string): boolean {
+    if (this.pending.has(id) || this.leased.has(id)) {
+      return false;
+    }
+
+    const job: RemittanceJob = {
+      id,
+      attempt: 0,
+    };
+
+    this.pending.set(id, job);
+    this.order.push(id);
+    return true;
+  }
+
+  async leaseNext(options: LeaseOptions): Promise<RemittanceJob | undefined> {
+    if (!this.gate.isOpen()) {
+      return undefined;
+    }
+
+    const ttlMs = options.ttlMs ?? this.defaultTtlMs;
+
+    while (this.order.length > 0) {
+      const id = this.order.shift();
+      if (!id) {
+        continue;
+      }
+
+      const pending = this.pending.get(id);
+      if (!pending) {
+        continue;
+      }
+
+      const existingLease = this.leased.get(id);
+      if (existingLease && existingLease.expiresAt > this.clock()) {
+        // Lease is still active, skip this job.
+        this.order.push(id);
+        continue;
+      }
+
+      const job: RemittanceJob = {
+        id,
+        attempt: pending.attempt + 1,
+      };
+
+      const record: LeaseRecord = {
+        owner: options.owner,
+        expiresAt: this.clock() + ttlMs,
+        job,
+      };
+
+      this.pending.delete(id);
+      this.leased.set(id, record);
+      return job;
+    }
+
+    return undefined;
+  }
+
+  ack(id: string, owner: string): boolean {
+    const lease = this.leased.get(id);
+    if (!lease || lease.owner !== owner) {
+      return false;
+    }
+
+    this.leased.delete(id);
+    return true;
+  }
+
+  release(id: string, owner: string, options: ReleaseOptions = {}): boolean {
+    const lease = this.leased.get(id);
+    if (!lease || lease.owner !== owner) {
+      return false;
+    }
+
+    this.leased.delete(id);
+
+    if (!options.requeue) {
+      return true;
+    }
+
+    const job: RemittanceJob = {
+      id: lease.job.id,
+      attempt: lease.job.attempt,
+    };
+
+    const requeue = () => {
+      this.pending.set(id, job);
+      this.order.push(id);
+    };
+
+    if (options.delayMs && options.delayMs > 0) {
+      setTimeout(requeue, options.delayMs);
+    } else {
+      requeue();
+    }
+
+    return true;
+  }
+
+  isPending(id: string): boolean {
+    return this.pending.has(id) || this.order.includes(id);
+  }
+}

--- a/apgms/services/payments/src/server.ts
+++ b/apgms/services/payments/src/server.ts
@@ -1,0 +1,70 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { randomUUID } from 'node:crypto';
+
+import { ConsoleLogger, type Logger } from './logger.js';
+import { PaymentsMetrics } from './metrics.js';
+import { Gate } from './gate.js';
+import { InMemoryRemittanceQueue } from './queue.js';
+import { TransferStore } from './store.js';
+import type { CreateRemittanceInput, Remittance } from './types.js';
+
+export interface CreatePaymentsServerOptions {
+  readonly store?: TransferStore;
+  readonly queue?: InMemoryRemittanceQueue;
+  readonly gate?: Gate;
+  readonly metrics?: PaymentsMetrics;
+  readonly logger?: Logger;
+}
+
+export interface PaymentsServer {
+  readonly app: FastifyInstance;
+  readonly store: TransferStore;
+  readonly queue: InMemoryRemittanceQueue;
+  readonly gate: Gate;
+  readonly metrics: PaymentsMetrics;
+}
+
+export function createPaymentsServer(options: CreatePaymentsServerOptions = {}): PaymentsServer {
+  const logger = options.logger ?? new ConsoleLogger();
+  const gate = options.gate ?? new Gate('OPEN');
+  const store = options.store ?? new TransferStore();
+  const queue = options.queue ?? new InMemoryRemittanceQueue(gate);
+  const metrics = options.metrics ?? new PaymentsMetrics();
+
+  const app = Fastify();
+  app.post<{ Body: CreateRemittanceInput }>('/remit', async (request, reply) => {
+    const correlationId = request.headers['x-correlation-id']?.toString() ?? `req-${randomUUID()}`;
+    const remittance = await store.createRemittance({
+      amount: request.body.amount,
+      currency: request.body.currency,
+      method: request.body.method,
+      beneficiary: request.body.beneficiary,
+      correlationId,
+    });
+
+    queue.enqueue(remittance.id);
+    metrics.remittanceEnqueued.inc();
+
+    logger.info(
+      { correlationId, remittanceId: remittance.id, status: remittance.status },
+      'remittance enqueued',
+    );
+
+    await reply.code(201).send(remittance satisfies Remittance);
+  });
+
+  app.get<{ Params: { id: string } }>('/remit/:id', async (request, reply) => {
+    const remittance = await store.getRemittance(request.params.id);
+    if (!remittance) {
+      return reply.code(404).send({ message: 'Not Found' });
+    }
+
+    return reply.send(remittance satisfies Remittance);
+  });
+
+  app.get('/metrics', async (_request, reply) => {
+    return reply.type('text/plain').send(metrics.metrics());
+  });
+
+  return { app, store, queue, gate, metrics };
+}

--- a/apgms/services/payments/src/store.ts
+++ b/apgms/services/payments/src/store.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from 'node:crypto';
+
+import type {
+  CreateRemittanceInput,
+  Remittance,
+  RemittanceEvent,
+  RemittanceStatus,
+} from './types.js';
+
+type Mutable<T> = {
+  -readonly [K in keyof T]: T[K];
+};
+
+const NOW = () => new Date().toISOString();
+
+export class TransferStore {
+  private readonly transfers = new Map<string, Mutable<Remittance>>();
+
+  async createRemittance(input: CreateRemittanceInput): Promise<Remittance> {
+    const id = randomUUID();
+    const correlationId = input.correlationId ?? `remit-${id}`;
+    const timestamp = NOW();
+    const initialEvent: RemittanceEvent = {
+      type: 'PENDING',
+      at: timestamp,
+      detail: { reason: 'remittance enqueued' },
+    };
+
+    const remittance: Mutable<Remittance> = {
+      id,
+      amount: input.amount,
+      currency: input.currency,
+      method: input.method,
+      beneficiary: input.beneficiary,
+      correlationId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      status: 'PENDING',
+      events: [initialEvent],
+    };
+
+    this.transfers.set(id, remittance);
+    return structuredClone(remittance);
+  }
+
+  async getRemittance(id: string): Promise<Remittance | undefined> {
+    const existing = this.transfers.get(id);
+    return existing ? structuredClone(existing) : undefined;
+  }
+
+  async transitionStatus(
+    id: string,
+    nextStatus: RemittanceStatus,
+    detail: Record<string, unknown> = {},
+  ): Promise<Remittance> {
+    const current = this.transfers.get(id);
+    if (!current) {
+      throw new Error(`Remittance ${id} not found`);
+    }
+
+    if (!isValidTransition(current.status, nextStatus)) {
+      throw new Error(`Invalid status transition from ${current.status} to ${nextStatus}`);
+    }
+
+    const timestamp = NOW();
+    current.status = nextStatus;
+    current.updatedAt = timestamp;
+    current.events = [
+      ...current.events,
+      {
+        type: nextStatus,
+        at: timestamp,
+        detail,
+      },
+    ];
+
+    return structuredClone(current);
+  }
+
+  async setRemoteReference(id: string, reference: string): Promise<Remittance> {
+    const current = this.transfers.get(id);
+    if (!current) {
+      throw new Error(`Remittance ${id} not found`);
+    }
+
+    current.remoteReference = reference;
+    current.updatedAt = NOW();
+
+    return structuredClone(current);
+  }
+
+  async listAll(): Promise<Remittance[]> {
+    return Array.from(this.transfers.values()).map((transfer) => structuredClone(transfer));
+  }
+}
+
+function isValidTransition(current: RemittanceStatus, next: RemittanceStatus): boolean {
+  if (current === next) {
+    return true;
+  }
+
+  if (current === 'PENDING' && next === 'INITIATED') {
+    return true;
+  }
+
+  if (current === 'INITIATED' && next === 'SETTLED') {
+    return true;
+  }
+
+  return false;
+}

--- a/apgms/services/payments/src/types.ts
+++ b/apgms/services/payments/src/types.ts
@@ -1,0 +1,45 @@
+export type PaymentMethod = 'PAYTO' | 'BECS';
+
+export type RemittanceStatus = 'PENDING' | 'INITIATED' | 'SETTLED';
+
+export interface RemittanceEvent {
+  readonly type: string;
+  readonly at: string;
+  readonly detail?: Record<string, unknown>;
+}
+
+export interface Remittance {
+  readonly id: string;
+  readonly amount: number;
+  readonly currency: string;
+  readonly method: PaymentMethod;
+  readonly beneficiary: string;
+  readonly correlationId: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly status: RemittanceStatus;
+  readonly events: readonly RemittanceEvent[];
+  readonly remoteReference?: string;
+}
+
+export interface CreateRemittanceInput {
+  readonly amount: number;
+  readonly currency: string;
+  readonly method: PaymentMethod;
+  readonly beneficiary: string;
+  readonly correlationId?: string;
+}
+
+export interface PaymentAdapterContext {
+  readonly correlationId: string;
+}
+
+export interface PaymentAdapter {
+  create(remittance: Remittance, context: PaymentAdapterContext): Promise<{
+    transferId: string;
+  }>;
+
+  status(transferId: string, context: PaymentAdapterContext): Promise<'INITIATED' | 'SETTLED'>;
+
+  cancel(transferId: string, context: PaymentAdapterContext): Promise<void>;
+}

--- a/apgms/services/payments/test/index.test.ts
+++ b/apgms/services/payments/test/index.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createPaymentsServer, Gate, PaymentsMetrics } from '../src/index.js';
+
+test('POST /remit enqueues a new remittance with correlation id', async () => {
+  const metrics = new PaymentsMetrics();
+  const gate = new Gate('OPEN');
+  const { app, store, queue } = createPaymentsServer({ metrics, gate });
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/remit',
+    payload: {
+      amount: 105,
+      currency: 'AUD',
+      method: 'PAYTO',
+      beneficiary: 'John Citizen',
+    },
+    headers: {
+      'x-correlation-id': 'corr-123',
+    },
+  });
+
+  assert.equal(response.statusCode, 201);
+  const body = response.json();
+  assert.equal(body.status, 'PENDING');
+  assert.equal(body.correlationId, 'corr-123');
+  assert.equal(metrics.metrics().includes('payments_remittance_enqueued_total 1'), true);
+
+  assert.equal(queue.isPending(body.id), true);
+
+  await app.close();
+  const stored = await store.getRemittance(body.id);
+  assert.equal(stored?.events.at(0)?.type, 'PENDING');
+});
+
+test('GET /remit/:id returns 404 when missing', async () => {
+  const { app } = createPaymentsServer();
+  const response = await app.inject({ method: 'GET', url: '/remit/does-not-exist' });
+  assert.equal(response.statusCode, 404);
+  await app.close();
+});

--- a/apgms/services/worker/package.json
+++ b/apgms/services/worker/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "tsx test/index.test.ts"
+  }
+}

--- a/apgms/services/worker/src/index.ts
+++ b/apgms/services/worker/src/index.ts
@@ -1,0 +1,1 @@
+export * from './scheduler.js';

--- a/apgms/services/worker/src/scheduler.ts
+++ b/apgms/services/worker/src/scheduler.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  type PaymentAdapter,
+  type PaymentMethod,
+  type Remittance,
+  type RemittanceStatus,
+  Gate,
+  InMemoryRemittanceQueue,
+  PaymentsMetrics,
+  TransferStore,
+} from '../../payments/src/index.js';
+
+interface SchedulerOptions {
+  readonly store: TransferStore;
+  readonly queue: InMemoryRemittanceQueue;
+  readonly gate: Gate;
+  readonly metrics: PaymentsMetrics;
+  readonly adapters: Record<PaymentMethod, PaymentAdapter>;
+  readonly backoffMs?: (attempt: number) => number;
+}
+
+export class RemittanceScheduler {
+  private readonly workerId = `worker-${randomUUID()}`;
+
+  constructor(private readonly options: SchedulerOptions) {}
+
+  async runOnce(): Promise<boolean> {
+    const lease = await this.options.queue.leaseNext({ owner: this.workerId });
+    if (!lease) {
+      return false;
+    }
+
+    try {
+      const remittance = await this.options.store.getRemittance(lease.id);
+      if (!remittance) {
+        this.options.queue.ack(lease.id, this.workerId);
+        return false;
+      }
+
+      await this.process(remittance, lease.attempt);
+      this.options.queue.ack(lease.id, this.workerId);
+      return true;
+    } catch (error) {
+      const backoff = this.options.backoffMs?.(lease.attempt) ?? 250 * lease.attempt;
+      this.options.metrics.remittanceRetries.inc();
+      this.options.queue.release(lease.id, this.workerId, { requeue: true, delayMs: backoff });
+      return false;
+    }
+  }
+
+  private async process(remittance: Remittance, attempt: number): Promise<void> {
+    if (remittance.status === 'SETTLED') {
+      return;
+    }
+
+    if (remittance.status === 'PENDING') {
+      await this.transition(remittance.id, 'INITIATED', {
+        correlationId: remittance.correlationId,
+        attempt,
+      });
+    }
+
+    const refreshed = await this.options.store.getRemittance(remittance.id);
+    if (!refreshed) {
+      return;
+    }
+
+    const adapter = this.options.adapters[refreshed.method];
+    const context = { correlationId: refreshed.correlationId } as const;
+
+    if (!refreshed.remoteReference) {
+      const result = await adapter.create(refreshed, context);
+      await this.options.store.setRemoteReference(refreshed.id, result.transferId);
+      this.options.metrics.remittanceInitiated.inc();
+    }
+
+    const reference = (await this.options.store.getRemittance(refreshed.id))?.remoteReference;
+    if (!reference) {
+      return;
+    }
+
+    const status = await adapter.status(reference, context);
+    if (status === 'SETTLED') {
+      await this.transition(refreshed.id, 'SETTLED', {
+        correlationId: refreshed.correlationId,
+        reference,
+      });
+      this.options.metrics.remittanceSettled.inc();
+    }
+  }
+
+  private async transition(
+    id: string,
+    status: RemittanceStatus,
+    detail: Record<string, unknown>,
+  ): Promise<void> {
+    await this.options.store.transitionStatus(id, status, detail);
+  }
+}

--- a/apgms/services/worker/test/index.test.ts
+++ b/apgms/services/worker/test/index.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  Gate,
+  InMemoryRemittanceQueue,
+  MockBECSAdapter,
+  MockPayToAdapter,
+  PaymentsMetrics,
+  TransferStore,
+} from '../../payments/src/index.js';
+
+import { RemittanceScheduler } from '../src/index.js';
+
+test('scheduler waits for gate to open before dequeuing', async () => {
+  const gate = new Gate('CLOSED');
+  const queue = new InMemoryRemittanceQueue(gate);
+  const store = new TransferStore();
+  const metrics = new PaymentsMetrics();
+  const payTo = new MockPayToAdapter();
+  const becs = new MockBECSAdapter();
+
+  const remit = await store.createRemittance({
+    amount: 99,
+    currency: 'AUD',
+    method: 'PAYTO',
+    beneficiary: 'ACME',
+  });
+
+  queue.enqueue(remit.id);
+  const scheduler = new RemittanceScheduler({
+    gate,
+    queue,
+    store,
+    metrics,
+    adapters: { PAYTO: payTo, BECS: becs },
+  });
+
+  const firstAttempt = await scheduler.runOnce();
+  assert.equal(firstAttempt, false);
+  assert.equal(payTo.createCalls, 0);
+
+  gate.open();
+  await scheduler.runOnce();
+  assert.equal(payTo.createCalls, 1);
+  const settled = await store.getRemittance(remit.id);
+  assert.equal(settled?.status, 'SETTLED');
+});
+
+test('no double-send occurs under concurrent workers', async () => {
+  const gate = new Gate('OPEN');
+  const queue = new InMemoryRemittanceQueue(gate);
+  const store = new TransferStore();
+  const metrics = new PaymentsMetrics();
+  const payTo = new MockPayToAdapter();
+  const becs = new MockBECSAdapter();
+
+  const remit = await store.createRemittance({
+    amount: 250,
+    currency: 'AUD',
+    method: 'PAYTO',
+    beneficiary: 'Widget Co',
+  });
+
+  queue.enqueue(remit.id);
+
+  const schedulerA = new RemittanceScheduler({
+    gate,
+    queue,
+    store,
+    metrics,
+    adapters: { PAYTO: payTo, BECS: becs },
+  });
+
+  const schedulerB = new RemittanceScheduler({
+    gate,
+    queue,
+    store,
+    metrics,
+    adapters: { PAYTO: payTo, BECS: becs },
+  });
+
+  await Promise.all([schedulerA.runOnce(), schedulerB.runOnce()]);
+
+  assert.equal(payTo.createCalls, 1);
+  const final = await store.getRemittance(remit.id);
+  assert.equal(final?.status, 'SETTLED');
+  const eventTypes = final?.events.map((event) => event.type) ?? [];
+  assert.deepEqual(eventTypes, ['PENDING', 'INITIATED', 'SETTLED']);
+});


### PR DESCRIPTION
## Summary
- add a payments service with remittance store, redis-style queue, metrics, and REST endpoints for /remit and /metrics
- implement mock PayTo and BECS adapters plus a worker scheduler that respects the gate, applies leases/backoff, and records lifecycle events
- cover the new flows with API and worker tests including concurrency and lifecycle scenarios

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f32bed04ac8327a9252f200b418624