### PR TITLE
Add policy engine allocation preview module

### DIFF
--- a/apgms/shared/policy-engine/index.spec.ts
+++ b/apgms/shared/policy-engine/index.spec.ts
@@ -1,0 +1,139 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { previewAllocations, type BankLine, type Ruleset } from './index.js';
+
+const baseBankLine: BankLine = {
+  id: 'bank-1',
+  orgId: 'org-1',
+  amountCents: 10000,
+  date: '2024-01-01',
+  payee: 'Example Payee',
+  desc: 'Payment received',
+};
+
+const baseRuleset: Ruleset = {
+  gstRate: 0.1,
+  paygwRate: 0.2,
+  taxBufferRate: 0.15,
+  gates: {
+    remit: true,
+  },
+};
+
+test('conserves total allocation amount', () => {
+  const preview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: baseRuleset,
+    accountStates: {},
+  });
+
+  const sum = preview.allocations.reduce((acc, allocation) => acc + allocation.amountCents, 0);
+  assert.equal(sum, baseBankLine.amountCents);
+});
+
+test('allocations are non-negative', () => {
+  const preview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: baseRuleset,
+    accountStates: {},
+  });
+
+  for (const allocation of preview.allocations) {
+    assert.ok(allocation.amountCents >= 0);
+  }
+});
+
+test('uses bankers rounding for half values', () => {
+  const bankLine: BankLine = {
+    ...baseBankLine,
+    amountCents: 5,
+  };
+
+  const ruleset: Ruleset = {
+    gstRate: 0.1,
+    paygwRate: 0.3,
+    taxBufferRate: 0,
+    gates: { remit: true },
+  };
+
+  const preview = previewAllocations({ bankLine, ruleset, accountStates: {} });
+  const gst = preview.allocations.find((entry) => entry.bucket === 'GST');
+  const paygw = preview.allocations.find((entry) => entry.bucket === 'PAYGW');
+  assert.equal(gst?.amountCents, 0, '0.5 should round to 0 because 0 is even');
+  assert.equal(paygw?.amountCents, 2, '1.5 should round to 2 because 2 is even');
+});
+
+test('policy hash is deterministic for a ruleset', () => {
+  const preview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: baseRuleset,
+    accountStates: {},
+  });
+
+  assert.equal(
+    preview.policyHash,
+    '520ac588656540efbb6c686c7b12bbe4bdc25dc1afadd5c6db92eedb31cce67b',
+  );
+});
+
+test('remit gate does not change allocation values', () => {
+  const closedPreview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: {
+      ...baseRuleset,
+      gates: { remit: false },
+    },
+    accountStates: {},
+  });
+
+  const openPreview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: baseRuleset,
+    accountStates: {},
+  });
+
+  assert.deepEqual(
+    closedPreview.allocations,
+    openPreview.allocations,
+    'Remittance gate should not influence allocation amounts',
+  );
+});
+
+test('handles over allocation gracefully by reducing from tax-related buckets first', () => {
+  const bankLine: BankLine = {
+    ...baseBankLine,
+    amountCents: 1000,
+  };
+
+  const ruleset: Ruleset = {
+    gstRate: 0.4,
+    paygwRate: 0.4,
+    taxBufferRate: 0.4,
+    gates: { remit: true },
+  };
+
+  const preview = previewAllocations({ bankLine, ruleset, accountStates: {} });
+  const operating = preview.allocations.find((entry) => entry.bucket === 'OPERATING');
+  assert.ok(operating);
+  assert.equal(
+    preview.allocations.reduce((acc, allocation) => acc + allocation.amountCents, 0),
+    bankLine.amountCents,
+  );
+  for (const allocation of preview.allocations) {
+    assert.ok(allocation.amountCents >= 0);
+  }
+});
+
+test('explain string reflects gate status', () => {
+  const preview = previewAllocations({
+    bankLine: baseBankLine,
+    ruleset: {
+      ...baseRuleset,
+      gates: { remit: false },
+    },
+    accountStates: {},
+  });
+
+  assert.match(preview.explain, /Remittance gate is disabled/);
+});

