### PR TITLE
Add red-team job to CI workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,31 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  red-team:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Red-team checks
+        run: npm run redteam
+      - name: Upload red-team report
+        if: ${{ always() && hashFiles('eval/redteam-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: redteam-report
+          path: eval/redteam-report.json


### PR DESCRIPTION
## Summary
- add a red-team job that depends on the unit test build
- cache node_modules, install dependencies, and run the red-team script
- always upload the red-team report artifact when it exists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f383ebe330832786623dcf7e12d1cc