### PR TITLE
feat: secure api gateway with auth, cors, and rate limits

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,19 +8,26 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import authPlugin from "./plugins/auth.js";
+import corsPlugin from "./plugins/cors.js";
+import rateLimitPlugin from "./plugins/rate-limit.js";
+import bankLinesRoutes from "./routes/bank-lines.js";
 
-const app = Fastify({ logger: true });
+const app = Fastify({
+  logger: true,
+  bodyLimit: 1024 * 1024,
+});
 
-await app.register(cors, { origin: true });
+await app.register(authPlugin);
+await app.register(corsPlugin);
+await app.register(rateLimitPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
 app.get("/users", async () => {
   const users = await prisma.user.findMany({
     select: { email: true, orgId: true, createdAt: true },
@@ -29,41 +36,7 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+await app.register(bankLinesRoutes);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +50,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,132 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  orgId: string;
+  roles: string[];
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user: AuthenticatedUser | null;
+  }
+}
+
+const parseCsv = (value: string | undefined): string[] => {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+};
+
+const unauthorized = (reply: FastifyReply) =>
+  reply.code(401).send({ error: "unauthorized" });
+
+const authPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateRequest("user", null);
+
+  fastify.addHook("onRequest", async (req, reply) => {
+    req.user = null;
+
+    if (process.env.AUTH_BYPASS === "true") {
+      const headers = req.headers;
+      const userId = headers["x-dev-user"];
+      const email = headers["x-dev-email"];
+      const orgId = headers["x-dev-org"];
+      req.user = {
+        id: Array.isArray(userId) ? userId[0] ?? "" : String(userId ?? ""),
+        email: Array.isArray(email) ? email[0] ?? "" : String(email ?? ""),
+        orgId: Array.isArray(orgId) ? orgId[0] ?? "" : String(orgId ?? ""),
+        roles: parseCsv(
+          Array.isArray(headers["x-dev-roles"]) ? headers["x-dev-roles"][0] : headers["x-dev-roles"]
+        ),
+      };
+      return;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return unauthorized(reply);
+    }
+
+    const token = authHeader.substring("Bearer ".length).trim();
+    if (!token) {
+      return unauthorized(reply);
+    }
+
+    const segments = token.split(".");
+    if (segments.length < 2) {
+      return unauthorized(reply);
+    }
+
+    try {
+      const payloadJson = Buffer.from(segments[1], "base64url").toString("utf8");
+      const payload = JSON.parse(payloadJson) as Partial<AuthenticatedUser> & {
+        sub?: string;
+        roles?: string[] | string;
+      };
+
+      const id = typeof payload.id === "string" ? payload.id : payload.sub ?? "";
+      const email = typeof payload.email === "string" ? payload.email : "";
+      const orgId = typeof payload.orgId === "string" ? payload.orgId : "";
+      const rawRoles = Array.isArray(payload.roles)
+        ? payload.roles
+        : typeof payload.roles === "string"
+        ? parseCsv(payload.roles)
+        : [];
+
+      if (!id || !email || !orgId) {
+        return unauthorized(reply);
+      }
+
+      req.user = {
+        id,
+        email,
+        orgId,
+        roles: rawRoles,
+      };
+    } catch {
+      return unauthorized(reply);
+    }
+  });
+};
+
+export const requireRole = (...roles: string[]) => {
+  const expected = new Set(roles);
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const user = req.user;
+    if (!user) {
+      return unauthorized(reply);
+    }
+    if (expected.size === 0) {
+      return;
+    }
+    const hasRole = user.roles.some((role) => expected.has(role));
+    if (!hasRole) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+  };
+};
+
+export const requireOrgScope = () => {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    const user = req.user;
+    if (!user) {
+      return unauthorized(reply);
+    }
+
+    const bodyOrgId = typeof (req.body as any)?.orgId === "string" ? (req.body as any).orgId : undefined;
+    const queryOrgId = typeof (req.query as any)?.orgId === "string" ? (req.query as any).orgId : undefined;
+    const targetOrgId = bodyOrgId ?? queryOrgId;
+
+    if (!targetOrgId || targetOrgId !== user.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+  };
+};
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/plugins/cors.ts
+++ b/apgms/services/api-gateway/src/plugins/cors.ts
@@ -1,0 +1,39 @@
+import cors from "@fastify/cors";
+import type { FastifyCorsOptions } from "@fastify/cors";
+import type { FastifyPluginAsync } from "fastify";
+
+const corsPlugin: FastifyPluginAsync = async (fastify) => {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  let options: FastifyCorsOptions;
+  if (!isProduction) {
+    options = {
+      origin: ["http://localhost:5173"],
+      credentials: true,
+    };
+  } else {
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean);
+
+    options = {
+      credentials: true,
+      origin: (origin, cb) => {
+        if (!origin) {
+          cb(new Error("CORS origin not allowed"), false);
+          return;
+        }
+        if (allowedOrigins.includes(origin)) {
+          cb(null, true);
+          return;
+        }
+        cb(new Error("CORS origin not allowed"), false);
+      },
+    };
+  }
+
+  await fastify.register(cors, options);
+};
+
+export default corsPlugin;

