### PR TITLE
feat(api-gateway): add allocation preview/apply and audit routes

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,16 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import responseGuard from "./plugins/response-guard";
+import allocationsRoutes from "./routes/allocations";
+import auditRoutes from "./routes/audit";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(responseGuard);
+await app.register(allocationsRoutes);
+await app.register(auditRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/lib/allocations.ts
+++ b/apgms/services/api-gateway/src/lib/allocations.ts
@@ -1,0 +1,120 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+export class AllocationError extends Error {
+  constructor(public readonly code: string, message?: string) {
+    super(message ?? code);
+    this.name = "AllocationError";
+  }
+}
+
+export const allocationItemSchema = z.object({
+  invoiceId: z.string().min(1, "invoiceId is required"),
+  amount: z.coerce.number().finite("amount must be a finite number"),
+  memo: z
+    .string()
+    .trim()
+    .max(1024, "memo must be at most 1024 characters")
+    .optional(),
+});
+
+export const previewAllocationsSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  bankLineId: z.string().min(1, "bankLineId is required"),
+  policyHash: z.string().min(1, "policyHash is required"),
+  allocations: z.array(allocationItemSchema).min(1, "allocations must not be empty"),
+});
+
+export const applyAllocationsSchema = previewAllocationsSchema.extend({
+  prevHash: z.string().min(1, "prevHash is required"),
+});
+
+export type AllocationItem = {
+  invoiceId: string;
+  amount: number;
+  memo: string | null;
+};
+export type PreviewAllocationsInput = z.infer<typeof previewAllocationsSchema>;
+export type ApplyAllocationsInput = z.infer<typeof applyAllocationsSchema>;
+
+export interface AllocationPreview {
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: AllocationItem[];
+  totalAllocated: number;
+  hash: string;
+}
+
+const hashPreviewBase = (preview: Omit<AllocationPreview, "hash">) =>
+  createHash("sha256").update(JSON.stringify(preview)).digest("hex");
+
+const normalizeAllocations = (
+  allocations: ReadonlyArray<{ invoiceId: string; amount: number; memo?: string | null }>,
+): AllocationItem[] =>
+  allocations.map((allocation) => ({
+    invoiceId: allocation.invoiceId,
+    amount: Number(allocation.amount),
+    memo: allocation.memo ?? null,
+  }));
+
+export const previewAllocations = (input: PreviewAllocationsInput): AllocationPreview => {
+  const allocations = normalizeAllocations(input.allocations);
+
+  if (allocations.some((allocation) => !Number.isFinite(allocation.amount))) {
+    throw new AllocationError("invalid_allocation_amount", "Allocation amounts must be finite numbers");
+  }
+
+  if (allocations.some((allocation) => allocation.amount <= 0)) {
+    throw new AllocationError("invalid_allocation_amount", "Allocation amounts must be positive");
+  }
+
+  const totalAllocated = allocations.reduce((sum, allocation) => sum + allocation.amount, 0);
+
+  if (!Number.isFinite(totalAllocated) || totalAllocated <= 0) {
+    throw new AllocationError("invalid_total", "Total allocation must be positive and finite");
+  }
+
+  const base = {
+    orgId: input.orgId,
+    bankLineId: input.bankLineId,
+    policyHash: input.policyHash,
+    allocations,
+    totalAllocated,
+  } satisfies Omit<AllocationPreview, "hash">;
+
+  return {
+    ...base,
+    hash: hashPreviewBase(base),
+  };
+};
+
+export const verifyConservation = (preview: AllocationPreview, expectedHash: string): string => {
+  const base: Omit<AllocationPreview, "hash"> = {
+    orgId: preview.orgId,
+    bankLineId: preview.bankLineId,
+    policyHash: preview.policyHash,
+    allocations: normalizeAllocations(preview.allocations),
+    totalAllocated: preview.totalAllocated,
+  };
+
+  const computedHash = hashPreviewBase(base);
+
+  if (preview.hash !== computedHash) {
+    throw new AllocationError("preview_hash_mismatch", "Preview hash does not match computed value");
+  }
+
+  if (expectedHash !== computedHash) {
+    throw new AllocationError("invalid_prev_hash", "prevHash does not match preview");
+  }
+
+  if (base.totalAllocated <= 0) {
+    throw new AllocationError("invalid_total", "Total allocation must be positive");
+  }
+
+  if (base.allocations.some((allocation) => allocation.amount <= 0)) {
+    throw new AllocationError("invalid_allocation_amount", "Allocation amounts must be positive");
+  }
+
+  return computedHash;
+};

