### PR TITLE
feat: add allocation schemas and response guard

### DIFF
--- a/apgms/services/api-gateway/src/plugins/response-guard.ts
+++ b/apgms/services/api-gateway/src/plugins/response-guard.ts
@@ -1,0 +1,67 @@
+import fp from "fastify-plugin";
+import type { FastifyReply, FastifyPluginAsync } from "fastify";
+import { ZodTypeAny } from "zod";
+
+const shouldValidate = () => process.env.NODE_ENV !== "production";
+
+const parsePayload = (payload: unknown, reply: FastifyReply): unknown => {
+  if (payload === null || payload === undefined) {
+    return payload;
+  }
+
+  const contentType = reply.getHeader("content-type");
+  const isJson = typeof contentType === "string" && contentType.includes("application/json");
+
+  if (typeof payload === "string") {
+    if (!isJson) {
+      return payload;
+    }
+    return JSON.parse(payload);
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    if (!isJson) {
+      return payload;
+    }
+    return JSON.parse(payload.toString("utf-8"));
+  }
+
+  return payload;
+};
+
+const responseGuardPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    if (!shouldValidate()) {
+      return payload;
+    }
+
+    const zodResponse: ZodTypeAny | undefined =
+      (request.routeOptions?.schema as { zodResponse?: ZodTypeAny } | undefined)?.zodResponse;
+
+    if (!zodResponse) {
+      return payload;
+    }
+
+    let data: unknown = payload;
+
+    try {
+      data = parsePayload(payload, reply);
+    } catch (error) {
+      request.log.error({ err: error }, "response guard: failed to parse payload for validation");
+      reply.code(500);
+      throw new Error("Response validation failed");
+    }
+
+    const validationResult = zodResponse.safeParse(data);
+
+    if (!validationResult.success) {
+      request.log.error({ err: validationResult.error }, "response guard: schema validation failed");
+      reply.code(500);
+      throw new Error("Response validation failed");
+    }
+
+    return payload;
+  });
+};
+
+export default fp(responseGuardPlugin);

--- a/apgms/services/api-gateway/src/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const moneySchema = z.object({
+  currency: z.string().min(3).max(3),
+  value: z.string(),
+});
+
+export const allocationSchema = z.object({
+  allocationId: z.string(),
+  ledgerAccountId: z.string(),
+  ledgerAccountName: z.string(),
+  direction: z.enum(["debit", "credit"]),
+  amount: moneySchema,
+  memo: z.string().optional(),
+});
+
+export const allocationsPreviewRequestSchema = z.object({
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policyHash: z.string(),
+});
+
+export const allocationsPreviewResponseSchema = z.object({
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policyHash: z.string(),
+  prevHash: z.string(),
+  allocations: z.array(allocationSchema),
+  totals: z.object({
+    debit: moneySchema,
+    credit: moneySchema,
+  }),
+});
+
+export const allocationsApplyRequestSchema = z.object({
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policyHash: z.string(),
+  allocations: z.array(allocationSchema),
+  prevHash: z.string(),
+});
+
+export const allocationsApplyResponseSchema = z.object({
+  rptId: z.string(),
+});
+
+export type AllocationsPreviewRequest = z.infer<typeof allocationsPreviewRequestSchema>;
+export type AllocationsPreviewResponse = z.infer<typeof allocationsPreviewResponseSchema>;
+export type AllocationsApplyRequest = z.infer<typeof allocationsApplyRequestSchema>;
+export type AllocationsApplyResponse = z.infer<typeof allocationsApplyResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+import { allocationSchema } from "./allocations";
+
+export const rptParamsSchema = z.object({
+  id: z.string(),
+});
+
+export const rptResponseSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policyHash: z.string(),
+  prevHash: z.string(),
+  allocations: z.array(allocationSchema),
+  totals: z.object({
+    debit: z.object({
+      currency: z.string().min(3).max(3),
+      value: z.string(),
+    }),
+    credit: z.object({
+      currency: z.string().min(3).max(3),
+      value: z.string(),
+    }),
+  }),
+  status: z.enum(["preview", "applied"]),
+  createdAt: z.string(),
+  updatedAt: z.string().optional(),
+});
+
+export type RptParams = z.infer<typeof rptParamsSchema>;
+export type RptResponse = z.infer<typeof rptResponseSchema>;


### PR DESCRIPTION
## Summary
- add zod schemas for allocation preview/apply and rpt
- add a development-only response guard plugin to validate replies against zod schemas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f38a37c1b88327ba940e11a20e8a7e