### PR TITLE
Add API gateway health tests to CI

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+      - name: Liveness & readiness tests
+        run: npm --prefix services/api-gateway run test:health

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test:health": "jest -i test/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- add a health test npm script to the API gateway service
- run the health test in CI after unit tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f38825d7f48327a8c3a574e5f5c474