### PR TITLE
feat: scaffold webapp shell and shared utilities

### DIFF
--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,47 @@
+import axios, { AxiosInstance } from 'axios';
+
+const API_BASE_URL = 'http://localhost:3000';
+
+const createClient = (): AxiosInstance =>
+  axios.create({
+    baseURL: API_BASE_URL,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+const client = createClient();
+
+export const getDashboard = async () => {
+  const response = await client.get('/dashboard');
+  return response.data;
+};
+
+export interface BankLinesParams {
+  orgId: string;
+  take?: number;
+  cursor?: string;
+}
+
+export const getBankLines = async ({ orgId, take, cursor }: BankLinesParams) => {
+  const response = await client.get('/bank-lines', {
+    params: {
+      orgId,
+      take,
+      cursor,
+    },
+  });
+
+  return response.data;
+};
+
+export const getRptByLine = async (id: string) => {
+  if (!id) {
+    throw new Error('A bank line identifier is required to load the report.');
+  }
+
+  const response = await client.get(`/bank-lines/${id}/report`);
+  return response.data;
+};
+
+export default client;

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,97 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+
+import AppShell from './shell/AppShell';
+
+type Theme = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'apgms:theme';
+
+const isTheme = (value: unknown): value is Theme => value === 'light' || value === 'dark';
+
+const getPreferredTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage?.getItem(THEME_STORAGE_KEY);
+  if (isTheme(stored)) {
+    return stored;
+  }
+
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+
+  return 'light';
+};
+
+const applyTheme = (theme: Theme) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  document.documentElement.setAttribute('data-theme', theme);
+};
+
+const initialTheme = getPreferredTheme();
+applyTheme(initialTheme);
+
+const queryClient = new QueryClient();
+
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <AppShell initialTheme={initialTheme} storageKey={THEME_STORAGE_KEY} />,
+    children: [
+      { index: true, element: <DashboardPage /> },
+      { path: 'bank-lines', element: <BankLinesPage /> },
+    ],
+  },
+]);
+
+function DashboardPage() {
+  return (
+    <section aria-labelledby="dashboard-heading" style={{ padding: '1.5rem' }}>
+      <h1 id="dashboard-heading" style={{ fontSize: '1.5rem', marginBottom: '0.75rem' }}>
+        Dashboard
+      </h1>
+      <p style={{ lineHeight: 1.6, maxWidth: '38rem' }}>
+        Welcome to the APGMS console. Use the navigation to explore operational insights and
+        financial overviews tailored for your organisation.
+      </p>
+    </section>
+  );
+}
+
+function BankLinesPage() {
+  return (
+    <section aria-labelledby="bank-lines-heading" style={{ padding: '1.5rem' }}>
+      <h1 id="bank-lines-heading" style={{ fontSize: '1.5rem', marginBottom: '0.75rem' }}>
+        Bank Lines
+      </h1>
+      <p style={{ lineHeight: 1.6, maxWidth: '38rem' }}>
+        Review the facilities that power your bank lines. Filter and drill into each line to monitor
+        utilisation, repayments, and upcoming maturities.
+      </p>
+    </section>
+  );
+}
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Root element with id "root" was not found.');
+}
+
+const root = ReactDOM.createRoot(container);
+
+root.render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/shell/AppShell.tsx
+++ b/apgms/webapp/src/shell/AppShell.tsx
@@ -1,0 +1,269 @@
+import React from 'react';
+import { Link, NavLink, Outlet } from 'react-router-dom';
+
+type Theme = 'light' | 'dark';
+
+interface AppShellProps {
+  initialTheme: Theme;
+  storageKey: string;
+}
+
+const layoutStyles = `
+  :root[data-theme='light'] .app-shell {
+    --app-bg: #f8fafc;
+    --app-fg: #0f172a;
+    --app-panel: #ffffff;
+    --app-border: rgba(15, 23, 42, 0.1);
+    --app-muted: #64748b;
+  }
+  :root[data-theme='dark'] .app-shell {
+    --app-bg: #0f172a;
+    --app-fg: #e2e8f0;
+    --app-panel: #1e293b;
+    --app-border: rgba(148, 163, 184, 0.25);
+    --app-muted: #94a3b8;
+  }
+  .app-shell {
+    min-height: 100vh;
+    background-color: var(--app-bg);
+    color: var(--app-fg);
+    font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  }
+  .app-shell__skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0.5rem;
+    background: var(--app-panel);
+    color: var(--app-fg);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+    z-index: 1000;
+  }
+  .app-shell__skip-link:focus {
+    left: 0.75rem;
+  }
+  .focus-ring:focus-visible {
+    outline: 3px solid currentColor;
+    outline-offset: 3px;
+  }
+  .app-shell__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: var(--app-panel);
+    border-bottom: 1px solid var(--app-border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+  .app-shell__brand {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .app-shell__brand-name {
+    font-size: 1.125rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .app-shell__brand-tagline {
+    font-size: 0.875rem;
+    color: var(--app-muted);
+  }
+  .app-shell__theme-toggle {
+    border: 1px solid var(--app-border);
+    background: transparent;
+    color: inherit;
+    padding: 0.5rem 0.85rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+  .app-shell__theme-toggle:hover {
+    background: rgba(148, 163, 184, 0.08);
+  }
+  .app-shell__layout {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 64px);
+  }
+  .app-shell__sidebar {
+    background: var(--app-panel);
+    border-bottom: 1px solid var(--app-border);
+  }
+  .app-shell__nav {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+  }
+  .app-shell__nav-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 0.5rem;
+    padding: 0.65rem 0.9rem;
+    border-radius: 0.75rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: inherit;
+    text-decoration: none;
+  }
+  .app-shell__nav-link:hover {
+    background: rgba(148, 163, 184, 0.12);
+  }
+  .app-shell__nav-link--active {
+    background: rgba(59, 130, 246, 0.18);
+    color: #2563eb;
+  }
+  .app-shell__content {
+    flex: 1;
+    background: transparent;
+  }
+  .app-shell__main {
+    min-height: 100%;
+  }
+  @media (min-width: 768px) {
+    .app-shell__layout {
+      flex-direction: row;
+    }
+    .app-shell__sidebar {
+      width: 240px;
+      border-right: 1px solid var(--app-border);
+      border-bottom: none;
+    }
+    .app-shell__nav {
+      flex-direction: column;
+      gap: 0.25rem;
+      padding: 1.25rem 1rem;
+    }
+    .app-shell__content {
+      padding-left: 0;
+    }
+  }
+`;
+
+let stylesInjected = false;
+
+const ensureStyles = () => {
+  if (stylesInjected || typeof document === 'undefined') {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.setAttribute('data-app-shell-styles', 'true');
+  style.textContent = layoutStyles;
+  document.head.appendChild(style);
+  stylesInjected = true;
+};
+
+const AppShell: React.FC<AppShellProps> = ({ initialTheme, storageKey }) => {
+  const [theme, setTheme] = React.useState<Theme>(initialTheme);
+
+  React.useEffect(() => {
+    ensureStyles();
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage?.setItem(storageKey, theme);
+    }
+  }, [theme, storageKey]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener('change', handleChange);
+    } else {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const navLinkClassName = React.useCallback(
+    ({ isActive }: { isActive: boolean }) =>
+      [
+        'app-shell__nav-link',
+        'focus-ring',
+        isActive ? 'app-shell__nav-link--active' : undefined,
+      ]
+        .filter(Boolean)
+        .join(' '),
+    [],
+  );
+
+  const toggleTheme = () => {
+    setTheme((current) => (current === 'light' ? 'dark' : 'light'));
+  };
+
+  const themeLabel = theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme';
+
+  return (
+    <div className="app-shell">
+      <a className="app-shell__skip-link focus-ring" href="#main-content">
+        Skip to main content
+      </a>
+      <header className="app-shell__header" role="banner">
+        <Link to="/" className="focus-ring" style={{ textDecoration: 'none', color: 'inherit' }}>
+          <span className="app-shell__brand">
+            <span className="app-shell__brand-name">APGMS Console</span>
+            <span className="app-shell__brand-tagline">Operational insights &amp; treasury tools</span>
+          </span>
+        </Link>
+        <button
+          type="button"
+          className="app-shell__theme-toggle focus-ring"
+          onClick={toggleTheme}
+          aria-pressed={theme === 'dark'}
+          aria-label={themeLabel}
+        >
+          <span aria-hidden="true">{theme === 'dark' ? '🌙' : '🌞'}</span>
+          <span>{theme === 'dark' ? 'Dark' : 'Light'} mode</span>
+        </button>
+      </header>
+      <div className="app-shell__layout">
+        <aside className="app-shell__sidebar" role="complementary">
+          <nav aria-label="Primary" className="app-shell__nav">
+            <NavLink to="/" end className={navLinkClassName}>
+              Overview
+            </NavLink>
+            <NavLink to="/bank-lines" className={navLinkClassName}>
+              Bank lines
+            </NavLink>
+          </nav>
+        </aside>
+        <div className="app-shell__content">
+          <main id="main-content" className="app-shell__main" role="main">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/apgms/webapp/src/ui/DateText.tsx
+++ b/apgms/webapp/src/ui/DateText.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+export interface DateTextProps {
+  value?: string | Date | null;
+  className?: string;
+  fallback?: React.ReactNode;
+}
+
+const dateFormatter = new Intl.DateTimeFormat('en-AU', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
+});
+
+const joinClassNames = (...values: Array<string | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const toDateInstance = (value?: string | Date | null): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const DateText: React.FC<DateTextProps> = ({ value, className, fallback = '—' }) => {
+  const dateValue = toDateInstance(value);
+
+  if (!dateValue) {
+    return <span className={joinClassNames('date-text', className)}>{fallback}</span>;
+  }
+
+  const formatted = dateFormatter.format(dateValue);
+
+  return (
+    <time
+      className={joinClassNames('date-text', className)}
+      dateTime={dateValue.toISOString()}
+      suppressHydrationWarning
+    >
+      {formatted}
+    </time>
+  );
+};
+
+export default DateText;

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+export const formatCentsToAud = (cents: number): string => {
+  const dollars = cents / 100;
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(dollars);
+};
+
+export interface MoneyProps {
+  cents?: number | null;
+  className?: string;
+  zeroPlaceholder?: string;
+  nullPlaceholder?: React.ReactNode;
+}
+
+const joinClassNames = (...values: Array<string | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Money: React.FC<MoneyProps> = ({
+  cents,
+  className,
+  zeroPlaceholder = formatCentsToAud(0),
+  nullPlaceholder = '—',
+}) => {
+  if (cents == null) {
+    return <span className={joinClassNames('money', className)}>{nullPlaceholder}</span>;
+  }
+
+  if (cents === 0 && zeroPlaceholder) {
+    return <span className={joinClassNames('money', className)}>{zeroPlaceholder}</span>;
+  }
+
+  return <span className={joinClassNames('money', className)}>{formatCentsToAud(cents)}</span>;
+};
+
+export default Money;

--- a/apgms/webapp/src/ui/Skeleton.tsx
+++ b/apgms/webapp/src/ui/Skeleton.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+export interface SkeletonProps {
+  width?: number | string;
+  height?: number | string;
+  borderRadius?: number | string;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const skeletonStyles = `
+  :root[data-theme='light'] .skeleton {
+    --skeleton-base: rgba(148, 163, 184, 0.32);
+    --skeleton-highlight: rgba(148, 163, 184, 0.58);
+  }
+  :root[data-theme='dark'] .skeleton {
+    --skeleton-base: rgba(148, 163, 184, 0.22);
+    --skeleton-highlight: rgba(148, 163, 184, 0.45);
+  }
+  .skeleton {
+    position: relative;
+    overflow: hidden;
+    background: linear-gradient(
+      90deg,
+      var(--skeleton-base) 25%,
+      var(--skeleton-highlight) 37%,
+      var(--skeleton-base) 63%
+    );
+    background-size: 400% 100%;
+    animation: skeleton-shimmer 1.4s ease infinite;
+  }
+  @keyframes skeleton-shimmer {
+    0% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0 50%;
+    }
+  }
+`;
+
+let skeletonStylesInjected = false;
+
+const ensureSkeletonStyles = () => {
+  if (skeletonStylesInjected || typeof document === 'undefined') {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.setAttribute('data-skeleton-styles', 'true');
+  style.textContent = skeletonStyles;
+  document.head.appendChild(style);
+  skeletonStylesInjected = true;
+};
+
+const joinClassNames = (...values: Array<string | undefined>) =>
+  values.filter(Boolean).join(' ');
+
+const Skeleton: React.FC<SkeletonProps> = ({
+  width = '100%',
+  height = '1rem',
+  borderRadius = '0.75rem',
+  className,
+  style,
+}) => {
+  React.useEffect(() => {
+    ensureSkeletonStyles();
+  }, []);
+
+  return (
+    <span
+      className={joinClassNames('skeleton', className)}
+      style={{
+        display: 'inline-block',
+        width,
+        height,
+        borderRadius,
+        ...style,
+      }}
+      role="presentation"
+      aria-hidden="true"
+    />
+  );
+};
+
+export default Skeleton;


### PR DESCRIPTION
## Summary
- bootstrap the React entrypoint with QueryClientProvider, router, and theme initialisation
- add a responsive app shell with navigation, skip link, and theme toggle
- provide an axios API client plus shared UI helpers for money, dates, and skeleton placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f38adaeec48327a269675742111cec