### PR TITLE
feat: secure payto webhook ingestion

### DIFF
--- a/apgms/services/api-gateway/src/plugins/webhook-signing.ts
+++ b/apgms/services/api-gateway/src/plugins/webhook-signing.ts
@@ -1,0 +1,160 @@
+import crypto from "node:crypto";
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+export interface RedisSetOptions {
+  EX?: number;
+  PX?: number;
+  NX?: boolean;
+}
+
+export interface RedisLike {
+  set(key: string, value: string, options: RedisSetOptions): Promise<"OK" | null>;
+}
+
+export interface WebhookSigningOptions {
+  secret?: string;
+  redis: RedisLike;
+  skewSeconds?: number;
+  nonceTtlSeconds?: number;
+}
+
+export class InMemoryNonceStore implements RedisLike {
+  private readonly entries = new Map<string, number>();
+
+  async set(key: string, _value: string, options: RedisSetOptions): Promise<"OK" | null> {
+    const now = Date.now();
+    this.cleanup(now);
+
+    const ttlMs = options.PX ?? (options.EX ? options.EX * 1000 : 0);
+    const expiresAt = ttlMs > 0 ? now + ttlMs : Number.POSITIVE_INFINITY;
+
+    if (options.NX) {
+      const existing = this.entries.get(key);
+      if (existing !== undefined && existing > now) {
+        return null;
+      }
+    }
+
+    this.entries.set(key, expiresAt);
+    return "OK";
+  }
+
+  private cleanup(now: number) {
+    for (const [key, expiresAt] of this.entries) {
+      if (expiresAt <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+}
+
+class WebhookSignatureError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+type VerifyHandler = (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+
+const webhookSigningPlugin: FastifyPluginAsync<WebhookSigningOptions> = async (fastify, opts) => {
+  const secret = opts.secret ?? process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    throw new Error("WEBHOOK_SECRET is not configured");
+  }
+
+  const skewSeconds = opts.skewSeconds ?? 300;
+  const nonceTtlSeconds = opts.nonceTtlSeconds ?? skewSeconds;
+
+  const ensureRawBody = (request: FastifyRequest, body: string) => {
+    (request as FastifyRequest & { rawBody?: string }).rawBody = body;
+  };
+
+  fastify.removeContentTypeParser("application/json");
+  fastify.removeContentTypeParser("application/*+json");
+  fastify.addContentTypeParser(
+    "application/json",
+    { parseAs: "string" },
+    (request, body: string, done) => {
+      try {
+        ensureRawBody(request, body);
+        done(null, body.length > 0 ? JSON.parse(body) : {});
+      } catch (err) {
+        const error = err as Error & { statusCode?: number };
+        error.statusCode = 400;
+        done(error);
+      }
+    },
+  );
+
+  fastify.addContentTypeParser(
+    "application/*+json",
+    { parseAs: "string" },
+    (request, body: string, done) => {
+      try {
+        ensureRawBody(request, body);
+        done(null, body.length > 0 ? JSON.parse(body) : {});
+      } catch (err) {
+        const error = err as Error & { statusCode?: number };
+        error.statusCode = 400;
+        done(error);
+      }
+    },
+  );
+
+  const verify: VerifyHandler = async (request) => {
+    const signature = request.headers["x-signature"];
+    const timestampHeader = request.headers["x-timestamp"];
+    const nonce = request.headers["x-nonce"];
+
+    if (typeof signature !== "string" || typeof timestampHeader !== "string" || typeof nonce !== "string") {
+      throw new WebhookSignatureError("missing_headers", 400);
+    }
+
+    const timestamp = Date.parse(timestampHeader);
+    if (Number.isNaN(timestamp)) {
+      throw new WebhookSignatureError("invalid_timestamp", 400);
+    }
+
+    const now = Date.now();
+    if (Math.abs(now - timestamp) > skewSeconds * 1000) {
+      throw new WebhookSignatureError("timestamp_out_of_range", 401);
+    }
+
+    const rawBody = (request as FastifyRequest & { rawBody?: string }).rawBody ?? "";
+    const data = `${timestampHeader}.${nonce}.${rawBody}`;
+    const expected = crypto.createHmac("sha256", secret).update(data).digest();
+
+    let provided: Buffer;
+    try {
+      provided = Buffer.from(signature, "hex");
+    } catch {
+      throw new WebhookSignatureError("invalid_signature_format", 400);
+    }
+
+    if (provided.length !== expected.length || !crypto.timingSafeEqual(expected, provided)) {
+      throw new WebhookSignatureError("signature_mismatch", 401);
+    }
+
+    const key = `webhook:nonce:${nonce}`;
+    const result = await opts.redis.set(key, "1", { EX: nonceTtlSeconds, NX: true });
+    if (result !== "OK") {
+      throw new WebhookSignatureError("nonce_reused", 409);
+    }
+  };
+
+  fastify.decorate<VerifyHandler>("verifyWebhookSignature", verify);
+};
+
+export default webhookSigningPlugin;
+
+declare module "fastify" {
+  interface FastifyInstance {
+    verifyWebhookSignature: VerifyHandler;
+  }
+
+  interface FastifyRequest {
+    rawBody?: string;
+  }
+}

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,41 @@
+import { FastifyPluginAsync } from "fastify";
+import webhookSigningPlugin, {
+  InMemoryNonceStore,
+  RedisLike,
+  WebhookSigningOptions,
+} from "../plugins/webhook-signing";
+
+export interface WebhookRouteOptions {
+  secret: string;
+  redis?: RedisLike;
+  skewSeconds?: number;
+  nonceTtlSeconds?: number;
+}
+
+const webhooksRoutes: FastifyPluginAsync<WebhookRouteOptions> = async (fastify, opts) => {
+  const secret = opts.secret;
+  if (!secret) {
+    throw new Error("Webhook secret is required");
+  }
+
+  const redis = opts.redis ?? new InMemoryNonceStore();
+
+  await fastify.register(async (instance) => {
+    await webhookSigningPlugin(instance, {
+      secret,
+      redis,
+      skewSeconds: opts.skewSeconds,
+      nonceTtlSeconds: opts.nonceTtlSeconds,
+    } satisfies WebhookSigningOptions);
+
+    instance.post("/webhooks/payto", {
+      preHandler: instance.verifyWebhookSignature,
+      handler: async (request, reply) => {
+        void request;
+        return reply.code(202).send({ status: "accepted" });
+      },
+    });
+  });
+};
+
+export default webhooksRoutes;

--- a/apgms/services/api-gateway/test/webhooks.spec.ts
+++ b/apgms/services/api-gateway/test/webhooks.spec.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { test } from "node:test";
+import Fastify from "fastify";
+import webhooksRoutes from "../src/routes/webhooks";
+import { InMemoryNonceStore } from "../src/plugins/webhook-signing";
+
+const SECRET = "test-secret";
+
+const signPayload = (timestamp: string, nonce: string, body: string) =>
+  crypto.createHmac("sha256", SECRET).update(`${timestamp}.${nonce}.${body}`).digest("hex");
+
+const buildApp = async () => {
+  const app = Fastify();
+  await app.register(webhooksRoutes, { secret: SECRET, redis: new InMemoryNonceStore() });
+  await app.ready();
+  return app;
+};
+
+test("accepts a valid webhook request", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const body = JSON.stringify({ amount: 100 });
+  const timestamp = new Date().toISOString();
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const signature = signPayload(timestamp, nonce, body);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(response.statusCode, 202);
+});
+
+test("rejects stale webhook requests", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const body = JSON.stringify({ amount: 100 });
+  const timestamp = new Date(Date.now() - 301_000).toISOString();
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const signature = signPayload(timestamp, nonce, body);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(response.statusCode, 401);
+});
+
+test("rejects replayed webhook requests", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const body = JSON.stringify({ amount: 100 });
+  const timestamp = new Date().toISOString();
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const signature = signPayload(timestamp, nonce, body);
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(first.statusCode, 202);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(second.statusCode, 409);
+});
+
+test("rejects invalid signatures", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const body = JSON.stringify({ amount: 100 });
+  const timestamp = new Date().toISOString();
+  const nonce = crypto.randomBytes(16).toString("hex");
+  const badSignature = "00".repeat(32);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: body,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": badSignature,
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+    },
+  });
+
+  assert.equal(response.statusCode, 401);
+});


### PR DESCRIPTION
## Summary
- add a webhook signing plugin that validates timestamp, nonce reuse, and HMAC signatures against the shared secret
- register the /webhooks/payto route in the API gateway and wire it to the signing guard with in-memory nonce storage
- cover webhook acceptance, stale timestamps, replay attempts, and bad signatures with integration-style Fastify tests

## Testing
- pnpm --filter @apgms/api-gateway exec tsx test/webhooks.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f3aee2008c8327a3f4dcece3e1edf0