### PR TITLE
feat: add allocations preview/apply and audit routes

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,16 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import responseGuard from "./plugins/response-guard";
+import allocationsRoutes from "./routes/allocations";
+import auditRoutes from "./routes/audit";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(responseGuard);
+await app.register(allocationsRoutes);
+await app.register(auditRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/lib/allocations.ts
+++ b/apgms/services/api-gateway/src/lib/allocations.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+
+export const allocationItemSchema = z.object({
+  allocationId: z.string().min(1, "allocationId is required"),
+  amount: z
+    .number()
+    .finite("amount must be a finite number")
+    .nonnegative("amount must be zero or positive"),
+  memo: z.string().max(1024).optional(),
+});
+
+export const allocationRequestSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  currency: z.string().min(3).max(3),
+  total: z.number().finite("total must be a finite number"),
+  allocations: z.array(allocationItemSchema).min(1, "allocations must not be empty"),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type AllocationItem = z.infer<typeof allocationItemSchema>;
+export type AllocationRequest = z.infer<typeof allocationRequestSchema>;
+
+export interface AllocationPreview extends AllocationRequest {
+  metadata: Record<string, unknown>;
+  totals: {
+    requested: number;
+    allocated: number;
+    delta: number;
+    conserved: boolean;
+  };
+}
+
+const EPSILON = 0.000001;
+
+export const previewAllocations = (request: AllocationRequest): AllocationPreview => {
+  const allocated = request.allocations.reduce((sum, allocation) => sum + allocation.amount, 0);
+  const delta = allocated - request.total;
+
+  return {
+    ...request,
+    metadata: request.metadata ?? {},
+    totals: {
+      requested: request.total,
+      allocated,
+      delta,
+      conserved: Math.abs(delta) <= EPSILON,
+    },
+  };
+};

--- a/apgms/services/api-gateway/src/lib/kms.ts
+++ b/apgms/services/api-gateway/src/lib/kms.ts
@@ -1,0 +1,5 @@
+import { DevKms } from "./rpt";
+
+const secret = process.env.DEV_KMS_SECRET ?? "dev-secret";
+
+export const kms = new DevKms(secret);

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,64 @@
+import { createHmac, randomUUID } from "node:crypto";
+import type { AllocationItem } from "./allocations";
+
+export interface RptPayload {
+  orgId: string;
+  currency: string;
+  total: number;
+  allocations: AllocationItem[];
+  metadata: Record<string, unknown>;
+}
+
+export interface RptToken {
+  id: string;
+  version: number;
+  issuedAt: string;
+  payload: RptPayload;
+  signature: string;
+}
+
+export class DevKms {
+  constructor(private readonly secret: string) {}
+
+  sign(message: string): string {
+    return createHmac("sha256", this.secret).update(message).digest("hex");
+  }
+
+  verify(message: string, signature: string): boolean {
+    return this.sign(message) === signature;
+  }
+}
+
+const canonicalise = (token: Omit<RptToken, "signature">): string =>
+  JSON.stringify({
+    id: token.id,
+    version: token.version,
+    issuedAt: token.issuedAt,
+    payload: token.payload,
+  });
+
+export const mintRpt = (kms: DevKms, payload: RptPayload): RptToken => {
+  const enrichedPayload: RptPayload = {
+    ...payload,
+    metadata: payload.metadata ?? {},
+  };
+
+  const baseToken: Omit<RptToken, "signature"> = {
+    id: randomUUID(),
+    version: 1,
+    issuedAt: new Date().toISOString(),
+    payload: enrichedPayload,
+  };
+
+  const signature = kms.sign(canonicalise(baseToken));
+
+  return {
+    ...baseToken,
+    signature,
+  };
+};
+
+export const verifyRpt = (kms: DevKms, token: RptToken): boolean => {
+  const { signature, ...withoutSignature } = token;
+  return kms.verify(canonicalise(withoutSignature), signature);
+};

--- a/apgms/services/api-gateway/src/plugins/response-guard.ts
+++ b/apgms/services/api-gateway/src/plugins/response-guard.ts
@@ -1,0 +1,17 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const responseGuard: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("onSend", async (_request, reply, payload) => {
+    if (
+      typeof payload === "object" &&
+      payload !== null &&
+      !reply.hasHeader("content-type")
+    ) {
+      reply.header("content-type", "application/json; charset=utf-8");
+    }
+
+    return payload;
+  });
+};
+
+export default responseGuard;

