### PR TITLE
feat: add SBR AS4 dev stub with artifact persistence

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,6 +1,7 @@
 ﻿node_modules/
 dist/
 coverage/
+var/
 .env*
 .DS_Store
 .vscode/

--- a/apgms/docker/dev/docker-compose.yml
+++ b/apgms/docker/dev/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  sbr:
+    image: node:20
+    working_dir: /workspace/apgms
+    entrypoint: ["/bin/bash", "-lc"]
+    command:
+      - |
+        corepack enable pnpm \
+        && pnpm install \
+        && pnpm --filter @apgms/sbr dev
+    environment:
+      NODE_ENV: development
+      PORT: 3300
+    ports:
+      - "3300:3300"
+    volumes:
+      - ../..:/workspace
+      - ../../var/as4:/workspace/apgms/var/as4
+    depends_on: []

--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.6.1",
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/as4/client.ts
+++ b/apgms/services/sbr/src/as4/client.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const artifactsRoot = path.resolve(__dirname, "../../../../var/as4");
+
+export interface SendOptions {
+  action: string;
+  orgId: string;
+}
+
+export interface SendResult {
+  messageId: string;
+  sentAt: string;
+  receiptId: string;
+}
+
+const buildReceiptXml = (details: {
+  messageId: string;
+  receiptId: string;
+  orgId: string;
+  action: string;
+  sentAt: string;
+}) => `<?xml version="1.0" encoding="UTF-8"?>\n` +
+  `<receipt>` +
+  `<messageId>${details.messageId}</messageId>` +
+  `<receiptId>${details.receiptId}</receiptId>` +
+  `<orgId>${details.orgId}</orgId>` +
+  `<action>${details.action}</action>` +
+  `<sentAt>${details.sentAt}</sentAt>` +
+  `</receipt>\n`;
+
+export const send = async (
+  payload: string | Buffer,
+  { action, orgId }: SendOptions,
+): Promise<SendResult> => {
+  const messageId = randomUUID();
+  const receiptId = randomUUID();
+  const sentAt = new Date().toISOString();
+
+  const messageDir = path.join(artifactsRoot, messageId);
+  await fs.mkdir(messageDir, { recursive: true });
+
+  const payloadContent = typeof payload === "string" ? payload : payload.toString("utf-8");
+  await fs.writeFile(path.join(messageDir, "request.xml"), payloadContent, "utf-8");
+
+  const receiptXml = buildReceiptXml({ messageId, receiptId, orgId, action, sentAt });
+  await fs.writeFile(path.join(messageDir, "receipt.xml"), receiptXml, "utf-8");
+
+  const signatures = {
+    messageId,
+    receiptId,
+    sentAt,
+    action,
+    orgId,
+    stub: true,
+  };
+
+  await fs.writeFile(
+    path.join(messageDir, "signatures.json"),
+    JSON.stringify(signatures, null, 2),
+    "utf-8",
+  );
+
+  return { messageId, sentAt, receiptId };
+};

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,53 @@
-﻿console.log('sbr service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import Fastify from "fastify";
+
+import { send } from "./as4/client.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: "sbr" }));
+
+if (process.env.NODE_ENV !== "production") {
+  app.post("/sbr/send", async (req, rep) => {
+    try {
+      const body = req.body as {
+        payload?: string;
+        action?: string;
+        orgId?: string;
+      };
+
+      if (!body?.payload || !body?.action || !body?.orgId) {
+        return rep.code(400).send({ error: "invalid_request" });
+      }
+
+      const result = await send(body.payload, {
+        action: body.action,
+        orgId: body.orgId,
+      });
+
+      return rep.code(202).send(result);
+    } catch (error) {
+      req.log.error(error);
+      return rep.code(500).send({ error: "internal_error" });
+    }
+  });
+}
+
+app.ready(() => {
+  app.log.info(app.printRoutes());
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((err) => {
+  app.log.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a development AS4 client stub that persists payload, receipt and signature artifacts under var/as4
- expose a POST /sbr/send development endpoint and add a service package for running the SBR stub
- scaffold docker dev compose configuration with the var/as4 bind mount and ignore stored artifacts

## Testing
- pnpm install *(fails: registry returns 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f39a11c39083278888c8ff039f1918