### PR TITLE
feat: add dashboard and bank lines console

### DIFF
--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>APGMS Console</title>
+  </head>
+  <body class="bg-slate-50 dark:bg-slate-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,32 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo 'No tests specified'"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.28.4",
+    "@tanstack/react-router": "^1.51.10",
+    "axios": "^1.6.7",
+    "clsx": "^2.1.0",
+    "date-fns": "^3.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8"
+  }
+}

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 antialiased;
+}
+
+.dark body {
+  @apply bg-slate-950 text-slate-100;
+}

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: 'http://localhost:3000',
+  withCredentials: true,
+});
+
+api.interceptors.request.use((config) => {
+  const token = window.localStorage.getItem('session-token');
+  if (token) {
+    config.headers.set('Authorization', `Bearer ${token}`);
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401) {
+      console.warn('Session expired');
+    }
+    return Promise.reject(error);
+  },
+);
+
+export type ApiError = {
+  message: string;
+  statusCode?: number;
+  errors?: Record<string, string[]>;
+};

--- a/apgms/webapp/src/lib/queryClient.ts
+++ b/apgms/webapp/src/lib/queryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 30,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,37 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider, createRouter } from '@tanstack/react-router';
+
+import { routeTree } from './routeTree';
+import { queryClient } from './lib/queryClient';
+import type { RouterContext } from './types/router';
+
+import './index.css';
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+  context: {
+    queryClient,
+  } satisfies RouterContext,
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/routeTree.ts
+++ b/apgms/webapp/src/routeTree.ts
@@ -1,0 +1,5 @@
+import { Route as RootRoute } from './routes/__root';
+import { Route as DashboardRoute } from './routes/index';
+import { Route as BankLinesRoute } from './routes/bank-lines';
+
+export const routeTree = RootRoute.addChildren([DashboardRoute, BankLinesRoute]);

