### PR TITLE
Add OAIC NDB runbook and notification templates

### DIFF
--- a/apgms/SECURITY.md
+++ b/apgms/SECURITY.md
@@ -1,2 +1,6 @@
-﻿# Security Policy
+# Security Policy
+
 Email: security@yourdomain.example
+
+## Notifiable Data Breach Response
+For guidance on assessing and responding to potential OAIC Notifiable Data Breaches, see the [NDB response runbook](../runbooks/ndb.md).

--- a/runbooks/ndb.md
+++ b/runbooks/ndb.md
@@ -1,0 +1,51 @@
+# OAIC Notifiable Data Breach (NDB) Response Runbook
+
+**Scope:** Applies to all suspected or confirmed breaches involving personal information regulated under the Australian Privacy Act.
+
+## Immediate Response Timeline
+- **T+0 mins:** Incident discovered or reported to Security Operations (SecOps) on-call.
+- **Within 30 mins:** Duty Incident Manager (IM) validates incident, opens case in incident platform, assigns Severity.
+- **Within 2 hrs:** IM convenes Response Team (Legal, Privacy Officer, Communications, Engineering Lead) and documents initial findings.
+- **Within 24 hrs:** Confirm breach status, implement containment, and determine notifiability.
+- **Within 72 hrs:** Prepare notifications, obtain executive sign-off, notify individuals and Office of the Australian Information Commissioner (OAIC) if required.
+
+## Roles & Responsibilities
+| Role | Primary Contacts | Key Duties |
+| --- | --- | --- |
+| Incident Manager (IM) | SecOps on-call | Lead assessment & containment, maintain log, coordinate team. |
+| Privacy Officer | Privacy@company | Interpret NDB criteria, coordinate OAIC liaison. |
+| Legal Counsel | Legal on-call | Advise on obligations, review communications. |
+| Engineering Lead | Relevant service owner | Technical investigation, containment, recovery. |
+| Communications Lead | Corporate comms | Draft messaging for individuals, media, partners. |
+| Evidence Custodian | Security analyst | Preserve artefacts, chain-of-custody. |
+
+## Phase 1: Assess
+1. **Trigger & triage:** IM records incident details (who/what/when) and severity in incident system.
+2. **Assemble team:** Page roles above; confirm availability; schedule situation room bridge.
+3. **Initial fact-finding:** Engineering Lead gathers logs, access records, and affected systems; Privacy Officer identifies personal data involved; capture all data sources in evidence log.
+4. **Determine NDB applicability:** Use Privacy Act criteria (serious harm, remedial actions). Escalate uncertain cases to Legal & Privacy for decision within 24 hrs.
+5. **Decision point:** If not notifiable, document rationale and close with post-incident review; if potentially notifiable, proceed to Contain.
+
+## Phase 2: Contain & Eradicate
+1. **Stabilise systems:** Isolate affected infrastructure (disable compromised accounts, revoke tokens, block malicious IPs).
+2. **Preserve evidence:** Evidence Custodian snapshots systems, exports relevant logs, hashes artefacts; store in secure evidence repository.
+3. **Remediation plan:** Engineering Lead drafts action plan for fixes and monitoring; IM tracks tasks in incident board.
+4. **Stakeholder updates:** Provide hourly updates to leadership; document status in incident timeline.
+
+## Phase 3: Notify & Recover
+1. **Assess harm & impacted individuals:** Privacy Officer quantifies affected records, risk of serious harm, and required notifications.
+2. **Draft notices:** Communications Lead prepares individual and OAIC notices using templates. Legal reviews before distribution.
+3. **Notify individuals:** Deliver by most direct method (email, letter, in-product messaging) as soon as practicable after confirmation, typically within 72 hrs.
+4. **Notify OAIC:** Submit statement via OAIC Notifiable Data Breach form; log submission ID and timestamp.
+5. **Post-notification support:** Establish hotline/email support, FAQs, and credit monitoring if warranted. Track inquiries.
+
+## Documentation & Evidence Collection
+- Maintain central incident log including decisions, timestamps, contacts.
+- Store artefacts (logs, screenshots, system images) in read-only evidence repository; maintain chain-of-custody form.
+- Record all communications drafts and approvals.
+- Schedule post-incident review within 7 days of containment to capture lessons learned and control improvements.
+
+## Escalation & Contact Points
+- **Emergency:** IM contacts CISO if severity is High/Critical.
+- **Regulators/Partners:** Privacy Officer coordinates all external communications.
+- **After Hours:** Use on-call rotation numbers in SecOps runbook appendix.

