### PR TITLE
feat(api-gateway): add health checks and graceful shutdown

### DIFF
--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,18 @@
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/healthz", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/readyz", async (_req, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return { ready: true };
+    } catch (error) {
+      app.log.error({ err: error }, "database readiness check failed");
+      return reply.code(503).send({ ready: false, reason: "db_unreachable" });
+    }
+  });
+};
+
+export default healthRoutes;


### PR DESCRIPTION
## Summary
- add healthz and readyz endpoints via Fastify plugin
- perform readiness check against Postgres using Prisma
- implement graceful shutdown handling for Fastify and Prisma

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3880316348327833d47f090fcfe4f