### PR TITLE
Add axe accessibility checks in development

### DIFF
--- a/apgms/webapp/src/dev/axe.ts
+++ b/apgms/webapp/src/dev/axe.ts
@@ -1,0 +1,17 @@
+export async function runAxe() {
+  if (!import.meta.env.DEV) {
+    return;
+  }
+
+  try {
+    const axeModule = await import('axe-core');
+    const axe = axeModule.default ?? axeModule;
+    const { violations } = await axe.run(document);
+
+    if (violations.length > 0) {
+      console.warn('[axe] Accessibility violations detected:', violations);
+    }
+  } catch (error) {
+    console.warn('[axe] Failed to run accessibility checks:', error);
+  }
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,12 @@
-﻿console.log('webapp');
+const rootElement = document.querySelector('#root');
+
+if (rootElement) {
+  rootElement.textContent = 'webapp';
+}
+
+if (import.meta.env.DEV) {
+  requestAnimationFrame(async () => {
+    const { runAxe } = await import('./dev/axe');
+    await runAxe();
+  });
+}


### PR DESCRIPTION
## Summary
- add a development-only helper to run axe accessibility checks
- lazy-load the helper after mounting the app in development

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f38750f86483279067da14df84ce9e