### PR TITLE
Add property-based policy engine and RPT integrity tests

### DIFF
--- a/apgms/services/api-gateway/test/policy-engine.property.spec.ts
+++ b/apgms/services/api-gateway/test/policy-engine.property.spec.ts
@@ -1,0 +1,212 @@
+import fc from "fast-check";
+import { describe, it, expect } from "vitest";
+
+const policyEngineModule: any = (() => {
+  try {
+    return require("../src/policy-engine");
+  } catch (error) {
+    throw new Error("Expected ../src/policy-engine to be resolvable for property tests");
+  }
+})();
+
+const previewAllocations: any =
+  policyEngineModule?.previewAllocations ??
+  policyEngineModule?.preview ??
+  policyEngineModule?.default?.previewAllocations;
+
+if (typeof previewAllocations !== "function") {
+  throw new Error("previewAllocations export not found in policy engine module");
+}
+
+type SimpleRuleLeaf = {
+  id: string;
+  shareBps: number;
+  percentage: number;
+  weight: number;
+  type: string;
+  allocation: {
+    shareBps: number;
+    percentage: number;
+    weight: number;
+    type: string;
+  };
+  target: {
+    type: string;
+    accountId: string;
+  };
+  accountId: string;
+  children: SimpleRuleLeaf[];
+  splits: SimpleRuleLeaf[];
+  rules: SimpleRuleLeaf[];
+};
+
+type SimpleRuleSet = {
+  id: string;
+  type: string;
+  shareBps: number;
+  percentage: number;
+  weight: number;
+  allocation: {
+    shareBps: number;
+    percentage: number;
+    weight: number;
+    type: string;
+  };
+  children: SimpleRuleLeaf[];
+  splits: SimpleRuleLeaf[];
+  rules: SimpleRuleLeaf[];
+};
+
+const simpleRuleSetArb = fc
+  .array(fc.integer({ min: 0, max: 10_000 }), { minLength: 1, maxLength: 8 })
+  .map((weights) => {
+    const normalized = [...weights];
+    if (!normalized.some((value) => value > 0)) {
+      normalized[0] = 1;
+    }
+    const totalWeight = normalized.reduce((sum, value) => sum + value, 0);
+
+    let remainder = 10_000;
+    const leaves: SimpleRuleLeaf[] = normalized.map((weight, index, array) => {
+      const proportionalShare = Math.floor((weight * 10_000) / totalWeight);
+      const shareBps = index === array.length - 1 ? remainder : proportionalShare;
+      remainder -= shareBps;
+
+      const percentage = shareBps / 100;
+      const node: SimpleRuleLeaf = {
+        id: `leaf-${index}`,
+        shareBps,
+        percentage,
+        weight: shareBps,
+        type: "allocation",
+        allocation: {
+          shareBps,
+          percentage,
+          weight: shareBps,
+          type: "allocation",
+        },
+        target: {
+          type: "account",
+          accountId: `acct-${index}`,
+        },
+        accountId: `acct-${index}`,
+        children: [],
+        splits: [],
+        rules: [],
+      };
+
+      return node;
+    });
+
+    const root: SimpleRuleSet = {
+      id: "root",
+      type: "split",
+      shareBps: 10_000,
+      percentage: 100,
+      weight: 10_000,
+      allocation: {
+        shareBps: 10_000,
+        percentage: 100,
+        weight: 10_000,
+        type: "split",
+      },
+      children: leaves,
+      splits: leaves,
+      rules: leaves,
+    };
+
+    return root;
+  });
+
+function attemptPreview(amountCents: number, ruleset: SimpleRuleSet) {
+  const attempts = [
+    () => previewAllocations(amountCents, ruleset),
+    () => previewAllocations({ amountCents, ruleset }),
+    () => previewAllocations({ amountCents, rules: ruleset }),
+    () => previewAllocations({ amountCents, policy: ruleset }),
+    () => previewAllocations(ruleset, amountCents),
+    () => previewAllocations({ policy: ruleset, amountCents }),
+  ];
+
+  let lastError: unknown;
+  for (const attempt of attempts) {
+    try {
+      const result = attempt();
+      if (result !== undefined) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error("Unable to obtain preview allocations result");
+}
+
+function extractAllocations(result: any): any[] {
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (Array.isArray(result?.allocations)) {
+    return result.allocations;
+  }
+  if (Array.isArray(result?.allocation)) {
+    return result.allocation;
+  }
+  if (Array.isArray(result?.preview)) {
+    return result.preview;
+  }
+  if (Array.isArray(result?.entries)) {
+    return result.entries;
+  }
+  throw new Error("previewAllocations result did not contain an allocations collection");
+}
+
+function readAmountCents(allocation: any): number {
+  const candidates = [
+    allocation?.amountCents,
+    allocation?.cents,
+    allocation?.amount,
+    allocation?.value,
+    allocation?.allocation?.amountCents,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Allocation object does not expose a numeric amount");
+}
+
+describe("policy-engine preview allocations", () => {
+  it("conserves total amount and keeps allocations non-negative", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 500_000_000 }),
+        simpleRuleSetArb,
+        (amountCents, ruleset) => {
+          const preview = attemptPreview(amountCents, ruleset);
+          const allocations = extractAllocations(preview);
+
+          expect(allocations.length).toBeGreaterThan(0);
+
+          let total = 0;
+          for (const allocation of allocations) {
+            const value = Math.trunc(readAmountCents(allocation));
+            expect(value).toBeGreaterThanOrEqual(0);
+            total += value;
+          }
+
+          expect(total).toBe(amountCents);
+        }
+      ),
+      { numRuns: 10000 }
+    );
+  });
+});

