### PR TITLE
feat(api-gateway): add webhook signature verification

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import webhooksRoutes from "./routes/webhooks.js";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(webhooksRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/webhook-signing.ts
+++ b/apgms/services/api-gateway/src/plugins/webhook-signing.ts
@@ -1,0 +1,158 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const NONCE_TTL_SECONDS = Math.ceil(FIVE_MINUTES_MS / 1000);
+
+export type VerificationResult =
+  | { ok: true }
+  | {
+      ok: false;
+      statusCode: number;
+      error:
+        | "missing_signature"
+        | "timestamp_expired"
+        | "replay_detected"
+        | "invalid_signature"
+        | "secret_not_configured";
+    };
+
+type RequestWithRawBody = FastifyRequest & { rawBody?: Buffer | string };
+
+export interface NonceStore {
+  has(nonce: string): Promise<boolean>;
+  set(nonce: string, ttlSeconds: number): Promise<void>;
+}
+
+let configuredStore: NonceStore | null = null;
+let redisStorePromise: Promise<NonceStore | null> | null = null;
+
+function nonceKey(nonce: string): string {
+  return `webhook:nonce:${nonce}`;
+}
+
+const memoryNonces = new Map<string, number>();
+
+const memoryStore: NonceStore = {
+  async has(nonce) {
+    const entry = memoryNonces.get(nonce);
+    if (!entry) {
+      return false;
+    }
+    if (entry <= Date.now()) {
+      memoryNonces.delete(nonce);
+      return false;
+    }
+    return true;
+  },
+  async set(nonce, ttlSeconds) {
+    memoryNonces.set(nonce, Date.now() + ttlSeconds * 1000);
+  },
+};
+
+async function loadRedisStore(): Promise<NonceStore | null> {
+  if (!redisStorePromise) {
+    redisStorePromise = (async () => {
+      try {
+        const { createClient } = await import("redis");
+        const url = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
+        const client = createClient({ url });
+        client.on("error", (err: unknown) => {
+          console.error({ err }, "redis connection error");
+        });
+        await client.connect();
+        const store: NonceStore = {
+          async has(nonce) {
+            const exists = await client.exists(nonceKey(nonce));
+            return exists === 1;
+          },
+          async set(nonce, ttlSeconds) {
+            await client.set(nonceKey(nonce), "1", { EX: ttlSeconds });
+          },
+        };
+        return store;
+      } catch (err) {
+        console.warn({ err }, "falling back to in-memory nonce store");
+        return null;
+      }
+    })();
+  }
+
+  return redisStorePromise;
+}
+
+async function getNonceStore(): Promise<NonceStore> {
+  if (configuredStore) {
+    return configuredStore;
+  }
+  const redisBacked = await loadRedisStore();
+  if (redisBacked) {
+    return redisBacked;
+  }
+  return memoryStore;
+}
+
+export function setNonceStore(store: NonceStore | null): void {
+  configuredStore = store;
+}
+
+function normalizeHeader(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function getRawBodyString(rawBody: Buffer | string | undefined): string {
+  if (!rawBody) {
+    return "";
+  }
+  if (typeof rawBody === "string") {
+    return rawBody;
+  }
+  return rawBody.toString("utf8");
+}
+
+export async function verifySignature(req: RequestWithRawBody): Promise<VerificationResult> {
+  const secret = process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    return { ok: false, statusCode: 500, error: "secret_not_configured" };
+  }
+
+  const signature = normalizeHeader(req.headers["x-signature"]);
+  const timestamp = normalizeHeader(req.headers["x-timestamp"]);
+  const nonce = normalizeHeader(req.headers["x-nonce"]);
+
+  if (!signature || !timestamp || !nonce) {
+    return { ok: false, statusCode: 401, error: "missing_signature" };
+  }
+
+  const timestampMs = Date.parse(timestamp);
+  if (Number.isNaN(timestampMs) || Date.now() - timestampMs > FIVE_MINUTES_MS) {
+    return { ok: false, statusCode: 401, error: "timestamp_expired" };
+  }
+
+  const store = await getNonceStore();
+  if (await store.has(nonce)) {
+    return { ok: false, statusCode: 409, error: "replay_detected" };
+  }
+
+  const rawBody = getRawBodyString(req.rawBody);
+  const data = `${timestamp}.${nonce}.${rawBody}`;
+
+  const computed = createHmac("sha256", secret).update(data).digest();
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(signature, "hex");
+  } catch {
+    return { ok: false, statusCode: 401, error: "invalid_signature" };
+  }
+
+  if (provided.length !== computed.length || !timingSafeEqual(provided, computed)) {
+    return { ok: false, statusCode: 401, error: "invalid_signature" };
+  }
+
+  await store.set(nonce, NONCE_TTL_SECONDS);
+  return { ok: true };
+}
+

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from "fastify";
+import { verifySignature } from "../plugins/webhook-signing.js";
+
+export default async function webhooksRoutes(app: FastifyInstance): Promise<void> {
+  app.removeContentTypeParser("application/json");
+  app.removeContentTypeParser("application/*+json");
+
+  const captureRawBody = (req: any, body: Buffer, done: (err: Error | null, value?: unknown) => void) => {
+    req.rawBody = body;
+    done(null, body);
+  };
+
+  app.addContentTypeParser("application/json", { parseAs: "buffer" }, captureRawBody);
+  app.addContentTypeParser("application/*+json", { parseAs: "buffer" }, captureRawBody);
+  app.addContentTypeParser("*", { parseAs: "buffer" }, (req, body, done) => {
+    (req as any).rawBody = body;
+    done(null, body);
+  });
+
+  app.post("/webhooks/payto", async (req, rep) => {
+    const verification = await verifySignature(req as any);
+    if (!verification.ok) {
+      return rep.code(verification.statusCode).send({ error: verification.error });
+    }
+
+    return rep.code(202).send({ status: "accepted" });
+  });
+}
+

