### PR TITLE
feat(api-gateway): add allocation schemas and response guard

### DIFF
--- a/apgms/services/api-gateway/src/plugins/response-guard.ts
+++ b/apgms/services/api-gateway/src/plugins/response-guard.ts
@@ -1,0 +1,98 @@
+import fp from "fastify-plugin";
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeAny } from "zod";
+
+declare module "fastify" {
+  interface FastifyContextConfig {
+    responseGuard?: Record<string, ZodTypeAny>;
+  }
+}
+
+const responseGuardPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("onRoute", (routeOptions) => {
+    const response = routeOptions.schema?.response as
+      | Record<string, unknown>
+      | undefined;
+
+    if (!response) {
+      return;
+    }
+
+    const zodSchemas = Object.fromEntries(
+      Object.entries(response).filter(([, schema]) => {
+        if (!schema || typeof schema !== "object") {
+          return false;
+        }
+        return typeof (schema as ZodTypeAny).safeParse === "function";
+      })
+    ) as Record<string, ZodTypeAny>;
+
+    if (Object.keys(zodSchemas).length === 0) {
+      return;
+    }
+
+    routeOptions.config = {
+      ...routeOptions.config,
+      responseGuard: {
+        ...(routeOptions.config?.responseGuard ?? {}),
+        ...zodSchemas,
+      },
+    };
+  });
+
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    const schemaMap = reply.context.config?.responseGuard;
+
+    if (!schemaMap) {
+      return payload;
+    }
+
+    const statusKey = String(reply.statusCode);
+    const schema = schemaMap[statusKey] ?? schemaMap.default;
+
+    if (!schema) {
+      return payload;
+    }
+
+    let body: unknown = payload;
+
+    if (Buffer.isBuffer(payload)) {
+      const text = payload.toString("utf8");
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    } else if (typeof payload === "string") {
+      try {
+        body = JSON.parse(payload);
+      } catch {
+        body = payload;
+      }
+    }
+
+    const result = schema.safeParse(body);
+
+    if (result.success) {
+      return payload;
+    }
+
+    const errorPayload = {
+      route: request.routerPath,
+      statusCode: reply.statusCode,
+      issues: result.error.issues,
+    };
+
+    request.log.error(errorPayload, "response validation failed");
+
+    if (process.env.NODE_ENV === "production") {
+      return payload;
+    }
+
+    throw fastify.httpErrors.internalServerError("Response validation failed");
+  });
+};
+
+export default fp(responseGuardPlugin, {
+  name: "response-guard",
+});

--- a/apgms/services/api-gateway/src/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+const currencyCodeSchema = z
+  .string()
+  .trim()
+  .length(3)
+  .regex(/^[A-Z]{3}$/u, "Invalid ISO currency code");
+
+const monetaryAmountSchema = z.number().finite();
+
+const allocationLineInputSchema = z.object({
+  allocationId: z.string().min(1),
+  bankLineId: z.string().min(1),
+  amount: monetaryAmountSchema,
+  currency: currencyCodeSchema,
+  gstCode: z.string().min(1),
+  description: z.string().min(1),
+  notes: z.string().max(2000).optional(),
+});
+
+export const allocationSummarySchema = z.object({
+  currency: currencyCodeSchema,
+  totalAllocations: z.number().int().nonnegative(),
+  totalAmount: monetaryAmountSchema,
+  gstAmount: monetaryAmountSchema,
+});
+
+export const allocationsPreviewRequestSchema = z.object({
+  orgId: z.string().min(1),
+  allocations: z.array(allocationLineInputSchema).min(1),
+});
+
+const allocationPreviewLineSchema = allocationLineInputSchema.extend({
+  status: z.enum(["proposed", "confirmed"]).default("proposed"),
+});
+
+export const allocationsPreviewResponseSchema = z.object({
+  previewId: z.string().min(1),
+  orgId: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  allocations: z.array(allocationPreviewLineSchema),
+  summary: allocationSummarySchema,
+});
+
+export const allocationsApplyRequestSchema = z.object({
+  previewId: z.string().min(1),
+  orgId: z.string().min(1),
+  allocations: z
+    .array(
+      z.object({
+        allocationId: z.string().min(1),
+        bankLineId: z.string().min(1),
+      })
+    )
+    .min(1),
+});
+
+export const allocationsApplyResponseSchema = z.object({
+  rptId: z.string().min(1),
+  summary: allocationSummarySchema,
+});
+
+export type AllocationsPreviewRequest = z.infer<typeof allocationsPreviewRequestSchema>;
+export type AllocationsPreviewResponse = z.infer<typeof allocationsPreviewResponseSchema>;
+export type AllocationsApplyRequest = z.infer<typeof allocationsApplyRequestSchema>;
+export type AllocationsApplyResponse = z.infer<typeof allocationsApplyResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { allocationSummarySchema } from "./allocations";
+
+const allocationLineSchema = z.object({
+  allocationId: z.string().min(1),
+  bankLineId: z.string().min(1),
+  amount: z.number().finite(),
+  currency: z
+    .string()
+    .trim()
+    .length(3)
+    .regex(/^[A-Z]{3}$/u, "Invalid ISO currency code"),
+  gstCode: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export const rptParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const rptResponseSchema = z.object({
+  rptId: z.string().min(1),
+  orgId: z.string().min(1),
+  mintedAt: z.string().datetime(),
+  summary: allocationSummarySchema,
+  allocations: z.array(allocationLineSchema),
+});
+
+export type RptParams = z.infer<typeof rptParamsSchema>;
+export type RptResponse = z.infer<typeof rptResponseSchema>;


### PR DESCRIPTION
## Summary
- add zod schemas for allocations preview and apply endpoints
- add rpt zod schema for fetching minted payment tokens
- add a Fastify response guard plugin to validate responses during development

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f38671069c8327a5361ed1b79894db