### PR TITLE
Add basic safety refusal helpers

### DIFF
--- a/apgms/services/api-gateway/src/lib/safety.ts
+++ b/apgms/services/api-gateway/src/lib/safety.ts
@@ -1,0 +1,36 @@
+const refusalPatterns: RegExp[] = [
+  /prompt\s+injection/i,
+  /ignore\s+previous\s+instructions/i,
+  /drop\s+table/i,
+  /select\s+\*\s+from/i,
+  /password\s*=/i,
+  /api\s*key/i,
+  /secret\s*key/i,
+  /kill\s+(yourself|urself)/i,
+  /hate\s+speech/i,
+];
+
+export function shouldRefuse(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+
+  return refusalPatterns.some((pattern) => pattern.test(text));
+}
+
+export function refusalMessage(): string {
+  return "I'm sorry, but I can't help with that request.";
+}
+
+// Example usage within a hypothetical /llm route handler:
+// import type { Request, Response } from 'express';
+//
+// export async function handleLlmRequest(req: Request, res: Response) {
+//   const userInput = req.body?.prompt ?? '';
+//
+//   if (shouldRefuse(userInput)) {
+//     return res.status(200).json({ message: refusalMessage() });
+//   }
+//
+//   // ... proceed with normal LLM handling logic.
+// }


### PR DESCRIPTION
## Summary
- add a lightweight safety helper that flags common injection, exfiltration, and toxic phrases
- expose a reusable refusal message for consistent responses
- document example usage for an LLM route handler

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3555ec0b083278d334f72e9b52494