### PR TITLE
Add accessibility and performance CI checks

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,66 @@
+name: Accessibility and Performance
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  axe:
+    name: Axe accessibility audit
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apgms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run accessibility checks
+        run: pnpm exec playwright test
+
+  lighthouse:
+    name: Lighthouse budget check
+    runs-on: ubuntu-latest
+    needs: axe
+    defaults:
+      run:
+        working-directory: apgms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Lighthouse CI
+        run: pnpm exec lhci autorun --config=./lighthouserc.json

--- a/apgms/lighthouserc.json
+++ b/apgms/lighthouserc.json
@@ -1,0 +1,40 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "webapp",
+      "url": [
+        "/",
+        "/bank-lines/"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "formFactor": "desktop",
+        "screenEmulation": {
+          "mobile": false,
+          "width": 1280,
+          "height": 720,
+          "deviceScaleFactor": 1
+        },
+        "throttlingMethod": "devtools"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "first-contentful-paint": [
+          "error",
+          {
+            "maxNumericValue": 2000,
+            "aggregationMethod": "optimistic"
+          }
+        ],
+        "total-blocking-time": [
+          "error",
+          {
+            "maxNumericValue": 200,
+            "aggregationMethod": "optimistic"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,31 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^1.6.1",
+    "@lhci/cli": "^0.14.0",
+    "@playwright/test": "^1.48.2",
+    "@types/node": "^24.7.1",
+    "http-server": "^14.1.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,22 @@
-﻿export default {};
+import { defineConfig } from '@playwright/test';
+
+const DEFAULT_PORT = Number(process.env.WEBAPP_PORT ?? 4173);
+const fallbackBaseUrl = `http://localhost:${DEFAULT_PORT}`;
+
+export default defineConfig({
+  testDir: './webapp/tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: process.env.BASE_URL ?? fallbackBaseUrl,
+    trace: 'on-first-retry'
+  },
+  webServer: process.env.BASE_URL
+    ? undefined
+    : {
+        command: `pnpm exec http-server webapp -p ${DEFAULT_PORT} -c-1 --silent`,
+        url: fallbackBaseUrl,
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000
+      }
+});

--- a/apgms/webapp/bank-lines/index.html
+++ b/apgms/webapp/bank-lines/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Bank Lines</title>
+  </head>
+  <body>
+    <header>
+      <h1>Bank Lines</h1>
+      <p>Support for banks offering guarantee lines.</p>
+      <nav aria-label="Main navigation">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/bank-lines/">Bank lines</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section aria-labelledby="overview">
+        <h2 id="overview">Overview</h2>
+        <p>
+          Guarantee lines provide resilience for agricultural producers. This placeholder content ensures
+          accessibility checks run against a realistic document structure.
+        </p>
+      </section>
+      <section aria-labelledby="next-steps">
+        <h2 id="next-steps">Next steps</h2>
+        <ol>
+          <li>Contact your financial partner.</li>
+          <li>Prepare the required documentation.</li>
+          <li>Review eligibility criteria with the program team.</li>
+        </ol>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2024 APGMS</p>
+    </footer>
+  </body>
+</html>

--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,30 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>APGMS</title>
+  </head>
+  <body>
+    <header>
+      <h1>APGMS Portal</h1>
+      <nav aria-label="Main navigation">
+        <ul>
+          <li><a href="/">Home</a></li>
+          <li><a href="/bank-lines/">Bank lines</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main>
+      <section aria-labelledby="introduction">
+        <h2 id="introduction">Welcome</h2>
+        <p>
+          This placeholder application demonstrates automated accessibility and performance checks using Playwright,
+          axe, and Lighthouse.
+        </p>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2024 APGMS</p>
+    </footer>
+  </body>
+</html>

--- a/apgms/webapp/tests/axe.spec.ts
+++ b/apgms/webapp/tests/axe.spec.ts
@@ -1,0 +1,30 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { AxeResults } from 'axe-core';
+import { expect, test } from '@playwright/test';
+
+const routes = ['/', '/bank-lines'];
+
+for (const route of routes) {
+  test(`${route} has no accessibility violations`, async ({ page }) => {
+    await page.goto(route, { waitUntil: 'networkidle' });
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  });
+}
+
+function formatViolations(violations: AxeResults['violations']): string {
+  if (!violations.length) {
+    return 'No accessibility violations detected';
+  }
+
+  return violations
+    .map((violation) => {
+      const nodes = violation.nodes
+        .map((node) => `  - ${node.target.join(' ')}`)
+        .join('\n');
+
+      return `${violation.id} (${violation.impact ?? 'impact n/a'})\n${nodes}`;
+    })
+    .join('\n\n');
+}


### PR DESCRIPTION
## Summary
- add Playwright axe coverage for the webapp home and bank-lines pages
- provide accessible static markup for the audited routes
- enforce Lighthouse performance budgets and wire both checks into CI

## Testing
- pnpm install *(fails in sandbox: registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f3bec27b148327a93829dd46283ed3