### PR TITLE
feat: add zod validation for bank line routes

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerBankLineRoutes } from "./routes/bank-lines";
 
 const app = Fastify({ logger: true });
 
@@ -29,41 +30,7 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+await app.register(registerBankLineRoutes);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/middleware/validate.ts
+++ b/apgms/services/api-gateway/src/middleware/validate.ts
@@ -1,0 +1,38 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { ZodTypeAny, z } from "zod";
+
+export const validateBody = <T extends ZodTypeAny>(schema: T) =>
+  async (request: FastifyRequest, reply: FastifyReply) => {
+    const result = schema.safeParse(request.body);
+    if (!result.success) {
+      return reply.code(400).send({
+        error: "invalid_body",
+        details: result.error.flatten(),
+      });
+    }
+
+    (request as FastifyRequest & { body: z.infer<T> }).body = result.data;
+  };
+
+export const validateQuery = <T extends ZodTypeAny>(schema: T) =>
+  async (request: FastifyRequest, reply: FastifyReply) => {
+    const result = schema.safeParse(request.query);
+    if (!result.success) {
+      return reply.code(400).send({
+        error: "invalid_query",
+        details: result.error.flatten(),
+      });
+    }
+
+    (request as FastifyRequest & { query: z.infer<T> }).query = result.data;
+  };
+
+export const validateReply = <T extends ZodTypeAny>(schema: T) =>
+  async (_request: FastifyRequest, _reply: FastifyReply, payload: unknown) => {
+    const result = schema.safeParse(payload);
+    if (!result.success) {
+      throw new Error("Invalid response payload");
+    }
+
+    return result.data;
+  };

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,73 @@
+import { BankLine } from "@prisma/client";
+import { FastifyPluginAsync } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+import { validateBody, validateQuery, validateReply } from "../middleware/validate";
+import {
+  BankLineResp,
+  CreateBankLineBody,
+  ListBankLinesQuery,
+} from "../schemas/bank-lines";
+import { z } from "zod";
+
+const BankLinesReply = z.object({ lines: BankLineResp.array() });
+
+const toBankLineResp = (line: BankLine) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amountCents: Math.round(line.amount.toNumber() * 100),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+export const registerBankLineRoutes: FastifyPluginAsync = async (app) => {
+  app.get(
+    "/bank-lines",
+    {
+      preHandler: [validateQuery(ListBankLinesQuery)],
+      preSerialization: validateReply(BankLinesReply),
+    },
+    async (req) => {
+      const query = req.query as z.infer<typeof ListBankLinesQuery>;
+      const take = query.take ?? 20;
+
+      const lines = await prisma.bankLine.findMany({
+        where: { orgId: query.orgId },
+        orderBy: { date: "desc" },
+        take,
+        ...(query.cursor
+          ? {
+              skip: 1,
+              cursor: { id: query.cursor },
+            }
+          : {}),
+      });
+
+      return { lines: lines.map(toBankLineResp) };
+    }
+  );
+
+  app.post(
+    "/bank-lines",
+    {
+      preHandler: [validateBody(CreateBankLineBody)],
+      preSerialization: validateReply(BankLineResp),
+    },
+    async (req, reply) => {
+      const body = req.body as z.infer<typeof CreateBankLineBody>;
+
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: (body.amountCents / 100).toFixed(2),
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      return reply.code(201).send(toBankLineResp(created));
+    }
+  );
+};

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { zDate, zId, zMoneyCents, zOrgId } from "./common";
+
+export const CreateBankLineBody = z.object({
+  orgId: zOrgId,
+  date: zDate,
+  amountCents: zMoneyCents,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const BankLineResp = z.object({
+  id: zId,
+  orgId: zOrgId,
+  date: zDate,
+  amountCents: zMoneyCents,
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: zDate,
+});
+
+export const ListBankLinesQuery = z.object({
+  orgId: zOrgId,
+  take: z.number().int().min(1).max(200).optional(),
+  cursor: z.string().optional(),
+});

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const zId = z.string().min(1);
+
+export const zOrgId = z.string().min(1);
+
+export const zDate = z.string().datetime();
+
+export const zMoneyCents = z.number().int().nonnegative();


### PR DESCRIPTION
## Summary
- add common zod schemas for ids, dates, and money values
- introduce reusable request/reply validation middleware
- refactor bank line routes to enforce schemas and normalized responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f3aec444c483279459d1853fa11541