--- a/runbooks/ndb_templates/individual_notice.md
+++ b/runbooks/ndb_templates/individual_notice.md
@@ -1,0 +1,34 @@
+# Individual Breach Notification Template
+
+**Subject:** Important Information About Your Personal Data
+
+Dear {{individual_name}},
+
+We are writing to inform you of a data incident identified on {{discovery_date}} that may involve your personal information.
+
+## What happened
+On {{incident_date_range}}, we detected {{brief_description_of_incident}}. Our security team contained the incident on {{containment_date}}.
+
+## What information was involved
+Our investigation indicates that the following information related to you may have been accessed: {{data_types}}.
+
+## Actions we have taken
+- Contained the incident and implemented additional safeguards.
+- Engaged independent experts to assist with the investigation.
+- Notified the Office of the Australian Information Commissioner (OAIC).
+
+## What you can do
+- Monitor your accounts for unusual activity.
+- Be cautious of unsolicited communications requesting personal information.
+- Consider updating passwords or enabling multi-factor authentication where available.
+
+If you notice suspicious activity, please contact {{support_contact}} immediately. Additional guidance is available at {{support_url}}.
+
+We apologise for any concern this may cause and remain committed to protecting your information.
+
+Sincerely,
+
+{{company_contact}}
+{{title}}
+{{company_name}}
+{{contact_details}}

--- a/runbooks/ndb_templates/oaic_notice.md
+++ b/runbooks/ndb_templates/oaic_notice.md
@@ -1,0 +1,43 @@
+# OAIC Notifiable Data Breach Statement Template
+
+**Organisation name:** {{organisation_name}}
+
+**Contact person:** {{contact_name}}, {{role}}, {{contact_phone}}, {{contact_email}}
+
+**Date of submission:** {{submission_date}}
+
+## Part A – Organisation details
+- Australian Business Number (ABN): {{abn}}
+- Address: {{address}}
+- Industry sector: {{industry}}
+
+## Part B – Description of breach
+- Date(s) of the data breach: {{incident_date_range}}
+- Date the breach was discovered: {{discovery_date}}
+- Date containment was achieved: {{containment_date}}
+- Location of breach (systems/services affected): {{systems_impacted}}
+- Description of incident and cause: {{incident_description}}
+
+## Part C – Personal information involved
+List the categories of personal information affected:
+- {{personal_information_categories}}
+
+## Part D – Containment and assessment
+- Steps taken to contain the breach: {{containment_actions}}
+- Steps taken to assess the breach: {{assessment_actions}}
+- Whether the breach is contained: {{containment_status}}
+
+## Part E – Harm assessment and notification
+- Likelihood of serious harm to affected individuals: {{harm_assessment}}
+- Number of individuals affected: {{impacted_individuals}}
+- Date individuals were notified / will be notified: {{individual_notification_timing}}
+- Method of notification to individuals: {{notification_method}}
+
+## Part F – Preventative actions
+- Immediate remediation steps: {{remediation_actions}}
+- Long-term risk mitigation / control improvements: {{preventative_actions}}
+
+## Attachments
+- Investigation report summary
+- Evidence log references
+- Copies of individual notices (if available)


### PR DESCRIPTION
## Summary
- add an OAIC Notifiable Data Breach response runbook covering assessment, containment, notification, and evidence handling
- provide templates for notifying affected individuals and the OAIC
- link the security policy to the new runbook for breach response guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f39a0764508327be780a4e0a068403