### PR TITLE
Add Zod validation middleware for bank line routes

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import bankLinesRoutes from "./routes/bank-lines";
 
 const app = Fastify({ logger: true });
 
@@ -29,41 +30,7 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+await app.register(bankLinesRoutes);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/middleware/validate.ts
+++ b/apgms/services/api-gateway/src/middleware/validate.ts
@@ -1,0 +1,78 @@
+import type {
+  FastifyReply,
+  FastifyRequest,
+  preSerializationHookHandler,
+  preValidationHookHandler,
+} from "fastify";
+import { ZodError, type ZodTypeAny } from "zod";
+
+const formatIssues = (error: ZodError) =>
+  error.issues.map((issue) => ({
+    path: issue.path.join("."),
+    message: issue.message,
+    code: issue.code,
+  }));
+
+const handleValidationFailure = (
+  reply: FastifyReply,
+  error: ZodError,
+  source: "body" | "query"
+) => {
+  reply.log.warn({ source, issues: error.issues }, "validation failed");
+  reply.code(400).send({
+    error: "validation_error",
+    source,
+    issues: formatIssues(error),
+  });
+};
+
+export const validateBody = <Schema extends ZodTypeAny>(
+  schema: Schema
+): preValidationHookHandler => {
+  return async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<void | FastifyReply> => {
+    const result = await schema.safeParseAsync(request.body);
+    if (!result.success) {
+      handleValidationFailure(reply, result.error, "body");
+      return reply;
+    }
+
+    (request as any).body = result.data;
+  };
+};
+
+export const validateQuery = <Schema extends ZodTypeAny>(
+  schema: Schema
+): preValidationHookHandler => {
+  return async (
+    request: FastifyRequest,
+    reply: FastifyReply
+  ): Promise<void | FastifyReply> => {
+    const result = await schema.safeParseAsync(request.query);
+    if (!result.success) {
+      handleValidationFailure(reply, result.error, "query");
+      return reply;
+    }
+
+    (request as any).query = result.data;
+  };
+};
+
+export const validateReply = <Schema extends ZodTypeAny>(
+  schema: Schema
+): preSerializationHookHandler => {
+  return async (request, reply, payload) => {
+    const result = await schema.safeParseAsync(payload);
+    if (!result.success) {
+      request.log.error({ issues: result.error.issues }, "reply validation failed");
+      reply.code(500);
+      return {
+        error: "internal_error",
+      };
+    }
+
+    return result.data;
+  };
+};

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,85 @@
+import { Prisma } from "@prisma/client";
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+import {
+  bankLineResponseSchema,
+  createBankLineBodySchema,
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+  type BankLineResponse,
+  type CreateBankLineBody,
+  type ListBankLinesQuery,
+} from "../schemas/bank-lines";
+import {
+  validateBody,
+  validateQuery,
+  validateReply,
+} from "../middleware/validate";
+
+const decimalToCents = (value: Prisma.Decimal) =>
+  Number(value.mul(100).toFixed(0));
+
+const toBankLineResponse = (line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: Prisma.Decimal;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}): BankLineResponse => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amountCents: decimalToCents(line.amount),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+export default async function bankLinesRoutes(app: FastifyInstance) {
+  app.get(
+    "/bank-lines",
+    {
+      preValidation: [validateQuery(listBankLinesQuerySchema)],
+      preSerialization: [validateReply(listBankLinesResponseSchema)],
+    },
+    async (request) => {
+      const { take = 20 } = (request.query ?? {}) as ListBankLinesQuery;
+
+      const lines = await prisma.bankLine.findMany({
+        orderBy: { date: "desc" },
+        take,
+      });
+
+      return {
+        lines: lines.map(toBankLineResponse),
+      };
+    }
+  );
+
+  app.post(
+    "/bank-lines",
+    {
+      preValidation: [validateBody(createBankLineBodySchema)],
+      preSerialization: [validateReply(bankLineResponseSchema)],
+    },
+    async (request, reply) => {
+      const body = request.body as CreateBankLineBody;
+
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: new Prisma.Decimal(body.amountCents).div(100),
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      reply.code(201);
+
+      return toBankLineResponse(created);
+    }
+  );
+}

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { zId, zOrgId, zMoneyCents, zIsoDate } from "./common";
+
+export const createBankLineBodySchema = z.object({
+  orgId: zOrgId,
+  date: zIsoDate,
+  amountCents: zMoneyCents,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export type CreateBankLineBody = z.infer<typeof createBankLineBodySchema>;
+
+export const bankLineResponseSchema = z.object({
+  id: zId,
+  orgId: zOrgId,
+  date: zIsoDate,
+  amountCents: zMoneyCents,
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: zIsoDate,
+});
+
+export type BankLineResponse = z.infer<typeof bankLineResponseSchema>;
+
+export const listBankLinesQuerySchema = z.object({
+  take: z
+    .coerce.number()
+    .int()
+    .min(1)
+    .max(200)
+    .optional(),
+});
+
+export type ListBankLinesQuery = z.infer<typeof listBankLinesQuerySchema>;
+
+export const listBankLinesResponseSchema = z.object({
+  lines: z.array(bankLineResponseSchema),
+});
+
+export type ListBankLinesResponse = z.infer<typeof listBankLinesResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const zId = z.string().cuid();
+export const zOrgId = zId;
+export const zMoneyCents = z.coerce.number().int();
+export const zIsoDate = z
+  .string()
+  .datetime({ offset: true })
+  .or(z.string().datetime({ offset: false }));


### PR DESCRIPTION
## Summary
- add shared Zod schemas for identifiers, money, and ISO dates
- define bank line request/response schemas and Fastify validation middleware
- refactor bank line routes to apply validation on queries, bodies, and replies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f399d7dc488327b5d5495ee3d5830a