### PR TITLE
Add policy and ledger Prisma models and migrate bank line amount

### DIFF
--- a/apgms/shared/prisma/migrations/20251111120000_policy_gate_rpt_audit_ledger/migration.sql
+++ b/apgms/shared/prisma/migrations/20251111120000_policy_gate_rpt_audit_ledger/migration.sql
@@ -1,0 +1,81 @@
+-- AlterTable
+ALTER TABLE "BankLine" ADD COLUMN     "amountCents" INTEGER;
+
+UPDATE "BankLine" SET "amountCents" = ("amount" * 100)::INTEGER;
+
+ALTER TABLE "BankLine" ALTER COLUMN "amountCents" SET NOT NULL;
+
+ALTER TABLE "BankLine" DROP COLUMN "amount";
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "definition" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Gate" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Gate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RptToken" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RptToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditBlob" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "blob" BYTEA NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditBlob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LedgerEntry" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "description" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LedgerEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RptToken_token_key" ON "RptToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Gate" ADD CONSTRAINT "Gate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
@@ -8,11 +9,16 @@ datasource db {
 }
 
 model Org {
-  id        String   @id @default(cuid())
-  name      String
-  createdAt DateTime @default(now())
-  users     User[]
-  lines     BankLine[]
+  id            String        @id @default(cuid())
+  name          String
+  createdAt     DateTime      @default(now())
+  users         User[]
+  lines         BankLine[]
+  policies      Policy[]
+  gates         Gate[]
+  ledgerEntries LedgerEntry[]
+  rptTokens     RptToken[]
+  auditBlobs    AuditBlob[]
 }
 
 model User {
@@ -25,12 +31,57 @@ model User {
 }
 
 model BankLine {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  date        DateTime
+  amountCents Int
+  payee       String
+  desc        String
+  createdAt   DateTime @default(now())
+}
+
+model Policy {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  name        String
+  definition  Json
+  createdAt   DateTime @default(now())
+}
+
+model Gate {
   id        String   @id @default(cuid())
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
-  date      DateTime
-  amount    Decimal
-  payee     String
-  desc      String
+  name      String
+  config    Json
   createdAt DateTime @default(now())
+}
+
+model RptToken {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  token     String   @unique
+  expiresAt DateTime?
+  createdAt DateTime @default(now())
+}
+
+model AuditBlob {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  blob      Bytes
+  createdAt DateTime @default(now())
+}
+
+model LedgerEntry {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  occurredAt  DateTime
+  amountCents Int
+  description String
+  createdAt   DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- replace BankLine amount decimal with amountCents integer to track cents explicitly
- add Policy, Gate, RptToken, AuditBlob, and LedgerEntry models tied to Org

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f391204d048327aa8dbbbe258041aa