### PR TITLE
feat: add config validation, structured logging, and telemetry to api-gateway

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!**/.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/ops/env/.env.example
+++ b/apgms/ops/env/.env.example
@@ -1,0 +1,10 @@
+DATABASE_URL=postgres://user:pass@db:5432/app
+REDIS_URL=redis://redis:6379/0
+ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+AUTH_ISSUER=https://auth.example.com/
+AUTH_AUDIENCE=api://default
+AUTH_BYPASS=false
+WEBHOOK_SECRET=replace-me
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+LOG_LEVEL=info
+NODE_ENV=development

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -7,10 +7,21 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.53.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.53.0",
+    "@opentelemetry/instrumentation-fastify": "^0.45.1",
+    "@opentelemetry/resources": "^1.9.0",
+    "@opentelemetry/sdk-metrics": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.53.0",
+    "@opentelemetry/semantic-conventions": "^1.25.1",
+    "@prisma/instrumentation": "^5.18.0",
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "fastify-plugin": "^5.0.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "ulid": "^2.3.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+
+const rawSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  REDIS_URL: z.string().min(1, "REDIS_URL is required"),
+  ALLOWED_ORIGINS: z.string().min(1, "ALLOWED_ORIGINS is required"),
+  AUTH_ISSUER: z.string().min(1, "AUTH_ISSUER is required"),
+  AUTH_AUDIENCE: z.string().min(1, "AUTH_AUDIENCE is required"),
+  AUTH_BYPASS: z.string().optional(),
+  WEBHOOK_SECRET: z.string().min(1, "WEBHOOK_SECRET is required"),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().optional(),
+  LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace", "silent"]),
+  NODE_ENV: z.enum(["development", "test", "staging", "production"]),
+  PORT: z
+    .string()
+    .optional()
+    .transform((value, ctx) => {
+      if (!value) {
+        return 3000;
+      }
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isNaN(parsed)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "PORT must be a number" });
+        return z.NEVER;
+      }
+      return parsed;
+    }),
+});
+
+type RawConfig = z.input<typeof rawSchema>;
+
+const truthyValues = new Set(["1", "true", "yes", "y", "on"]);
+
+function parseAllowedOrigins(value: string): string[] | true {
+  const trimmed = value.trim();
+  if (trimmed === "*") {
+    return true;
+  }
+  const origins = trimmed
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+  if (origins.length === 0) {
+    throw new Error("ALLOWED_ORIGINS must contain at least one origin or be '*'");
+  }
+  return origins;
+}
+
+function normalizeEndpoint(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  return trimmed.replace(/\/$/, "");
+}
+
+const rawConfig: RawConfig = {
+  DATABASE_URL: process.env.DATABASE_URL ?? "",
+  REDIS_URL: process.env.REDIS_URL ?? "",
+  ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS ?? "",
+  AUTH_ISSUER: process.env.AUTH_ISSUER ?? "",
+  AUTH_AUDIENCE: process.env.AUTH_AUDIENCE ?? "",
+  AUTH_BYPASS: process.env.AUTH_BYPASS,
+  WEBHOOK_SECRET: process.env.WEBHOOK_SECRET ?? "",
+  OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  LOG_LEVEL: (process.env.LOG_LEVEL ?? "") as RawConfig["LOG_LEVEL"],
+  NODE_ENV: (process.env.NODE_ENV ?? "") as RawConfig["NODE_ENV"],
+  PORT: process.env.PORT,
+};
+
+const parsed = rawSchema.safeParse(rawConfig);
+
+if (!parsed.success) {
+  const formatted = parsed.error.issues
+    .map((issue) => `${issue.path.join(".") || "root"}: ${issue.message}`)
+    .join("; ");
+  throw new Error(`Configuration validation failed: ${formatted}`);
+}
+
+const authBypass = rawConfig.AUTH_BYPASS
+  ? truthyValues.has(rawConfig.AUTH_BYPASS.trim().toLowerCase())
+  : false;
+
+const allowedOrigins = parseAllowedOrigins(parsed.data.ALLOWED_ORIGINS);
+
+function deepFreeze<T>(object: T): T {
+  if (object && typeof object === "object" && !Object.isFrozen(object)) {
+    Object.freeze(object);
+    for (const value of Object.values(object as Record<string, unknown>)) {
+      if (value && typeof value === "object" && !Object.isFrozen(value)) {
+        deepFreeze(value as Record<string, unknown>);
+      }
+    }
+  }
+  return object;
+}
+
+const appConfig = deepFreeze({
+  databaseUrl: parsed.data.DATABASE_URL,
+  redisUrl: parsed.data.REDIS_URL,
+  http: {
+    allowedOrigins,
+    port: parsed.data.PORT,
+    host: "0.0.0.0",
+  },
+  auth: {
+    issuer: parsed.data.AUTH_ISSUER,
+    audience: parsed.data.AUTH_AUDIENCE,
+    bypass: authBypass,
+  },
+  webhook: {
+    secret: parsed.data.WEBHOOK_SECRET,
+  },
+  telemetry: {
+    otlpEndpoint: normalizeEndpoint(parsed.data.OTEL_EXPORTER_OTLP_ENDPOINT),
+  },
+  logging: {
+    level: parsed.data.LOG_LEVEL,
+  },
+  nodeEnv: parsed.data.NODE_ENV,
+} as const);
+
+export type AppConfig = typeof appConfig;
+
+export const config: AppConfig = appConfig;

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,26 +1,41 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+const { config } = await import("./config");
+const { startTelemetry } = await import("./otel");
+const loggingPlugin = (await import("./plugins/logging")).default;
 
