### PR TITLE
Add privacy inventory and retention docs plus NDB tabletop runbook

### DIFF
--- a/apgms/SECURITY.md
+++ b/apgms/SECURITY.md
@@ -1,2 +1,7 @@
-﻿# Security Policy
+# Security Policy
+
 Email: security@yourdomain.example
+
+## Privacy & Data Protection
+
+Refer to the [PII inventory](../privacy/pii-inventory.csv) and [data retention policy](../privacy/data-retention.md) for current classifications, handling expectations, and retention schedules.

--- a/apgms/docs/comms_templates.md
+++ b/apgms/docs/comms_templates.md
@@ -1,0 +1,10 @@
+# Incident Communications Templates
+
+## Customer Impact Notice
+Provide clear description of incident scope, actions taken, and customer steps. Include contact information for follow-up questions.
+
+## Regulator Brief
+Summarize incident timeline, data affected, containment steps, and planned remedial actions. Highlight NDB notification requirements and supporting evidence.
+
+## Internal Slack Update
+Concise update for internal stakeholders covering detection status, immediate mitigation steps, and next review checkpoint.

--- a/privacy/data-retention.md
+++ b/privacy/data-retention.md
@@ -1,0 +1,10 @@
+# Data Retention Windows
+
+The following retention windows apply to production systems and derived stores unless otherwise noted. Durations are measured from the time the data is collected or, where applicable, from the end of the customer relationship.
+
+- **AuditBlob artifacts**: Retain for 7 years to meet statutory audit requirements and preserve evidentiary integrity.
+- **RptToken secrets**: Retain for 7 years to align with finance reporting requirements and ensure investigation traceability.
+- **BankLine records**: Retain for 7 years in accordance with financial record-keeping obligations.
+- **Security logs**: Retain for 1 year to support security incident investigations while minimizing long-term exposure.
+
+Review these retention windows annually with Legal and Compliance to validate applicability and adjust for regulatory changes.

--- a/privacy/pii-inventory.csv
+++ b/privacy/pii-inventory.csv
@@ -1,0 +1,5 @@
+Field,System,Purpose,LawfulBasis,Retention,EncryptionAtRest,InTransit,AccessByRole
+User.email,IdentityService,Account login and notifications,Contract,Active users + 2 years,AES-256,TLS 1.2+,Support;Engineering;Security
+BankLine.*,PaymentsCore,Settlement reporting and reconciliation,Legal obligation,7 years,AES-256,TLS 1.2+,Finance;Security
+RptToken.*,AnalyticsPlatform,Report scheduling tokens and access control,Legitimate interests,7 years,AES-256,TLS 1.2+,Analytics;Security
+AuditBlob.*,ComplianceVault,Immutable audit evidence and traceability,Legal obligation,7 years,AES-256,TLS 1.2+,Security;Compliance

--- a/runbooks/tabletop/ndb_scenario_01.md
+++ b/runbooks/tabletop/ndb_scenario_01.md
@@ -1,0 +1,48 @@
+# NDB Tabletop Scenario 01: Webhook Secret Leak and Replay Attacks
+
+## Quick-Start Checklist
+- [ ] Send calendar invite and circulate this scenario 48 hours in advance.
+- [ ] Assign facilitator, scribe, and decision lead.
+- [ ] Prepare copies of the [Incident Communications Templates](../../apgms/docs/comms_templates.md) and regulatory contact list.
+- [ ] Confirm access to webhook delivery dashboards and key logs.
+- [ ] Set a visible timer for a 30-minute exercise.
+
+## Scenario Overview
+An attacker exfiltrated the production webhook signing secret during a supply-chain compromise of a third-party deploy runner. Within the last 24 hours they replayed previously captured webhook payloads to partner endpoints, causing fraudulent account state changes. The objective of this tabletop is to walk through notification obligations under the Notifiable Data Breach (NDB) scheme while containing continued replay activity.
+
+## Participants
+- Facilitator: Oversees timeline prompts and keeps the group on schedule.
+- Scribe: Records decisions in the shared decision log.
+- Incident Commander: Coordinates technical response and approves actions.
+- Comms Lead: Coordinates customer, partner, and regulator messaging.
+- Legal/Privacy Lead: Advises on NDB notification thresholds and timing.
+
+## Timeline Prompts
+**T0 (00:00)** – PagerDuty alert for anomalous webhook traffic triggered. Security analyst joins and notes signature mismatches across multiple partners.
+
+**T+5 (00:05)** – Vendor support notifies us that their artifact server was breached last week. Initial containment efforts begin; webhook secret rotation will take ~45 minutes.
+
+**T+10 (00:10)** – Partners report seeing legitimate-looking payloads toggling feature flags for high-value customers. Need to decide whether to pause webhook deliveries.
+
+**T+15 (00:15)** – Customer Support escalates three tickets from affected customers asking why account state changed. Media inquiry received referencing social media chatter about "compromised automations".
+
+**T+20 (00:20)** – Engineering confirms replay came from attacker IPs across multiple regions. Replacement secret deployed but propagation to all services will take additional 20 minutes. Risk that attackers continue replaying cached payloads.
+
+**T+25 (00:25)** – Legal notes potential NDB trigger because webhook payloads contain personal information. Must decide on notification timeline and evidence collection to support regulator briefing.
+
+**T+30 (00:30)** – Exercise debrief: capture lessons learned, next steps, and update incident response plans.
+
+## Decision Log Template
+| Time | Decision | Owner | Rationale | Follow-up |
+| ---- | -------- | ----- | --------- | --------- |
+|      |          |       |           |           |
+
+## Communications References
+- Customer + partner emails: see [Customer Impact Comms Template](../../apgms/docs/comms_templates.md#customer-impact-notice).
+- Regulatory notification letter: see [Regulator Brief Template](../../apgms/docs/comms_templates.md#regulator-brief).
+- Internal updates: use Slack template in [Internal Comms Guide](../../apgms/docs/comms_templates.md#internal-slack-update).
+
+## Facilitator Notes
+- Keep emphasis on when the NDB scheme requires notifying the OAIC and affected individuals.
+- Encourage team to identify additional data sources (e.g., CDN logs) to validate scope.
+- Capture ownership for post-incident hardening tasks, especially eliminating shared secrets and adopting per-partner signing keys.


### PR DESCRIPTION
## Summary
- add privacy inventory and retention policy documents with explicit retention windows
- update SECURITY.md to reference new privacy documentation
- create communications templates reference and an NDB tabletop scenario runbook for leaked webhook secrets

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f3b51f85f88327a5384ae2bce79da9