--- a/apgms/webapp/src/routes/__root.tsx
+++ b/apgms/webapp/src/routes/__root.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from '@tanstack/react-router';
+import { createRootRouteWithContext } from '@tanstack/react-router';
+
+import { AppShell } from '../shell/AppShell';
+import type { RouterContext } from '../types/router';
+
+export const Route = createRootRouteWithContext<RouterContext>()({
+  component: RootComponent,
+});
+
+function RootComponent() {
+  return (
+    <AppShell>
+      <Outlet />
+    </AppShell>
+  );
+}

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createRoute } from '@tanstack/react-router';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { clsx } from 'clsx';
+
+import { api } from '../lib/api';
+import { DateText } from '../ui/DateText';
+import { Money } from '../ui/Money';
+import { Skeleton } from '../ui/Skeleton';
+import { Route as RootRoute } from './__root';
+
+const TAKE = 20;
+const DEFAULT_ORG = 'core';
+
+type BankLine = {
+  id: string;
+  date: string;
+  description: string;
+  counterparty: string;
+  amount: number;
+  status: 'pending' | 'verified' | 'flagged';
+  category?: string;
+  rptAvailable?: boolean;
+};
+
+type BankLinesResponse = {
+  data: BankLine[];
+  nextCursor?: string | null;
+  prevCursor?: string | null;
+};
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: 'bank-lines',
+  component: BankLinesPage,
+});
+
+function BankLinesPage() {
+  const [cursor, setCursor] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isFetching, isError, error } = useQuery<BankLinesResponse>({
+    queryKey: ['bank-lines', { orgId: DEFAULT_ORG, cursor, take: TAKE }],
+    queryFn: async () => {
+      const response = await api.get<BankLinesResponse>('/bank-lines', {
+        params: {
+          orgId: DEFAULT_ORG,
+          cursor: cursor ?? undefined,
+          take: TAKE,
+        },
+      });
+      return response.data;
+    },
+    keepPreviousData: true,
+  });
+
+  useEffect(() => {
+    if (!data?.nextCursor) return;
+    queryClient.prefetchQuery({
+      queryKey: ['bank-lines', { orgId: DEFAULT_ORG, cursor: data.nextCursor, take: TAKE }],
+      queryFn: async () => {
+        const response = await api.get<BankLinesResponse>('/bank-lines', {
+          params: { orgId: DEFAULT_ORG, cursor: data.nextCursor ?? undefined, take: TAKE },
+        });
+        return response.data;
+      },
+    });
+  }, [data?.nextCursor, queryClient]);
+
+  const [selected, setSelected] = useState<BankLine | null>(null);
+
+  useEffect(() => {
+    if (selected && data?.data) {
+      const exists = data.data.find((line) => line.id === selected.id);
+      if (!exists) {
+        setSelected(null);
+      }
+    }
+  }, [data?.data, selected]);
+
+  const rows = data?.data ?? [];
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">Bank lines</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Review incoming and outgoing transactions synced from your bank feeds.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <span className={clsx('flex items-center gap-2 rounded-full px-3 py-1', isFetching && 'bg-brand-50 text-brand-600 dark:bg-brand-900/40 dark:text-brand-200')}>
+            <span className="h-2 w-2 rounded-full bg-brand-500" aria-hidden />
+            {isFetching ? 'Syncing latest entries…' : 'Up to date'}
+          </span>
+        </div>
+      </header>
+
+      <div className="flex-1 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-card dark:border-slate-800 dark:bg-slate-900">
+        {isLoading ? (
+          <BankLinesSkeleton />
+        ) : isError ? (
+          <div className="flex h-full items-center justify-center p-8 text-sm text-rose-500">
+            {(error as Error)?.message ?? 'Unable to load bank lines.'}
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="flex h-full items-center justify-center p-10 text-sm text-slate-500 dark:text-slate-400">
+            No lines found for this organisation.
+          </div>
+        ) : (
+          <div className="flex h-full">
+            <div className="w-full overflow-auto">
+              <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+                <thead className="bg-slate-50/60 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
+                  <tr>
+                    <th className="px-4 py-3">Date</th>
+                    <th className="px-4 py-3">Description</th>
+                    <th className="px-4 py-3">Counterparty</th>
+                    <th className="px-4 py-3 text-right">Amount</th>
+                    <th className="px-4 py-3">Status</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200 text-sm dark:divide-slate-800">
+                  {rows.map((line) => (
+                    <tr
+                      key={line.id}
+                      className="cursor-pointer bg-white transition hover:bg-brand-50/40 dark:bg-slate-900 dark:hover:bg-slate-800/60"
+                      onClick={() => setSelected(line)}
+                    >
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-200">
+                        <DateText value={line.date} />
+                      </td>
+                      <td className="px-4 py-3 text-slate-700 dark:text-slate-200">{line.description}</td>
+                      <td className="px-4 py-3 text-slate-500 dark:text-slate-400">{line.counterparty}</td>
+                      <td className="px-4 py-3 text-right font-medium text-slate-900 dark:text-slate-100">
+                        <Money value={line.amount} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusPill status={line.status} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/50 dark:text-slate-300">
+                <button
+                  type="button"
+                  onClick={() => data?.prevCursor && setCursor(data.prevCursor)}
+                  disabled={!data?.prevCursor}
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 font-medium transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                >
+                  ← Previous
+                </button>
+                <span>
+                  Showing <strong>{rows.length}</strong> of <strong>{TAKE}</strong>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => data?.nextCursor && setCursor(data.nextCursor)}
+                  disabled={!data?.nextCursor}
+                  className="inline-flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 font-medium transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+            {selected && <BankLineDrawer key={selected.id} line={selected} onClose={() => setSelected(null)} />}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BankLinesSkeleton() {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-4 border-b border-slate-200 bg-slate-50/60 px-4 py-3 dark:border-slate-800 dark:bg-slate-900/40">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+      <div className="flex-1 space-y-3 p-4">
+        {[...Array(6)].map((_, index) => (
+          <Skeleton key={index} className="h-14 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type StatusPillProps = {
+  status: BankLine['status'];
+};
+
+function StatusPill({ status }: StatusPillProps) {
+  const classes = {
+    pending: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-200',
+    verified: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200',
+    flagged: 'bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-200',
+  }[status];
+
+  return <span className={clsx('inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold capitalize', classes)}>{status}</span>;
+}
+
+type BankLineDrawerProps = {
+  line: BankLine;
+  onClose: () => void;
+};
+
+function BankLineDrawer({ line, onClose }: BankLineDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const firstFocusable = useRef<HTMLButtonElement | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!line.rptAvailable) return;
+      await api.post(`/audit/rpt/by-line/${line.id}`);
+    },
+  });
+
+  useEffect(() => {
+    firstFocusable.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+
+      if (event.key !== 'Tab') return;
+      const focusable = drawerRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusable || focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          (last as HTMLElement).focus();
+        }
+      } else if (document.activeElement === last) {
+        event.preventDefault();
+        (first as HTMLElement).focus();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const fields = useMemo(
+    () => [
+      { label: 'Date', value: <DateText value={line.date} pattern="dd MMM yyyy, h:mma" /> },
+      { label: 'Amount', value: <Money value={line.amount} /> },
+      { label: 'Status', value: <StatusPill status={line.status} /> },
+      { label: 'Counterparty', value: line.counterparty },
+      { label: 'Category', value: line.category ?? 'Unassigned' },
+    ],
+    [line],
+  );
+
+  return (
+    <aside
+      ref={drawerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Line details"
+      className="flex w-96 flex-col border-l border-slate-200 bg-white/95 p-6 shadow-xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/95"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Line details</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Match, annotate, or escalate this record.</p>
+        </div>
+        <button
+          ref={firstFocusable}
+          type="button"
+          onClick={onClose}
+          className="rounded-full border border-slate-200 p-2 text-slate-500 transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 dark:border-slate-700 dark:hover:bg-slate-800"
+        >
+          ✕
+        </button>
+      </div>
+
+      <dl className="mt-6 space-y-4 text-sm text-slate-600 dark:text-slate-300">
+        {fields.map((field) => (
+          <div key={field.label}>
+            <dt className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">{field.label}</dt>
+            <dd className="mt-1 text-base text-slate-900 dark:text-slate-100">{field.value}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="mt-auto flex flex-col gap-3 pt-6">
+        <button
+          type="button"
+          onClick={() => mutation.mutate()}
+          disabled={!line.rptAvailable || mutation.isPending}
+          className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-500 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-brand-600 disabled:cursor-not-allowed disabled:bg-slate-300 disabled:text-slate-500 dark:disabled:bg-slate-700 dark:disabled:text-slate-400"
+        >
+          Verify RPT
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        >
+          Close
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,182 @@
+import { createRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import type { TooltipProps } from 'recharts';
+
+import { api } from '../lib/api';
+import { Money } from '../ui/Money';
+import { Skeleton } from '../ui/Skeleton';
+import { Route as RootRoute } from './__root';
+
+export type DashboardResponse = {
+  summary: {
+    cashOnHand: number;
+    outstanding: number;
+    verified: number;
+    runRate: number;
+  };
+  trend: Array<{
+    date: string;
+    value: number;
+  }>;
+};
+
+export const Route = createRoute({
+  getParentRoute: () => RootRoute,
+  path: '/',
+  component: DashboardPage,
+});
+
+function DashboardPage() {
+  const { data, isError, error, isLoading, isFetching } = useQuery<DashboardResponse>({
+    queryKey: ['dashboard'],
+    queryFn: async () => {
+      const response = await api.get<DashboardResponse>('/dashboard');
+      return response.data;
+    },
+  });
+
+  return (
+    <div className="flex h-full flex-col gap-8">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">Welcome back</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Monitor balances, approvals, and revenue momentum in one view.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Key metrics</h2>
+        <DashboardSummary isLoading={isLoading} isFetching={isFetching} data={data?.summary} isError={isError} error={error} />
+      </section>
+
+      <section className="flex-1">
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          30-day inflows
+        </h2>
+        <DashboardTrend isLoading={isLoading} data={data?.trend ?? []} />
+      </section>
+    </div>
+  );
+}
+
+type DashboardSummaryProps = {
+  isLoading: boolean;
+  isFetching: boolean;
+  data?: DashboardResponse['summary'];
+  isError: boolean;
+  error: unknown;
+};
+
+function DashboardSummary({ isLoading, isFetching, data, isError, error }: DashboardSummaryProps) {
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[...Array(4)].map((_, index) => (
+          <div key={index} className="rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900">
+            <Skeleton className="h-20 w-full" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-xl border border-rose-200 bg-rose-50/80 p-6 text-rose-700 dark:border-rose-900 dark:bg-rose-950/60 dark:text-rose-200">
+        {(error as Error)?.message ?? 'Unable to load metrics right now.'}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="rounded-xl border border-dashed border-slate-300 p-6 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+        No metrics available yet. Connect your first bank feed to unlock insights.
+      </div>
+    );
+  }
+
+  const cards = [
+    {
+      label: 'Cash on hand',
+      value: <Money value={data.cashOnHand} />,
+    },
+    {
+      label: 'Outstanding',
+      value: <Money value={data.outstanding} />,
+    },
+    {
+      label: 'Verified this month',
+      value: <Money value={data.verified} />,
+    },
+    {
+      label: 'Run rate',
+      value: <Money value={data.runRate} />,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {cards.map((card) => (
+        <article
+          key={card.label}
+          className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-white via-white to-brand-50/40 p-6 shadow-card transition hover:-translate-y-0.5 hover:shadow-lg dark:border-slate-800 dark:from-slate-900 dark:via-slate-900 dark:to-brand-900/20"
+        >
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{card.label}</p>
+          <p className="mt-3 text-3xl font-semibold text-slate-900 dark:text-slate-50">{card.value}</p>
+          {isFetching && <span className="absolute right-4 top-4 h-2 w-2 animate-ping rounded-full bg-brand-500" />}
+        </article>
+      ))}
+    </div>
+  );
+}
+
+type DashboardTrendProps = {
+  isLoading: boolean;
+  data: DashboardResponse['trend'];
+};
+
+function DashboardTrend({ isLoading, data }: DashboardTrendProps) {
+  if (isLoading) {
+    return <Skeleton className="h-64 w-full" />;
+  }
+
+  if (!data.length) {
+    return (
+      <div className="flex h-64 items-center justify-center rounded-xl border border-dashed border-slate-300 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">
+        Connect more bank feeds to see rolling performance.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-72 rounded-2xl border border-slate-200 bg-white p-4 shadow-inner dark:border-slate-800 dark:bg-slate-900">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 10, bottom: 10, left: 0, right: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" strokeOpacity={0.2} />
+          <XAxis dataKey="date" tickLine={false} axisLine={false} tick={{ fill: 'currentColor', fontSize: 12 }} />
+          <YAxis strokeOpacity={0} tickLine={false} tick={{ fill: 'currentColor', fontSize: 12 }} />
+          <Tooltip content={<ChartTooltip />} />
+          <Line type="monotone" dataKey="value" stroke="hsl(235 86% 65%)" strokeWidth={3} dot={false} activeDot={{ r: 6 }} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function ChartTooltip(props: TooltipProps<number, string>) {
+  if (!props.active || !props.payload?.length) {
+    return null;
+  }
+
+  const [{ value, payload }] = props.payload;
+  const formattedValue = new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' }).format(value ?? 0);
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-900/90 px-3 py-2 text-xs text-white shadow-lg">
+      <div className="font-semibold">{payload?.date}</div>
+      <div>{formattedValue}</div>
+    </div>
+  );
+}

--- a/apgms/webapp/src/shell/AppShell.tsx
+++ b/apgms/webapp/src/shell/AppShell.tsx
@@ -1,0 +1,140 @@
+import { Link, useRouterState } from '@tanstack/react-router';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+const NAVIGATION = [
+  { to: '/', label: 'Dashboard', icon: '📊' },
+  { to: '/bank-lines', label: 'Bank Lines', icon: '🏦' },
+];
+
+const STORAGE_KEY = 'apgms-theme';
+
+type Theme = 'light' | 'dark';
+
+const getSystemTheme = (): Theme =>
+  typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') {
+      return 'light';
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    return stored ?? getSystemTheme();
+  });
+  const routerState = useRouterState();
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleMedia = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    media.addEventListener('change', handleMedia);
+    return () => media.removeEventListener('change', handleMedia);
+  }, []);
+
+  const activePath = useMemo(() => routerState.location.pathname, [routerState.location.pathname]);
+
+  return (
+    <div className="flex h-full bg-slate-100 text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100">
+      <aside className="hidden w-64 flex-col border-r border-slate-200 bg-white/90 p-6 backdrop-blur dark:border-slate-800 dark:bg-slate-900 lg:flex">
+        <div className="mb-10 text-2xl font-semibold text-brand-600 dark:text-brand-400">APGMS</div>
+        <nav className="space-y-1">
+          {NAVIGATION.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={clsx(
+                'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:bg-brand-50 hover:text-brand-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 dark:hover:bg-slate-800 dark:hover:text-brand-300 dark:focus-visible:ring-offset-slate-900',
+                activePath === item.to &&
+                  'bg-brand-100 text-brand-700 shadow-sm dark:bg-slate-800 dark:text-brand-300',
+              )}
+            >
+              <span className="text-lg" aria-hidden>
+                {item.icon}
+              </span>
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="mt-auto text-xs text-slate-500 dark:text-slate-400">
+          &copy; {new Date().getFullYear()} APGMS
+        </div>
+      </aside>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <header className="flex items-center gap-4 border-b border-slate-200 bg-white/70 px-4 py-3 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+          <button
+            type="button"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+          >
+            <span className="text-lg" aria-hidden>
+              📁
+            </span>
+            Switch Org
+          </button>
+          <div className="ml-auto flex items-center gap-2">
+            <ThemeToggle theme={theme} onToggle={setTheme} />
+            <button
+              type="button"
+              className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-100 text-sm font-semibold text-brand-700 shadow-inner transition hover:bg-brand-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 dark:bg-brand-900/40 dark:text-brand-200 dark:hover:bg-brand-900/60"
+              aria-label="Account"
+            >
+              JD
+            </button>
+          </div>
+        </header>
+        <main className="flex-1 overflow-y-auto bg-slate-50 p-4 dark:bg-slate-950">
+          <div className="mx-auto flex h-full max-w-6xl flex-col gap-6 lg:flex-row">
+            <section className="flex-1 rounded-2xl border border-slate-200 bg-white p-6 shadow-card dark:border-slate-800 dark:bg-slate-900">
+              {children}
+            </section>
+            <aside className="hidden w-80 shrink-0 flex-col gap-4 rounded-2xl border border-dashed border-slate-300 bg-white/60 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-400 lg:flex">
+              <h2 className="text-base font-semibold text-slate-700 dark:text-slate-200">Secondary Screen</h2>
+              <p>
+                Pin quick actions, upcoming settlements, or audit tasks here. This area stays visible while you work through
+                records.
+              </p>
+              <div className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                <span className="text-xs uppercase tracking-wide text-slate-400 dark:text-slate-500">Alerts</span>
+                <p className="text-sm font-medium text-slate-700 dark:text-slate-200">3 reconciliations ready for review.</p>
+              </div>
+            </aside>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}
+
+type ThemeToggleProps = {
+  theme: Theme;
+  onToggle: (theme: Theme) => void;
+};
+
+function ThemeToggle({ theme, onToggle }: ThemeToggleProps) {
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(isDark ? 'light' : 'dark')}
+      className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-2 text-sm font-medium shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-900 dark:hover:bg-slate-800"
+      aria-pressed={isDark}
+      aria-label="Toggle theme"
+    >
+      <span className="text-lg" aria-hidden>
+        {isDark ? '🌙' : '🌞'}
+      </span>
+      {isDark ? 'Dark' : 'Light'}
+    </button>
+  );
+}

--- a/apgms/webapp/src/types/router.ts
+++ b/apgms/webapp/src/types/router.ts
@@ -1,0 +1,5 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+export type RouterContext = {
+  queryClient: QueryClient;
+};

--- a/apgms/webapp/src/ui/DateText.tsx
+++ b/apgms/webapp/src/ui/DateText.tsx
@@ -1,0 +1,16 @@
+import { format, isValid, parseISO } from 'date-fns';
+
+type DateTextProps = {
+  value: string | Date | null | undefined;
+  pattern?: string;
+};
+
+export function DateText({ value, pattern = 'dd MMM yyyy' }: DateTextProps) {
+  const date = typeof value === 'string' ? parseISO(value) : value instanceof Date ? value : null;
+
+  if (!date || !isValid(date)) {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  return <time dateTime={date.toISOString()}>{format(date, pattern)}</time>;
+}

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,9 @@
+const formatter = new Intl.NumberFormat('en-AU', {
+  style: 'currency',
+  currency: 'AUD',
+  minimumFractionDigits: 2,
+});
+
+export function Money({ value }: { value: number }) {
+  return <span>{formatter.format(value)}</span>;
+}

--- a/apgms/webapp/src/ui/Skeleton.tsx
+++ b/apgms/webapp/src/ui/Skeleton.tsx
@@ -1,0 +1,9 @@
+import { clsx } from 'clsx';
+
+type SkeletonProps = {
+  className?: string;
+};
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div className={clsx('animate-pulse rounded-md bg-slate-200/80 dark:bg-slate-700/60', className)} />;
+}

--- a/apgms/webapp/tailwind.config.ts
+++ b/apgms/webapp/tailwind.config.ts
@@ -1,0 +1,31 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+      },
+      colors: {
+        brand: {
+          50: '#f4f6ff',
+          100: '#e5ebff',
+          200: '#ccd6ff',
+          300: '#a5b6ff',
+          400: '#7b8fff',
+          500: '#4d63ff',
+          600: '#3847db',
+          700: '#2d37b3',
+          800: '#252f8f',
+          900: '#202874',
+        },
+      },
+      boxShadow: {
+        card: '0 10px 30px -12px rgba(15, 23, 42, 0.25)',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "baseUrl": "./src"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apgms/webapp/tsconfig.node.json
+++ b/apgms/webapp/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React 18 workspace with Tailwind styling and shared utilities
- implement the AppShell layout with navigation, secondary panel, and theme toggling
- add dashboard and bank-line routes with data fetching, charts, tables, and accessible drawer interactions

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f3afa3e1f483279ac610de152dd2ec