### PR TITLE
Add property-based coverage for policy engine and RPT verification

### DIFF
--- a/apgms/services/api-gateway/test/policy-engine.property.spec.ts
+++ b/apgms/services/api-gateway/test/policy-engine.property.spec.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+import { previewAllocations } from "@apgms/policy-engine";
+
+type PercentageAllocation = {
+  destinationAccountId: string;
+  percentageBasisPoints: number;
+};
+
+const amountArb = fc.integer({ min: 0, max: 500_000_000 });
+
+const percentageAllocationsArb = fc
+  .array(
+    fc.record({
+      destinationAccountId: fc.uuidV4(),
+      weight: fc.integer({ min: 1, max: 10_000 }),
+    }),
+    { minLength: 1, maxLength: 6 }
+  )
+  .map((entries) => {
+    const totalWeight = entries.reduce((sum, entry) => sum + entry.weight, 0);
+    let remainingBasisPoints = 10_000;
+
+    return entries.map((entry, index) => {
+      const basisPoints =
+        index === entries.length - 1
+          ? remainingBasisPoints
+          : Math.max(
+              0,
+              Math.min(
+                remainingBasisPoints,
+                Math.floor((entry.weight * 10_000) / totalWeight)
+              )
+            );
+
+      remainingBasisPoints -= basisPoints;
+
+      return {
+        destinationAccountId: entry.destinationAccountId,
+        percentageBasisPoints: basisPoints,
+      } satisfies PercentageAllocation;
+    });
+  })
+  .filter((allocations) =>
+    allocations.some((allocation) => allocation.percentageBasisPoints > 0)
+  );
+
+const rulesetArb = fc.array(
+  fc.record({
+    id: fc.uuidV4(),
+    allocations: percentageAllocationsArb,
+  }),
+  { minLength: 1, maxLength: 4 }
+);
+
+test("previewAllocations conserves amountCents and never allocates negative values", async () => {
+  await fc.assert(
+    fc.asyncProperty(amountArb, rulesetArb, async (amountCents, rulesets) => {
+      const preview = await previewAllocations({
+        amountCents,
+        rulesets: rulesets.map((ruleset) => ({
+          id: ruleset.id,
+          allocations: ruleset.allocations.map((allocation) => ({
+            type: "percentage",
+            percentageBasisPoints: allocation.percentageBasisPoints,
+            destinationAccountId: allocation.destinationAccountId,
+          })),
+        })),
+      } as any);
+
+      const allocations = Array.isArray(preview)
+        ? preview
+        : preview.allocations ?? [];
+
+      assert.ok(
+        Array.isArray(allocations),
+        "previewAllocations should return an array of allocations or an object with an allocations array"
+      );
+
+      const totalAllocated = allocations.reduce((sum, allocation) => {
+        assert.ok(
+          typeof allocation.amountCents === "number",
+          "each allocation should expose amountCents"
+        );
+        assert.ok(
+          allocation.amountCents >= 0,
+          "allocated cents must never be negative"
+        );
+        return sum + allocation.amountCents;
+      }, 0);
+
+      assert.equal(
+        totalAllocated,
+        amountCents,
+        "allocation preview must conserve the original amount"
+      );
+    }),
+    { numRuns: 10_000 }
+  );
+});

--- a/apgms/services/api-gateway/test/rpt.spec.ts
+++ b/apgms/services/api-gateway/test/rpt.spec.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mint, verify, verifyChain } from "@apgms/rpt";
+
+const basePayload = {
+  rptVersion: 1,
+  orgId: "org-0001",
+  accountId: "acct-0001",
+  amountCents: 125_000,
+  currency: "AUD",
+  issuedAt: new Date(2024, 0, 1).toISOString(),
+};
+
+test("minted RPT verifies successfully", () => {
+  const rpt = mint({
+    payload: basePayload,
+    prevHash: "",
+  });
+
+  assert.equal(verify(rpt), true);
+});
+
+test("tampered RPT fails verification", () => {
+  const rpt = mint({
+    payload: basePayload,
+    prevHash: "",
+  });
+
+  const tampered = {
+    ...rpt,
+    payload: {
+      ...rpt.payload,
+      amountCents: rpt.payload.amountCents + 1,
+    },
+  };
+
+  assert.equal(verify(tampered), false);
+});
+
+test("chain verification passes and fails when link is broken", () => {
+  const rpt1 = mint({
+    payload: { ...basePayload, chainId: "rpt-1" },
+    prevHash: "",
+  });
+
+  const rpt2 = mint({
+    payload: { ...basePayload, chainId: "rpt-2" },
+    prevHash: rpt1.hash,
+  });
+
+  const rpt3 = mint({
+    payload: { ...basePayload, chainId: "rpt-3" },
+    prevHash: rpt2.hash,
+  });
+
+  assert.equal(verifyChain([rpt1, rpt2, rpt3]), true);
+
+  const broken = { ...rpt2, prevHash: "broken-link" };
+
+  assert.equal(verifyChain([rpt1, broken, rpt3]), false);
+});


### PR DESCRIPTION
## Summary
- add a fast-check property test exercising previewAllocations for conservation and non-negative allocations
- add RPT integrity tests covering mint/verify and chain verification failure cases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f38a4e9c3c8327ab513f1034a88e62