### PR TITLE
Add Playwright smoke test coverage

### DIFF
--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,19 @@
-﻿export default {};
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apgms/tests/smoke.spec.ts
+++ b/apgms/tests/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Smoke', () => {
+  test('dashboard KPIs render or show empty state', async ({ page }) => {
+    await page.goto('/');
+
+    const kpis = page.getByTestId('dashboard-kpis');
+    const emptyState = page.getByTestId('dashboard-empty-state');
+
+    await expect(kpis.or(emptyState)).toBeVisible();
+  });
+
+  test('verify button is focusable from bank line drawer', async ({ page }) => {
+    await page.goto('/bank-lines?orgId=org_demo');
+
+    const firstRow = page.getByRole('row').nth(1);
+    await firstRow.click();
+
+    const drawer = page.getByRole('dialog');
+    await expect(drawer).toBeVisible();
+
+    const verifyButton = drawer.getByRole('button', { name: /verify rpt/i });
+    await expect(verifyButton).toBeVisible();
+    await expect(verifyButton).toBeEnabled();
+
+    await verifyButton.focus();
+    await expect(verifyButton).toBeFocused();
+  });
+});

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,1 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp","test:e2e":"playwright test"},"devDependencies":{"@playwright/test":"^1.48.2"}}


### PR DESCRIPTION
## Summary
- configure Playwright with a chromium project and shared defaults for smoke tests
- add a smoke scenario that exercises dashboard KPIs and the bank lines drawer
- expose a `test:e2e` script and Playwright dependency from the webapp package

## Testing
- not run (environment only provides source changes)


------
https://chatgpt.com/codex/tasks/task_e_68f3875b1efc8327a603e0706c617a60