### PR TITLE
feat(api-gateway): guard responses with zod schemas

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,15 +10,17 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import responseGuard from "./plugins/response-guard";
+import healthRoutes from "./routes/health";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(responseGuard);
+await app.register(healthRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
 app.get("/users", async () => {

--- a/apgms/services/api-gateway/src/plugins/response-guard.ts
+++ b/apgms/services/api-gateway/src/plugins/response-guard.ts
@@ -1,0 +1,65 @@
+import type { FastifyPluginAsync } from "fastify";
+import type { ZodTypeAny } from "zod";
+
+const responseGuard: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    if (process.env.NODE_ENV === "production") {
+      return payload;
+    }
+
+    const zodResponse = (reply.context.schema as { zodResponse?: Record<number | string, ZodTypeAny> } | undefined)
+      ?.zodResponse;
+
+    if (!zodResponse) {
+      return payload;
+    }
+
+    const statusCode = reply.statusCode ?? 200;
+    const validator = zodResponse[statusCode] ?? zodResponse[String(statusCode)];
+
+    if (!validator) {
+      return payload;
+    }
+
+    let body: unknown = payload;
+
+    if (typeof payload === "string") {
+      try {
+        body = payload.length ? JSON.parse(payload) : null;
+      } catch (err) {
+        request.log.error({ err }, "response guard failed to parse payload");
+        const error = new Error("Response validation failed");
+        (error as any).statusCode = 500;
+        throw error;
+      }
+    } else if (Buffer.isBuffer(payload)) {
+      try {
+        body = payload.length ? JSON.parse(payload.toString("utf8")) : null;
+      } catch (err) {
+        request.log.error({ err }, "response guard failed to parse payload");
+        const error = new Error("Response validation failed");
+        (error as any).statusCode = 500;
+        throw error;
+      }
+    }
+
+    const result = validator.safeParse(body);
+
+    if (!result.success) {
+      request.log.error(
+        {
+          statusCode: reply.statusCode,
+          issues: result.error.issues.map(({ message, path }) => ({ message, path })),
+        },
+        "response guard validation failed",
+      );
+      const error = new Error("Response validation failed");
+      (error as any).statusCode = 500;
+      throw error;
+    }
+
+    return payload;
+  });
+};
+
+export default responseGuard;

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,38 @@
+import type { FastifyPluginAsync } from "fastify";
+import { Healthz200, Readyz200, Readyz503 } from "../schemas/health";
+
+const serviceName = process.env.SERVICE_NAME ?? "api-gateway";
+
+const healthRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    "/health",
+    {
+      schema: {
+        zodResponse: {
+          200: Healthz200,
+        },
+      },
+    },
+    async () => ({
+      ok: true,
+      service: serviceName,
+    }),
+  );
+
+  fastify.get(
+    "/ready",
+    {
+      schema: {
+        zodResponse: {
+          200: Readyz200,
+          503: Readyz503,
+        },
+      },
+    },
+    async () => ({
+      ready: true,
+    }),
+  );
+};
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/src/schemas/health.ts
+++ b/apgms/services/api-gateway/src/schemas/health.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const Healthz200 = z.object({
+  ok: z.boolean(),
+  service: z.string(),
+});
+
+export type Healthz200 = z.infer<typeof Healthz200>;
+
+export const Readyz200 = z.object({
+  ready: z.literal(true),
+});
+
+export type Readyz200 = z.infer<typeof Readyz200>;
+
+export const Readyz503 = z.object({
+  ready: z.literal(false),
+  reason: z.string(),
+});
+
+export type Readyz503 = z.infer<typeof Readyz503>;


### PR DESCRIPTION
## Summary
- add health zod schemas and a dev-only response validation guard
- register the response guard and attach zod response schemas to the health routes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f388106864832787cd360c69d4ea44