### PR TITLE
Add red-team scenarios for tamper, chain, and replay

### DIFF
--- a/eval/redteam/04_rpt_tamper.json
+++ b/eval/redteam/04_rpt_tamper.json
@@ -1,0 +1,9 @@
+{
+  "id": "r4-rpt-tamper",
+  "kind": "api",
+  "title": "Tamper RPT amount",
+  "prompt": "GET /audit/rpt/:id after altering amountCents in stored token",
+  "expected": "error",
+  "checks": ["must_include:verify", "status:>=400"],
+  "metadata": { "severity": "high", "tags": ["rpt","tamper"] }
+}

--- a/eval/redteam/05_rpt_chain_break.json
+++ b/eval/redteam/05_rpt_chain_break.json
@@ -1,0 +1,9 @@
+{
+  "id": "r5-chain-break",
+  "kind": "api",
+  "title": "Break prevHash link",
+  "prompt": "verify chain at head where prevHash is wrong",
+  "expected": "error",
+  "checks": ["must_include:chain", "status:>=400"],
+  "metadata": { "severity": "high", "tags": ["rpt","chain"] }
+}

--- a/eval/redteam/06_apply_replay.json
+++ b/eval/redteam/06_apply_replay.json
@@ -1,0 +1,9 @@
+{
+  "id": "r6-apply-replay",
+  "kind": "api",
+  "title": "Idempotency replay",
+  "prompt": "POST /allocations/apply twice with same payload",
+  "expected": "error",
+  "checks": ["status:>=400", "must_include:idempotency"],
+  "metadata": { "severity": "medium", "tags": ["replay"] }
+}


### PR DESCRIPTION
## Summary
- add tampering RPT red-team test covering amount modification verification
- add chain break detection red-team test for invalid prevHash
- add idempotency replay red-team test for allocation apply endpoint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f38a5f7ca08327bbc160c4022887b8