--- a/apgms/services/api-gateway/src/types/redis.d.ts
+++ b/apgms/services/api-gateway/src/types/redis.d.ts
@@ -1,0 +1,8 @@
+declare module "redis" {
+  export function createClient(options: { url: string }): {
+    on(event: "error", listener: (err: unknown) => void): void;
+    connect(): Promise<void>;
+    exists(key: string): Promise<number>;
+    set(key: string, value: string, options: { EX: number }): Promise<void>;
+  };
+}

--- a/apgms/services/api-gateway/test/webhooks.spec.ts
+++ b/apgms/services/api-gateway/test/webhooks.spec.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+import Fastify from "fastify";
+
+import webhooksRoutes from "../src/routes/webhooks.js";
+import { setNonceStore, type NonceStore } from "../src/plugins/webhook-signing.js";
+
+const SECRET = "test-secret";
+
+function createMemoryNonceStore(): NonceStore {
+  const nonces = new Set<string>();
+  return {
+    async has(nonce) {
+      return nonces.has(nonce);
+    },
+    async set(nonce) {
+      nonces.add(nonce);
+    },
+  };
+}
+
+test("accepts valid webhook signature", async (t) => {
+  process.env.WEBHOOK_SECRET = SECRET;
+  setNonceStore(createMemoryNonceStore());
+
+  const app = Fastify();
+  await app.register(webhooksRoutes);
+
+  t.after(async () => {
+    await app.close();
+    setNonceStore(null);
+  });
+
+  const payload = JSON.stringify({ event: "payment.settled" });
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-123";
+  const signature = createHmac("sha256", SECRET)
+    .update(`${timestamp}.${nonce}.${payload}`)
+    .digest("hex");
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(response.json(), { status: "accepted" });
+});
+
+test("rejects replayed webhook signature", async (t) => {
+  process.env.WEBHOOK_SECRET = SECRET;
+  const store = createMemoryNonceStore();
+  setNonceStore(store);
+
+  const app = Fastify();
+  await app.register(webhooksRoutes);
+
+  t.after(async () => {
+    await app.close();
+    setNonceStore(null);
+  });
+
+  const payload = JSON.stringify({ event: "payment.pending" });
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-replay";
+  const signature = createHmac("sha256", SECRET)
+    .update(`${timestamp}.${nonce}.${payload}`)
+    .digest("hex");
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(first.statusCode, 202);
+
+  const replay = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(replay.statusCode, 409);
+  assert.deepEqual(replay.json(), { error: "replay_detected" });
+});
+


### PR DESCRIPTION
## Summary
- add a webhook signing helper that validates timestamps, HMAC signatures, and replay protection via nonce storage
- expose a /webhooks/payto endpoint that captures the raw request body and enforces signature checks
- add integration-style tests covering acceptance and replay rejection

## Testing
- pnpm --filter @apgms/api-gateway exec tsx test/webhooks.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f399ef7e8c8327a27157f3353989bd