--- a/apgms/services/api-gateway/src/routes/allocations.ts
+++ b/apgms/services/api-gateway/src/routes/allocations.ts
@@ -1,0 +1,57 @@
+import type { FastifyPluginAsync } from "fastify";
+import { allocationRequestSchema, previewAllocations } from "../lib/allocations";
+import { mintRpt, type RptPayload } from "../lib/rpt";
+import { kms } from "../lib/kms";
+import { rptStore } from "../stores/rpt-store";
+
+const allocationsRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post("/allocations/preview", async (request, reply) => {
+    const result = allocationRequestSchema.safeParse(request.body);
+
+    if (!result.success) {
+      return reply.code(400).send({
+        error: "invalid_request",
+        details: result.error.format(),
+      });
+    }
+
+    const preview = previewAllocations(result.data);
+    return reply.send(preview);
+  });
+
+  fastify.post("/allocations/apply", async (request, reply) => {
+    const result = allocationRequestSchema.safeParse(request.body);
+
+    if (!result.success) {
+      return reply.code(400).send({
+        error: "invalid_request",
+        details: result.error.format(),
+      });
+    }
+
+    const preview = previewAllocations(result.data);
+
+    if (!preview.totals.conserved) {
+      return reply.code(400).send({
+        error: "allocation_not_conserved",
+        totals: preview.totals,
+      });
+    }
+
+    const payload: RptPayload = {
+      orgId: result.data.orgId,
+      currency: result.data.currency,
+      total: result.data.total,
+      allocations: result.data.allocations,
+      metadata: result.data.metadata ?? {},
+    };
+
+    const rpt = mintRpt(kms, payload);
+
+    rptStore.set(rpt.id, rpt);
+
+    return reply.code(201).send({ rptId: rpt.id });
+  });
+};
+
+export default allocationsRoutes;

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,38 @@
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import { rptStore } from "../stores/rpt-store";
+import { kms } from "../lib/kms";
+import { verifyRpt } from "../lib/rpt";
+
+const auditRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get("/audit/rpt/:id", async (request, reply) => {
+    const paramsResult = z
+      .object({ id: z.string().min(1, "id is required") })
+      .safeParse(request.params);
+
+    if (!paramsResult.success) {
+      return reply.code(400).send({
+        error: "invalid_request",
+        details: paramsResult.error.format(),
+      });
+    }
+
+    const { id } = paramsResult.data;
+    const token = rptStore.get(id);
+
+    if (!token) {
+      return reply.code(404).send({ error: "rpt_not_found" });
+    }
+
+    const valid = verifyRpt(kms, token);
+
+    if (!valid) {
+      rptStore.delete(id);
+      return reply.code(400).send({ error: "rpt_tampered" });
+    }
+
+    return reply.send(token);
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/src/stores/rpt-store.ts
+++ b/apgms/services/api-gateway/src/stores/rpt-store.ts
@@ -1,0 +1,3 @@
+import type { RptToken } from "../lib/rpt";
+
+export const rptStore = new Map<string, RptToken>();


### PR DESCRIPTION
## Summary
- add allocation validation helpers, DevKms signing helpers, and an in-memory RPT store
- expose /allocations/preview and /allocations/apply endpoints that validate conservation and mint RPTs
- add an audit endpoint with basic response guarding and wire the new routes into the API gateway

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: @prisma/client has no exported member PrismaClient in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68f38a43805883278b5be2dd8f44fb68