### PR TITLE
feat(webapp): scaffold app shell and utilities

### DIFF
--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,52 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:3000',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+type RequestConfig<T> = AxiosRequestConfig<T>;
+
+async function request<T>(config: RequestConfig<T>): Promise<T> {
+  const response = await api.request<T>(config);
+  return response.data;
+}
+
+export async function get<T>(url: string, config?: RequestConfig<T>): Promise<T> {
+  return request<T>({ ...(config ?? {}), method: 'GET', url });
+}
+
+export async function post<T>(url: string, data?: unknown, config?: RequestConfig<T>): Promise<T> {
+  return request<T>({ ...(config ?? {}), method: 'POST', url, data });
+}
+
+export async function patch<T>(url: string, data?: unknown, config?: RequestConfig<T>): Promise<T> {
+  return request<T>({ ...(config ?? {}), method: 'PATCH', url, data });
+}
+
+export async function remove<T>(url: string, config?: RequestConfig<T>): Promise<T> {
+  return request<T>({ ...(config ?? {}), method: 'DELETE', url });
+}
+
+export type BankLinesParams = {
+  orgId: string;
+  take?: number;
+  cursor?: string;
+};
+
+export async function getDashboard<T = unknown>() {
+  return get<T>('/dashboard');
+}
+
+export async function getBankLines<T = unknown>(params: BankLinesParams) {
+  return get<T>('/bank-lines', { params });
+}
+
+export async function getRptByLine<T = unknown>(id: string) {
+  return get<T>(`/bank-lines/${id}/reports`);
+}
+
+export { api };

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,87 @@
-﻿console.log('webapp');
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  RouterProvider,
+  RootRoute,
+  Route,
+  createRouter,
+} from '@tanstack/react-router';
+
+import AppShell, { ThemeProvider } from './shell/AppShell';
+
+const queryClient = new QueryClient();
+
+const rootRoute = new RootRoute({
+  component: AppShell,
+});
+
+const dashboardRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: DashboardPage,
+});
+
+const bankLinesRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: 'bank-lines',
+  component: BankLinesPage,
+});
+
+const routeTree = rootRoute.addChildren([dashboardRoute, bankLinesRoute]);
+
+const router = createRouter({ routeTree });
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+function DashboardPage() {
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Review organisation insights and trends.
+        </p>
+      </header>
+      <div className="grid gap-4 rounded-lg border border-dashed border-slate-300 p-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-300">
+        Connect data sources to populate this dashboard.
+      </div>
+    </section>
+  );
+}
+
+function BankLinesPage() {
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Bank Lines</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Track utilisation, covenants, and reporting for each facility.
+        </p>
+      </header>
+      <div className="grid gap-4 rounded-lg border border-dashed border-slate-300 p-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-300">
+        Select a facility to view available reports.
+      </div>
+    </section>
+  );
+}
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+createRoot(rootElement).render(
+  <StrictMode>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </ThemeProvider>
+  </StrictMode>,
+);

