### PR TITLE
feat: secure API gateway front door

### DIFF
--- a/apgms/SECURITY.md
+++ b/apgms/SECURITY.md
@@ -1,2 +1,18 @@
-﻿# Security Policy
+# Security Policy
+
 Email: security@yourdomain.example
+
+## Auth, CORS, Rate limiting
+
+The API Gateway enforces authentication, authorization, and transport policies through dedicated Fastify plugins.
+
+- **Authentication & Authorization**
+  - `AUTH_BYPASS=true` (development only) enables a stubbed bearer flow that trusts the headers `x-dev-user`, `x-dev-email`, `x-dev-org`, and `x-dev-roles`. Requests missing the minimum `x-dev-user` and `x-dev-org` headers are rejected with `401`.
+  - When `AUTH_BYPASS` is unset or `false`, the gateway expects a standard `Authorization: Bearer <token>` header. Token verification is not yet implemented, but the JWT payload (if present) seeds the request `user` context for downstream guards.
+  - Route guards `requireRole(...roles)` and `requireOrgScope()` are available to handlers. `requireRole` enforces that the authenticated user possesses at least one of the supplied roles, while `requireOrgScope` confirms that the caller's `orgId` matches the `orgId` present in the request body or query string.
+- **CORS**
+  - In development (`NODE_ENV !== "production"`), cross-origin requests are limited to `http://localhost:5173`.
+  - In production, allowed origins are sourced exclusively from the comma-separated `ALLOWED_ORIGINS` environment variable. Empty configuration results in all browser origins being denied.
+- **Rate limiting & request size**
+  - Each client IP is limited to **100 requests per minute** and **10 requests per 10 seconds**. Exceeding either window returns `429 rate_limit_exceeded`.
+  - Incoming payloads over **1 MiB** are rejected with `413 payload_too_large`. The Fastify server also sets an application-wide `bodyLimit` of 1 MiB.

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,159 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+export type AuthenticatedUser = {
+  id: string;
+  email: string;
+  orgId: string;
+  roles: string[];
+};
+
+type GuardHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<void> | void;
+
+const normalizeBoolean = (value: string | undefined) => value?.toLowerCase() === "true";
+
+const authPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateRequest<AuthenticatedUser | undefined>("user", undefined);
+
+  fastify.decorate<(...roles: string[]) => GuardHandler>(
+    "requireRole",
+    (...roles) => async (request, reply) => {
+      if (!request.user) {
+        reply.code(401).send({ error: "unauthenticated" });
+        return;
+      }
+
+      if (roles.length === 0) {
+        return;
+      }
+
+      const userRoles = new Set(request.user.roles.map((role) => role.toLowerCase()));
+      const hasRole = roles.some((role) => userRoles.has(role.toLowerCase()));
+
+      if (!hasRole) {
+        reply.code(403).send({ error: "forbidden" });
+      }
+    },
+  );
+
+  fastify.decorate<() => GuardHandler>(
+    "requireOrgScope",
+    () => async (request, reply) => {
+      if (!request.user) {
+        reply.code(401).send({ error: "unauthenticated" });
+        return;
+      }
+
+      const userOrgId = request.user.orgId;
+      const bodyOrgId = (request.body as Record<string, unknown> | undefined)?.orgId;
+      const queryOrgId = (request.query as Record<string, unknown> | undefined)?.orgId;
+      const requestOrgId = typeof bodyOrgId === "string" ? bodyOrgId : typeof queryOrgId === "string" ? queryOrgId : undefined;
+
+      if (!requestOrgId) {
+        reply.code(400).send({ error: "org_scope_required" });
+        return;
+      }
+
+      if (userOrgId !== requestOrgId) {
+        reply.code(403).send({ error: "forbidden" });
+      }
+    },
+  );
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (request.routeOptions.config?.public) {
+      return;
+    }
+
+    if (request.user) {
+      return;
+    }
+
+    if (normalizeBoolean(process.env.AUTH_BYPASS)) {
+      const devUser = request.headers["x-dev-user"];
+      const devEmail = request.headers["x-dev-email"];
+      const devOrg = request.headers["x-dev-org"];
+      const devRoles = request.headers["x-dev-roles"];
+
+      if (typeof devUser !== "string" || typeof devOrg !== "string") {
+        reply.code(401).send({ error: "unauthenticated" });
+        return;
+      }
+
+      const roles = typeof devRoles === "string" && devRoles.length > 0 ? devRoles.split(",").map((role) => role.trim()).filter(Boolean) : [];
+
+      request.user = {
+        id: devUser,
+        email: typeof devEmail === "string" ? devEmail : "",
+        orgId: devOrg,
+        roles,
+      } satisfies AuthenticatedUser;
+      return;
+    }
+
+    const authorization = request.headers.authorization;
+    if (typeof authorization !== "string") {
+      reply.code(401).send({ error: "unauthenticated" });
+      return;
+    }
+
+    const [scheme, token] = authorization.split(" ");
+    if (scheme !== "Bearer" || !token) {
+      reply.code(401).send({ error: "unauthenticated" });
+      return;
+    }
+
+    try {
+      const payload = parseTokenPayload(token);
+      const roles = Array.isArray(payload.roles)
+        ? payload.roles.map((role) => String(role))
+        : typeof payload.roles === "string"
+          ? payload.roles.split(",").map((role) => role.trim()).filter(Boolean)
+          : [];
+
+      const user: AuthenticatedUser = {
+        id: String(payload.sub ?? payload.userId ?? ""),
+        email: payload.email ? String(payload.email) : "",
+        orgId: String(payload.orgId ?? payload.org_id ?? ""),
+        roles,
+      };
+
+      if (!user.id || !user.orgId) {
+        reply.code(403).send({ error: "forbidden" });
+        return;
+      }
+
+      request.user = user;
+    } catch (error) {
+      request.log.warn({ err: error }, "failed to parse auth token");
+      reply.code(401).send({ error: "unauthenticated" });
+    }
+  });
+};
+
+const parseTokenPayload = (token: string): Record<string, unknown> => {
+  const parts = token.split(".");
+  if (parts.length < 2) {
+    throw new Error("invalid token");
+  }
+
+  const payloadSegment = parts[1];
+  const decoded = Buffer.from(payloadSegment, "base64url").toString("utf8");
+  return JSON.parse(decoded);
+};
+
+export default authPlugin;
+
+declare module "fastify" {
+  interface FastifyInstance {
+    requireRole: (...roles: string[]) => GuardHandler;
+    requireOrgScope: () => GuardHandler;
+  }
+
+  interface FastifyRequest {
+    user?: AuthenticatedUser;
+  }
+
+  interface FastifyContextConfig {
+    public?: boolean;
+  }
+}

