### PR TITLE
feat: add distroless api gateway container

### DIFF
--- a/apgms/docker/compose.prod.yml
+++ b/apgms/docker/compose.prod.yml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: apgms
+      POSTGRES_PASSWORD: apgms
+      POSTGRES_DB: apgms
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U apgms"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  api-gateway:
+    build:
+      context: ..
+      dockerfile: services/api-gateway/Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://apgms:apgms@postgres:5432/apgms
+      PORT: "3000"
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "3000:3000"
+    restart: unless-stopped
+
+volumes:
+  postgres-data:

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.6
+
+FROM node:20-bookworm-slim AS base
+ENV PNPM_HOME=/usr/local/share/pnpm
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN corepack enable
+WORKDIR /workspace
+
+FROM base AS install
+COPY apgms/pnpm-workspace.yaml ./
+COPY apgms/pnpm-lock.yaml ./
+COPY apgms/package.json ./
+COPY apgms/services/api-gateway/package.json services/api-gateway/
+COPY apgms/shared/package.json shared/
+RUN pnpm install --frozen-lockfile
+
+FROM install AS build
+COPY apgms ./
+RUN pnpm install --frozen-lockfile
+RUN pnpm exec prisma generate --schema shared/prisma/schema.prisma
+
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build --chown=nonroot:nonroot /workspace/node_modules ./node_modules
+COPY --from=build --chown=nonroot:nonroot /workspace/package.json ./package.json
+COPY --from=build --chown=nonroot:nonroot /workspace/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=build --chown=nonroot:nonroot /workspace/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=build --chown=nonroot:nonroot /workspace/services/api-gateway ./services/api-gateway
+COPY --from=build --chown=nonroot:nonroot /workspace/shared ./shared
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s CMD ["node", "-e", "const http=require('http');const port=process.env.PORT||3000;const req=http.get('http://127.0.0.1:'+port+'/healthz', res=>{if(res.statusCode===200){process.exit(0);}process.exit(1);});req.on('error',()=>process.exit(1));setTimeout(()=>{req.destroy();process.exit(1);},4000);"]
+
+USER nonroot
+ENTRYPOINT ["node", "--loader", "tsx", "services/api-gateway/src/index.ts"]

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -18,7 +18,10 @@ await app.register(cors, { origin: true });
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+const healthPayload = () => ({ ok: true, service: "api-gateway" });
+
+app.get("/health", async () => healthPayload());
+app.get("/healthz", async () => healthPayload());
 
 // List users (email + org)
 app.get("/users", async () => {


### PR DESCRIPTION
## Summary
- add a multi-stage distroless Dockerfile for the API gateway that runs as a non-root user with a health probe
- expose a /healthz route to satisfy the container healthcheck
- provide a production-oriented docker compose file for local testing with read-only filesystem settings

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: Prisma client is not generated in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f3be8e7580832780bbafc869280e51