### PR TITLE
Add dashboard route with schema and tests

### DIFF
--- a/apgms/docs/api.md
+++ b/apgms/docs/api.md
@@ -1,0 +1,19 @@
+# API Reference
+
+## GET /dashboard
+
+Returns default dashboard metrics used by the APGMS GUI.
+
+**Response**
+
+```json
+{
+  "kpis": {
+    "operating": 0,
+    "taxBuffer": 0,
+    "paygw": 0,
+    "gst": 0
+  },
+  "series": []
+}
+```

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test ./test/dashboard.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerDashboardRoutes } from "./routes/dashboard";
 
 const app = Fastify({ logger: true });
 
@@ -19,6 +20,8 @@ await app.register(cors, { origin: true });
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+await registerDashboardRoutes(app);
 
 // List users (email + org)
 app.get("/users", async () => {

--- a/apgms/services/api-gateway/src/routes/dashboard.ts
+++ b/apgms/services/api-gateway/src/routes/dashboard.ts
@@ -1,0 +1,20 @@
+import type { FastifyInstance } from "fastify";
+import { dashboardResponseSchema } from "../schemas/dashboard";
+
+const DEFAULT_DASHBOARD_PAYLOAD = {
+  kpis: {
+    operating: 0,
+    taxBuffer: 0,
+    paygw: 0,
+    gst: 0,
+  },
+  series: [] as unknown[],
+};
+
+export async function registerDashboardRoutes(app: FastifyInstance) {
+  app.get("/dashboard", async () => {
+    return dashboardResponseSchema.parse(DEFAULT_DASHBOARD_PAYLOAD);
+  });
+}
+
+export type RegisterDashboardRoutes = typeof registerDashboardRoutes;

--- a/apgms/services/api-gateway/src/schemas/dashboard.ts
+++ b/apgms/services/api-gateway/src/schemas/dashboard.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const dashboardResponseSchema = z.object({
+  kpis: z.object({
+    operating: z.number(),
+    taxBuffer: z.number(),
+    paygw: z.number(),
+    gst: z.number(),
+  }),
+  series: z.array(z.unknown()),
+});
+
+export type DashboardResponse = z.infer<typeof dashboardResponseSchema>;

--- a/apgms/services/api-gateway/test/dashboard.test.ts
+++ b/apgms/services/api-gateway/test/dashboard.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { registerDashboardRoutes } from "../src/routes/dashboard";
+import { dashboardResponseSchema } from "../src/schemas/dashboard";
+
+const expectedPayload = {
+  kpis: {
+    operating: 0,
+    taxBuffer: 0,
+    paygw: 0,
+    gst: 0,
+  },
+  series: [],
+};
+
+test("GET /dashboard returns the default dashboard payload", async (t) => {
+  const app = Fastify();
+
+  await registerDashboardRoutes(app);
+  await app.ready();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/dashboard",
+  });
+
+  assert.equal(response.statusCode, 200);
+
+  const payload = dashboardResponseSchema.parse(response.json());
+  assert.deepStrictEqual(payload, expectedPayload);
+});


### PR DESCRIPTION
## Summary
- add a dedicated `/dashboard` route that serves the default KPI payload
- define a reusable Zod schema for the dashboard response and validate responses
- document the dashboard endpoint and cover it with a Fastify integration test

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f334893e6883278441ec6a02c3e624