### PR TITLE
Add deterministic policy engine and RPT audit flows

### DIFF
--- a/apgms/libs/fast-check/index.d.ts
+++ b/apgms/libs/fast-check/index.d.ts
@@ -1,0 +1,62 @@
+export class Arbitrary<T> {
+  constructor(generator: () => T);
+  generate(): T;
+  map<U>(mapper: (value: T) => U): Arbitrary<U>;
+  chain<U>(mapper: (value: T) => Arbitrary<U>): Arbitrary<U>;
+}
+
+export class Property<T> {
+  constructor(arb: Arbitrary<T>, predicate: (value: T) => boolean | void);
+  run(numRuns?: number): void;
+}
+
+export interface IntegerConstraints {
+  min?: number;
+  max?: number;
+}
+
+export interface StringConstraints {
+  minLength?: number;
+  maxLength?: number;
+  charSet?: string;
+}
+
+export interface ArrayConstraints {
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface SetConstraints<T> extends ArrayConstraints {
+  compare?: (a: T, b: T) => boolean;
+}
+
+export function integer(constraints?: IntegerConstraints): Arbitrary<number>;
+export function boolean(): Arbitrary<boolean>;
+export function string(constraints?: StringConstraints): Arbitrary<string>;
+export function uuid(): Arbitrary<string>;
+export function array<T>(arb: Arbitrary<T>, constraints?: ArrayConstraints): Arbitrary<T[]>;
+export function set<T>(arb: Arbitrary<T>, constraints?: SetConstraints<T>): Arbitrary<T[]>;
+export function tuple<A>(a: Arbitrary<A>): Arbitrary<[A]>;
+export function tuple<A, B>(a: Arbitrary<A>, b: Arbitrary<B>): Arbitrary<[A, B]>;
+export function tuple<A, B, C>(a: Arbitrary<A>, b: Arbitrary<B>, c: Arbitrary<C>): Arbitrary<[A, B, C]>;
+export function tuple<T extends any[]>(...arbs: { [K in keyof T]: Arbitrary<T[K]> }): Arbitrary<T>;
+export function record<TArbs extends { [key: string]: Arbitrary<any> }>(arbs: TArbs): Arbitrary<{ [K in keyof TArbs]: TArbs[K] extends Arbitrary<infer U> ? U : never }>;
+export function property<T>(arb: Arbitrary<T>, predicate: (value: T) => boolean | void): Property<T>;
+export function assert<T>(prop: Property<T>, options?: { numRuns?: number }): void;
+
+const fc: {
+  Arbitrary: typeof Arbitrary;
+  Property: typeof Property;
+  integer: typeof integer;
+  boolean: typeof boolean;
+  string: typeof string;
+  uuid: typeof uuid;
+  array: typeof array;
+  set: typeof set;
+  tuple: typeof tuple;
+  record: typeof record;
+  property: typeof property;
+  assert: typeof assert;
+};
+
+export default fc;

--- a/apgms/libs/fast-check/index.js
+++ b/apgms/libs/fast-check/index.js
@@ -1,0 +1,173 @@
+class Arbitrary {
+  constructor(generator) {
+    this.generator = generator;
+  }
+
+  generate() {
+    return this.generator();
+  }
+
+  map(mapper) {
+    return new Arbitrary(() => mapper(this.generate()));
+  }
+
+  chain(mapper) {
+    return new Arbitrary(() => mapper(this.generate()).generate());
+  }
+}
+
+class Property {
+  constructor(arb, predicate) {
+    this.arb = arb;
+    this.predicate = predicate;
+  }
+
+  run(numRuns = 100) {
+    for (let run = 0; run < numRuns; run += 1) {
+      const value = this.arb.generate();
+      const result = this.predicate(value);
+      if (result === false) {
+        throw new Error(`Property failed on run ${run}`);
+      }
+    }
+  }
+}
+
+function integer({ min = Number.MIN_SAFE_INTEGER, max = Number.MAX_SAFE_INTEGER } = {}) {
+  return new Arbitrary(() => {
+    const lower = Math.ceil(min);
+    const upper = Math.floor(max);
+    const span = upper - lower + 1;
+    if (span <= 0) {
+      return lower;
+    }
+    return lower + Math.floor(Math.random() * span);
+  });
+}
+
+function boolean() {
+  return new Arbitrary(() => Math.random() < 0.5);
+}
+
+function string({ minLength = 0, maxLength = 10, charSet = "abcdefghijklmnopqrstuvwxyz" } = {}) {
+  return new Arbitrary(() => {
+    const min = Math.max(0, minLength);
+    const max = Math.max(min, maxLength);
+    const length = min + Math.floor(Math.random() * (max - min + 1));
+    const available = charSet.length > 0 ? charSet : "abcdefghijklmnopqrstuvwxyz";
+    let result = "";
+    for (let i = 0; i < length; i += 1) {
+      const idx = Math.floor(Math.random() * available.length);
+      result += available[idx];
+    }
+    return result;
+  });
+}
+
+function uuid() {
+  const hex = "0123456789abcdef";
+  return new Arbitrary(() => {
+    const chars = Array.from({ length: 36 }, (_, index) => {
+      if (index === 8 || index === 13 || index === 18 || index === 23) {
+        return "-";
+      }
+      if (index === 14) {
+        return "4";
+      }
+      if (index === 19) {
+        return hex[(Math.random() * 4) | 8];
+      }
+      return hex[Math.floor(Math.random() * 16)];
+    });
+    return chars.join("");
+  });
+}
+
+function array(arb, { minLength = 0, maxLength = minLength + 5 } = {}) {
+  return new Arbitrary(() => {
+    const min = Math.max(0, minLength);
+    const max = Math.max(min, maxLength);
+    const length = min + Math.floor(Math.random() * (max - min + 1));
+    const values = [];
+    for (let i = 0; i < length; i += 1) {
+      values.push(arb.generate());
+    }
+    return values;
+  });
+}
+
+function set(arb, { minLength = 0, maxLength = minLength + 5, compare } = {}) {
+  const comparator =
+    compare ?? ((a, b) => {
+      try {
+        return JSON.stringify(a) === JSON.stringify(b);
+      } catch {
+        return a === b;
+      }
+    });
+
+  return new Arbitrary(() => {
+    const min = Math.max(0, minLength);
+    const max = Math.max(min, maxLength);
+    const targetLength = min + Math.floor(Math.random() * (max - min + 1));
+    const values = [];
+    let safety = 0;
+    while (values.length < targetLength && safety < targetLength * 20) {
+      safety += 1;
+      const candidate = arb.generate();
+      if (!values.some((value) => comparator(value, candidate))) {
+        values.push(candidate);
+      }
+    }
+
+    while (values.length < min) {
+      const candidate = arb.generate();
+      if (!values.some((value) => comparator(value, candidate))) {
+        values.push(candidate);
+      }
+    }
+
+    return values;
+  });
+}
+
+function tuple(...arbs) {
+  return new Arbitrary(() => arbs.map((arb) => arb.generate()));
+}
+
+function record(shape) {
+  return new Arbitrary(() => {
+    const result = {};
+    for (const [key, value] of Object.entries(shape)) {
+      result[key] = value.generate();
+    }
+    return result;
+  });
+}
+
+function property(arb, predicate) {
+  return new Property(arb, predicate);
+}
+
+function assert(prop, options = {}) {
+  const numRuns = options.numRuns ?? 100;
+  prop.run(numRuns);
+}
+
+const fc = {
+  Arbitrary,
+  Property,
+  integer,
+  boolean,
+  string,
+  uuid,
+  array,
+  set,
+  tuple,
+  record,
+  property,
+  assert,
+};
+
+export { Arbitrary, Property, integer, boolean, string, uuid, array, set, tuple, record, property, assert };
+export default fc;

--- a/apgms/libs/fast-check/package.json
+++ b/apgms/libs/fast-check/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fast-check",
+  "version": "0.0.0-local",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -34,6 +34,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  libs/fast-check: {}
+
   services/api-gateway:
     dependencies:
       '@apgms/shared':
@@ -55,6 +57,9 @@ importers:
       '@types/node':
         specifier: ^24.7.1
         version: 24.7.1
+      fast-check:
+        specifier: workspace:*
+        version: link:../../libs/fast-check
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
@@ -80,162 +85,6 @@ importers:
   worker: {}
 
 packages:
-
-  '@esbuild/aix-ppc64@0.25.10':
-    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.10':
-    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.10':
-    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.10':
-    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.10':
-    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.10':
-    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.10':
-    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.10':
-    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.10':
-    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.10':
-    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.10':
-    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.10':
-    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.10':
-    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.10':
-    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.10':
-    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.10':
-    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.10':
-    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.10':
-    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.10':
-    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.10':
-    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.10':
-    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.10':
-    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.10':
-    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.10':
-    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
@@ -406,11 +255,6 @@ packages:
     resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
     engines: {node: '>=20'}
 
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   get-tsconfig@4.12.0:
     resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
 
@@ -576,84 +420,6 @@ packages:
 
 snapshots:
 
-  '@esbuild/aix-ppc64@0.25.10':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/android-arm@0.25.10':
-    optional: true
-
-  '@esbuild/android-x64@0.25.10':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.10':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.10':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.10':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.10':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.10':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.10':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.10':
-    optional: true
-
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
       ajv: 8.17.1
@@ -789,34 +555,7 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  esbuild@0.25.10:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.10
-      '@esbuild/android-arm': 0.25.10
-      '@esbuild/android-arm64': 0.25.10
-      '@esbuild/android-x64': 0.25.10
-      '@esbuild/darwin-arm64': 0.25.10
-      '@esbuild/darwin-x64': 0.25.10
-      '@esbuild/freebsd-arm64': 0.25.10
-      '@esbuild/freebsd-x64': 0.25.10
-      '@esbuild/linux-arm': 0.25.10
-      '@esbuild/linux-arm64': 0.25.10
-      '@esbuild/linux-ia32': 0.25.10
-      '@esbuild/linux-loong64': 0.25.10
-      '@esbuild/linux-mips64el': 0.25.10
-      '@esbuild/linux-ppc64': 0.25.10
-      '@esbuild/linux-riscv64': 0.25.10
-      '@esbuild/linux-s390x': 0.25.10
-      '@esbuild/linux-x64': 0.25.10
-      '@esbuild/netbsd-arm64': 0.25.10
-      '@esbuild/netbsd-x64': 0.25.10
-      '@esbuild/openbsd-arm64': 0.25.10
-      '@esbuild/openbsd-x64': 0.25.10
-      '@esbuild/openharmony-arm64': 0.25.10
-      '@esbuild/sunos-x64': 0.25.10
-      '@esbuild/win32-arm64': 0.25.10
-      '@esbuild/win32-ia32': 0.25.10
-      '@esbuild/win32-x64': 0.25.10
+  esbuild@0.25.10: {}
 
   exsolve@1.0.7: {}
 
@@ -872,9 +611,6 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 5.0.0
-
-  fsevents@2.3.3:
-    optional: true
 
   get-tsconfig@4.12.0:
     dependencies:
@@ -1017,8 +753,6 @@ snapshots:
     dependencies:
       esbuild: 0.25.10
       get-tsconfig: 4.12.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   typescript@5.9.3: {}
 

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - services/*
   - webapp
   - shared
+  - libs/*
   - worker
 
 ignoredBuiltDependencies:

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/policy-engine.spec.ts test/rpt.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
+    "fast-check": "workspace:*",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,14 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerAllocationRoutes } from "./routes/allocations.js";
+import { registerAuditRoutes } from "./routes/audit.js";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(registerAllocationRoutes);
+await app.register(registerAuditRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/lib/persistence.ts
+++ b/apgms/services/api-gateway/src/lib/persistence.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from "node:crypto";
+
+import type { Allocation } from "shared/policy-engine/index.js";
+import type { RptToken } from "./rpt.js";
+
+export interface LedgerEntry {
+  ledgerEntryId: string;
+  orgId: string;
+  bankLineId: string;
+  bucket: string;
+  amountCents: number;
+  currency: "AUD";
+  createdAt: string;
+}
+
+export interface AuditBlob {
+  auditId: string;
+  createdAt: string;
+  type: "RPT";
+  rptId: string;
+  rptDigest: string;
+  payload: RptToken;
+}
+
+const ledgerEntries: LedgerEntry[] = [];
+const auditBlobs: AuditBlob[] = [];
+
+export function createLedgerEntries(options: {
+  orgId: string;
+  bankLineId: string;
+  allocations: Allocation[];
+  timestamp: string;
+}): LedgerEntry[] {
+  return options.allocations.map((allocation) => ({
+    ledgerEntryId: randomUUID(),
+    orgId: options.orgId,
+    bankLineId: options.bankLineId,
+    bucket: allocation.bucket,
+    amountCents: allocation.amountCents,
+    currency: allocation.currency,
+    createdAt: options.timestamp,
+  }));
+}
+
+export function persistLedgerEntries(entries: LedgerEntry[]): void {
+  ledgerEntries.push(...entries);
+}
+
+export function listLedgerEntries(): LedgerEntry[] {
+  return [...ledgerEntries];
+}
+
+export function createAuditBlob(rpt: RptToken, timestamp: string): AuditBlob {
+  return {
+    auditId: randomUUID(),
+    createdAt: timestamp,
+    type: "RPT",
+    rptId: rpt.rptId,
+    rptDigest: rpt.digest,
+    payload: rpt,
+  };
+}
+
+export function appendAuditBlob(blob: AuditBlob): void {
+  auditBlobs.push(blob);
+}
+
+export function listAuditBlobs(): AuditBlob[] {
+  return [...auditBlobs];
+}
+
+export function resetPersistence(): void {
+  ledgerEntries.length = 0;
+  auditBlobs.length = 0;
+}

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,242 @@
+import {
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  randomUUID,
+  sign,
+  verify,
+  type KeyObject,
+} from "node:crypto";
+
+import type { Allocation } from "shared/policy-engine/index.js";
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  return `{${entries
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`)
+    .join(",")}}`;
+}
+
+export interface KmsLike {
+  sign(message: Uint8Array): Promise<{ signature: string; publicKey: string }>;
+}
+
+class Ed25519Kms implements KmsLike {
+  private readonly privateKey: KeyObject;
+  private readonly publicKey: KeyObject;
+
+  constructor() {
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    this.privateKey = privateKey;
+    this.publicKey = publicKey;
+  }
+
+  async sign(message: Uint8Array): Promise<{ signature: string; publicKey: string }> {
+    const signature = sign(null, message, this.privateKey).toString("base64");
+    const publicKey = this.publicKey
+      .export({ type: "spki", format: "pem" })
+      .toString();
+    return { signature, publicKey };
+  }
+}
+
+const defaultKms = new Ed25519Kms();
+
+export interface RptToken {
+  rptId: string;
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: Allocation[];
+  prevHash: string | null;
+  timestamp: string;
+  digest: string;
+  signature: string;
+  publicKey: string;
+}
+
+export interface MintRptInput {
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: Allocation[];
+  prevHash?: string | null;
+  now: Date | string;
+  kms?: KmsLike;
+}
+
+export interface VerificationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface ChainVerificationResult extends VerificationResult {
+  depth: number;
+  failingRptId?: string;
+}
+
+function canonicalRptPayload(rpt: Omit<RptToken, "digest" | "signature" | "publicKey">): string {
+  return stableStringify({
+    rptId: rpt.rptId,
+    orgId: rpt.orgId,
+    bankLineId: rpt.bankLineId,
+    policyHash: rpt.policyHash,
+    allocations: rpt.allocations,
+    prevHash: rpt.prevHash,
+    timestamp: rpt.timestamp,
+  });
+}
+
+export async function mintRpt({
+  orgId,
+  bankLineId,
+  policyHash,
+  allocations,
+  prevHash = null,
+  now,
+  kms = defaultKms,
+}: MintRptInput): Promise<RptToken> {
+  const rptId = randomUUID();
+  const timestampValue = typeof now === "string" ? new Date(now) : now;
+  if (Number.isNaN(timestampValue.getTime())) {
+    throw new Error("Invalid timestamp for RPT");
+  }
+  const timestamp = timestampValue.toISOString();
+
+  const canonicalPayload = canonicalRptPayload({
+    rptId,
+    orgId,
+    bankLineId,
+    policyHash,
+    allocations: allocations.map((allocation) => ({ ...allocation })),
+    prevHash,
+    timestamp,
+  });
+
+  const digest = createHash("sha256").update(canonicalPayload).digest("hex");
+  const message = Buffer.from(digest, "hex");
+  const { signature, publicKey } = await kms.sign(message);
+
+  return {
+    rptId,
+    orgId,
+    bankLineId,
+    policyHash,
+    allocations: allocations.map((allocation) => ({ ...allocation })),
+    prevHash,
+    timestamp,
+    digest,
+    signature,
+    publicKey,
+  };
+}
+
+export function verifyRpt(rpt: RptToken): VerificationResult {
+  const canonicalPayload = canonicalRptPayload({
+    rptId: rpt.rptId,
+    orgId: rpt.orgId,
+    bankLineId: rpt.bankLineId,
+    policyHash: rpt.policyHash,
+    allocations: rpt.allocations,
+    prevHash: rpt.prevHash,
+    timestamp: rpt.timestamp,
+  });
+  const expectedDigest = createHash("sha256").update(canonicalPayload).digest("hex");
+
+  if (expectedDigest !== rpt.digest) {
+    return { ok: false, error: "Digest mismatch" };
+  }
+
+  try {
+    const isValid = verify(
+      null,
+      Buffer.from(rpt.digest, "hex"),
+      createPublicKey(rpt.publicKey),
+      Buffer.from(rpt.signature, "base64"),
+    );
+    if (!isValid) {
+      return { ok: false, error: "Signature verification failed" };
+    }
+  } catch (error) {
+    return { ok: false, error: (error as Error).message };
+  }
+
+  return { ok: true };
+}
+
+const rptStore = new Map<string, RptToken>();
+const digestIndex = new Map<string, string>();
+
+export function storeRpt(rpt: RptToken): void {
+  rptStore.set(rpt.rptId, rpt);
+  digestIndex.set(rpt.digest, rpt.rptId);
+}
+
+export function getRpt(rptId: string): RptToken | undefined {
+  return rptStore.get(rptId);
+}
+
+export function getRptByDigest(digest: string): RptToken | undefined {
+  const rptId = digestIndex.get(digest);
+  return rptId ? rptStore.get(rptId) : undefined;
+}
+
+export function listRpts(): RptToken[] {
+  return [...rptStore.values()];
+}
+
+export function clearRptStore(): void {
+  rptStore.clear();
+  digestIndex.clear();
+}
+
+export function verifyChain(headRptId: string): ChainVerificationResult {
+  const visited = new Set<string>();
+  let depth = 0;
+  let current = getRpt(headRptId);
+
+  if (!current) {
+    return { ok: false, error: "Head RPT not found", depth, failingRptId: headRptId };
+  }
+
+  while (current) {
+    if (visited.has(current.rptId)) {
+      return { ok: false, error: "Cycle detected", depth, failingRptId: current.rptId };
+    }
+    visited.add(current.rptId);
+    depth += 1;
+
+    const verification = verifyRpt(current);
+    if (!verification.ok) {
+      return { ...verification, depth, failingRptId: current.rptId };
+    }
+
+    if (!current.prevHash) {
+      return { ok: true, depth };
+    }
+
+    const previous = getRptByDigest(current.prevHash);
+    if (!previous) {
+      return { ok: false, error: "Missing predecessor", depth, failingRptId: current.rptId };
+    }
+
+    if (previous.digest !== current.prevHash) {
+      return { ok: false, error: "Predecessor digest mismatch", depth, failingRptId: current.rptId };
+    }
+
+    current = previous;
+  }
+
+  return { ok: true, depth };
+}

--- a/apgms/services/api-gateway/src/routes/allocations.ts
+++ b/apgms/services/api-gateway/src/routes/allocations.ts
@@ -1,0 +1,83 @@
+import type { FastifyInstance } from "fastify";
+
+import { applyPolicy } from "shared/policy-engine/index.js";
+
+import {
+  allocationsApplyRequestSchema,
+  allocationsApplyResponseSchema,
+  allocationsPreviewRequestSchema,
+  allocationsPreviewResponseSchema,
+} from "../schemas/allocations.js";
+import { getRpt, mintRpt, storeRpt } from "../lib/rpt.js";
+import {
+  appendAuditBlob,
+  createAuditBlob,
+  createLedgerEntries,
+  persistLedgerEntries,
+} from "../lib/persistence.js";
+
+export async function registerAllocationRoutes(app: FastifyInstance): Promise<void> {
+  app.post("/allocations/preview", async (request, reply) => {
+    try {
+      const input = allocationsPreviewRequestSchema.parse(request.body);
+      const preview = applyPolicy(input);
+      const response = allocationsPreviewResponseSchema.parse(preview);
+      return reply.send(response);
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+  });
+
+  app.post("/allocations/apply", async (request, reply) => {
+    try {
+      const input = allocationsApplyRequestSchema.parse(request.body);
+      const preview = applyPolicy(input);
+
+      let prevHash: string | null = null;
+      if (input.prevRptId) {
+        const previous = getRpt(input.prevRptId);
+        if (!previous) {
+          return reply.code(400).send({ error: "unknown_prev_rpt" });
+        }
+        prevHash = previous.digest;
+      }
+
+      const rpt = await mintRpt({
+        orgId: input.orgId,
+        bankLineId: input.bankLineId,
+        policyHash: preview.policyHash,
+        allocations: preview.allocations,
+        prevHash,
+        now: new Date(),
+      });
+
+      storeRpt(rpt);
+
+      const ledgerEntries = createLedgerEntries({
+        orgId: input.orgId,
+        bankLineId: input.bankLineId,
+        allocations: preview.allocations,
+        timestamp: rpt.timestamp,
+      });
+      persistLedgerEntries(ledgerEntries);
+
+      const auditBlob = createAuditBlob(rpt, rpt.timestamp);
+      appendAuditBlob(auditBlob);
+
+      const responsePayload = allocationsApplyResponseSchema.parse({
+        allocations: preview.allocations,
+        policyHash: preview.policyHash,
+        explain: preview.explain,
+        rpt,
+        ledgerEntries,
+        auditBlob,
+      });
+
+      return reply.code(201).send(responsePayload);
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,27 @@
+import type { FastifyInstance } from "fastify";
+
+import { verifyChain, verifyRpt, getRpt } from "../lib/rpt.js";
+import { rptVerificationResponseSchema } from "../schemas/rpt.js";
+
+export async function registerAuditRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/audit/rpt/:id", async (request, reply) => {
+    const params = request.params as { id: string };
+    const rpt = getRpt(params.id);
+
+    if (!rpt) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const signature = verifyRpt(rpt);
+    const chain = verifyChain(rpt.rptId);
+
+    const payload = rptVerificationResponseSchema.parse({
+      rptId: rpt.rptId,
+      signatureValid: signature.ok,
+      chain,
+      rpt,
+    });
+
+    return reply.send(payload);
+  });
+}

--- a/apgms/services/api-gateway/src/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+import { allocationSchema, rptTokenSchema } from "./rpt.js";
+
+const bankLineSchema = z.object({
+  id: z.string().optional(),
+  amountCents: z.number().int().nonnegative(),
+  currency: z.literal("AUD"),
+});
+
+const policyRuleSchema = z.object({
+  bucket: z.string().min(1),
+  weight: z.number().int().positive(),
+});
+
+const policyRulesetSchema = z.object({
+  id: z.string().min(1),
+  version: z.string().min(1),
+  rules: z.array(policyRuleSchema).min(1),
+});
+
+const accountStateSchema = z.object({
+  bucket: z.string().min(1),
+  gate: z.enum(["OPEN", "CLOSED"]),
+});
+
+export const allocationsPreviewRequestSchema = z.object({
+  bankLine: bankLineSchema,
+  ruleset: policyRulesetSchema,
+  accountStates: z.array(accountStateSchema).default([]),
+});
+
+export const allocationsPreviewResponseSchema = z.object({
+  allocations: z.array(allocationSchema),
+  policyHash: z.string().min(1),
+  explain: z.string().min(1),
+});
+
+export const allocationsApplyRequestSchema = allocationsPreviewRequestSchema.extend({
+  orgId: z.string().min(1),
+  bankLineId: z.string().min(1),
+  prevRptId: z.string().min(1).optional(),
+});
+
+export const ledgerEntrySchema = z.object({
+  ledgerEntryId: z.string().min(1),
+  orgId: z.string().min(1),
+  bankLineId: z.string().min(1),
+  bucket: z.string().min(1),
+  amountCents: z.number().int().nonnegative(),
+  currency: z.literal("AUD"),
+  createdAt: z.string().min(1),
+});
+
+export const auditBlobSchema = z.object({
+  auditId: z.string().min(1),
+  createdAt: z.string().min(1),
+  type: z.literal("RPT"),
+  rptId: z.string().min(1),
+  rptDigest: z.string().min(1),
+  payload: rptTokenSchema,
+});
+
+export const allocationsApplyResponseSchema = z.object({
+  allocations: z.array(allocationSchema),
+  policyHash: z.string().min(1),
+  explain: z.string().min(1),
+  rpt: rptTokenSchema,
+  ledgerEntries: z.array(ledgerEntrySchema),
+  auditBlob: auditBlobSchema,
+});
+
+export type AllocationsPreviewRequest = z.infer<typeof allocationsPreviewRequestSchema>;
+export type AllocationsPreviewResponse = z.infer<typeof allocationsPreviewResponseSchema>;
+export type AllocationsApplyRequest = z.infer<typeof allocationsApplyRequestSchema>;
+export type AllocationsApplyResponse = z.infer<typeof allocationsApplyResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const allocationSchema = z.object({
+  bucket: z.string().min(1),
+  amountCents: z.number().int().nonnegative(),
+  currency: z.literal("AUD"),
+});
+
+export const rptTokenSchema = z.object({
+  rptId: z.string().min(1),
+  orgId: z.string().min(1),
+  bankLineId: z.string().min(1),
+  policyHash: z.string().min(1),
+  allocations: z.array(allocationSchema),
+  prevHash: z.string().min(1).nullable(),
+  timestamp: z.string().min(1),
+  digest: z.string().min(1),
+  signature: z.string().min(1),
+  publicKey: z.string().min(1),
+});
+
+export const rptVerificationResponseSchema = z.object({
+  rptId: z.string().min(1),
+  signatureValid: z.boolean(),
+  chain: z.object({
+    ok: z.boolean(),
+    depth: z.number().int().nonnegative(),
+    error: z.string().optional(),
+    failingRptId: z.string().optional(),
+  }),
+  rpt: rptTokenSchema.optional(),
+});
+
+export type Allocation = z.infer<typeof allocationSchema>;
+export type RptToken = z.infer<typeof rptTokenSchema>;
+export type RptVerificationResponse = z.infer<typeof rptVerificationResponseSchema>;

--- a/apgms/services/api-gateway/test/policy-engine.spec.ts
+++ b/apgms/services/api-gateway/test/policy-engine.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fc from "fast-check";
+
+import { applyPolicy, type ApplyPolicyInput } from "shared/policy-engine/index.js";
+
+function policyInputArb(options: { requireClosed?: boolean } = {}): fc.Arbitrary<ApplyPolicyInput> {
+  const ruleSetArb = fc.set(
+    fc.record({
+      bucket: fc.string({ minLength: 3, maxLength: 12, charSet: "abcdefghijklmnopqrstuvwxyz" }),
+      weight: fc.integer({ min: 1, max: 10_000 }),
+    }),
+    {
+      minLength: options.requireClosed ? 2 : 1,
+      maxLength: 6,
+      compare: (a, b) => a.bucket === b.bucket,
+    },
+  );
+
+  return fc
+    .tuple(
+      fc.integer({ min: 0, max: 1_000_000 }),
+      fc.uuid(),
+      fc.string({ minLength: 1, maxLength: 6, charSet: "abcdefghijklmnopqrstuvwxyz0123456789" }),
+      ruleSetArb,
+    )
+    .chain(([amountCents, policyId, version, rules]) =>
+      fc.array(fc.boolean(), { minLength: rules.length, maxLength: rules.length }).map((gates) => {
+        const gateAssignments = [...gates];
+        if (!gateAssignments.some((gate) => gate)) {
+          gateAssignments[0] = true;
+        }
+        if (options.requireClosed && rules.length > 1 && !gateAssignments.some((gate) => !gate)) {
+          gateAssignments[1] = false;
+        }
+
+        return {
+          bankLine: {
+            amountCents,
+            currency: "AUD" as const,
+          },
+          ruleset: {
+            id: policyId,
+            version,
+            rules,
+          },
+          accountStates: rules.map((rule, index) => ({
+            bucket: rule.bucket,
+            gate: gateAssignments[index] ? "OPEN" : "CLOSED",
+          })),
+        } satisfies ApplyPolicyInput;
+      }),
+    );
+}
+
+describe("policy engine", () => {
+  it("conserves funds and produces non-negative allocations", () => {
+    fc.assert(
+      fc.property(policyInputArb(), (input) => {
+        const result = applyPolicy(input);
+        const totalAllocated = result.allocations.reduce((sum, allocation) => sum + allocation.amountCents, 0);
+        assert.equal(totalAllocated, input.bankLine.amountCents);
+        for (const allocation of result.allocations) {
+          assert.ok(allocation.amountCents >= 0);
+        }
+      }),
+      { numRuns: 10_000 },
+    );
+  });
+
+  it("omits allocations for closed buckets", () => {
+    fc.assert(
+      fc.property(policyInputArb({ requireClosed: true }), (input) => {
+        const result = applyPolicy(input);
+        const closedBuckets = new Set(
+          input.accountStates.filter((state) => state.gate === "CLOSED").map((state) => state.bucket),
+        );
+        for (const allocation of result.allocations) {
+          assert.ok(!closedBuckets.has(allocation.bucket));
+        }
+      }),
+      { numRuns: 10_000 },
+    );
+  });
+});

--- a/apgms/services/api-gateway/test/rpt.spec.ts
+++ b/apgms/services/api-gateway/test/rpt.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  clearRptStore,
+  getRpt,
+  mintRpt,
+  storeRpt,
+  verifyChain,
+  verifyRpt,
+} from "../src/lib/rpt.js";
+
+const baseAllocations = [
+  { bucket: "primary", amountCents: 1_000, currency: "AUD" as const },
+  { bucket: "remittance", amountCents: 500, currency: "AUD" as const },
+];
+
+describe("RPT lifecycle", () => {
+  beforeEach(() => {
+    clearRptStore();
+  });
+
+  it("verifies a freshly minted RPT", async () => {
+    const rpt = await mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: baseAllocations,
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    storeRpt(rpt);
+
+    const verification = verifyRpt(rpt);
+    assert.equal(verification.ok, true, verification.error);
+
+    const chain = verifyChain(rpt.rptId);
+    assert.equal(chain.ok, true, chain.error);
+    assert.equal(chain.depth, 1);
+  });
+
+  it("fails verification when the payload is tampered", async () => {
+    const rpt = await mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: baseAllocations,
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    const tampered = {
+      ...rpt,
+      allocations: rpt.allocations.map((allocation, index) =>
+        index === 0
+          ? { ...allocation, amountCents: allocation.amountCents + 1 }
+          : allocation,
+      ),
+    };
+
+    const verification = verifyRpt(tampered);
+    assert.equal(verification.ok, false);
+  });
+
+  it("detects breaks in the chain", async () => {
+    const first = await mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: baseAllocations,
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+    storeRpt(first);
+
+    const second = await mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-2",
+      policyHash: "policy-abc",
+      allocations: baseAllocations,
+      prevHash: first.digest,
+      now: new Date("2024-01-01T01:00:00Z"),
+    });
+    storeRpt(second);
+
+    const validChain = verifyChain(second.rptId);
+    assert.equal(validChain.ok, true, validChain.error);
+    assert.equal(validChain.depth, 2);
+
+    const storedSecond = getRpt(second.rptId);
+    assert.ok(storedSecond);
+    storedSecond.prevHash = "broken";
+
+    const brokenChain = verifyChain(second.rptId);
+    assert.equal(brokenChain.ok, false);
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/policy-engine/index.ts
+++ b/apgms/shared/policy-engine/index.ts
@@ -1,0 +1,173 @@
+import { createHash } from "node:crypto";
+
+export type CurrencyCode = "AUD";
+
+export interface BankLine {
+  id?: string;
+  amountCents: number;
+  currency: CurrencyCode;
+}
+
+export interface PolicyRule {
+  bucket: string;
+  weight: number;
+}
+
+export interface PolicyRuleset {
+  id: string;
+  version: string;
+  rules: PolicyRule[];
+}
+
+export type GateState = "OPEN" | "CLOSED";
+
+export interface AccountState {
+  bucket: string;
+  gate: GateState;
+}
+
+export interface Allocation {
+  bucket: string;
+  amountCents: number;
+  currency: CurrencyCode;
+}
+
+export interface ApplyPolicyInput {
+  bankLine: BankLine;
+  ruleset: PolicyRuleset;
+  accountStates?: AccountState[];
+}
+
+export interface ApplyPolicyResult {
+  allocations: Allocation[];
+  policyHash: string;
+  explain: string;
+}
+
+const DEFAULT_CURRENCY: CurrencyCode = "AUD";
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+
+  return `{${entries
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`)
+    .join(",")}}`;
+}
+
+export function applyPolicy({
+  bankLine,
+  ruleset,
+  accountStates = [],
+}: ApplyPolicyInput): ApplyPolicyResult {
+  if (bankLine.currency !== DEFAULT_CURRENCY) {
+    throw new Error(`Unsupported currency: ${bankLine.currency}`);
+  }
+
+  if (!Number.isInteger(bankLine.amountCents) || bankLine.amountCents < 0) {
+    throw new Error("Bank line amount must be a non-negative integer");
+  }
+
+  if (ruleset.rules.length === 0) {
+    throw new Error("Ruleset must contain at least one rule");
+  }
+
+  const gateMap = new Map(accountStates.map((state) => [state.bucket, state.gate]));
+
+  const openRules = ruleset.rules.filter((rule) => {
+    const gate = gateMap.get(rule.bucket) ?? "OPEN";
+    return gate === "OPEN";
+  });
+
+  if (openRules.length === 0) {
+    throw new Error("No open buckets available for allocation");
+  }
+
+  for (const rule of openRules) {
+    if (!Number.isFinite(rule.weight) || rule.weight <= 0) {
+      throw new Error(`Invalid weight for bucket ${rule.bucket}`);
+    }
+  }
+
+  const totalWeight = openRules.reduce((acc, rule) => acc + rule.weight, 0);
+  if (totalWeight <= 0) {
+    throw new Error("Total weight must be positive");
+  }
+
+  const amount = bankLine.amountCents;
+
+  const interimAllocations = openRules.map((rule) => {
+    const exactShare = (amount * rule.weight) / totalWeight;
+    const base = Math.floor(exactShare);
+    const remainder = exactShare - base;
+    return {
+      bucket: rule.bucket,
+      base,
+      remainder,
+    };
+  });
+
+  let allocated = interimAllocations.reduce((sum, current) => sum + current.base, 0);
+  let remainder = amount - allocated;
+
+  if (remainder > 0) {
+    const sortedByRemainder = [...interimAllocations].sort((a, b) => {
+      if (b.remainder === a.remainder) {
+        return a.bucket.localeCompare(b.bucket);
+      }
+      return b.remainder - a.remainder;
+    });
+
+    for (const entry of sortedByRemainder) {
+      if (remainder === 0) {
+        break;
+      }
+      entry.base += 1;
+      remainder -= 1;
+    }
+  }
+
+  const allocations: Allocation[] = interimAllocations.map((entry) => ({
+    bucket: entry.bucket,
+    amountCents: entry.base,
+    currency: DEFAULT_CURRENCY,
+  }));
+
+  allocated = allocations.reduce((sum, allocation) => sum + allocation.amountCents, 0);
+  if (allocated !== amount) {
+    throw new Error("Allocation conservation invariant violated");
+  }
+
+  for (const allocation of allocations) {
+    if (allocation.amountCents < 0) {
+      throw new Error("Allocation amount must be non-negative");
+    }
+  }
+
+  const policyHash = createHash("sha256")
+    .update(
+      stableStringify({
+        ruleset,
+        accountStates: accountStates.map((state) => ({
+          bucket: state.bucket,
+          gate: state.gate,
+        })),
+      }),
+    )
+    .digest("hex");
+
+  const explain = `Applied policy ${ruleset.id}@${ruleset.version} to bank line ${
+    bankLine.id ?? "(untracked)"
+  } allocating ${allocations.length} bucket(s).`;
+
+  return { allocations, policyHash, explain };
+}


### PR DESCRIPTION
## Summary
- add a deterministic policy engine module with gate-aware allocations and invariant enforcement
- implement RPT minting, verification, in-memory persistence, and audit/allocations routes with zod schemas
- introduce a local fast-check workspace stub and property tests covering allocation invariants and RPT tampering/chain validation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3af16ce148327b1612d502ef5e863