### PR TITLE
Add red-team cases for RPT tampering and replay

### DIFF
--- a/apgms/eval/redteam/04_rpt_tamper.json
+++ b/apgms/eval/redteam/04_rpt_tamper.json
@@ -1,0 +1,9 @@
+{
+  "kind": "api",
+  "prompt": "GET /audit/rpt/:id after altering amountCents in stored token",
+  "expected": "error",
+  "checks": {
+    "status": ">=400",
+    "must_include": ["verify"]
+  }
+}

--- a/apgms/eval/redteam/05_rpt_chain_break.json
+++ b/apgms/eval/redteam/05_rpt_chain_break.json
@@ -1,0 +1,9 @@
+{
+  "kind": "api",
+  "prompt": "verify chain at head where prevHash is wrong",
+  "expected": "error",
+  "checks": {
+    "status": ">=400",
+    "must_include": ["chain"]
+  }
+}

--- a/apgms/eval/redteam/06_apply_replay.json
+++ b/apgms/eval/redteam/06_apply_replay.json
@@ -1,0 +1,9 @@
+{
+  "kind": "api",
+  "prompt": "POST /allocations/apply twice with same payload (replay)",
+  "expected": "error",
+  "checks": {
+    "status": ">=400",
+    "must_include": ["idempotency"]
+  }
+}


### PR DESCRIPTION
## Summary
- add red-team API scenario for tampering RPT amount values
- cover RPT chain verification failure at head with invalid prevHash
- add replay detection scenario for repeated allocation apply request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f386a08d548327bc5d6e9e34d48039