--- a/apgms/services/api-gateway/src/lib/dev-kms.ts
+++ b/apgms/services/api-gateway/src/lib/dev-kms.ts
@@ -1,0 +1,82 @@
+import { createHash, createHmac, randomUUID } from "node:crypto";
+import type { AllocationPreview } from "./allocations";
+
+export interface MintRptInput extends AllocationPreview {
+  prevHash: string;
+}
+
+export interface RptToken extends MintRptInput {
+  id: string;
+  mintedAt: string;
+  signature: string;
+  hash: string;
+}
+
+const secret = process.env.DEV_KMS_SECRET ?? "dev-kms-secret";
+
+type RptPayload = Pick<
+  RptToken,
+  "orgId" | "bankLineId" | "policyHash" | "allocations" | "totalAllocated" | "prevHash" | "mintedAt"
+>;
+
+const buildPayload = (input: RptPayload) =>
+  JSON.stringify({
+    orgId: input.orgId,
+    bankLineId: input.bankLineId,
+    policyHash: input.policyHash,
+    allocations: input.allocations,
+    totalAllocated: input.totalAllocated,
+    prevHash: input.prevHash,
+    mintedAt: input.mintedAt,
+  });
+
+const computeSignature = (payload: string) =>
+  createHmac("sha256", secret).update(payload).digest("hex");
+
+const computeHash = (payload: string) => createHash("sha256").update(payload).digest("hex");
+
+export class DevKms {
+  async mintRpt(input: MintRptInput): Promise<RptToken> {
+    const mintedAt = new Date().toISOString();
+    const payload = buildPayload({
+      orgId: input.orgId,
+      bankLineId: input.bankLineId,
+      policyHash: input.policyHash,
+      allocations: input.allocations,
+      totalAllocated: input.totalAllocated,
+      prevHash: input.prevHash,
+      mintedAt,
+    });
+
+    const signature = computeSignature(payload);
+    const hash = computeHash(payload);
+
+    return {
+      id: randomUUID(),
+      ...input,
+      mintedAt,
+      signature,
+      hash,
+    };
+  }
+
+  verifyRpt(token: RptToken): boolean {
+    const payload = buildPayload({
+      orgId: token.orgId,
+      bankLineId: token.bankLineId,
+      policyHash: token.policyHash,
+      allocations: token.allocations,
+      totalAllocated: token.totalAllocated,
+      prevHash: token.prevHash,
+      mintedAt: token.mintedAt,
+    });
+    const expectedSignature = computeSignature(payload);
+    const expectedHash = computeHash(payload);
+
+    return token.signature === expectedSignature && token.hash === expectedHash;
+  }
+}
+
+export const devKms = new DevKms();
+
+export const verifyRpt = (token: RptToken): boolean => devKms.verifyRpt(token);

--- a/apgms/services/api-gateway/src/plugins/response-guard.ts
+++ b/apgms/services/api-gateway/src/plugins/response-guard.ts
@@ -1,0 +1,16 @@
+import type { FastifyInstance } from "fastify";
+
+const guardError = new Error("Response payload missing");
+
+export const responseGuard = async (app: FastifyInstance) => {
+  app.addHook("onSend", async (request, reply, payload) => {
+    if (payload === undefined || payload === null) {
+      request.log.error({ method: request.method, url: request.url }, "Response payload missing");
+      throw guardError;
+    }
+
+    return payload;
+  });
+};
+
+export default responseGuard;

