### PR TITLE
Add JSON schemas for allocation preview and RPT

### DIFF
--- a/apgms/contracts/allocations.preview.schema.json
+++ b/apgms/contracts/allocations.preview.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "allocations.preview.schema.json",
+  "type": "object",
+  "required": ["policyHash", "allocations", "explain"],
+  "properties": {
+    "policyHash": { "type": "string", "minLength": 32 },
+    "allocations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["bucket", "amountCents", "currency"],
+        "properties": {
+          "bucket": { "enum": ["OPERATING", "TAX_BUFFER", "PAYGW", "GST"] },
+          "amountCents": { "type": "integer", "minimum": 0 },
+          "currency": { "type": "string", "pattern": "^[A-Z]{3}$" }
+        }
+      }
+    },
+    "explain": { "type": "string", "maxLength": 2000 }
+  }
+}

--- a/apgms/contracts/rpt.schema.json
+++ b/apgms/contracts/rpt.schema.json
@@ -1,0 +1,27 @@
+{
+  "$id": "rpt.schema.json",
+  "type": "object",
+  "required": ["rptId", "orgId", "bankLineId", "policyHash", "allocations", "prevHash", "sig", "timestamp"],
+  "properties": {
+    "rptId": { "type": "string", "pattern": "^rpt_[a-z0-9]{8,}$" },
+    "orgId": { "type": "string" },
+    "bankLineId": { "type": "string" },
+    "policyHash": { "type": "string", "minLength": 32 },
+    "allocations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["bucket", "amountCents", "currency"],
+        "properties": {
+          "bucket": { "enum": ["OPERATING", "TAX_BUFFER", "PAYGW", "GST"] },
+          "amountCents": { "type": "integer", "minimum": 0 },
+          "currency": { "type": "string", "pattern": "^[A-Z]{3}$" }
+        }
+      }
+    },
+    "prevHash": { "type": "string" },
+    "sig": { "type": "string" },
+    "timestamp": { "type": "string", "format": "date-time" }
+  }
+}


### PR DESCRIPTION
## Summary
- add allocations preview contract schema covering hash, allocations, and explain fields
- add RPT contract schema including identifiers, allocations, and metadata constraints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f38a10ad58832780f82cddde64103c