--- a/apgms/shared/policy-engine/index.ts
+++ b/apgms/shared/policy-engine/index.ts
@@ -1,0 +1,166 @@
+import { createHash } from 'crypto';
+
+export type BankLine = {
+  id: string;
+  orgId: string;
+  amountCents: number;
+  date: string;
+  payee: string;
+  desc: string;
+};
+
+export type Ruleset = {
+  gstRate: number;
+  paygwRate: number;
+  taxBufferRate: number;
+  gates: {
+    remit: boolean;
+  };
+};
+
+export type AccountStates = Record<string, unknown>;
+
+export type Allocation = {
+  bucket: 'OPERATING' | 'TAX_BUFFER' | 'PAYGW' | 'GST';
+  amountCents: number;
+  currency: 'AUD';
+};
+
+export type Preview = {
+  allocations: Allocation[];
+  policyHash: string;
+  explain: string;
+};
+
+const POLICY_VERSION = 'v1';
+
+const BUCKET_ORDER: Allocation['bucket'][] = [
+  'GST',
+  'PAYGW',
+  'TAX_BUFFER',
+  'OPERATING',
+];
+
+function bankersRound(value: number): number {
+  const integer = Math.trunc(value);
+  const fraction = value - integer;
+
+  if (fraction > 0.5) {
+    return integer + 1;
+  }
+
+  if (fraction < 0.5) {
+    return integer;
+  }
+
+  return integer % 2 === 0 ? integer : integer + 1;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const entries = Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, canonicalize((value as Record<string, unknown>)[key])]);
+
+    return entries.reduce<Record<string, unknown>>((acc, [key, val]) => {
+      acc[key] = val;
+      return acc;
+    }, {});
+  }
+
+  return value;
+}
+
+function policyHashForRuleset(ruleset: Ruleset): string {
+  const canonicalJson = JSON.stringify(
+    canonicalize({
+      ruleset,
+      version: POLICY_VERSION,
+    }),
+  );
+
+  return createHash('sha256').update(canonicalJson).digest('hex');
+}
+
+function allocationAmount(baseAmount: number, rate: number): number {
+  if (rate <= 0) {
+    return 0;
+  }
+
+  const raw = baseAmount * rate;
+  return bankersRound(raw);
+}
+
+export function previewAllocations(input: {
+  bankLine: BankLine;
+  ruleset: Ruleset;
+  accountStates: AccountStates;
+}): Preview {
+  const { bankLine, ruleset } = input;
+  const baseAmount = bankLine.amountCents;
+
+  const gst: Allocation = { bucket: 'GST', amountCents: allocationAmount(baseAmount, ruleset.gstRate), currency: 'AUD' };
+  const paygw: Allocation = { bucket: 'PAYGW', amountCents: allocationAmount(baseAmount, ruleset.paygwRate), currency: 'AUD' };
+  const taxBuffer: Allocation = {
+    bucket: 'TAX_BUFFER',
+    amountCents: allocationAmount(baseAmount, ruleset.taxBufferRate),
+    currency: 'AUD',
+  };
+
+  let operating: Allocation = {
+    bucket: 'OPERATING',
+    amountCents: baseAmount - (gst.amountCents + paygw.amountCents + taxBuffer.amountCents),
+    currency: 'AUD',
+  };
+
+  if (operating.amountCents < 0) {
+    let overAllocated = -operating.amountCents;
+    operating = { ...operating, amountCents: 0 };
+
+    const adjustable = [taxBuffer, paygw, gst];
+    for (const allocation of adjustable) {
+      if (overAllocated <= 0) {
+        break;
+      }
+
+      const deduction = Math.min(allocation.amountCents, overAllocated);
+      allocation.amountCents -= deduction;
+      overAllocated -= deduction;
+    }
+  }
+
+  const allocations: Allocation[] = [gst, paygw, taxBuffer, operating];
+
+  const sum = allocations.reduce((acc, allocation) => acc + allocation.amountCents, 0);
+  let difference = baseAmount - sum;
+
+  if (difference > 0) {
+    operating.amountCents += difference;
+  } else if (difference < 0) {
+    difference = -difference;
+    const adjustable = [operating, taxBuffer, paygw, gst];
+    for (const allocation of adjustable) {
+      if (difference <= 0) {
+        break;
+      }
+
+      const deduction = Math.min(allocation.amountCents, difference);
+      allocation.amountCents -= deduction;
+      difference -= deduction;
+    }
+  }
+
+  const policyHash = policyHashForRuleset(ruleset);
+
+  const explain = `Allocated according to GST ${ruleset.gstRate}, PAYGW ${ruleset.paygwRate}, tax buffer ${ruleset.taxBufferRate}. Remittance gate is ${ruleset.gates.remit ? 'enabled' : 'disabled'}.`;
+
+  return {
+    allocations: BUCKET_ORDER.map((bucket) => allocations.find((entry) => entry.bucket === bucket)!),
+    policyHash,
+    explain,
+  };
+}


### PR DESCRIPTION
## Summary
- implement the v1 policy engine preview with deterministic hashing and allocation balancing
- add unit tests covering conservation, rounding, gating, and over-allocation behaviour

## Testing
- pnpm exec tsx --test shared/policy-engine/index.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f38657016c832792e8de9fdca7fd4b