--- a/apgms/services/api-gateway/src/routes/allocations.ts
+++ b/apgms/services/api-gateway/src/routes/allocations.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import {
+  AllocationError,
+  applyAllocationsSchema,
+  previewAllocations,
+  previewAllocationsSchema,
+  verifyConservation,
+} from "../lib/allocations";
+import { devKms } from "../lib/dev-kms";
+import { saveRpt } from "../stores/rpt-store";
+
+const formatZodError = (error: z.ZodError) => ({
+  error: "invalid_request",
+  details: error.flatten(),
+});
+
+export const allocationsRoutes = async (app: FastifyInstance) => {
+  app.post("/allocations/preview", async (request, reply) => {
+    const parsed = previewAllocationsSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send(formatZodError(parsed.error));
+    }
+
+    try {
+      const preview = previewAllocations(parsed.data);
+      return reply.send({ preview });
+    } catch (error) {
+      request.log.error({ err: error }, "preview allocations failed");
+
+      if (error instanceof AllocationError) {
+        return reply.code(400).send({ error: error.code, message: error.message });
+      }
+
+      return reply.code(500).send({ error: "preview_failed" });
+    }
+  });
+
+  app.post("/allocations/apply", async (request, reply) => {
+    const parsed = applyAllocationsSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send(formatZodError(parsed.error));
+    }
+
+    try {
+      const preview = previewAllocations(parsed.data);
+      const computedHash = verifyConservation(preview, parsed.data.prevHash);
+
+      const rpt = await devKms.mintRpt({ ...preview, prevHash: computedHash });
+      saveRpt(rpt);
+
+      return reply.code(201).send({ rptId: rpt.id });
+    } catch (error) {
+      request.log.error({ err: error }, "apply allocations failed");
+
+      if (error instanceof AllocationError) {
+        return reply.code(400).send({ error: error.code, message: error.message });
+      }
+
+      return reply.code(500).send({ error: "apply_failed" });
+    }
+  });
+};
+
+export default allocationsRoutes;

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,27 @@
+import type { FastifyInstance } from "fastify";
+import { verifyRpt } from "../lib/dev-kms";
+import { findRpt } from "../stores/rpt-store";
+
+export const auditRoutes = async (app: FastifyInstance) => {
+  app.get("/audit/rpt/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+
+    if (!id) {
+      return reply.code(400).send({ error: "invalid_request", message: "id is required" });
+    }
+
+    const token = findRpt(id);
+
+    if (!token) {
+      return reply.code(404).send({ error: "not_found", message: "RPT not found" });
+    }
+
+    if (!verifyRpt(token)) {
+      return reply.code(409).send({ error: "invalid_rpt", message: "RPT verification failed" });
+    }
+
+    return reply.send({ rpt: token });
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/src/stores/rpt-store.ts
+++ b/apgms/services/api-gateway/src/stores/rpt-store.ts
@@ -1,0 +1,10 @@
+import type { RptToken } from "../lib/dev-kms";
+
+export const rptStore = new Map<string, RptToken>();
+
+export const saveRpt = (token: RptToken) => {
+  rptStore.set(token.id, token);
+  return token;
+};
+
+export const findRpt = (id: string) => rptStore.get(id);

--- a/apgms/services/api-gateway/src/types/prisma.d.ts
+++ b/apgms/services/api-gateway/src/types/prisma.d.ts
@@ -1,0 +1,6 @@
+declare module "@prisma/client" {
+  export class PrismaClient {
+    $disconnect(): Promise<void>;
+    [key: string]: any;
+  }
+}


### PR DESCRIPTION
## Summary
- add allocation preview/apply routes with validation and DevKms-backed RPT minting
- expose audit endpoint backed by in-memory rptStore and verification utilities
- register the response guard plugin and stub Prisma types for local compilation

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68f3867bf5b0832791e9ea83b03a6ea3