--- a/apgms/services/api-gateway/src/plugins/rate-limit.ts
+++ b/apgms/services/api-gateway/src/plugins/rate-limit.ts
@@ -1,0 +1,80 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const ONE_MINUTE = 60_000;
+const TEN_SECONDS = 10_000;
+const MINUTE_LIMIT = 100;
+const TEN_SECOND_LIMIT = 10;
+const BODY_LIMIT_BYTES = 1024 * 1024;
+
+type Bucket = {
+  minuteTokens: number;
+  minuteUpdatedAt: number;
+  tenSecondTokens: number;
+  tenSecondUpdatedAt: number;
+};
+
+const refill = (current: number, lastUpdated: number, now: number, windowMs: number, capacity: number) => {
+  if (current >= capacity) {
+    return { tokens: capacity, updatedAt: now };
+  }
+  const delta = now - lastUpdated;
+  if (delta <= 0) {
+    return { tokens: current, updatedAt: lastUpdated };
+  }
+  const refillAmount = (delta / windowMs) * capacity;
+  const nextTokens = Math.min(capacity, current + refillAmount);
+  return { tokens: nextTokens, updatedAt: now };
+};
+
+const rateLimitPlugin: FastifyPluginAsync = async (fastify) => {
+  const buckets = new Map<string, Bucket>();
+
+  fastify.addHook("onRequest", async (req, reply) => {
+    const contentLengthHeader = req.headers["content-length"];
+    if (contentLengthHeader) {
+      const contentLength = Array.isArray(contentLengthHeader)
+        ? Number(contentLengthHeader[0])
+        : Number(contentLengthHeader);
+      if (Number.isFinite(contentLength) && contentLength > BODY_LIMIT_BYTES) {
+        return reply.code(413).send({ error: "payload_too_large" });
+      }
+    }
+
+    const ip = req.ip;
+    const now = Date.now();
+    const existing = buckets.get(ip) ?? {
+      minuteTokens: MINUTE_LIMIT,
+      minuteUpdatedAt: now,
+      tenSecondTokens: TEN_SECOND_LIMIT,
+      tenSecondUpdatedAt: now,
+    };
+
+    const minuteState = refill(existing.minuteTokens, existing.minuteUpdatedAt, now, ONE_MINUTE, MINUTE_LIMIT);
+    const tenSecondState = refill(
+      existing.tenSecondTokens,
+      existing.tenSecondUpdatedAt,
+      now,
+      TEN_SECONDS,
+      TEN_SECOND_LIMIT
+    );
+
+    if (minuteState.tokens < 1 || tenSecondState.tokens < 1) {
+      buckets.set(ip, {
+        minuteTokens: minuteState.tokens,
+        minuteUpdatedAt: minuteState.updatedAt,
+        tenSecondTokens: tenSecondState.tokens,
+        tenSecondUpdatedAt: tenSecondState.updatedAt,
+      });
+      return reply.code(429).send({ error: "rate_limit_exceeded" });
+    }
+
+    buckets.set(ip, {
+      minuteTokens: minuteState.tokens - 1,
+      minuteUpdatedAt: minuteState.updatedAt,
+      tenSecondTokens: tenSecondState.tokens - 1,
+      tenSecondUpdatedAt: tenSecondState.updatedAt,
+    });
+  });
+};
+
+export default rateLimitPlugin;

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,61 @@
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "../../../shared/src/db";
+import { requireOrgScope, requireRole } from "../plugins/auth.js";
+
+const bankLinesRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get(
+    "/bank-lines",
+    {
+      preHandler: [requireRole("bank:read", "admin"), requireOrgScope()],
+    },
+    async (req) => {
+      const { take, orgId } = req.query as { take?: string; orgId: string };
+      const numericTake = Number(take ?? 20);
+      const safeTake = Number.isFinite(numericTake) ? numericTake : 20;
+      const limit = Math.min(Math.max(safeTake, 1), 200);
+
+      const lines = await prisma.bankLine.findMany({
+        where: { orgId },
+        orderBy: { date: "desc" },
+        take: limit,
+      });
+
+      return { lines };
+    }
+  );
+
+  fastify.post(
+    "/bank-lines",
+    {
+      preHandler: [requireRole("bank:write", "admin"), requireOrgScope()],
+    },
+    async (req, rep) => {
+      try {
+        const body = req.body as {
+          orgId: string;
+          date: string;
+          amount: number | string;
+          payee: string;
+          desc: string;
+        };
+
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: body.orgId,
+            date: new Date(body.date),
+            amount: body.amount as any,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+
+        return rep.code(201).send(created);
+      } catch (error) {
+        req.log.error(error);
+        return rep.code(400).send({ error: "bad_request" });
+      }
+    }
+  );
+};
+
+export default bankLinesRoutes;


### PR DESCRIPTION
## Summary
- add an authentication plugin that supports dev bypass headers, JWT parsing, and reusable role/org guards
- introduce environment-aware CORS handling and request rate limiting/body size protections
- protect bank line routes with role/org scope checks and align database queries with scoped access

## Testing
- not run (pnpm registry access unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68f3ae9f0ea08327908b96ffe01c70f4