--- a/apgms/services/api-gateway/src/plugins/cors.ts
+++ b/apgms/services/api-gateway/src/plugins/cors.ts
@@ -1,0 +1,43 @@
+import cors from "@fastify/cors";
+import type { FastifyPluginAsync } from "fastify";
+
+const corsPlugin: FastifyPluginAsync = async (fastify) => {
+  const nodeEnv = (process.env.NODE_ENV ?? "").toLowerCase();
+  const isProduction = nodeEnv === "production";
+
+  let origins: string[] = [];
+  if (isProduction) {
+    const configured = process.env.ALLOWED_ORIGINS ?? "";
+    origins = configured
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0);
+
+    if (origins.length === 0) {
+      fastify.log.warn("ALLOWED_ORIGINS is empty; CORS will deny all browser origins");
+    }
+  } else {
+    origins = ["http://localhost:5173"];
+  }
+
+  const allowed = new Set(origins);
+
+  await fastify.register(cors, {
+    credentials: true,
+    origin(origin, callback) {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      if (allowed.has(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(null, false);
+    },
+  });
+};
+
+export default corsPlugin;

--- a/apgms/services/api-gateway/src/plugins/rate-limit.ts
+++ b/apgms/services/api-gateway/src/plugins/rate-limit.ts
@@ -1,0 +1,51 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const MINUTE_WINDOW_MS = 60_000;
+const MINUTE_LIMIT = 100;
+const SHORT_WINDOW_MS = 10_000;
+const SHORT_LIMIT = 10;
+const ONE_MIB = 1024 * 1024;
+
+type RateWindow = {
+  minute: number[];
+  short: number[];
+};
+
+const rateLimitPlugin: FastifyPluginAsync = async (fastify) => {
+  const hits = new Map<string, RateWindow>();
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const contentLengthHeader = request.headers["content-length"];
+    if (typeof contentLengthHeader === "string") {
+      const contentLength = Number.parseInt(contentLengthHeader, 10);
+      if (Number.isFinite(contentLength) && contentLength > ONE_MIB) {
+        reply.code(413).send({ error: "payload_too_large" });
+        return;
+      }
+    }
+
+    const ip = request.ip ?? request.socket.remoteAddress ?? "unknown";
+    const now = Date.now();
+    const window = hits.get(ip) ?? { minute: [], short: [] };
+
+    window.minute = window.minute.filter((timestamp) => now - timestamp < MINUTE_WINDOW_MS);
+    if (window.minute.length >= MINUTE_LIMIT) {
+      hits.set(ip, window);
+      reply.code(429).send({ error: "rate_limit_exceeded" });
+      return;
+    }
+
+    window.short = window.short.filter((timestamp) => now - timestamp < SHORT_WINDOW_MS);
+    if (window.short.length >= SHORT_LIMIT) {
+      hits.set(ip, window);
+      reply.code(429).send({ error: "rate_limit_exceeded" });
+      return;
+    }
+
+    window.minute.push(now);
+    window.short.push(now);
+    hits.set(ip, window);
+  });
+};
+
+export default rateLimitPlugin;


### PR DESCRIPTION
## Summary
- add an authentication plugin with dev bypass headers, bearer parsing, and route guards for roles and org scope
- lock CORS behaviour to localhost in development and ALLOWED_ORIGINS in production
- enforce per-IP rate limits and body size checks while documenting the new security posture

## Testing
- pnpm tsc --noEmit *(fails: Module '@prisma/client' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68f3a2c60be4832781c051e5a7965506