### PR TITLE
Add compliance documentation for PII, retention, and NDB runbook

### DIFF
--- a/apgms/SECURITY.md
+++ b/apgms/SECURITY.md
@@ -1,2 +1,8 @@
-﻿# Security Policy
+# Security Policy
+
 Email: security@yourdomain.example
+
+## Compliance Documentation
+- [PII Inventory](../privacy/pii-inventory.csv)
+- [Data Retention Schedule](../privacy/data-retention.md)
+- [Notifiable Data Breach Runbook](../runbooks/ndb.md)

--- a/privacy/data-retention.md
+++ b/privacy/data-retention.md
@@ -1,0 +1,16 @@
+# Data Retention Schedule
+
+This schedule defines authoritative retention requirements for systems processing personal and financial data.
+
+| Dataset / System | Retention Duration | Notes |
+| --- | --- | --- |
+| CRM (Customer profiles, contact history) | 7 years from account closure | Supports customer enquiries and statutory record-keeping obligations. |
+| AuditBlob / RPT logs | 7 years rolling | Required to demonstrate compliance with CDR and SOC2 evidence obligations. |
+| Payments settlement records | 7 years from transaction date | Aligns with AU taxation documentation requirements. |
+| Tax Engine TFN cache | Current financial year + 4 years | Ensures TFNs are purged when no longer required for active assessments. |
+| Support platform conversations | 3 years from last interaction | Maintains historical context while minimising stored PII. |
+| Analytics telemetry | 13 months from collection | Aggregated prior to long-term storage to reduce re-identification risk. |
+| Marketing consents | Until withdrawn or 2 years after inactivity | Periodic reconfirmation ensures compliance with consent requirements. |
+| Backup archives | 35 days rolling | Automated purge schedule applied to encrypted backups. |
+
+Review this schedule annually or when regulatory drivers change.

--- a/privacy/pii-inventory.csv
+++ b/privacy/pii-inventory.csv
@@ -1,0 +1,9 @@
+Field,System,Purpose,LawfulBasis,Retention,AtRest,InTransit,AccessByRole
+CustomerFullName,CRM,Account onboarding,Consent,7 years,AES-256 encrypted,Mutual TLS,"Sales:Read; Compliance:Read/Write"
+CustomerEmail,CRM,Account onboarding and notifications,Consent,7 years,AES-256 encrypted,Mutual TLS,"Sales:Read; Support:Read"
+ABN,Registries Service,Identity verification,Legal obligation,7 years,AES-256 encrypted,Mutual TLS,"Compliance:Read/Write; Recon:Read"
+BankAccountNumber,Payments Service,Settlement processing,Contractual necessity,7 years,Tokenized,AES-GCM over HTTPS,"Payments Ops:Read/Write; Finance:Read"
+TransactionHistory,Audit Service,Audit logging,Legal obligation,7 years,Immutable storage,VPN over HTTPS,"Audit:Read; Compliance:Read"
+TaxFileNumber,Tax Engine,Tax calculations,Legal obligation,Current financial year + 4 years,Encrypted with KMS,Mutual TLS,"Tax Specialists:Read/Write; Compliance:Read"
+SupportTickets,Support Platform,Customer support,Legitimate interests,3 years,Encrypted database,HTTPS,"Tier2 Support:Read/Write; Compliance:Read"
+UsageTelemetry,Analytics Platform,Product improvement,Legitimate interests,13 months,Aggregated in data lake,HTTPS,"Product:Read; Engineering:Read"

--- a/runbooks/ndb.md
+++ b/runbooks/ndb.md
@@ -1,0 +1,78 @@
+# Notifiable Data Breach (NDB) Runbook
+
+This runbook describes the steps to assess, contain, and report eligible data breaches under the Australian OAIC Notifiable Data Breaches scheme.
+
+## 1. Detection & Initial Response (Day 0)
+1. **Trigger:** Security alert, customer report, or internal observation indicating potential personal data exposure.
+2. **Assemble response team:** Incident commander (Security Lead), Legal counsel, Privacy officer, Communications lead, Engineering representative.
+3. **Containment:** Isolate affected systems, revoke exposed credentials, enable additional monitoring, preserve forensic evidence.
+4. **Logging:** Open incident ticket in OpsGenie with severity, initial scope, and timestamp to start the 30-day assessment timer.
+
+## 2. Assessment (Day 0-30)
+1. **Identify breached data:** Determine what personal information was involved and the number of individuals affected.
+2. **Risk evaluation:** Assess likelihood of serious harm considering sensitivity, security controls, and possible misuse.
+3. **Decision checkpoint:** Privacy officer and Legal counsel must decide if the incident is an *eligible data breach* within 30 calendar days of detection. Document rationale in the incident ticket.
+4. **OAIC notification preparation:** If eligible, draft the statement for the OAIC including description, kinds of information, and steps taken. Use the template in [Appendix A](#appendix-a-oaic-notification-template).
+
+## 3. Notification & Communication (If eligible)
+1. **OAIC submission:** Lodge the statement via OAIC's Notifiable Data Breach form without undue delay once eligibility is confirmed.
+2. **Affected individuals:** Use [Appendix B](#appendix-b-customer-notification-template) to notify individuals via email or secure portal. Notifications must describe the breach, recommended actions, and contact details.
+3. **Partners and regulators:** Inform impacted partners and, if applicable, APRA or ASIC liaison contacts.
+
+## 4. Post-Incident Review
+1. **Lessons learned workshop** within 14 days of closure to document control improvements.
+2. **Control remediation plan** tracked in the risk register with accountable owners and due dates.
+3. **Update evidence**: File OAIC submission, communications, and post-mortem in the compliance repository.
+
+## Appendix A: OAIC Notification Template
+```
+Subject: Notifiable Data Breach Statement - <Incident Name>
+
+1. Organisation Details
+   - Entity name: APGMS Birchal Pty Ltd
+   - Contact: privacy@apgms.example
+
+2. Incident Summary
+   - Date detected: <DD MMM YYYY>
+   - Incident description: <Concise narrative>
+   - Containment actions: <Steps taken>
+
+3. Personal Information Involved
+   - Categories: <e.g. identification, financial, credentials>
+   - Number of individuals: <Estimated count>
+
+4. Assessment of Serious Harm
+   - Likelihood and consequences analysis.
+
+5. Steps Taken / Planned
+   - Mitigation actions and support offered to individuals.
+
+6. Notifications to Individuals
+   - Method and timing of notifications.
+
+7. Contact for OAIC
+   - Name, role, phone, and email.
+```
+
+## Appendix B: Customer Notification Template
+```
+Subject: Important information about your personal data
+
+Hello <Customer Name>,
+
+We recently discovered a security incident that may have involved some of your personal information. Our investigation confirmed the following:
+- What happened: <Plain-language summary>
+- Information involved: <Specific data>
+- When it occurred: <Date range>
+
+We have taken immediate steps to contain the issue and have reported the matter to the Office of the Australian Information Commissioner (OAIC).
+
+### What you can do
+- <Recommended protective steps>
+
+We are here to help. Contact us at privacy@apgms.example or 1300 000 000.
+
+Thank you,
+APGMS Birchal Privacy Team
+```
+


### PR DESCRIPTION
## Summary
- add a structured PII inventory covering key systems and access roles
- document data retention durations for major datasets and evidence sources
- publish the OAIC-aligned notifiable data breach runbook and link all artefacts from SECURITY.md

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68f3bedd9d5083279efcdcd136cfeee9