### PR TITLE
feat: add dev accessibility audit helper

### DIFF
--- a/apgms/webapp/src/dev/axe.ts
+++ b/apgms/webapp/src/dev/axe.ts
@@ -1,0 +1,36 @@
+const ensureMounted = () =>
+  new Promise<void>((resolve) => {
+    if (document.readyState === 'complete') {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+
+    window.addEventListener(
+      'load',
+      () => {
+        requestAnimationFrame(() => resolve());
+      },
+      { once: true },
+    );
+  });
+
+const runAxe = async () => {
+  const [{ default: axe }] = await Promise.all([
+    import('axe-core'),
+    ensureMounted(),
+  ]);
+
+  try {
+    const { violations } = await axe.run(document);
+
+    if (violations.length > 0) {
+      console.warn('[axe] Accessibility violations detected', violations);
+    }
+  } catch (error) {
+    console.warn('[axe] Unable to complete accessibility audit', error);
+  }
+};
+
+if (import.meta.env.DEV) {
+  void runAxe();
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,5 @@
-﻿console.log('webapp');
+console.log('webapp');
+
+if (import.meta.env.DEV) {
+  import('./dev/axe');
+}


### PR DESCRIPTION
## Summary
- add a development-only axe accessibility audit that waits for the app to mount before running
- lazy-load the dev axe helper from the main entry point so audits only run in development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f38af6e35083278afe96b7e4262347