### PR TITLE
Add policy and ledger models and convert bank line amount to cents

### DIFF
--- a/apgms/shared/prisma/migrations/20260207120000_policy_gate_ledger_rpt_audit/migration.sql
+++ b/apgms/shared/prisma/migrations/20260207120000_policy_gate_ledger_rpt_audit/migration.sql
@@ -1,0 +1,91 @@
+-- AlterTable
+ALTER TABLE "BankLine" ADD COLUMN "amountCents" INTEGER;
+UPDATE "BankLine" SET "amountCents" = CAST(ROUND("amount" * 100) AS INTEGER);
+ALTER TABLE "BankLine" ALTER COLUMN "amountCents" SET NOT NULL;
+ALTER TABLE "BankLine" DROP COLUMN "amount";
+
+-- CreateTable
+CREATE TABLE "Policy" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "rules" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Policy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Gate" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Gate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "LedgerEntry" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "bankLineId" TEXT NOT NULL,
+    "bucket" TEXT NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LedgerEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RptToken" (
+    "id" TEXT NOT NULL,
+    "rptId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "bankLineId" TEXT NOT NULL,
+    "policyHash" TEXT NOT NULL,
+    "allocations" JSONB NOT NULL,
+    "prevHash" TEXT NOT NULL,
+    "sig" TEXT NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RptToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AuditBlob" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "prevHash" TEXT NOT NULL,
+    "hash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditBlob_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RptToken_rptId_key" ON "RptToken"("rptId");
+
+-- AddForeignKey
+ALTER TABLE "Policy" ADD CONSTRAINT "Policy_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Gate" ADD CONSTRAINT "Gate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "LedgerEntry" ADD CONSTRAINT "LedgerEntry_bankLineId_fkey" FOREIGN KEY ("bankLineId") REFERENCES "BankLine"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RptToken" ADD CONSTRAINT "RptToken_bankLineId_fkey" FOREIGN KEY ("bankLineId") REFERENCES "BankLine"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -12,7 +12,12 @@ model Org {
   name      String
   createdAt DateTime @default(now())
   users     User[]
-  lines     BankLine[]
+  lines          BankLine[]
+  policies       Policy[]
+  gates          Gate[]
+  ledgerEntries  LedgerEntry[]
+  rptTokens      RptToken[]
+  audits         AuditBlob[]
 }
 
 model User {
@@ -29,8 +34,64 @@ model BankLine {
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
   date      DateTime
-  amount    Decimal
+  amountCents Int
   payee     String
   desc      String
+  createdAt DateTime @default(now())
+  ledgerEntries LedgerEntry[]
+  rptTokens     RptToken[]
+}
+
+model Policy {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  name      String
+  rules     Json
+  createdAt DateTime @default(now())
+}
+
+model Gate {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  name      String
+  status    String   @default("OPEN")
+  createdAt DateTime @default(now())
+}
+
+model LedgerEntry {
+  id          String    @id @default(cuid())
+  org         Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  bankLine    BankLine  @relation(fields: [bankLineId], references: [id], onDelete: Cascade)
+  bankLineId  String
+  bucket      String
+  amountCents Int
+  createdAt   DateTime  @default(now())
+}
+
+model RptToken {
+  id          String    @id @default(cuid())
+  rptId       String    @unique
+  org         Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  bankLine    BankLine  @relation(fields: [bankLineId], references: [id], onDelete: Cascade)
+  bankLineId  String
+  policyHash  String
+  allocations Json
+  prevHash    String
+  sig         String
+  timestamp   DateTime
+}
+
+model AuditBlob {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  type      String
+  payload   Json
+  prevHash  String
+  hash      String
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- convert bank line amounts to integer cents in the Prisma schema
- introduce policy, gate, ledger entry, RPT token, and audit blob models with org relationships
- add SQL migration updating existing data and creating the new tables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3aefb2ac083278452517c70a79082