### PR TITLE
Add API gateway security hardening and validation

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,62 +8,252 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { z } from "zod";
+import { prisma } from "@apgms/shared/src/db";
+import securityPlugin from "./plugins/security";
+import authPlugin from "./plugins/auth";
+import validationPlugin from "./plugins/validation";
+import idempotencyPlugin from "./plugins/idempotency";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(validationPlugin);
+await app.register(securityPlugin);
+await app.register(authPlugin);
+await app.register(idempotencyPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
+const userSchema = z.object({
+  email: z.string().email(),
+  orgId: z.string(),
+  createdAt: z.string().datetime(),
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
+const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amount: z.string(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime(),
 });
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+const serializeBankLine = (line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: { toString(): string };
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amount: line.amount.toString(),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+const ensureDecimal = (value: string | number) => {
+  if (typeof value === "number") {
+    return Number.isFinite(value);
   }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return false;
+    }
+
+    return /^-?\d+(\.\d+)?$/.test(trimmed);
+  }
+
+  return false;
+};
+
+app.get(
+  "/health",
+  app.withValidation(
+    { response: { 200: z.object({ ok: z.literal(true), service: z.literal("api-gateway") }) } },
+    async () => ({ ok: true, service: "api-gateway" as const })
+  )
+);
+
+app.get(
+  "/users",
+  app.withValidation(
+    {
+      response: {
+        200: z.object({ users: z.array(userSchema) }),
+      },
+    },
+    async (request) => {
+      const users = (await prisma.user.findMany({
+        select: { email: true, orgId: true, createdAt: true },
+        where: { orgId: request.orgId },
+        orderBy: { createdAt: "desc" },
+      })) as Array<{ email: string; orgId: string; createdAt: Date }>;
+
+      return {
+        users: users.map((user) => ({
+          email: user.email,
+          orgId: user.orgId,
+          createdAt: user.createdAt.toISOString(),
+        })),
+      };
+    }
+  )
+);
+
+const listBankLinesQuerySchema = z.object({
+  take: z.coerce.number().min(1).max(200).optional(),
 });
+
+app.get(
+  "/bank-lines",
+  app.withValidation(
+    {
+      querystring: listBankLinesQuerySchema,
+      response: {
+        200: z.object({ lines: z.array(bankLineSchema) }),
+      },
+    },
+    async (request) => {
+      const { take = 20 } = request.query as z.infer<typeof listBankLinesQuerySchema>;
+      const lines = await prisma.bankLine.findMany({
+        where: { orgId: request.orgId },
+        orderBy: { date: "desc" },
+        take,
+      });
+
+      return { lines: lines.map(serializeBankLine) };
+    }
+  )
+);
+
+const createBankLineBodySchema = z.object({
+  date: z.string().datetime(),
+  amount: z.union([z.string(), z.number()]).refine(ensureDecimal, "invalid_amount"),
+  payee: z.string().min(1).max(256),
+  desc: z.string().min(1).max(1024),
+});
+
+app.post(
+  "/bank-lines",
+  app.withValidation(
+    {
+      body: createBankLineBodySchema,
+      response: {
+        201: bankLineSchema,
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as z.infer<typeof createBankLineBodySchema>;
+
+      const result = await app.useIdempotency(request, reply, async () => {
+        const normalizedAmount =
+          typeof body.amount === "number"
+            ? body.amount.toString()
+            : body.amount.trim();
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: request.orgId,
+            date: new Date(body.date),
+            amount: normalizedAmount,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+
+        reply.code(201);
+        return serializeBankLine(created);
+      });
+
+      if (reply.sent) {
+        return;
+      }
+
+      return result;
+    }
+  )
+);
+
+const applyAllocationsBodySchema = z.object({
+  allocations: z
+    .array(
+      z.object({
+        bankLineId: z.string().min(1),
+        amount: z.coerce.number().positive(),
+        memo: z.string().max(256).optional(),
+      })
+    )
+    .min(1),
+});
+
+const applyAllocationsResponseSchema = z.object({
+  applied: z.number().int().min(0),
+  processedAt: z.string().datetime(),
+  allocations: z.array(
+    z.object({
+      bankLineId: z.string(),
+      amount: z.number().positive(),
+      memo: z.string().max(256).optional(),
+    })
+  ),
+});
+
+const errorResponseSchema = z.object({ error: z.string() });
+
+app.post(
+  "/allocations/apply",
+  app.withValidation(
+    {
+      body: applyAllocationsBodySchema,
+      response: {
+        200: applyAllocationsResponseSchema,
+        400: errorResponseSchema,
+      },
+    },
+    async (request, reply) => {
+      const body = request.body as z.infer<typeof applyAllocationsBodySchema>;
+      const bankLineIds = body.allocations.map((item) => item.bankLineId);
+
+      const bankLines = await prisma.bankLine.findMany({
+        where: { id: { in: bankLineIds }, orgId: request.orgId },
+        select: { id: true },
+      });
+
+      if (bankLines.length !== bankLineIds.length) {
+        reply.code(400);
+        return { error: "unknown_bank_line" } as const;
+      }
+
+      const result = await app.useIdempotency(request, reply, async () => {
+        const processedAt = new Date().toISOString();
+        return {
+          applied: body.allocations.length,
+          processedAt,
+          allocations: body.allocations.map((item) => ({
+            bankLineId: item.bankLineId,
+            amount: item.amount,
+            memo: item.memo,
+          })),
+        };
+      });
+
+      if (reply.sent) {
+        return;
+      }
+
+      return result;
+    }
+  )
+);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +267,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,68 @@
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+
+const TOKEN_REGEX = /^org:([a-zA-Z0-9_-]+)(?::user:([a-zA-Z0-9_-]+))?$/;
+
+type OrgRecord = {
+  id: string;
+  name: string;
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    orgId: string;
+    org: OrgRecord;
+    authToken: string;
+    userId?: string;
+  }
+}
+
+const authPlugin: FastifyPluginAsync = async (fastify) => {
+  const orgCache = new Map<string, OrgRecord>();
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    if (request.method === "OPTIONS" || request.url === "/health") {
+      return;
+    }
+
+    const header = request.headers.authorization;
+    if (!header?.startsWith("Bearer ")) {
+      reply.header("www-authenticate", "Bearer");
+      await reply.code(401).send({ error: "unauthorized" });
+      return;
+    }
+
+    const token = header.slice("Bearer ".length).trim();
+    const match = TOKEN_REGEX.exec(token);
+    if (!match) {
+      reply.header("www-authenticate", "Bearer error=\"invalid_token\"");
+      await reply.code(401).send({ error: "invalid_token" });
+      return;
+    }
+
+    const [, orgId, userId] = match;
+
+    let org: OrgRecord | undefined = orgCache.get(orgId);
+    if (!org) {
+      const found = (await prisma.org.findUnique({
+        where: { id: orgId },
+        select: { id: true, name: true },
+      })) as OrgRecord | null;
+
+      if (!found) {
+        await reply.code(403).send({ error: "forbidden" });
+        return;
+      }
+
+      org = found;
+      orgCache.set(orgId, org);
+    }
+
+    request.orgId = orgId;
+    request.org = org;
+    request.authToken = token;
+    request.userId = userId ?? undefined;
+  });
+};
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,88 @@
+import crypto from "node:crypto";
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    useIdempotency<T>(
+      request: FastifyRequest,
+      reply: FastifyReply,
+      executor: () => Promise<T>
+    ): Promise<T | undefined>;
+  }
+}
+
+const normalizePath = (path: string) => path.split("?")[0];
+const ENTRY_TTL_MS = 24 * 60 * 60 * 1000;
+
+type CacheEntry = {
+  requestHash: string;
+  response: unknown;
+  responseCode: number;
+  createdAt: number;
+};
+
+const idempotencyPlugin: FastifyPluginAsync = async (fastify) => {
+  const cache = new Map<string, CacheEntry>();
+
+  const cleanup = () => {
+    const now = Date.now();
+    for (const [key, entry] of cache.entries()) {
+      if (entry.createdAt + ENTRY_TTL_MS <= now) {
+        cache.delete(key);
+      }
+    }
+  };
+
+  fastify.addHook("onResponse", cleanup);
+
+  fastify.decorate(
+    "useIdempotency",
+    async function useIdempotency(
+      request: FastifyRequest,
+      reply: FastifyReply,
+      executor: () => Promise<unknown>
+    ) {
+      const header = request.headers["idempotency-key"];
+      if (typeof header !== "string" || header.trim().length === 0) {
+        await reply.code(400).send({ error: "missing_idempotency_key" });
+        return undefined;
+      }
+
+      const key = header.trim();
+      const payload = request.body ?? null;
+      const payloadHash = crypto.createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+      const method = request.method.toUpperCase();
+      const path = normalizePath(request.routeOptions?.url ?? request.url);
+      const cacheKey = `${request.orgId}:${method}:${path}:${key}`;
+
+      const existing = cache.get(cacheKey);
+      if (existing) {
+        if (existing.requestHash !== payloadHash) {
+          await reply.code(409).send({ error: "idempotency_conflict" });
+          return undefined;
+        }
+
+        await reply.code(200).send(existing.response);
+        return undefined;
+      }
+
+      const result = await executor();
+
+      if (reply.sent) {
+        return undefined;
+      }
+
+      const normalizedResponse = result === undefined ? null : JSON.parse(JSON.stringify(result));
+      cache.set(cacheKey, {
+        requestHash: payloadHash,
+        response: normalizedResponse,
+        responseCode: reply.statusCode,
+        createdAt: Date.now(),
+      });
+
+      return result;
+    }
+  );
+};
+
+export default idempotencyPlugin;

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,59 @@
+import cors from "@fastify/cors";
+import type { FastifyPluginAsync } from "fastify";
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 100;
+
+const securityPlugin: FastifyPluginAsync = async (fastify) => {
+  const devOrigins = ["http://localhost:5173"];
+  const configuredOrigins = (process.env.CORS_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  const isDev = (process.env.NODE_ENV ?? "development").toLowerCase() === "development";
+  const allowedOrigins = isDev
+    ? devOrigins
+    : configuredOrigins.length > 0
+      ? configuredOrigins
+      : undefined;
+
+  await fastify.register(cors, {
+    origin: allowedOrigins ?? false,
+    credentials: true,
+  });
+
+  const hits = new Map<string, { count: number; expiresAt: number }>();
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    if (request.method === "OPTIONS") {
+      return;
+    }
+
+    const now = Date.now();
+    const ip = request.ip ?? request.socket.remoteAddress ?? "unknown";
+    const bucket = hits.get(ip);
+
+    if (!bucket || bucket.expiresAt <= now) {
+      hits.set(ip, { count: 1, expiresAt: now + RATE_LIMIT_WINDOW_MS });
+      return;
+    }
+
+    if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
+      await reply.code(429).send({ error: "rate_limited" });
+      return;
+    }
+
+    bucket.count += 1;
+  });
+
+  fastify.addHook("onResponse", () => {
+    const now = Date.now();
+    for (const [ip, bucket] of hits.entries()) {
+      if (bucket.expiresAt <= now) {
+        hits.delete(ip);
+      }
+    }
+  });
+};
+
+export default securityPlugin;

