### PR TITLE
feat(api-gateway): add observability instrumentation

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,8 +9,17 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.53.0",
+    "@opentelemetry/instrumentation-fastify": "^0.53.0",
+    "@opentelemetry/resources": "^1.12.0",
+    "@opentelemetry/sdk-node": "^0.53.0",
+    "@opentelemetry/semantic-conventions": "^1.26.0",
+    "@prisma/instrumentation": "6.17.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "fastify-plugin": "^5.0.1",
+    "pino": "^9.5.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/otel.ts
+++ b/apgms/services/api-gateway/src/otel.ts
@@ -1,0 +1,45 @@
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+
+let sdk: NodeSDK | undefined;
+
+const serviceName = process.env.OTEL_SERVICE_NAME ?? "api-gateway";
+
+export const startOtel = async () => {
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    return undefined;
+  }
+
+  if (sdk) {
+    return sdk;
+  }
+
+  sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    }),
+    traceExporter: new OTLPTraceExporter({
+      url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+    }),
+    instrumentations: [
+      new FastifyInstrumentation(),
+      new PrismaInstrumentation(),
+    ],
+  });
+
+  await sdk.start();
+  return sdk;
+};
+
+export const shutdownOtel = async () => {
+  if (!sdk) {
+    return;
+  }
+
+  await sdk.shutdown();
+  sdk = undefined;
+};

--- a/apgms/services/api-gateway/src/plugins/logging.ts
+++ b/apgms/services/api-gateway/src/plugins/logging.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+import { FastifyPluginAsync } from "fastify";
+import fp from "fastify-plugin";
+
+const startTimeKey = Symbol("requestStartTime");
+
+type SecurityEventDetails = Record<string, unknown>;
+
+const loggingPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateRequest("requestId", "");
+
+  fastify.decorate("logSecurityEvent", (event: string, details: SecurityEventDetails = {}) => {
+    fastify.log.warn({
+      type: "security_event",
+      event,
+      ...details,
+    });
+  });
+
+  fastify.decorateRequest(
+    "logSecurityEvent",
+    function (this: FastifyRequest, event: string, details: SecurityEventDetails = {}) {
+      fastify.logSecurityEvent(event, { req_id: this.requestId, ...details });
+    },
+  );
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const requestId = request.id ?? randomUUID();
+    request.requestId = requestId;
+    (request as any)[startTimeKey] = process.hrtime.bigint();
+    reply.header("x-request-id", requestId);
+
+    request.log = request.log.child({ req_id: requestId }) as typeof request.log;
+  });
+
+  fastify.addHook("onResponse", async (request, reply) => {
+    const startTime = (request as any)[startTimeKey] as bigint | undefined;
+    const latency = startTime ? Number((process.hrtime.bigint() - startTime) / BigInt(1e6)) : 0;
+
+    request.log.info(
+      {
+        req_id: request.requestId,
+        method: request.method,
+        url: request.url,
+        status_code: reply.statusCode,
+        latency,
+      },
+      "request completed",
+    );
+  });
+};
+
+export default fp(loggingPlugin);
+
+declare module "fastify" {
+  interface FastifyInstance {
+    logSecurityEvent(event: string, details?: SecurityEventDetails): void;
+  }
+
+  interface FastifyRequest {
+    requestId: string;
+    logSecurityEvent(event: string, details?: SecurityEventDetails): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Fastify logging plugin that emits structured request records with latency and request identifiers
- expose helpers for logging security events alongside request context
- bootstrap OpenTelemetry when configured to trace Fastify and Prisma activity

## Testing
- pnpm install *(fails: registry returned 403 while fetching @opentelemetry/api)*

------
https://chatgpt.com/codex/tasks/task_e_68f3bea18d0c8327b86ea883b6f6cd33