### PR TITLE
Add red-team pnpm job to CI

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,28 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  red-team:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - run: corepack enable
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Red-team checks
+        run: pnpm redteam
+
+      - name: Upload red-team report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: redteam-report
+          path: eval/redteam-report.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a red-team job that runs pnpm redteam with node 20
- enable Corepack and install dependencies with pnpm using a frozen lockfile
- persist the red-team report as an artifact even when the job fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3849e800883279f9eebf25a204624