--- a/apgms/services/api-gateway/src/plugins/validation.ts
+++ b/apgms/services/api-gateway/src/plugins/validation.ts
@@ -1,0 +1,63 @@
+import type {
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+  RouteHandlerMethod,
+} from "fastify";
+import type { ZodTypeAny } from "zod";
+
+export type ZodRouteSchemas = {
+  body?: ZodTypeAny;
+  params?: ZodTypeAny;
+  querystring?: ZodTypeAny;
+  headers?: ZodTypeAny;
+  response?: Partial<Record<number, ZodTypeAny>> & { default?: ZodTypeAny };
+};
+
+declare module "fastify" {
+  interface FastifyInstance {
+    withValidation: (schemas: ZodRouteSchemas, handler: RouteHandlerMethod) => RouteHandlerMethod;
+  }
+}
+
+const validationPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorate(
+    "withValidation",
+    function withValidation(schemas: ZodRouteSchemas, handler: RouteHandlerMethod) {
+      return (async function validatedHandler(this: unknown, request: FastifyRequest, reply: FastifyReply) {
+        if (schemas.headers) {
+          const parsed = schemas.headers.parse(request.headers ?? {});
+          Object.assign(request.headers, parsed);
+        }
+
+        if (schemas.querystring) {
+          const parsed = schemas.querystring.parse(request.query ?? {});
+          (request as unknown as { query: unknown }).query = parsed;
+        }
+
+        if (schemas.params) {
+          const parsed = schemas.params.parse(request.params ?? {});
+          (request as unknown as { params: unknown }).params = parsed;
+        }
+
+        if (schemas.body) {
+          const parsed = schemas.body.parse(request.body ?? {});
+          (request as unknown as { body: unknown }).body = parsed;
+        }
+
+        const result = await handler.apply(this as any, [request, reply]);
+
+        if (!reply.sent && schemas.response) {
+          const responseSchema = schemas.response[reply.statusCode] ?? schemas.response.default;
+          if (responseSchema) {
+            return responseSchema.parse(result);
+          }
+        }
+
+        return result;
+      }) as RouteHandlerMethod;
+    }
+  );
+};
+
+export default validationPlugin;


### PR DESCRIPTION
## Summary
- add Fastify security, auth, and idempotency plugins to the API gateway
- enforce Zod validation on all routes and scope database access by organization
- add an allocations apply endpoint with idempotency support

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: Prisma engine download blocked in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f391385cbc8327bc8e2ca88205046e