### PR TITLE
Add JSON schemas for health and readiness endpoints

### DIFF
--- a/healthz.200.schema.json
+++ b/healthz.200.schema.json
@@ -1,0 +1,15 @@
+{
+  "type": "object",
+  "required": [
+    "ok",
+    "service"
+  ],
+  "properties": {
+    "ok": {
+      "type": "boolean"
+    },
+    "service": {
+      "type": "string"
+    }
+  }
+}

--- a/readyz.200.schema.json
+++ b/readyz.200.schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "required": [
+    "ready"
+  ],
+  "properties": {
+    "ready": {
+      "type": "boolean",
+      "const": true
+    }
+  }
+}

--- a/readyz.503.schema.json
+++ b/readyz.503.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "required": [
+    "ready",
+    "reason"
+  ],
+  "properties": {
+    "ready": {
+      "type": "boolean",
+      "const": false
+    },
+    "reason": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add contract schemas for the health and readiness endpoints
- capture 200-OK responses for health and readiness checks
- define the 503 response schema for readiness failures

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f387f4fff88327be8a31c4d6870b0a