### PR TITLE
feat: add bank line validation middleware

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerBankLineRoutes } from "./routes/bank-lines";
 
 const app = Fastify({ logger: true });
 
@@ -29,41 +30,7 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+registerBankLineRoutes(app);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/middleware/validate.ts
+++ b/apgms/services/api-gateway/src/middleware/validate.ts
@@ -1,0 +1,37 @@
+import { FastifyRequest } from "fastify";
+import type { ZodTypeAny, infer as ZodInfer } from "zod";
+
+type Infer<Schema extends ZodTypeAny> = ZodInfer<Schema>;
+
+const parseOrThrow = <Schema extends ZodTypeAny>(schema: Schema, value: unknown, statusCode: number): Infer<Schema> => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    const error = new Error("Validation failed");
+    (error as any).statusCode = statusCode;
+    (error as any).validation = result.error.flatten();
+    throw error;
+  }
+  return result.data as Infer<Schema>;
+};
+
+export const validateBody = <Schema extends ZodTypeAny>(schema: Schema) => {
+  return <Req extends FastifyRequest>(req: Req): Infer<Schema> => {
+    const parsed = parseOrThrow(schema, req.body, 400);
+    (req as any).body = parsed;
+    return parsed;
+  };
+};
+
+export const validateQuery = <Schema extends ZodTypeAny>(schema: Schema) => {
+  return <Req extends FastifyRequest>(req: Req): Infer<Schema> => {
+    const parsed = parseOrThrow(schema, req.query, 400);
+    (req as any).query = parsed;
+    return parsed;
+  };
+};
+
+export const validateReply = <Schema extends ZodTypeAny>(schema: Schema) => {
+  return (payload: unknown): Infer<Schema> => {
+    return parseOrThrow(schema, payload, 500);
+  };
+};

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,70 @@
+import { FastifyInstance } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+import { validateBody, validateQuery, validateReply } from "../middleware/validate";
+import {
+  BankLineResp,
+  CreateBankLineBody,
+  ListBankLinesQuery,
+  ListBankLinesResp,
+  type BankLineRespOutput,
+  type ListBankLinesRespOutput,
+} from "../schemas/bank-lines";
+
+const defaultTake = 20;
+
+const centsToDecimalString = (value: number) => (value / 100).toFixed(2);
+
+const toAmountCents = (value: unknown): number => {
+  const asString =
+    typeof value === "string"
+      ? value
+      : value !== null && typeof value === "object" && "toString" in value
+        ? value.toString()
+        : String(value ?? "0");
+  const numeric = Number.parseFloat(asString);
+  if (Number.isNaN(numeric)) {
+    return 0;
+  }
+  return Math.round(Math.abs(numeric) * 100);
+};
+
+type BankLineRecord = Awaited<ReturnType<typeof prisma.bankLine.create>>;
+
+const toBankLineResponse = (line: BankLineRecord): BankLineRespOutput => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amountCents: toAmountCents(line.amount),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+export const registerBankLineRoutes = (app: FastifyInstance) => {
+  app.get("/bank-lines", async (req, rep) => {
+    const query = validateQuery(ListBankLinesQuery)(req);
+    const take = query.take ?? defaultTake;
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+    const payload: ListBankLinesRespOutput = { lines: lines.map(toBankLineResponse) };
+    const response = validateReply(ListBankLinesResp)(payload);
+    return rep.send(response);
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    const body = validateBody(CreateBankLineBody)(req);
+    const created = await prisma.bankLine.create({
+      data: {
+        orgId: body.orgId,
+        date: new Date(body.date),
+        amount: centsToDecimalString(body.amountCents),
+        payee: body.payee,
+        desc: body.desc,
+      },
+    });
+    const response = validateReply(BankLineResp)(toBankLineResponse(created));
+    return rep.status(200).send(response);
+  });
+};

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { zDate, zId, zMoneyCents, zOrgId } from "./common";
+
+const zNonEmptyString = z.string().min(1);
+
+export const CreateBankLineBody = z.object({
+  orgId: zOrgId,
+  date: zDate,
+  amountCents: zMoneyCents,
+  payee: zNonEmptyString,
+  desc: zNonEmptyString,
+});
+
+export const BankLineResp = z.object({
+  id: zId,
+  orgId: zOrgId,
+  date: zDate,
+  amountCents: zMoneyCents,
+  payee: zNonEmptyString,
+  desc: zNonEmptyString,
+  createdAt: zDate,
+});
+
+export const ListBankLinesQuery = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+export const ListBankLinesResp = z.object({
+  lines: z.array(BankLineResp),
+});
+
+export type CreateBankLineBodyInput = z.infer<typeof CreateBankLineBody>;
+export type BankLineRespOutput = z.infer<typeof BankLineResp>;
+export type ListBankLinesQueryInput = z.infer<typeof ListBankLinesQuery>;
+export type ListBankLinesRespOutput = z.infer<typeof ListBankLinesResp>;

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const zId = z.string().min(1, "id_required");
+export const zOrgId = zId;
+export const zDate = z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+  message: "invalid_date",
+});
+export const zMoneyCents = z.number().int().min(0);


### PR DESCRIPTION
## Summary
- add shared zod schemas for ids, dates, and monetary values
- validate bank line requests and responses with zod middleware
- move bank line endpoints into a dedicated route module and register it in the app

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3a2d13f348327a5d9c130cb621e05