### PR TITLE
Add Playwright smoke test suite

### DIFF
--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,20 @@
-﻿export default {};
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apgms/tests/smoke.spec.ts
+++ b/apgms/tests/smoke.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Smoke', () => {
+  test('KPIs render on the dashboard', async ({ page }) => {
+    await page.goto('/');
+
+    const kpiCards = page.locator('[data-testid="kpi-card"]');
+    const kpiEmptyState = page.locator('[data-testid="kpis-empty"], [data-testid="kpis-empty-state"]');
+
+    const kpiCardCount = await kpiCards.count();
+
+    if (kpiCardCount > 0) {
+      await expect(kpiCards.first()).toBeVisible();
+      return;
+    }
+
+    if ((await kpiEmptyState.count()) > 0) {
+      await expect(kpiEmptyState.first()).toBeVisible();
+      return;
+    }
+
+    throw new Error('Expected KPI cards or KPI empty state to be visible.');
+  });
+
+  test('Bank line drawer exposes Verify RPT action', async ({ page }) => {
+    await page.goto('/bank-lines?orgId=org_demo');
+
+    const dataRow = page
+      .getByRole('row')
+      .filter({ has: page.getByRole('cell') })
+      .first();
+
+    await expect(dataRow).toBeVisible();
+    await dataRow.click();
+
+    const drawer = page.getByRole('dialog');
+    await expect(drawer).toBeVisible();
+
+    const verifyButton = drawer.getByRole('button', { name: /verify rpt/i });
+    await expect(verifyButton).toBeVisible();
+    await expect(verifyButton).toBeEnabled();
+
+    await verifyButton.focus();
+    await expect(verifyButton).toBeFocused();
+  });
+});

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,10 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build webapp",
+    "test": "echo test webapp",
+    "test:e2e": "playwright test"
+  }
+}


### PR DESCRIPTION
## Summary
- configure Playwright to run smoke tests against the dashboard
- cover KPI visibility and Verify RPT drawer behaviour with a smoke spec
- expose an npm script for running the end-to-end Playwright suite

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38b0a31fc83279a1235dd3e53aa6f