### PR TITLE
Add health readiness routes and shutdown handling

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,72 +9,126 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import type { FastifyInstance } from "fastify";
 import { prisma } from "../../../shared/src/db";
+import healthRoutes from "./routes/health";
 
-const app = Fastify({ logger: true });
+export const buildApp = (): FastifyInstance => {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.register(healthRoutes);
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};
+
+export const app = buildApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+const start = async () => {
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+};
 
+if (process.env.NODE_ENV !== "test") {
+  start();
+}
+
+let shuttingDown = false;
+
+export const shutdown = async (): Promise<void> => {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  try {
+    await app.close();
+  } catch (err) {
+    app.log.error({ err }, "failed to close fastify instance");
+  }
+
+  try {
+    await prisma.$disconnect();
+  } catch (err) {
+    app.log.error({ err }, "failed to disconnect prisma client");
+  }
+};
+
+export const handleShutdownSignal = async (signal: NodeJS.Signals): Promise<void> => {
+  try {
+    app.log.info({ signal }, "received shutdown signal");
+    await shutdown();
+  } catch (err) {
+    app.log.error({ err, signal }, "error during shutdown");
+  }
+};
+
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.once(signal, () => {
+    handleShutdownSignal(signal).catch((err) => {
+      app.log.error({ err, signal }, "error during shutdown");
+    });
+  });
+}

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,21 @@
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/healthz", async () => ({
+    ok: true,
+    service: "api-gateway",
+  }));
+
+  app.get("/readyz", async (_, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return { ready: true };
+    } catch (error) {
+      app.log.error({ err: error }, "database readiness check failed");
+      return reply.code(503).send({ ready: false, reason: "db_unreachable" });
+    }
+  });
+};
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+process.env.NODE_ENV = "test";
+
+const { prisma } = await import("../../../shared/src/db");
+
+test("GET /healthz reports service availability", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { buildApp } = await import("../src/index.ts");
+  const app = buildApp();
+  await app.ready();
+
+  const response = await app.inject({ method: "GET", url: "/healthz" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepStrictEqual(response.json(), { ok: true, service: "api-gateway" });
+
+  await app.close();
+});
+
+test("GET /readyz returns ready when the database ping succeeds", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { buildApp } = await import("../src/index.ts");
+  const app = buildApp();
+  await app.ready();
+
+  const pingMock = t.mock.method(prisma, "$queryRaw", async () => []);
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepStrictEqual(response.json(), { ready: true });
+  assert.equal(pingMock.mock.callCount(), 1);
+
+  await app.close();
+  pingMock.mock.restore();
+});
+
+test("GET /readyz returns 503 when the database is unreachable", async (t) => {
+  process.env.NODE_ENV = "test";
+  const { buildApp } = await import("../src/index.ts");
+  const app = buildApp();
+  await app.ready();
+
+  const error = new Error("connection lost");
+  const pingMock = t.mock.method(prisma, "$queryRaw", async () => {
+    throw error;
+  });
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepStrictEqual(response.json(), {
+    ready: false,
+    reason: "db_unreachable",
+  });
+  assert.equal(pingMock.mock.callCount(), 1);
+
+  await app.close();
+  pingMock.mock.restore();
+});
+
+test("shutdown handlers close Fastify and Prisma", async (t) => {
+  process.env.NODE_ENV = "test";
+  const module = await import("../src/index.ts");
+  const { app, handleShutdownSignal, shutdown } = module;
+
+  const closeMock = t.mock.method(app, "close", async () => {});
+  const disconnectMock = t.mock.method(prisma, "$disconnect", async () => {});
+
+  await handleShutdownSignal("SIGTERM");
+  await shutdown();
+
+  assert.equal(closeMock.mock.callCount(), 1);
+  assert.equal(disconnectMock.mock.callCount(), 1);
+
+  closeMock.mock.restore();
+  disconnectMock.mock.restore();
+});

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,31 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+let PrismaClientConstructor: new () => any;
+
+try {
+  const mod = await import("@prisma/client");
+  if (!("PrismaClient" in mod) || typeof mod.PrismaClient !== "function") {
+    throw new Error("PrismaClient export is unavailable");
+  }
+  PrismaClientConstructor = mod.PrismaClient;
+} catch (error) {
+  if (process.env.NODE_ENV !== "test") {
+    throw error;
+  }
+
+  class PrismaClientStub {
+    user = { findMany: async () => [] };
+    bankLine = {
+      findMany: async () => [],
+      create: async () => ({}),
+    };
+
+    async $queryRaw() {
+      return [];
+    }
+
+    async $disconnect() {}
+  }
+
+  PrismaClientConstructor = PrismaClientStub;
+}
+
+export const prisma = new PrismaClientConstructor();


### PR DESCRIPTION
## Summary
- add dedicated health and readiness routes for the API gateway with Prisma connectivity checks
- export reusable Fastify app builder, install graceful shutdown handlers, and expose a shutdown helper
- provide node:test coverage for health, readiness, and shutdown behaviour while supplying a test-only Prisma fallback

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3aeefa4e083278d0659ea81f6acee