### PR TITLE
Add JSON schemas for allocations preview and rpt

### DIFF
--- a/allocations.preview.schema.json
+++ b/allocations.preview.schema.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/allocations.preview.schema.json",
+  "title": "Allocations Preview",
+  "type": "object",
+  "required": [
+    "policyHash",
+    "allocations",
+    "explain"
+  ],
+  "properties": {
+    "policyHash": {
+      "type": "string",
+      "minLength": 32
+    },
+    "allocations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/allocation"
+      }
+    },
+    "explain": {
+      "type": "string",
+      "maxLength": 2000
+    }
+  },
+  "$defs": {
+    "allocation": {
+      "type": "object",
+      "required": [
+        "bucket",
+        "amountCents",
+        "currency"
+      ],
+      "properties": {
+        "bucket": {
+          "type": "string",
+          "enum": [
+            "OPERATING",
+            "TAX_BUFFER",
+            "PAYGW",
+            "GST"
+          ]
+        },
+        "amountCents": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/rpt.schema.json
+++ b/rpt.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/rpt.schema.json",
+  "title": "RPT",
+  "type": "object",
+  "required": [
+    "rptId",
+    "orgId",
+    "bankLineId",
+    "policyHash",
+    "allocations",
+    "prevHash",
+    "sig",
+    "timestamp"
+  ],
+  "properties": {
+    "rptId": {
+      "type": "string",
+      "pattern": "^rpt_[a-z0-9]{8,}$"
+    },
+    "orgId": {
+      "type": "string"
+    },
+    "bankLineId": {
+      "type": "string"
+    },
+    "policyHash": {
+      "type": "string",
+      "minLength": 32
+    },
+    "allocations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/allocation"
+      }
+    },
+    "prevHash": {
+      "type": "string"
+    },
+    "sig": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "allocation": {
+      "type": "object",
+      "required": [
+        "bucket",
+        "amountCents",
+        "currency"
+      ],
+      "properties": {
+        "bucket": {
+          "type": "string",
+          "enum": [
+            "OPERATING",
+            "TAX_BUFFER",
+            "PAYGW",
+            "GST"
+          ]
+        },
+        "amountCents": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- define allocations preview JSON schema with policy hash, allocation rules, and explanation constraints
- add rpt JSON schema reusing allocation definitions and enforcing identifier formats

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3864907a083279d0d84df159238d9