### PR TITLE
feat: add SBR AS4 dev scaffold

### DIFF
--- a/apgms/services/sbr/src/as4/client.ts
+++ b/apgms/services/sbr/src/as4/client.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface SendOptions {
+  action: string;
+  orgId: string;
+}
+
+export interface SendResult {
+  messageId: string;
+  sentAt: string;
+  receiptId: string;
+}
+
+const BASE_DIR = path.resolve(process.cwd(), "var", "as4");
+
+const REQUEST_FILENAME = "request.xml";
+const RECEIPT_FILENAME = "receipt.xml";
+const SIGNATURES_FILENAME = "signatures.json";
+
+export async function send(
+  payload: unknown,
+  { action, orgId }: SendOptions,
+): Promise<SendResult> {
+  if (!action || !orgId) {
+    throw new Error("action and orgId are required");
+  }
+
+  await fs.mkdir(BASE_DIR, { recursive: true });
+
+  const input = JSON.stringify({ payload, action, orgId });
+  const hash = createHash("sha256").update(input).digest("hex");
+  const messageId = `DEV-${hash.slice(0, 12)}`;
+  const receiptId = `DEV-R-${hash.slice(12, 24)}`;
+  const sentAt = new Date().toISOString();
+
+  const messageDir = path.join(BASE_DIR, messageId);
+  await fs.mkdir(messageDir, { recursive: true });
+
+  const requestXml = buildRequestXml({
+    action,
+    orgId,
+    messageId,
+    sentAt,
+    payload,
+  });
+  const receiptXml = buildReceiptXml({
+    messageId,
+    receiptId,
+    sentAt,
+  });
+  const signatures = buildSignatures({
+    messageId,
+    receiptId,
+    hash,
+  });
+
+  await Promise.all([
+    fs.writeFile(path.join(messageDir, REQUEST_FILENAME), requestXml, "utf8"),
+    fs.writeFile(path.join(messageDir, RECEIPT_FILENAME), receiptXml, "utf8"),
+    fs.writeFile(
+      path.join(messageDir, SIGNATURES_FILENAME),
+      JSON.stringify(signatures, null, 2),
+      "utf8",
+    ),
+  ]);
+
+  return { messageId, sentAt, receiptId };
+}
+
+function buildRequestXml(args: {
+  action: string;
+  orgId: string;
+  messageId: string;
+  sentAt: string;
+  payload: unknown;
+}): string {
+  const payloadText =
+    typeof args.payload === "string"
+      ? args.payload
+      : JSON.stringify(args.payload ?? null, null, 2);
+
+  return [
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+    "<AS4Request>",
+    `  <MessageId>${args.messageId}</MessageId>`,
+    `  <Action>${escapeXml(args.action)}</Action>`,
+    `  <OrgId>${escapeXml(args.orgId)}</OrgId>`,
+    `  <SentAt>${args.sentAt}</SentAt>`,
+    "  <Payload><![CDATA[",
+    payloadText,
+    "]]></Payload>",
+    "</AS4Request>",
+    "",
+  ].join("\n");
+}
+
+function buildReceiptXml(args: {
+  messageId: string;
+  receiptId: string;
+  sentAt: string;
+}): string {
+  return [
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+    "<AS4Receipt>",
+    `  <ReceiptId>${args.receiptId}</ReceiptId>`,
+    `  <MessageId>${args.messageId}</MessageId>`,
+    `  <ReceivedAt>${args.sentAt}</ReceivedAt>`,
+    "</AS4Receipt>",
+    "",
+  ].join("\n");
+}
+
+function buildSignatures(args: {
+  messageId: string;
+  receiptId: string;
+  hash: string;
+}) {
+  return {
+    messageId: args.messageId,
+    receiptId: args.receiptId,
+    algorithm: "SHA-256",
+    checksum: args.hash,
+  };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export const filenames = {
+  request: REQUEST_FILENAME,
+  receipt: RECEIPT_FILENAME,
+  signatures: SIGNATURES_FILENAME,
+};
+
+export const paths = {
+  base: BASE_DIR,
+};

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,70 @@
-﻿console.log('sbr service');
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promises as fs } from "node:fs";
+import dotenv from "dotenv";
+import Fastify from "fastify";
+
+import { filenames, paths, send } from "./as4/client";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+const app = Fastify({ logger: true });
+
+app.get("/health", async () => ({ ok: true, service: "sbr" }));
+
+app.post("/sbr/send", async (req, rep) => {
+  try {
+    const body = req.body as {
+      payload: unknown;
+      action?: string;
+      orgId?: string;
+    };
+
+    if (!body || typeof body !== "object") {
+      return rep.code(400).send({ error: "invalid_request" });
+    }
+
+    const action = body.action ?? "";
+    const orgId = body.orgId ?? "";
+
+    if (!action || !orgId) {
+      return rep.code(400).send({ error: "action_and_org_required" });
+    }
+
+    const result = await send(body.payload, { action, orgId });
+
+    const messageDir = path.join(paths.base, result.messageId);
+    const [requestXml, receiptXml, signaturesRaw] = await Promise.all([
+      fs.readFile(path.join(messageDir, filenames.request), "utf8"),
+      fs.readFile(path.join(messageDir, filenames.receipt), "utf8"),
+      fs.readFile(path.join(messageDir, filenames.signatures), "utf8"),
+    ]);
+
+    return {
+      ...result,
+      files: {
+        request: requestXml,
+        receipt: receiptXml,
+        signatures: JSON.parse(signaturesRaw),
+      },
+    };
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(500).send({ error: "send_failed" });
+  }
+});
+
+app.ready(() => {
+  app.log.info(app.printRoutes());
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((err) => {
+  app.log.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add an AS4 client that writes deterministic request artifacts in var/as4
- expose a POST /sbr/send dev endpoint that stores payload artifacts and returns ids and file contents

## Testing
- pnpm exec tsc --noEmit *(fails: missing PrismaClient type declarations and dotenv types in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68f3af738e88832784e9800d3b246b85