### PR TITLE
Add golden route schema and starter cases

### DIFF
--- a/eval/golden/01_normal_simple.json
+++ b/eval/golden/01_normal_simple.json
@@ -1,0 +1,10 @@
+{
+  "id": "g1-normal-simple",
+  "kind": "route",
+  "route": "allocations.preview",
+  "input": {
+    "orgId": "org_demo",
+    "bankLine": { "id": "bl_001", "amountCents": 100000, "date": "2025-09-01T00:00:00Z", "payee": "Customer A", "desc": "Invoice 1001" }
+  },
+  "expect": { "valid_schema": true, "rules": ["conservation","non_negative"] }
+}

--- a/eval/golden/02_normal_rounding.json
+++ b/eval/golden/02_normal_rounding.json
@@ -1,0 +1,10 @@
+{
+  "id": "g2-normal-rounding",
+  "kind": "route",
+  "route": "allocations.preview",
+  "input": {
+    "orgId": "org_demo",
+    "bankLine": { "id": "bl_002", "amountCents": 9999, "date": "2025-09-02T00:00:00Z", "payee": "Customer B", "desc": "Small sale" }
+  },
+  "expect": { "valid_schema": true, "rules": ["conservation","non_negative"] }
+}

--- a/eval/golden/03_edge_gate_closed.json
+++ b/eval/golden/03_edge_gate_closed.json
@@ -1,0 +1,10 @@
+{
+  "id": "g3-edge-gate-closed",
+  "kind": "route",
+  "route": "allocations.apply",
+  "input": {
+    "orgId": "org_demo",
+    "bankLine": { "id": "bl_003", "amountCents": 200000, "date": "2025-09-03T00:00:00Z", "payee": "Customer C", "desc": "During closed gate" }
+  },
+  "expect": { "valid_schema": true, "rules": ["gate_respected"] }
+}

--- a/eval/golden/04_adversarial_string_amount.json
+++ b/eval/golden/04_adversarial_string_amount.json
@@ -1,0 +1,10 @@
+{
+  "id": "g4-adv-string-amount",
+  "kind": "route",
+  "route": "allocations.preview",
+  "input": {
+    "orgId": "org_demo",
+    "bankLine": { "id": "bl_004", "amountCents": "1000", "date": "2025-09-04T00:00:00Z", "payee": "Customer D", "desc": "Bad type" }
+  },
+  "expect": { "valid_schema": false, "rules": [] }
+}

--- a/eval/golden/_schema.json
+++ b/eval/golden/_schema.json
@@ -1,0 +1,11 @@
+{
+  "id": "unique",
+  "kind": "route",
+  "route": "allocations.apply | allocations.preview | dashboard",
+  "input": { "orgId": "org_123", "bankLine": { "id": "bl_1", "amountCents": 12345, "date": "2025-09-01T00:00:00Z", "payee": "ACME", "desc": "Sale" } },
+  "expect": {
+    "valid_schema": true,
+    "rules": ["conservation", "non_negative", "gate_respected"],
+    "notes": "optional"
+  }
+}


### PR DESCRIPTION
## Summary
- add shared schema definition for allocation-related routes
- add four starter golden cases covering normal, edge, and adversarial scenarios

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f389a2f4c88327870ac8f897a8162e