### PR TITLE
Add safety shim for LLM requests

### DIFF
--- a/apgms/services/api-gateway/src/lib/safety.ts
+++ b/apgms/services/api-gateway/src/lib/safety.ts
@@ -1,0 +1,27 @@
+const refusalPatterns: RegExp[] = [
+  /(prompt\s*inject|ignore\s+previous\s+instructions|override\s+instructions)/i,
+  /(exfiltrate|leak|steal|expose)\s+(data|information|credentials|secrets?)/i,
+  /(passwords?|api\s*keys?|credit\s*card|social\s*security|ssn)/i,
+  /(hate\s*speech|kill\s+\w+|violence\s+against|racial\s+slur|genocide)/i,
+];
+
+export function shouldRefuse(text: string): boolean {
+  return refusalPatterns.some((pattern) => pattern.test(text));
+}
+
+export function refusalMessage(): string {
+  return "I'm sorry, but I can't help with that request.";
+}
+
+// Example usage within a hypothetical /llm route handler:
+// import type { Request, Response } from 'express';
+// import { refusalMessage, shouldRefuse } from './lib/safety';
+//
+// async function handleLlmRoute(req: Request, res: Response) {
+//   const userInput = req.body?.prompt ?? '';
+//   if (shouldRefuse(userInput)) {
+//     return res.status(200).json({ message: refusalMessage() });
+//   }
+//
+//   // Continue with regular LLM processing when the input is acceptable.
+// }


### PR DESCRIPTION
## Summary
- add a lightweight safety shim for LLM inputs
- provide a helper for standard refusal messaging
- document an example /llm route usage of the safety helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38405cef083279eee05f43cfc1973