### PR TITLE
feat: add policy gating audit models

### DIFF
--- a/apgms/docs/erd.md
+++ b/apgms/docs/erd.md
@@ -1,0 +1,73 @@
+# Data Model Overview
+
+The platform uses PostgreSQL with Prisma ORM. The schema centres on organisations (`Org`), their users, bank activity, policies, gating events, and immutable audit trails. The following sections describe each entity and its relationships.
+
+## Org
+- **Fields:** `id`, `name`, `createdAt`.
+- **Relationships:**
+  - One-to-many with `User`, `BankLine`, `Policy`, `GateEvent`, `LedgerEntry`, `RptToken`, and `AuditBlob`.
+
+## User
+- **Fields:** `id`, `email`, `password`, `createdAt`, `orgId`.
+- **Relationships:**
+  - Many-to-one with `Org`.
+
+## BankLine
+- **Purpose:** Stores raw transaction data that downstream policies evaluate.
+- **Fields:** `id`, `orgId`, `date`, `amount`, `payee`, `desc`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Org`.
+
+## Policy
+- **Purpose:** Captures a versioned compliance or allocation policy for an organisation.
+- **Fields:** `id`, `orgId`, `name`, `version`, `summary`, `config`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Org`.
+  - One-to-many with `AllocationRuleSet`, `GateEvent`, and `RptToken`.
+  - Unique constraint on `(orgId, name, version)` provides simple policy versioning.
+
+## AllocationRuleSet
+- **Purpose:** JSON definition of allocation rules tied to a policy.
+- **Fields:** `id`, `policyId`, `name`, `definition`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Policy`.
+  - One-to-many with `GateEvent` and `RptToken`.
+
+## GateEvent
+- **Purpose:** Immutable events emitted while evaluating gates or policies.
+- **Fields:** `id`, `orgId`, `policyId`, `allocationRuleSetId`, `requestId`, `eventType`, `payload`, `prevEventId`, `prevHash`, `hash`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Org`, `Policy`, and optionally `AllocationRuleSet`.
+  - Self-referencing `prevEventId` forms a rolling hash chain per organisation; the combination of `prevEventId`, `prevHash`, and `hash` establishes tamper evidence.
+  - One-to-many with `LedgerEntry`, `RptToken`, and `AuditBlob`.
+  - `requestId` is unique to prevent duplicate processing.
+
+## LedgerEntry
+- **Purpose:** Immutable financial postings aligned with gate evaluations.
+- **Fields:** `id`, `orgId`, `gateEventId`, `requestId`, `entryType`, `amount`, `currency`, `memo`, `prevEntryId`, `prevHash`, `hash`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Org` and optionally `GateEvent`.
+  - Self-referencing `prevEntryId` plus the hash fields produce a rolling hash chain for ledger integrity.
+  - One-to-many with `AuditBlob`.
+  - `requestId` is unique for deduplication.
+
+## RptToken
+- **Purpose:** Represents issued or revoked RPT (Restricted Policy Token) artefacts.
+- **Fields:** `id`, `orgId`, `policyId`, `allocationRuleSetId`, `gateEventId`, `requestId`, `token`, `status`, `issuedAt`, `expiresAt`, `metadata`.
+- **Relationships:**
+  - Many-to-one with `Org`, `Policy`, and optionally `AllocationRuleSet` and `GateEvent`.
+  - Each token enforces unique `requestId` and `token` values.
+
+## AuditBlob
+- **Purpose:** Write-once immutable audit attachments (WORM storage).
+- **Fields:** `id`, `orgId`, `gateEventId`, `ledgerEntryId`, `requestId`, `content`, `contentType`, `prevBlobId`, `prevHash`, `hash`, `createdAt`.
+- **Relationships:**
+  - Many-to-one with `Org` and optionally `GateEvent`/`LedgerEntry`.
+  - Self-referencing `prevBlobId` and the rolling hash chain guard against mutation.
+  - `requestId` is unique to match upstream calls.
+
+## Hash Chains and Request Identifiers
+- `GateEvent`, `LedgerEntry`, and `AuditBlob` implement rolling hash chains. Each record stores the previous record's ID and hash, alongside its own hash, enabling verification without soft deletes.
+- `GateEvent`, `LedgerEntry`, `RptToken`, and `AuditBlob` enforce unique `requestId` values so that every ingest request is processed exactly once.
+
+These entities provide the foundation for policy evaluation, gating, financial reconciliation, RPT issuance, and immutable audit evidence across the demo organisation.

--- a/apgms/prisma/migrations
+++ b/apgms/prisma/migrations
@@ -1,0 +1,1 @@
+../shared/prisma/migrations

--- a/apgms/prisma/schema.prisma
+++ b/apgms/prisma/schema.prisma
@@ -1,0 +1,1 @@
+../shared/prisma/schema.prisma

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,5 +1,358 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { createHash } from "crypto";
+import { LedgerEntryType, PrismaClient, RptTokenStatus } from "@prisma/client";
+
 const prisma = new PrismaClient();
+
+function computeHash(kind: string, data: unknown, prevHash: string | null) {
+  return createHash("sha256")
+    .update(JSON.stringify({ kind, prevHash, data }))
+    .digest("hex");
+}
+
+async function seedBankLines(orgId: string) {
+  const payees = [
+    "Acme Office",
+    "Birchal",
+    "CloudCo",
+    "Dynamics Legal",
+    "Everyday Utilities",
+    "Founders Retreat",
+    "Growth Labs",
+    "Heritage Accounting",
+    "Inspire Media",
+    "Journey Travel"
+  ];
+  const descriptions = [
+    "Subscription renewal",
+    "Supplier payment",
+    "Professional services",
+    "Campaign spend",
+    "Investor funds received"
+  ];
+  const start = new Date();
+  start.setDate(start.getDate() - 60);
+
+  const bankLines = Array.from({ length: 50 }).map((_, index) => {
+    const entryDate = new Date(start.getTime());
+    entryDate.setDate(start.getDate() + index);
+    const payee = payees[index % payees.length];
+    const description = descriptions[index % descriptions.length];
+    const amount = (index % 5 === 0 ? 15000 : (index % 2 === 0 ? -499.95 : 1200.5)) + index * 3;
+
+    return {
+      id: `demo-bank-line-${index + 1}`,
+      orgId,
+      date: entryDate,
+      amount: amount.toFixed(2),
+      payee,
+      desc: description,
+      createdAt: entryDate,
+    };
+  });
+
+  await prisma.bankLine.createMany({ data: bankLines, skipDuplicates: true });
+}
+
+async function seedPolicies(orgId: string) {
+  const policy = await prisma.policy.upsert({
+    where: { id: "policy-demo-equity" },
+    update: {},
+    create: {
+      id: "policy-demo-equity",
+      orgId,
+      name: "Equity Crowdfunding Policy",
+      version: 1,
+      summary: "Baseline gating and allocation policy for demo investments",
+      config: {
+        jurisdiction: "AU",
+        thresholds: {
+          maxRaise: 5000000,
+          retailCap: 10000,
+        },
+        approvalsRequired: ["compliance", "finance"],
+      },
+    },
+  });
+
+  const ruleSets = [] as Awaited<ReturnType<typeof prisma.allocationRuleSet.upsert>>[];
+  const ruleDefinitions = [
+    {
+      id: "ars-standard",
+      name: "Standard Retail Allocation",
+      definition: {
+        rules: [
+          { tier: "retail", maxAllocation: 10000 },
+          { tier: "wholesale", maxAllocation: 250000 },
+        ],
+      },
+    },
+    {
+      id: "ars-priority",
+      name: "Priority Birchal Members",
+      definition: {
+        rules: [
+          { tier: "priority", multiplier: 1.5 },
+          { tier: "retail", multiplier: 1 },
+        ],
+        windowMinutes: 60,
+      },
+    },
+  ];
+
+  for (const definition of ruleDefinitions) {
+    const ruleSet = await prisma.allocationRuleSet.upsert({
+      where: { id: definition.id },
+      update: {},
+      create: {
+        id: definition.id,
+        policyId: policy.id,
+        name: definition.name,
+        definition: definition.definition,
+      },
+    });
+    ruleSets.push(ruleSet);
+  }
+
+  return { policy, ruleSets };
+}
+
+async function seedGateEventsAndLedgers(orgId: string, policyId: string, ruleSets: { id: string }[]) {
+  const gateEventsInput = [
+    {
+      id: "gate-event-001",
+      requestId: "REQ-GATE-001",
+      eventType: "POLICY_PUBLISHED",
+      payload: {
+        actor: "compliance@demo.org",
+        status: "draft",
+      },
+      allocationRuleSetId: null,
+    },
+    {
+      id: "gate-event-002",
+      requestId: "REQ-GATE-002",
+      eventType: "POLICY_APPROVED",
+      payload: {
+        actor: "finance@demo.org",
+        approvals: ["compliance", "finance"],
+      },
+      allocationRuleSetId: ruleSets[0]?.id ?? null,
+    },
+    {
+      id: "gate-event-003",
+      requestId: "REQ-GATE-003",
+      eventType: "RPT_ISSUED",
+      payload: {
+        tranche: "founders",
+        allocationRule: ruleSets[1]?.id ?? null,
+      },
+      allocationRuleSetId: ruleSets[1]?.id ?? null,
+    },
+  ];
+
+  const gateEvents = [] as Awaited<ReturnType<typeof prisma.gateEvent.upsert>>[];
+  let previousGate: { id: string; hash: string } | null = null;
+
+  for (const input of gateEventsInput) {
+    const hash = computeHash(
+      "GateEvent",
+      {
+        requestId: input.requestId,
+        eventType: input.eventType,
+        payload: input.payload,
+      },
+      previousGate?.hash ?? null,
+    );
+
+    const gateEvent = await prisma.gateEvent.upsert({
+      where: { id: input.id },
+      update: {},
+      create: {
+        id: input.id,
+        orgId,
+        policyId,
+        allocationRuleSetId: input.allocationRuleSetId,
+        requestId: input.requestId,
+        eventType: input.eventType,
+        payload: input.payload,
+        prevEventId: previousGate?.id ?? null,
+        prevHash: previousGate?.hash ?? null,
+        hash,
+      },
+    });
+
+    gateEvents.push(gateEvent);
+    previousGate = { id: gateEvent.id, hash: gateEvent.hash };
+  }
+
+  const ledgerInput = [
+    {
+      id: "ledger-entry-001",
+      requestId: "REQ-LEDGER-001",
+      entryType: LedgerEntryType.CREDIT,
+      amount: "50000.00",
+      memo: "Capital committed for Q4 round",
+      gateEventIndex: 1,
+    },
+    {
+      id: "ledger-entry-002",
+      requestId: "REQ-LEDGER-002",
+      entryType: LedgerEntryType.DEBIT,
+      amount: "1250.75",
+      memo: "Due diligence and legal fees",
+      gateEventIndex: 2,
+    },
+  ];
+
+  const ledgerEntries = [] as Awaited<ReturnType<typeof prisma.ledgerEntry.upsert>>[];
+  let previousLedger: { id: string; hash: string } | null = null;
+
+  for (const entry of ledgerInput) {
+    const hash = computeHash(
+      "LedgerEntry",
+      {
+        requestId: entry.requestId,
+        entryType: entry.entryType,
+        amount: entry.amount,
+        memo: entry.memo,
+      },
+      previousLedger?.hash ?? null,
+    );
+
+    const ledgerEntry = await prisma.ledgerEntry.upsert({
+      where: { id: entry.id },
+      update: {},
+      create: {
+        id: entry.id,
+        orgId,
+        gateEventId: typeof entry.gateEventIndex === "number" ? gateEvents[entry.gateEventIndex]?.id ?? null : null,
+        requestId: entry.requestId,
+        entryType: entry.entryType,
+        amount: entry.amount,
+        currency: "AUD",
+        memo: entry.memo,
+        prevEntryId: previousLedger?.id ?? null,
+        prevHash: previousLedger?.hash ?? null,
+        hash,
+      },
+    });
+
+    ledgerEntries.push(ledgerEntry);
+    previousLedger = { id: ledgerEntry.id, hash: ledgerEntry.hash };
+  }
+
+  const rptTokens = [] as Awaited<ReturnType<typeof prisma.rptToken.upsert>>[];
+  const rptInput = [
+    {
+      id: "rpt-token-001",
+      requestId: "REQ-RPT-001",
+      token: "RPT-DEMO-0001",
+      status: RptTokenStatus.ISSUED,
+      allocationRuleSetId: ruleSets[0]?.id ?? null,
+      gateEventIndex: 2,
+      metadata: {
+        tranche: "founders",
+        units: 1000,
+      },
+    },
+    {
+      id: "rpt-token-002",
+      requestId: "REQ-RPT-002",
+      token: "RPT-DEMO-0002",
+      status: RptTokenStatus.REVOKED,
+      allocationRuleSetId: ruleSets[1]?.id ?? null,
+      gateEventIndex: 2,
+      metadata: {
+        tranche: "priority",
+        units: 250,
+        revokedByRequest: "REQ-GATE-003",
+      },
+    },
+  ];
+
+  for (const token of rptInput) {
+    const record = await prisma.rptToken.upsert({
+      where: { id: token.id },
+      update: {},
+      create: {
+        id: token.id,
+        orgId,
+        policyId,
+        allocationRuleSetId: token.allocationRuleSetId,
+        gateEventId: typeof token.gateEventIndex === "number" ? gateEvents[token.gateEventIndex]?.id ?? null : null,
+        requestId: token.requestId,
+        token: token.token,
+        status: token.status,
+        metadata: token.metadata,
+      },
+    });
+
+    rptTokens.push(record);
+  }
+
+  const auditInput = [
+    {
+      id: "audit-blob-001",
+      requestId: "REQ-AUDIT-001",
+      gateEventIndex: 0,
+      ledgerEntryIndex: null,
+      content: "Initial policy draft snapshot",
+      contentType: "text/plain",
+    },
+    {
+      id: "audit-blob-002",
+      requestId: "REQ-AUDIT-002",
+      gateEventIndex: 1,
+      ledgerEntryIndex: 0,
+      content: "Finance approval certificate",
+      contentType: "text/plain",
+    },
+    {
+      id: "audit-blob-003",
+      requestId: "REQ-AUDIT-003",
+      gateEventIndex: 2,
+      ledgerEntryIndex: 1,
+      content: "RPT issuance confirmation",
+      contentType: "text/plain",
+    },
+  ];
+
+  const auditBlobs = [] as Awaited<ReturnType<typeof prisma.auditBlob.upsert>>[];
+  let previousBlob: { id: string; hash: string } | null = null;
+
+  for (const blob of auditInput) {
+    const hash = computeHash(
+      "AuditBlob",
+      {
+        requestId: blob.requestId,
+        content: blob.content,
+      },
+      previousBlob?.hash ?? null,
+    );
+
+    const record = await prisma.auditBlob.upsert({
+      where: { id: blob.id },
+      update: {},
+      create: {
+        id: blob.id,
+        orgId,
+        gateEventId: typeof blob.gateEventIndex === "number" ? gateEvents[blob.gateEventIndex]?.id ?? null : null,
+        ledgerEntryId: typeof blob.ledgerEntryIndex === "number" ? ledgerEntries[blob.ledgerEntryIndex]?.id ?? null : null,
+        requestId: blob.requestId,
+        content: Buffer.from(blob.content, "utf-8"),
+        contentType: blob.contentType,
+        prevBlobId: previousBlob?.id ?? null,
+        prevHash: previousBlob?.hash ?? null,
+        hash,
+      },
+    });
+
+    auditBlobs.push(record);
+    previousBlob = { id: record.id, hash: record.hash };
+  }
+
+  return { gateEvents, ledgerEntries, rptTokens, auditBlobs };
+}
 
 async function main() {
   const org = await prisma.org.upsert({
@@ -14,18 +367,42 @@ async function main() {
     create: { email: "founder@example.com", password: "password123", orgId: org.id },
   });
 
-  const today = new Date();
-  await prisma.bankLine.createMany({
-    data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
-    ],
-    skipDuplicates: true,
-  });
+  await seedBankLines(org.id);
 
-  console.log("Seed OK");
+  const { policy, ruleSets } = await seedPolicies(org.id);
+  await seedGateEventsAndLedgers(org.id, policy.id, ruleSets.map((rule) => ({ id: rule.id })));
+
+  const [orgCount, userCount, bankLineCount, policyCount, ruleSetCount, gateEventCount, ledgerEntryCount, rptTokenCount, auditBlobCount] =
+    await Promise.all([
+      prisma.org.count(),
+      prisma.user.count(),
+      prisma.bankLine.count(),
+      prisma.policy.count(),
+      prisma.allocationRuleSet.count(),
+      prisma.gateEvent.count(),
+      prisma.ledgerEntry.count(),
+      prisma.rptToken.count(),
+      prisma.auditBlob.count(),
+    ]);
+
+  console.log("Seed counts", {
+    orgs: orgCount,
+    users: userCount,
+    bankLines: bankLineCount,
+    policies: policyCount,
+    allocationRuleSets: ruleSetCount,
+    gateEvents: gateEventCount,
+    ledgerEntries: ledgerEntryCount,
+    rptTokens: rptTokenCount,
+    auditBlobs: auditBlobCount,
+  });
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/shared/prisma/migrations/20251012120000_add_policy_gate_rpt_audit/migration.sql
+++ b/apgms/shared/prisma/migrations/20251012120000_add_policy_gate_rpt_audit/migration.sql
@@ -1,0 +1,185 @@
+-- CreateEnum
+CREATE TYPE "LedgerEntryType" AS ENUM ('DEBIT', 'CREDIT', 'ADJUSTMENT');
+
+-- CreateEnum
+CREATE TYPE "RptTokenStatus" AS ENUM ('ISSUED', 'REVOKED', 'EXPIRED');
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "summary" TEXT,
+    "config" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AllocationRuleSet" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "definition" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AllocationRuleSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GateEvent" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "allocationRuleSetId" TEXT,
+    "requestId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "prevEventId" TEXT,
+    "prevHash" TEXT,
+    "hash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "GateEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LedgerEntry" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "gateEventId" TEXT,
+    "requestId" TEXT NOT NULL,
+    "entryType" "LedgerEntryType" NOT NULL,
+    "amount" DECIMAL(65,30) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'AUD',
+    "memo" TEXT,
+    "prevEntryId" TEXT,
+    "prevHash" TEXT,
+    "hash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LedgerEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RptToken" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "allocationRuleSetId" TEXT,
+    "gateEventId" TEXT,
+    "requestId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "status" "RptTokenStatus" NOT NULL DEFAULT 'ISSUED',
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+    "metadata" JSONB,
+
+    CONSTRAINT "RptToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditBlob" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "gateEventId" TEXT,
+    "ledgerEntryId" TEXT,
+    "requestId" TEXT NOT NULL,
+    "content" BYTEA NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "prevBlobId" TEXT,
+    "prevHash" TEXT,
+    "hash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditBlob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Policy_orgId_name_version_key" ON "Policy"("orgId", "name", "version");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GateEvent_requestId_key" ON "GateEvent"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GateEvent_prevEventId_key" ON "GateEvent"("prevEventId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GateEvent_hash_key" ON "GateEvent"("hash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LedgerEntry_requestId_key" ON "LedgerEntry"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LedgerEntry_prevEntryId_key" ON "LedgerEntry"("prevEntryId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LedgerEntry_hash_key" ON "LedgerEntry"("hash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RptToken_requestId_key" ON "RptToken"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RptToken_token_key" ON "RptToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuditBlob_requestId_key" ON "AuditBlob"("requestId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuditBlob_prevBlobId_key" ON "AuditBlob"("prevBlobId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuditBlob_hash_key" ON "AuditBlob"("hash");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AllocationRuleSet" ADD CONSTRAINT "AllocationRuleSet_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_allocationRuleSetId_fkey" FOREIGN KEY ("allocationRuleSetId") REFERENCES "AllocationRuleSet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GateEvent" ADD CONSTRAINT "GateEvent_prevEventId_fkey" FOREIGN KEY ("prevEventId") REFERENCES "GateEvent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_gateEventId_fkey" FOREIGN KEY ("gateEventId") REFERENCES "GateEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_prevEntryId_fkey" FOREIGN KEY ("prevEntryId") REFERENCES "LedgerEntry"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "Policy"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_allocationRuleSetId_fkey" FOREIGN KEY ("allocationRuleSetId") REFERENCES "AllocationRuleSet"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_gateEventId_fkey" FOREIGN KEY ("gateEventId") REFERENCES "GateEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_gateEventId_fkey" FOREIGN KEY ("gateEventId") REFERENCES "GateEvent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_ledgerEntryId_fkey" FOREIGN KEY ("ledgerEntryId") REFERENCES "LedgerEntry"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_prevBlobId_fkey" FOREIGN KEY ("prevBlobId") REFERENCES "AuditBlob"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -13,6 +13,11 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  policies  Policy[]
+  gateEvents GateEvent[]
+  ledgerEntries LedgerEntry[]
+  rptTokens RptToken[]
+  auditBlobs AuditBlob[]
 }
 
 model User {
@@ -33,4 +38,122 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+}
+
+model Policy {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  name      String
+  version   Int      @default(1)
+  summary   String?
+  config    Json?
+  createdAt DateTime @default(now())
+  ruleSets  AllocationRuleSet[]
+  gateEvents GateEvent[]
+  rptTokens RptToken[]
+
+  @@unique([orgId, name, version])
+}
+
+model AllocationRuleSet {
+  id          String   @id @default(cuid())
+  policy      Policy   @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  policyId    String
+  name        String
+  definition  Json
+  createdAt   DateTime @default(now())
+  gateEvents  GateEvent[]
+  rptTokens   RptToken[]
+}
+
+model GateEvent {
+  id                 String              @id @default(cuid())
+  org                Org                 @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId              String
+  policy             Policy              @relation(fields: [policyId], references: [id], onDelete: Restrict)
+  policyId           String
+  allocationRuleSet  AllocationRuleSet?  @relation(fields: [allocationRuleSetId], references: [id], onDelete: SetNull)
+  allocationRuleSetId String?
+  requestId          String              @unique
+  eventType          String
+  payload            Json
+  prevEvent          GateEvent?          @relation("GateEventChain", fields: [prevEventId], references: [id], onDelete: Restrict)
+  prevEventId        String?             @unique
+  nextEvents         GateEvent[]         @relation("GateEventChain")
+  prevHash           String?
+  hash               String              @unique
+  createdAt          DateTime            @default(now())
+  ledgerEntries      LedgerEntry[]
+  rptTokens          RptToken[]
+  auditBlobs         AuditBlob[]
+}
+
+enum LedgerEntryType {
+  DEBIT
+  CREDIT
+  ADJUSTMENT
+}
+
+model LedgerEntry {
+  id           String           @id @default(cuid())
+  org          Org              @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
+  gateEvent    GateEvent?       @relation(fields: [gateEventId], references: [id], onDelete: SetNull)
+  gateEventId  String?
+  requestId    String           @unique
+  entryType    LedgerEntryType
+  amount       Decimal
+  currency     String           @default("AUD")
+  memo         String?
+  prevEntry    LedgerEntry?     @relation("LedgerEntryChain", fields: [prevEntryId], references: [id], onDelete: Restrict)
+  prevEntryId  String?          @unique
+  nextEntries  LedgerEntry[]    @relation("LedgerEntryChain")
+  prevHash     String?
+  hash         String           @unique
+  createdAt    DateTime         @default(now())
+  auditBlobs   AuditBlob[]
+}
+
+enum RptTokenStatus {
+  ISSUED
+  REVOKED
+  EXPIRED
+}
+
+model RptToken {
+  id                 String             @id @default(cuid())
+  org                Org                @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId              String
+  policy             Policy             @relation(fields: [policyId], references: [id], onDelete: Restrict)
+  policyId           String
+  allocationRuleSet  AllocationRuleSet? @relation(fields: [allocationRuleSetId], references: [id], onDelete: SetNull)
+  allocationRuleSetId String?
+  gateEvent          GateEvent?         @relation(fields: [gateEventId], references: [id], onDelete: SetNull)
+  gateEventId        String?
+  requestId          String             @unique
+  token              String             @unique
+  status             RptTokenStatus     @default(ISSUED)
+  issuedAt           DateTime           @default(now())
+  expiresAt          DateTime?
+  metadata           Json?
+}
+
+model AuditBlob {
+  id            String        @id @default(cuid())
+  org           Org           @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId         String
+  gateEvent     GateEvent?    @relation(fields: [gateEventId], references: [id], onDelete: SetNull)
+  gateEventId   String?
+  ledgerEntry   LedgerEntry?  @relation(fields: [ledgerEntryId], references: [id], onDelete: SetNull)
+  ledgerEntryId String?
+  requestId     String        @unique
+  content       Bytes
+  contentType   String
+  prevBlob      AuditBlob?    @relation("AuditBlobChain", fields: [prevBlobId], references: [id], onDelete: Restrict)
+  prevBlobId    String?       @unique
+  nextBlobs     AuditBlob[]   @relation("AuditBlobChain")
+  prevHash      String?
+  hash          String        @unique
+  createdAt     DateTime      @default(now())
 }


### PR DESCRIPTION
## Summary
- add policy, allocation rule, gating, ledger, RPT token, and audit models with rolling hash chains
- create a migration and root Prisma symlinks so the new schema works with the default CLI commands
- extend the seed script and ERD documentation to demonstrate the new entities with sample data

## Testing
- `npx prisma generate` *(fails: Prisma engine download blocked by 403 in the offline container)*
- `npx prisma migrate dev --name test` *(fails: Prisma engine download blocked by 403 in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68f32bc230788327bde93e2837f257e5