### PR TITLE
feat: add idempotency support to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test ./test/idempotency.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,11 +9,15 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import idempotencyPlugin from "./plugins/idempotency";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(idempotencyPlugin, {
+  paths: ["/bank-lines", "/allocations/apply"],
+});
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -59,6 +63,30 @@ app.post("/bank-lines", async (req, rep) => {
       },
     });
     return rep.code(201).send(created);
+  } catch (e) {
+    req.log.error(e);
+    return rep.code(400).send({ error: "bad_request" });
+  }
+});
+
+app.post("/allocations/apply", async (req, rep) => {
+  try {
+    const body = req.body as {
+      orgId: string;
+      allocationId: string;
+      amount: number | string;
+    };
+
+    if (!body?.orgId || !body?.allocationId) {
+      return rep.code(400).send({ error: "bad_request" });
+    }
+
+    return rep.send({
+      orgId: body.orgId,
+      allocationId: body.allocationId,
+      amount: body.amount,
+      applied: true,
+    });
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,394 @@
+import crypto from "node:crypto";
+import net from "node:net";
+import { URL } from "node:url";
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+interface RedisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<unknown>;
+  set(key: string, value: string, mode: "EX", ttlSeconds: number): Promise<unknown>;
+  quit(): Promise<unknown>;
+}
+
+class InMemoryRedis implements RedisLike {
+  private store = new Map<string, { value: string; expiresAt?: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, mode?: "EX", ttlSeconds?: number): Promise<string> {
+    let expiresAt: number | undefined;
+    if (mode === "EX" && typeof ttlSeconds === "number") {
+      expiresAt = Date.now() + ttlSeconds * 1000;
+    }
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+
+  async quit(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+class SocketRedis implements RedisLike {
+  private socket: net.Socket;
+  private buffer = Buffer.alloc(0);
+  private queue: Array<{ resolve: (value: unknown) => void; reject: (err: Error) => void }> = [];
+  private ready: Promise<void>;
+  private ended = false;
+
+  constructor(redisUrl: string) {
+    const url = new URL(redisUrl);
+    const port = Number(url.port || 6379);
+    const host = url.hostname || "127.0.0.1";
+    const password = url.password ? decodeURIComponent(url.password) : undefined;
+
+    this.socket = net.createConnection({ host, port });
+    this.socket.on("data", (chunk) => this.onData(chunk));
+    this.socket.on("error", (err) => this.flushError(err));
+    this.socket.on("end", () => this.flushError(new Error("redis connection ended")));
+
+    this.ready = new Promise((resolve, reject) => {
+      const handleError = (err: Error) => {
+        this.socket.removeListener("connect", handleConnect);
+        reject(err);
+      };
+
+      const handleConnect = async () => {
+        this.socket.removeListener("error", handleError);
+        try {
+          if (password) {
+            await this.sendCommand(["AUTH", password], true);
+          }
+          resolve();
+        } catch (err) {
+          reject(err as Error);
+        }
+      };
+
+      this.socket.once("error", handleError);
+      this.socket.once("connect", handleConnect);
+    });
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ready;
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    this.processBuffer();
+  }
+
+  private processBuffer(): void {
+    while (true) {
+      const result = this.parseResponse();
+      if (result === undefined) {
+        break;
+      }
+      const pending = this.queue.shift();
+      if (!pending) {
+        continue;
+      }
+      if (result instanceof Error) {
+        pending.reject(result);
+      } else {
+        pending.resolve(result);
+      }
+    }
+  }
+
+  private parseResponse(): unknown {
+    if (this.buffer.length === 0) {
+      return undefined;
+    }
+    const prefix = String.fromCharCode(this.buffer[0]);
+    if (prefix === "+" || prefix === "-") {
+      const end = this.buffer.indexOf("\r\n");
+      if (end === -1) {
+        return undefined;
+      }
+      const payload = this.buffer.slice(1, end).toString();
+      this.buffer = this.buffer.slice(end + 2);
+      if (prefix === "-") {
+        return new Error(payload);
+      }
+      return payload;
+    }
+
+    if (prefix === "$") {
+      const end = this.buffer.indexOf("\r\n");
+      if (end === -1) {
+        return undefined;
+      }
+      const length = Number(this.buffer.slice(1, end).toString());
+      if (length === -1) {
+        this.buffer = this.buffer.slice(end + 2);
+        return null;
+      }
+      const total = end + 2 + length + 2;
+      if (this.buffer.length < total) {
+        return undefined;
+      }
+      const value = this.buffer.slice(end + 2, end + 2 + length).toString();
+      this.buffer = this.buffer.slice(total);
+      return value;
+    }
+
+    if (prefix === ":") {
+      const end = this.buffer.indexOf("\r\n");
+      if (end === -1) {
+        return undefined;
+      }
+      const numberValue = Number(this.buffer.slice(1, end).toString());
+      this.buffer = this.buffer.slice(end + 2);
+      return numberValue;
+    }
+
+    if (prefix === "*") {
+      const end = this.buffer.indexOf("\r\n");
+      if (end === -1) {
+        return undefined;
+      }
+      const count = Number(this.buffer.slice(1, end).toString());
+      this.buffer = this.buffer.slice(end + 2);
+      const values: unknown[] = [];
+      for (let i = 0; i < count; i += 1) {
+        const value = this.parseResponse();
+        if (value === undefined) {
+          return undefined;
+        }
+        values.push(value);
+      }
+      return values;
+    }
+
+    return undefined;
+  }
+
+  private flushError(err: Error): void {
+    if (this.ended) {
+      return;
+    }
+    this.ended = true;
+    while (this.queue.length) {
+      this.queue.shift()?.reject(err);
+    }
+  }
+
+  private sendCommand(args: string[], skipReady = false): Promise<unknown> {
+    const command = `*${args.length}\r\n${args
+      .map((arg) => `$${Buffer.byteLength(arg)}\r\n${arg}\r\n`)
+      .join("")}`;
+
+    return new Promise(async (resolve, reject) => {
+      try {
+        if (!skipReady) {
+          await this.ensureReady();
+        }
+
+        this.queue.push({ resolve, reject });
+        this.socket.write(command, (err) => {
+          if (err) {
+            this.queue.pop()?.reject(err);
+            reject(err);
+          }
+        });
+      } catch (err) {
+        reject(err as Error);
+      }
+    });
+  }
+
+  async get(key: string): Promise<string | null> {
+    const result = await this.sendCommand(["GET", key]);
+    if (result === null || result === undefined) {
+      return null;
+    }
+    return String(result);
+  }
+
+  async set(key: string, value: string, mode?: "EX", ttlSeconds?: number): Promise<string> {
+    const args = ["SET", key, value];
+    if (mode === "EX" && typeof ttlSeconds === "number") {
+      args.push("EX", String(ttlSeconds));
+    }
+    const result = await this.sendCommand(args);
+    return typeof result === "string" ? result : "OK";
+  }
+
+  async quit(): Promise<void> {
+    try {
+      await this.sendCommand(["QUIT"]);
+    } catch (err) {
+      // ignore quit failures
+    } finally {
+      this.socket.destroy();
+    }
+  }
+}
+
+interface IdempotencyPluginOptions {
+  paths: string[];
+  redisUrl?: string;
+  ttlSeconds?: number;
+}
+
+interface CacheRecord {
+  key: string;
+  method: string;
+  url: string;
+  orgId?: string;
+  bodyHash: string;
+  response: unknown;
+  status: number;
+}
+
+async function createRedisClient(redisUrl: string): Promise<RedisLike> {
+  if (redisUrl.startsWith("redis://mock")) {
+    return new InMemoryRedis();
+  }
+  return new SocketRedis(redisUrl);
+}
+
+function resolveRoutePath(request: FastifyRequest): string {
+  if (request.routerPath) {
+    return request.routerPath;
+  }
+  const rawUrl = request.raw.url ?? request.url;
+  return rawUrl.split("?")[0] ?? rawUrl;
+}
+
+function normaliseBody(body: unknown): string {
+  if (typeof body === "string") {
+    return body;
+  }
+  if (Buffer.isBuffer(body)) {
+    return body.toString("utf8");
+  }
+  return JSON.stringify(body ?? null);
+}
+
+function extractOrgId(body: unknown): string | undefined {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return undefined;
+  }
+  const value = (body as Record<string, unknown>).orgId;
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return String(value);
+}
+
+const idempotencyPlugin: FastifyPluginAsync<IdempotencyPluginOptions> = async (app, opts) => {
+  const trackedPaths = new Set(opts.paths);
+  if (trackedPaths.size === 0) {
+    app.log.warn("idempotency plugin registered with no tracked paths");
+    return;
+  }
+
+  const redisUrl = opts.redisUrl ?? process.env.REDIS_URL;
+  if (!redisUrl) {
+    throw new Error("REDIS_URL must be configured for idempotency middleware");
+  }
+
+  const redis = await createRedisClient(redisUrl);
+
+  app.addHook("onClose", async () => {
+    await redis.quit();
+  });
+
+  app.addHook("preHandler", async (request, reply) => {
+    if (request.method !== "POST") {
+      return;
+    }
+
+    const routePath = resolveRoutePath(request);
+    if (!trackedPaths.has(routePath)) {
+      return;
+    }
+
+    const keyHeader = request.headers["idempotency-key"];
+    if (typeof keyHeader !== "string" || keyHeader.trim() === "") {
+      reply.code(400);
+      return reply.send({ error: "idempotency_key_required" });
+    }
+
+    const idempotencyKey = keyHeader.trim();
+    const cacheKey = `idempotency:${idempotencyKey}`;
+    const bodyContent = normaliseBody(request.body);
+    const bodyHash = crypto.createHash("sha256").update(bodyContent).digest("hex");
+    const orgId = extractOrgId(request.body);
+
+    const cachedRaw = await redis.get(cacheKey);
+    if (cachedRaw) {
+      let cached: CacheRecord | undefined;
+      try {
+        cached = JSON.parse(cachedRaw) as CacheRecord;
+      } catch (err) {
+        request.log.warn({ err }, "invalid cache payload, discarding");
+      }
+
+      if (cached) {
+        const isMatch =
+          cached.method === request.method &&
+          cached.url === routePath &&
+          cached.bodyHash === bodyHash &&
+          cached.orgId === orgId;
+
+        if (isMatch) {
+          reply.header("idempotency-replay", "true");
+          reply.header("idempotency-original-status", String(cached.status));
+          reply.code(200);
+          return reply.send(cached.response);
+        }
+
+        reply.code(409);
+        return reply.send({ error: "idempotency_key_conflict" });
+      }
+    }
+
+    const originalSend = reply.send.bind(reply);
+
+    reply.send = async function patchedSend(this: FastifyReply, payload: unknown) {
+      const record: CacheRecord = {
+        key: idempotencyKey,
+        method: request.method,
+        url: routePath,
+        orgId,
+        bodyHash,
+        response: payload,
+        status: this.statusCode,
+      };
+
+      const ttlSeconds = opts.ttlSeconds;
+      const serialised = JSON.stringify(record);
+      try {
+        if (ttlSeconds && ttlSeconds > 0) {
+          await redis.set(cacheKey, serialised, "EX", ttlSeconds);
+        } else {
+          await redis.set(cacheKey, serialised);
+        }
+      } catch (err) {
+        request.log.error({ err }, "failed to persist idempotency record");
+      }
+
+      return await originalSend(payload);
+    };
+  });
+};
+
+const pluginMeta = idempotencyPlugin as unknown as Record<symbol, unknown>;
+pluginMeta[Symbol.for("skip-override")] = true;
+pluginMeta[Symbol.for("fastify.display-name")] = "idempotency-plugin";
+
+export default idempotencyPlugin;

--- a/apgms/services/api-gateway/test/idempotency.spec.ts
+++ b/apgms/services/api-gateway/test/idempotency.spec.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import Fastify, { type FastifyInstance } from "fastify";
+import idempotencyPlugin from "../src/plugins/idempotency";
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const app = Fastify();
+  await app.register(idempotencyPlugin, {
+    paths: ["/bank-lines", "/allocations/apply"],
+    redisUrl: process.env.REDIS_URL,
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    const body = req.body as Record<string, unknown>;
+    return rep.code(201).send({
+      id: "bank-line-1",
+      ...body,
+    });
+  });
+
+  app.post("/allocations/apply", async (req) => {
+    const body = req.body as Record<string, unknown>;
+    return { applied: true, ...body };
+  });
+
+  await app.ready();
+  return app;
+}
+
+describe("idempotency middleware", () => {
+  it("requires an Idempotency-Key header", async () => {
+    process.env.REDIS_URL = "redis://mock";
+    const app = await buildTestApp();
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        payload: { orgId: "org1" },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.deepEqual(response.json(), { error: "idempotency_key_required" });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("caches POST /bank-lines responses", async () => {
+    process.env.REDIS_URL = "redis://mock";
+    const app = await buildTestApp();
+
+    try {
+      const payload = {
+        orgId: "org1",
+        date: "2024-01-01",
+        amount: 100,
+        payee: "Vendor",
+        desc: "Invoice",
+      };
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        headers: { "idempotency-key": "line-1" },
+        payload,
+      });
+
+      assert.equal(first.statusCode, 201);
+      const firstBody = first.json();
+
+      const second = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        headers: { "idempotency-key": "line-1" },
+        payload,
+      });
+
+      assert.equal(second.statusCode, 200);
+      assert.equal(second.headers["idempotency-replay"], "true");
+      assert.equal(second.headers["idempotency-original-status"], "201");
+      assert.deepEqual(second.json(), firstBody);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("rejects conflicting payloads for the same key", async () => {
+    process.env.REDIS_URL = "redis://mock";
+    const app = await buildTestApp();
+
+    try {
+      const payload = { orgId: "org1", amount: 100 };
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        headers: { "idempotency-key": "conflict" },
+        payload,
+      });
+
+      assert.equal(first.statusCode, 201);
+
+      const conflict = await app.inject({
+        method: "POST",
+        url: "/bank-lines",
+        headers: { "idempotency-key": "conflict" },
+        payload: { orgId: "org1", amount: 200 },
+      });
+
+      assert.equal(conflict.statusCode, 409);
+      assert.deepEqual(conflict.json(), { error: "idempotency_key_conflict" });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("caches allocations apply requests", async () => {
+    process.env.REDIS_URL = "redis://mock";
+    const app = await buildTestApp();
+
+    try {
+      const payload = { orgId: "org1", allocationId: "alloc-1" };
+
+      const first = await app.inject({
+        method: "POST",
+        url: "/allocations/apply",
+        headers: { "idempotency-key": "alloc-key" },
+        payload,
+      });
+
+      assert.equal(first.statusCode, 200);
+
+      const replay = await app.inject({
+        method: "POST",
+        url: "/allocations/apply",
+        headers: { "idempotency-key": "alloc-key" },
+        payload,
+      });
+
+      assert.equal(replay.statusCode, 200);
+      assert.equal(replay.headers["idempotency-replay"], "true");
+      assert.equal(replay.headers["idempotency-original-status"], "200");
+      assert.deepEqual(replay.json(), first.json());
+    } finally {
+      await app.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a Redis-backed idempotency plugin that caches POST responses for tracked routes and enforces the Idempotency-Key header
- wire the middleware into /bank-lines and /allocations/apply along with a simple allocations apply handler
- add node:test coverage for cache hits, conflicts, and replay behaviour

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f3a2dd22fc8327871b6939b406415c