### PR TITLE
Add bench harness for allocations apply endpoint

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "bench:apply": "tsx services/api-gateway/scripts/bench-apply.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/api-gateway/scripts/bench-apply.ts
+++ b/apgms/services/api-gateway/scripts/bench-apply.ts
@@ -1,0 +1,79 @@
+const REQUEST_COUNT = 200;
+const TARGET_URL = "http://localhost:3000/allocations/apply";
+
+interface DurationStats {
+  p50: number;
+  p95: number;
+}
+
+const payload = {
+  amount: 1,
+  currency: "AUD",
+  metadata: { source: "perf-harness" },
+};
+
+async function main(): Promise<void> {
+  const durations: number[] = [];
+
+  for (let i = 0; i < REQUEST_COUNT; i += 1) {
+    const start = performance.now();
+    const response = await fetch(TARGET_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const elapsed = performance.now() - start;
+    durations.push(elapsed);
+
+    if (!response.ok) {
+      const bodyText = await safeReadBody(response);
+      throw new Error(`Request ${i + 1} failed: ${response.status} ${response.statusText} - ${bodyText}`);
+    }
+
+    // Consume body to avoid resource leaks.
+    await safeReadBody(response);
+  }
+
+  const stats = calculateStats(durations);
+
+  console.log(`Completed ${REQUEST_COUNT} sequential requests to ${TARGET_URL}`);
+  console.log(`p50: ${stats.p50.toFixed(2)}ms`);
+  console.log(`p95: ${stats.p95.toFixed(2)}ms`);
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch (error) {
+    return `<<unreadable body: ${error}>>`;
+  }
+}
+
+function calculateStats(samples: number[]): DurationStats {
+  if (samples.length === 0) {
+    return { p50: 0, p95: 0 };
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p50 = percentile(sorted, 0.5);
+  const p95 = percentile(sorted, 0.95);
+
+  return { p50, p95 };
+}
+
+function percentile(sortedSamples: number[], ratio: number): number {
+  if (sortedSamples.length === 0) {
+    return 0;
+  }
+
+  const index = Math.floor(ratio * (sortedSamples.length - 1));
+  return sortedSamples[index];
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a bench script that sends 200 sequential /allocations/apply requests and reports p50/p95
- expose a bench:apply workspace script to run the harness via tsx

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3869602888327bdcb6ba8ec9ebe80