### PR TITLE
feat(sbr): add dev AS4 client scaffolding

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -5,3 +5,5 @@ coverage/
 .DS_Store
 .vscode/
 **/__pycache__/
+
+var/

--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@apgms/sbr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node -e \"require('fs').mkdirSync('var/as4', { recursive: true });\" && tsx src/index.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/sbr/src/as4/client.ts
+++ b/apgms/services/sbr/src/as4/client.ts
@@ -1,0 +1,86 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface SendOptions {
+  action: string;
+  orgId: string;
+}
+
+export interface SendResult {
+  messageId: string;
+  sentAt: string;
+  receiptId: string;
+}
+
+const AS4_BASE_DIR = path.resolve(process.cwd(), "var", "as4");
+
+export async function send(
+  payload: string | Buffer,
+  options: SendOptions,
+): Promise<SendResult> {
+  const messageId = randomUUID();
+  const receiptId = randomUUID();
+  const sentAt = new Date().toISOString();
+
+  const payloadText =
+    typeof payload === "string" ? payload : payload.toString("utf-8");
+
+  const messageDir = path.join(AS4_BASE_DIR, messageId);
+
+  await mkdir(messageDir, { recursive: true });
+
+  const requestPath = path.join(messageDir, "request.xml");
+  const receiptPath = path.join(messageDir, "receipt.xml");
+  const signaturesPath = path.join(messageDir, "signatures.json");
+
+  const receiptXml = buildReceiptXml({
+    messageId,
+    receiptId,
+    sentAt,
+    action: options.action,
+    orgId: options.orgId,
+  });
+
+  const signatures = buildSignaturesArtifact(payloadText, receiptXml, sentAt);
+
+  await Promise.all([
+    writeFile(requestPath, payloadText, "utf-8"),
+    writeFile(receiptPath, receiptXml, "utf-8"),
+    writeFile(signaturesPath, JSON.stringify(signatures, null, 2), "utf-8"),
+  ]);
+
+  return { messageId, receiptId, sentAt };
+}
+
+function buildReceiptXml(params: {
+  messageId: string;
+  receiptId: string;
+  sentAt: string;
+  action: string;
+  orgId: string;
+}): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<Receipt>\n` +
+    `  <MessageId>${params.messageId}</MessageId>\n` +
+    `  <ReceiptId>${params.receiptId}</ReceiptId>\n` +
+    `  <OrgId>${params.orgId}</OrgId>\n` +
+    `  <Action>${params.action}</Action>\n` +
+    `  <SentAt>${params.sentAt}</SentAt>\n` +
+    `</Receipt>\n`;
+}
+
+function buildSignaturesArtifact(
+  requestXml: string,
+  receiptXml: string,
+  sentAt: string,
+) {
+  return [
+    {
+      algorithm: "SHA256",
+      signedAt: sentAt,
+      requestDigest: createHash("sha256").update(requestXml).digest("hex"),
+      receiptDigest: createHash("sha256").update(receiptXml).digest("hex"),
+    },
+  ];
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,52 @@
-﻿console.log('sbr service');
+import Fastify from "fastify";
+import { send } from "./as4/client";
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: "sbr" }));
+
+app.post("/sbr/send", async (req, rep) => {
+  if (process.env.NODE_ENV === "production") {
+    return rep.code(404).send({ error: "not_found" });
+  }
+
+  const body = req.body as {
+    payload?: string | Buffer;
+    action?: string;
+    orgId?: string;
+  };
+
+  if (
+    !body ||
+    typeof body.payload !== "string" ||
+    typeof body.action !== "string" ||
+    typeof body.orgId !== "string"
+  ) {
+    return rep.code(400).send({ error: "invalid_request" });
+  }
+
+  try {
+    const result = await send(body.payload, {
+      action: body.action,
+      orgId: body.orgId,
+    });
+
+    return rep.code(202).send(result);
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(500).send({ error: "failed_to_send" });
+  }
+});
+
+const port = Number(process.env.PORT ?? 3020);
+const host = "0.0.0.0";
+
+app
+  .listen({ port, host })
+  .then(() => {
+    app.log.info(`sbr dev server listening on http://${host}:${port}`);
+  })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add an AS4 client helper that persists request, receipt, and signature artifacts under var/as4
- expose a Fastify dev endpoint at POST /sbr/send to trigger AS4 artifact generation and return tracking ids
- ensure the dev script prepares the var/as4 directory and ignore generated artifacts in git

## Testing
- pnpm install --filter @apgms/sbr... *(fails: 403 Forbidden fetching typescript from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f3a33d69f4832781740f7f66106f45