--- a/apgms/webapp/src/shell/AppShell.tsx
+++ b/apgms/webapp/src/shell/AppShell.tsx
@@ -1,0 +1,204 @@
+import { Link, Outlet, useRouterState } from '@tanstack/react-router';
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem('app-theme');
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: PropsWithChildren) {
+  const [theme, setThemeState] = useState<Theme>(getPreferredTheme);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem('app-theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    root.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      setTheme,
+      toggleTheme,
+    }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}
+
+type NavItem = {
+  label: string;
+  to: string;
+  exact?: boolean;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { label: 'Dashboard', to: '/', exact: true },
+  { label: 'Bank Lines', to: '/bank-lines' },
+];
+
+function navLinkClass(base: string, active: boolean) {
+  return [
+    base,
+    active
+      ? 'bg-indigo-600 text-white dark:bg-indigo-500'
+      : 'text-slate-600 hover:bg-slate-200 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function useIsActive(item: NavItem) {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  if (item.exact) {
+    return pathname === item.to;
+  }
+
+  if (item.to === '/') {
+    return pathname === '/';
+  }
+
+  return pathname === item.to || pathname.startsWith(`${item.to.replace(/\/$/, '')}/`);
+}
+
+type NavLinkItemProps = {
+  item: NavItem;
+  baseClassName: string;
+};
+
+function NavLinkItem({ item, baseClassName }: NavLinkItemProps) {
+  const isActive = useIsActive(item);
+
+  return (
+    <Link
+      to={item.to}
+      preload="intent"
+      className={navLinkClass(baseClassName, isActive)}
+      aria-current={isActive ? 'page' : undefined}
+    >
+      {item.label}
+    </Link>
+  );
+}
+
+function AppShell() {
+  const { theme, toggleTheme } = useTheme();
+  const nextTheme = theme === 'light' ? 'dark' : 'light';
+
+  return (
+    <div
+      data-theme={theme}
+      className="flex min-h-screen flex-col bg-slate-100 text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100"
+    >
+      <header className="border-b border-slate-200 bg-white/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
+          <div className="flex items-center gap-2">
+            <span className="text-lg font-semibold">APGMS</span>
+            <span className="hidden text-sm text-slate-500 dark:text-slate-400 sm:inline">
+              Funding Intelligence
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="inline-flex items-center gap-2 rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+              aria-label={`Switch to ${nextTheme} theme`}
+              aria-pressed={theme === 'dark'}
+            >
+              <span aria-hidden="true">{theme === 'light' ? '🌞' : '🌙'}</span>
+              <span className="hidden sm:inline">{theme === 'light' ? 'Light' : 'Dark'} mode</span>
+            </button>
+          </div>
+        </div>
+        <nav className="mx-auto mt-2 flex w-full max-w-6xl gap-2 px-4 pb-3 md:hidden" aria-label="Main">
+          {NAV_ITEMS.map((item) => (
+            <NavLinkItem
+              key={item.to}
+              item={item}
+              baseClassName="flex-1 rounded-md px-3 py-2 text-center text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+            />
+          ))}
+        </nav>
+      </header>
+
+      <div className="flex flex-1">
+        <aside className="hidden w-64 shrink-0 border-r border-slate-200 bg-slate-50/80 px-4 py-6 dark:border-slate-800 dark:bg-slate-900/40 md:block">
+          <nav className="flex flex-col gap-2" aria-label="Sidebar">
+            {NAV_ITEMS.map((item) => (
+              <NavLinkItem
+                key={item.to}
+                item={item}
+                baseClassName="rounded-md px-3 py-2 text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500"
+              />
+            ))}
+          </nav>
+        </aside>
+
+        <main className="flex-1 overflow-y-auto">
+          <div className="mx-auto w-full max-w-6xl px-4 py-6 md:px-8">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+export default AppShell;

--- a/apgms/webapp/src/ui/DateText.tsx
+++ b/apgms/webapp/src/ui/DateText.tsx
@@ -1,0 +1,45 @@
+import type { HTMLAttributes } from 'react';
+
+type DateTextProps = {
+  value?: string | Date | null;
+} & HTMLAttributes<HTMLTimeElement>;
+
+function toDate(value?: string | Date | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function formatDate(value: Date) {
+  return new Intl.DateTimeFormat('en-AU', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(value);
+}
+
+export function DateText({ value, className = '', ...rest }: DateTextProps) {
+  const date = toDate(value);
+  const formatted = date ? formatDate(date) : '—';
+
+  return (
+    <time
+      className={[className, 'text-sm', 'text-slate-600', 'dark:text-slate-300']
+        .filter(Boolean)
+        .join(' ')}
+      dateTime={date?.toISOString()}
+      {...rest}
+    >
+      {formatted}
+    </time>
+  );
+}
+
+export default DateText;

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,39 @@
+import type { HTMLAttributes } from 'react';
+
+type MoneyProps = {
+  cents?: number | null;
+} & HTMLAttributes<HTMLSpanElement>;
+
+function formatAUD(value: number) {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function Money({ cents, className = '', ...rest }: MoneyProps) {
+  const combinedClassName = ['money', 'tabular-nums', 'font-semibold', 'text-slate-900',
+    'dark:text-slate-100', className]
+    .filter(Boolean)
+    .join(' ');
+
+  if (cents === null || cents === undefined) {
+    return (
+      <span className={combinedClassName} aria-live="polite" {...rest}>
+        —
+      </span>
+    );
+  }
+
+  const major = cents / 100;
+
+  return (
+    <span className={combinedClassName} aria-live="polite" {...rest}>
+      {formatAUD(major)}
+    </span>
+  );
+}
+
+export default Money;

--- a/apgms/webapp/src/ui/Skeleton.tsx
+++ b/apgms/webapp/src/ui/Skeleton.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes } from 'react';
+
+type SkeletonProps = HTMLAttributes<HTMLDivElement> & {
+  animate?: boolean;
+};
+
+export function Skeleton({ className = 'h-4 w-full', animate = true, ...rest }: SkeletonProps) {
+  const classes = [
+    'rounded-md',
+    'bg-slate-200',
+    'dark:bg-slate-700',
+    animate ? 'animate-pulse' : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return <div className={classes} aria-hidden="true" {...rest} />;
+}
+
+export default Skeleton;


### PR DESCRIPTION
## Summary
- initialize React Query, TanStack Router, and theme context in the app entrypoint
- add responsive app shell with navigation and theme toggle
- provide API client helpers plus formatting utilities for money, dates, and skeleton placeholders

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38730398083279ae812f37e94514c