### PR TITLE
Add safety utilities for API gateway LLM endpoint

### DIFF
--- a/apgms/services/api-gateway/src/lib/safety.ts
+++ b/apgms/services/api-gateway/src/lib/safety.ts
@@ -1,0 +1,16 @@
+const BAD_WORDS = /(ignore previous|reveal your system prompt|dump .*account|passwords?|bsb|ssn|credit card)/i;
+
+export function shouldRefuse(input: string): boolean {
+  return BAD_WORDS.test(input || "");
+}
+
+export function refusalMessage(): string {
+  return "I can’t help with that request.";
+}
+
+// Example usage (commented):
+// fastify.post("/llm", async (req, reply) => {
+//   const { prompt } = req.body as { prompt: string };
+//   if (shouldRefuse(prompt)) return reply.send({ text: refusalMessage() });
+//   // else call your LLM…
+// });


### PR DESCRIPTION
## Summary
- add a BAD_WORDS regex and helper to detect prompts that should be refused
- expose a refusal message helper with an example Fastify usage comment

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68f3890a89748327a992244c38f5151c