### PR TITLE
Add OSF DSP questionnaire scaffolding and evidence guidance

### DIFF
--- a/evidence/README.md
+++ b/evidence/README.md
@@ -1,0 +1,16 @@
+# Evidence Repository
+
+Place supporting materials in this folder to back up questionnaire responses.
+
+## Screenshots
+Store annotated screenshots in the `screenshots/` subdirectory. Include captions in a companion README or within filenames.
+
+## Configuration Exports
+Save configuration exports or settings files in `configs/`. Use descriptive filenames that match the referenced control or questionnaire section.
+
+## Log Samples
+Add sanitized log snippets or monitoring exports to `logs/`. Ensure sensitive data is redacted.
+
+## Referencing Evidence in PRs
+When submitting a pull request, reference evidence by relative path (e.g. `evidence/screenshots/auth-flow.png`). Briefly describe how the artifact supports the control response.
+

--- a/osf/questionnaire.md
+++ b/osf/questionnaire.md
@@ -1,0 +1,40 @@
+# Product scope
+
+TODO
+
+# Hosting
+
+TODO
+
+# MFA posture
+
+TODO
+
+# AuthZ model
+
+TODO
+
+# Logging/Monitoring
+
+TODO
+
+# Incident Mgmt
+
+TODO (link NDB)
+
+# Change Mgmt
+
+TODO
+
+# SDLC
+
+TODO
+
+# SBR/AS4 evidencing
+
+TODO
+
+# Supplier mgmt
+
+TODO
+


### PR DESCRIPTION
## Summary
- add an OSF DSP questionnaire template covering key governance and operational headings
- document how to organise supporting evidence such as screenshots, configurations, and logs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3af966fac8327abd999df1b63d04a