### PR TITLE
Add red-team gate to CI workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,22 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  red-team:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install deps
+        run: npm ci
+      - name: Red-team checks
+        run: npm run redteam
+      - name: Upload red-team report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: redteam-report
+          path: eval/redteam-report.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a red-team CI job that installs npm dependencies, runs the redteam script, and uploads the report

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f390f37fdc8327ac1d6ae6ef1d9539