--- a/apgms/services/api-gateway/test/rpt.spec.ts
+++ b/apgms/services/api-gateway/test/rpt.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+const rptModule: any = (() => {
+  try {
+    return require("../src/rpt");
+  } catch (error) {
+    throw new Error("Expected ../src/rpt to be resolvable for integrity tests");
+  }
+})();
+
+const mintReceipt: any =
+  rptModule?.mintReceipt ??
+  rptModule?.mint ??
+  rptModule?.default?.mintReceipt ??
+  rptModule?.default?.mint;
+
+const verifyReceipt: any =
+  rptModule?.verifyReceipt ??
+  rptModule?.verify ??
+  rptModule?.default?.verifyReceipt ??
+  rptModule?.default?.verify;
+
+const verifyChain: any =
+  rptModule?.verifyChain ??
+  rptModule?.verifyReceipts ??
+  rptModule?.default?.verifyChain ??
+  rptModule?.default?.verifyReceipts;
+
+if (typeof mintReceipt !== "function") {
+  throw new Error("mintReceipt export not found on RPT module");
+}
+if (typeof verifyReceipt !== "function") {
+  throw new Error("verifyReceipt export not found on RPT module");
+}
+if (typeof verifyChain !== "function") {
+  throw new Error("verifyChain export not found on RPT module");
+}
+
+function mint(payload: Record<string, any>, prevHash: string) {
+  const basePayload = { ...payload };
+  const attempts = [
+    () => mintReceipt({ ...basePayload, prevHash }),
+    () => mintReceipt(basePayload, { prevHash }),
+    () => mintReceipt(basePayload, prevHash),
+    () => mintReceipt({ payload: basePayload, prevHash }),
+    () => mintReceipt({ payload: basePayload, meta: { prevHash } }),
+    () => mintReceipt({ ...basePayload, meta: { prevHash } }),
+  ];
+
+  let lastError: unknown;
+  for (const attempt of attempts) {
+    try {
+      const result = attempt();
+      if (result) {
+        return result;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error("Unable to mint receipt with provided payload");
+}
+
+function readHash(receipt: any): string {
+  const candidates = [
+    receipt?.hash,
+    receipt?.receiptHash,
+    receipt?.digest,
+    receipt?.metadata?.hash,
+    receipt?.meta?.hash,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Receipt does not expose a hash field");
+}
+
+function readPrevHash(receipt: any): string {
+  const candidates = [
+    receipt?.prevHash,
+    receipt?.previousHash,
+    receipt?.meta?.prevHash,
+    receipt?.headers?.prevHash,
+    receipt?.metadata?.prevHash,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      return candidate;
+    }
+  }
+
+  throw new Error("Receipt does not expose a prevHash field");
+}
+
+function setPrevHash(receipt: any, value: string) {
+  if ("prevHash" in receipt) {
+    receipt.prevHash = value;
+  }
+  if (receipt.meta) {
+    receipt.meta.prevHash = value;
+  }
+  if (receipt.metadata) {
+    receipt.metadata.prevHash = value;
+  }
+  if (receipt.headers) {
+    receipt.headers.prevHash = value;
+  }
+}
+
+function tamperPayload(receipt: any) {
+  if (receipt.payload && typeof receipt.payload === "object") {
+    receipt.payload = { ...receipt.payload, __tampered: true };
+    return;
+  }
+  if (receipt.data && typeof receipt.data === "object") {
+    receipt.data = { ...receipt.data, __tampered: true };
+    return;
+  }
+  receipt.extra = { tampered: true };
+}
+
+describe("RPT integrity", () => {
+  it("mints a receipt that verifies", () => {
+    const receipt = mint({ id: "rpt-1", amountCents: 1234 }, "");
+    expect(verifyReceipt(receipt)).toBe(true);
+  });
+
+  it("fails verification when tampered", () => {
+    const receipt = mint({ id: "rpt-2", amountCents: 4321 }, "");
+    expect(verifyReceipt(receipt)).toBe(true);
+
+    const tampered = { ...receipt };
+    tamperPayload(tampered);
+
+    expect(verifyReceipt(tampered)).toBe(false);
+  });
+
+  it("validates and rejects RPT chains appropriately", () => {
+    const genesis = mint({ id: "rpt-1", amountCents: 111 }, "");
+    const rpt2 = mint({ id: "rpt-2", amountCents: 222 }, readHash(genesis));
+    const rpt3 = mint({ id: "rpt-3", amountCents: 333 }, readHash(rpt2));
+
+    expect(verifyChain([genesis, rpt2, rpt3])).toBe(true);
+
+    const broken = { ...rpt2 };
+    setPrevHash(broken, "not-the-right-prev-hash");
+    expect(verifyChain([genesis, broken, rpt3])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add fast-check property coverage to ensure preview allocations conserve funds and stay non-negative
- add RPT mint, tampering detection, and chain verification integrity tests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3868951d08327868f8099c4ddba41