-const app = Fastify({ logger: true });
+const telemetry = await startTelemetry(config.telemetry.otlpEndpoint);
 
-await app.register(cors, { origin: true });
+const [{ default: Fastify }, { default: cors }, sharedDb] = await Promise.all([
+  import("fastify"),
+  import("@fastify/cors"),
+  import("../../../shared/src/db"),
+]);
+const { prisma } = sharedDb as typeof import("../../../shared/src/db");
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+const app = Fastify({
+  logger: {
+    level: config.logging.level,
+  },
+});
+
+await app.register(loggingPlugin);
+
+const allowedOrigins = config.http.allowedOrigins === true ? true : config.http.allowedOrigins;
+await app.register(cors, { origin: allowedOrigins });
+
+app.addHook("onClose", async () => {
+  await telemetry.shutdown();
+});
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
 app.get("/users", async () => {
   const users = await prisma.user.findMany({
     select: { email: true, orgId: true, createdAt: true },
@@ -29,9 +44,8 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+  const take = Number((req.query as Record<string, unknown>).take ?? 20);
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
     take: Math.min(Math.max(take, 1), 200),
@@ -39,7 +53,6 @@ app.get("/bank-lines", async (req) => {
   return { lines };
 });
 
-// Create a bank line
 app.post("/bank-lines", async (req, rep) => {
   try {
     const body = req.body as {
@@ -49,32 +62,39 @@ app.post("/bank-lines", async (req, rep) => {
       payee: string;
       desc: string;
     };
+    const amountValue =
+      typeof body.amount === "string" ? Number.parseFloat(body.amount) : body.amount;
+    if (Number.isNaN(amountValue)) {
+      throw new Error("invalid_amount");
+    }
     const created = await prisma.bankLine.create({
       data: {
         orgId: body.orgId,
         date: new Date(body.date),
-        amount: body.amount as any,
+        amount: amountValue,
         payee: body.payee,
         desc: body.desc,
       },
     });
     return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
+  } catch (error) {
+    req.log.error(error);
     return rep.code(400).send({ error: "bad_request" });
   }
 });
 
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+const host = config.http.host;
+const port = config.http.port;
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err, "failed to start api-gateway");
+    return telemetry.shutdown().finally(() => {
+      process.exit(1);
+    });
+  });

--- a/apgms/services/api-gateway/src/otel.ts
+++ b/apgms/services/api-gateway/src/otel.ts
@@ -1,0 +1,174 @@
+import { context, Span, SpanStatusCode, trace } from "@opentelemetry/api";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+
+let sdk: NodeSDK | null = null;
+let telemetryEnabled = false;
+
+export const tracer = trace.getTracer("api-gateway");
+
+type FastifyRequestHookInfo = {
+  request: {
+    routeOptions?: { url?: string };
+    url: string;
+    method: string;
+  };
+};
+
+export interface TelemetryController {
+  shutdown(): Promise<void>;
+}
+
+function buildEndpoint(base: string, suffix: string): string {
+  const normalized = base.endsWith("/") ? base.slice(0, -1) : base;
+  return `${normalized}${suffix}`;
+}
+
+export async function startTelemetry(endpoint: string | null): Promise<TelemetryController> {
+  if (!endpoint) {
+    telemetryEnabled = false;
+    return {
+      shutdown: async () => {
+        /* noop */
+      },
+    };
+  }
+
+  if (sdk) {
+    telemetryEnabled = true;
+    return {
+      shutdown: async () => {
+        telemetryEnabled = false;
+        if (sdk) {
+          await sdk.shutdown();
+          sdk = null;
+        }
+      },
+    };
+  }
+
+  const traceExporter = new OTLPTraceExporter({
+    url: buildEndpoint(endpoint, "/v1/traces"),
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter({
+      url: buildEndpoint(endpoint, "/v1/metrics"),
+    }),
+  });
+
+  sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: "api-gateway",
+    }),
+    traceExporter,
+    metricReader,
+    instrumentations: [
+      new FastifyInstrumentation({
+        requestHook: (span: Span, info: FastifyRequestHookInfo) => {
+          const route = info.request.routeOptions?.url ?? info.request.url;
+          span.setAttributes({
+            "http.route": route,
+            "http.method": info.request.method,
+          });
+        },
+      }),
+      new PrismaInstrumentation(),
+    ],
+  });
+
+  await sdk.start();
+  telemetryEnabled = true;
+
+  return {
+    shutdown: async () => {
+      telemetryEnabled = false;
+      if (sdk) {
+        await sdk.shutdown();
+        sdk = null;
+      }
+    },
+  };
+}
+
+export function isTelemetryEnabled(): boolean {
+  return telemetryEnabled;
+}
+
+export async function withSpan<T>(
+  name: string,
+  fn: (span: Span) => Promise<T>,
+  attributes?: Record<string, unknown>,
+): Promise<T> {
+  if (!telemetryEnabled) {
+    const noopSpan = trace.getTracer("noop").startSpan(name);
+    try {
+      if (attributes) {
+        noopSpan.setAttributes(attributes);
+      }
+      return await fn(noopSpan);
+    } finally {
+      noopSpan.end();
+    }
+  }
+
+  return tracer.startActiveSpan(name, async (span: Span) => {
+    try {
+      if (attributes) {
+        span.setAttributes(attributes);
+      }
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export function startChildSpan(name: string, attributes?: Record<string, unknown>): Span | null {
+  if (!telemetryEnabled) {
+    return null;
+  }
+  const parentContext = context.active();
+  const span = tracer.startSpan(name, { attributes }, parentContext);
+  return span;
+}
+
+export function runWithSpan<T>(span: Span | null, fn: (span: Span | null) => Promise<T>): Promise<T> {
+  if (!telemetryEnabled || !span) {
+    return fn(span);
+  }
+  const spanContext = trace.setSpan(context.active(), span);
+  return context.with(spanContext, async () => {
+    try {
+      const result = await fn(span);
+      span.setStatus({ code: SpanStatusCode.OK });
+      return result;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export function startAllocationsSpan(operation: string): Span | null {
+  return startChildSpan(`allocations.${operation}`);
+}
+
+export function startRptVerifySpan(): Span | null {
+  return startChildSpan("rpt.verify");
+}

--- a/apgms/services/api-gateway/src/plugins/logging.ts
+++ b/apgms/services/api-gateway/src/plugins/logging.ts
@@ -1,0 +1,221 @@
+import fp from "fastify-plugin";
+import type {
+  FastifyInstance,
+  FastifyPluginAsync,
+  FastifyReply,
+  FastifyRequest,
+  RouteHandlerMethod,
+} from "fastify";
+import type { Span } from "@opentelemetry/api";
+import { ulid } from "ulid";
+import { runWithSpan, startAllocationsSpan, startRptVerifySpan } from "../otel";
+
+const securityEventNames = [
+  "auth_denied",
+  "idempotency_replay",
+  "webhook_replay",
+  "rpt_verify_fail",
+] as const;
+
+type SecurityEvent = (typeof securityEventNames)[number];
+
+const securityEventSet = new Set<SecurityEvent>(securityEventNames);
+
+type SecurityLogger = (event: SecurityEvent, details?: Record<string, unknown>) => Promise<void>;
+type RequestSecurityLogger = (
+  event: SecurityEvent,
+  details?: Record<string, unknown>,
+) => Promise<void>;
+type AllocationsSpanRunner = <T>(operation: string, fn: (span: Span | null) => Promise<T>) => Promise<T>;
+type RptSpanRunner = <T>(fn: (span: Span | null) => Promise<T>) => Promise<T>;
+
+declare module "fastify" {
+  interface FastifyInstance {
+    logSecurityEvent: SecurityLogger;
+  }
+
+  interface FastifyRequest {
+    requestStartTime?: bigint;
+    logSecurityEvent: RequestSecurityLogger;
+    withAllocationsSpan: AllocationsSpanRunner;
+    withRptVerifySpan: RptSpanRunner;
+  }
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function resolveOrgId(request: FastifyRequest): string | undefined {
+  const header = headerValue(request.headers["x-org-id"] as string | string[] | undefined);
+  if (header) {
+    return header;
+  }
+  const body = request.body as Record<string, unknown> | undefined;
+  if (body && typeof body.orgId === "string") {
+    return body.orgId;
+  }
+  const params = request.params as Record<string, unknown> | undefined;
+  if (params && typeof params.orgId === "string") {
+    return params.orgId;
+  }
+  return undefined;
+}
+
+function resolveUserId(request: FastifyRequest): string | undefined {
+  const header = headerValue(request.headers["x-user-id"] as string | string[] | undefined);
+  if (header) {
+    return header;
+  }
+  const body = request.body as Record<string, unknown> | undefined;
+  if (body && typeof body.userId === "string") {
+    return body.userId;
+  }
+  return undefined;
+}
+
+function resolveRoutePath(request: FastifyRequest): string {
+  const candidate = (request as { routerPath?: string }).routerPath;
+  if (typeof candidate === "string" && candidate.length > 0) {
+    return candidate;
+  }
+  const optionUrl = request.routeOptions?.url;
+  return (typeof optionUrl === "string" && optionUrl.length > 0) ? optionUrl : request.url;
+}
+
+const loggingPlugin: FastifyPluginAsync = fp(async (fastify: FastifyInstance): Promise<void> => {
+  fastify.decorate("logSecurityEvent", async (event: SecurityEvent, details: Record<string, unknown> = {}) => {
+    if (!securityEventSet.has(event)) {
+      fastify.log.warn({ type: "security_event_invalid", event, details }, "invalid security event");
+      return;
+    }
+
+    if (event === "rpt_verify_fail") {
+      await runWithSpan(startRptVerifySpan(), async (span) => {
+        if (span) {
+          span.setAttributes({
+            "security.event": event,
+            ...(typeof details.reason === "string" && { "security.reason": details.reason }),
+            ...(typeof details.orgId === "string" && { "security.org_id": details.orgId }),
+            ...(typeof details.userId === "string" && { "security.user_id": details.userId }),
+          });
+        }
+        return;
+      });
+    }
+
+    fastify.log.warn({ type: "security_event", event, ...details });
+  });
+
+  fastify.decorateRequest(
+    "logSecurityEvent",
+    async function logSecurityEvent(
+      this: FastifyRequest,
+      event: SecurityEvent,
+      details: Record<string, unknown> = {},
+    ) {
+      const base = {
+        req_id: this.id,
+        route: resolveRoutePath(this),
+        orgId: resolveOrgId(this),
+        userId: resolveUserId(this),
+      } satisfies Record<string, unknown>;
+      await fastify.logSecurityEvent(event, { ...base, ...details });
+    },
+  );
+
+  const withAllocationsSpan = async function withAllocationsSpan<T>(
+    this: FastifyRequest,
+    operation: string,
+    fn: (span: Span | null) => Promise<T>,
+  ): Promise<T> {
+    return runWithSpan(startAllocationsSpan(operation), (span) => fn(span));
+  };
+
+  const withRptVerifySpan = async function withRptVerifySpan<T>(
+    this: FastifyRequest,
+    fn: (span: Span | null) => Promise<T>,
+  ): Promise<T> {
+    return runWithSpan(startRptVerifySpan(), (span) => fn(span));
+  };
+
+  fastify.decorateRequest("withAllocationsSpan", withAllocationsSpan);
+  fastify.decorateRequest("withRptVerifySpan", withRptVerifySpan);
+
+  fastify.addHook("onRoute", (routeOptions: any) => {
+    if (!routeOptions.url || !routeOptions.url.startsWith("/allocations/")) {
+      return;
+    }
+    if (typeof routeOptions.handler !== "function") {
+      return;
+    }
+
+    const originalHandler = routeOptions.handler as RouteHandlerMethod;
+    routeOptions.handler = async function (request: FastifyRequest, reply: FastifyReply) {
+      const rawOperation = routeOptions.url.replace(/^\/allocations\/?/, "");
+      const operation = rawOperation.length > 0 ? rawOperation.replace(/\//g, ".") : "route";
+      return runWithSpan(startAllocationsSpan(operation), async (span) => {
+        if (span) {
+          span.setAttributes({
+            "allocations.operation": operation,
+            "http.route": routeOptions.url,
+            "http.method": request.method,
+          });
+        }
+        const result = await originalHandler.call(this, request, reply);
+        if (span) {
+          span.setAttribute("http.status_code", reply.statusCode);
+        }
+        return result;
+      });
+    };
+  });
+
+  fastify.addHook("onRequest", async (request: FastifyRequest, reply: FastifyReply) => {
+    const reqId = ulid();
+    request.id = reqId;
+    reply.header("x-request-id", reqId);
+    request.requestStartTime = process.hrtime.bigint();
+    (request as any).log = request.log.child({ req_id: reqId });
+  });
+
+  fastify.addHook("onResponse", async (request: FastifyRequest, reply: FastifyReply) => {
+    const finishedAt = process.hrtime.bigint();
+    const durationMs =
+      request.requestStartTime !== undefined
+        ? Number((finishedAt - request.requestStartTime) / BigInt(1_000_000))
+        : 0;
+    const route = resolveRoutePath(request);
+    const logPayload = {
+      event: "request_completed",
+      req_id: request.id,
+      method: request.method,
+      route,
+      status: reply.statusCode,
+      duration_ms: durationMs,
+      orgId: resolveOrgId(request) ?? null,
+      userId: resolveUserId(request) ?? null,
+    } satisfies Record<string, unknown>;
+    request.log.info(logPayload);
+  });
+
+  fastify.addHook("onError", async (request: FastifyRequest, reply: FastifyReply, error: Error) => {
+    request.log.error(
+      {
+        event: "request_error",
+        req_id: request.id,
+        method: request.method,
+        route: resolveRoutePath(request),
+        status: reply.statusCode ?? 500,
+        orgId: resolveOrgId(request) ?? null,
+        userId: resolveUserId(request) ?? null,
+      },
+      error,
+    );
+  });
+});
+
+export default loggingPlugin;


### PR DESCRIPTION
## Summary
- add a zod-backed configuration loader for the gateway and freeze the exported settings
- introduce a logging plugin that assigns ULID request IDs, records request metrics, and emits security events
- wire an OpenTelemetry SDK with Fastify and Prisma instrumentation plus helpers for allocations and RPT spans
- document the required environment variables in ops/env/.env.example and pull in supporting dependencies

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: registry returned 403 for @opentelemetry packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b4fe6ae88327ab108ca9485e2949