### PR TITLE
Add golden tests to CI workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,5 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+      - name: Golden tests
+        run: npm run golden


### PR DESCRIPTION
## Summary
- add a Golden tests step to the CI workflow to run `npm run golden`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f389bb2d788327886e4ff122368cbd