### PR TITLE
Add policy engine module with fast-check property tests

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/policy-engine.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
+    "fast-check": "^3.23.2",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/apgms/services/api-gateway/test/policy-engine.test.ts
+++ b/apgms/services/api-gateway/test/policy-engine.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fc from 'fast-check';
+
+import { applyPolicy, type GateState } from '@apgms/shared/policy-engine';
+
+type ArbitraryAccountState = Parameters<typeof applyPolicy>[0]['accountStates'][number];
+
+const gateArb = fc.constantFrom<GateState>('OPEN', 'CLOSED');
+const weightArb = fc.double({ min: 0, max: 10_000, noNaN: true, noDefaultInfinity: true });
+
+const accountStateArb = fc.record({
+  accountId: fc.hexaString({ minLength: 1, maxLength: 16 }),
+  gate: fc.option(gateArb, { nil: undefined }),
+  weight: fc.option(weightArb, { nil: undefined }),
+}) as fc.Arbitrary<ArbitraryAccountState>;
+
+const uniqueAccountStatesArb = fc.uniqueArray(accountStateArb, {
+  minLength: 0,
+  maxLength: 12,
+  selector: (account) => account.accountId,
+});
+
+const bankLineArb = fc.double({ min: 0, max: 1_000_000, noNaN: true, noDefaultInfinity: true });
+
+const propertyOptions = { numRuns: 10_000 } as const;
+
+test('applyPolicy conserves the bank line', async () => {
+  await fc.assert(
+    fc.property(bankLineArb, uniqueAccountStatesArb, (bankLine, accountStates) => {
+      const result = applyPolicy({ bankLine, ruleset: [], accountStates });
+      const total = result.allocations.reduce((sum, allocation) => sum + allocation.amount, 0);
+      const openAccounts = accountStates.filter((account) => account.gate !== 'CLOSED');
+      const expected = openAccounts.length > 0 && Number.isFinite(bankLine) && bankLine > 0 ? bankLine : 0;
+      assert.ok(
+        Math.abs(total - expected) <= Math.max(1e-9, Math.abs(expected) * 1e-12),
+        `total allocation ${total} does not conserve bank line ${expected}`,
+      );
+    }),
+    propertyOptions,
+  );
+});
+
+test('applyPolicy never allocates negative amounts', async () => {
+  await fc.assert(
+    fc.property(bankLineArb, uniqueAccountStatesArb, (bankLine, accountStates) => {
+      const result = applyPolicy({ bankLine, ruleset: [], accountStates });
+
+      for (const allocation of result.allocations) {
+        assert.ok(
+          allocation.amount >= -1e-9,
+          `allocation for ${allocation.accountId} is negative: ${allocation.amount}`,
+        );
+      }
+    }),
+    propertyOptions,
+  );
+});
+
+test('applyPolicy keeps gates closed', () => {
+  const result = applyPolicy({
+    bankLine: 1_000,
+    ruleset: [],
+    accountStates: [
+      { accountId: 'open-1', gate: 'OPEN' },
+      { accountId: 'closed-1', gate: 'CLOSED' },
+    ],
+  });
+
+  const closedAllocation = result.allocations.find((allocation) => allocation.accountId === 'closed-1');
+  assert.ok(closedAllocation);
+  assert.strictEqual(closedAllocation.amount, 0);
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,8 +9,9 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
+      "@apgms/shared/policy-engine": ["shared/policy-engine/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    "./policy-engine": {
+      "types": "./policy-engine/index.ts",
+      "default": "./policy-engine/index.ts"
+    }
+  },
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
     "build": "echo building shared"

--- a/apgms/shared/policy-engine/index.ts
+++ b/apgms/shared/policy-engine/index.ts
@@ -1,0 +1,174 @@
+export type GateState = 'OPEN' | 'CLOSED';
+
+export interface AccountState {
+  accountId: string;
+  gate?: GateState;
+  weight?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyRule {
+  accountId: string;
+  gate?: GateState;
+  weight?: number;
+}
+
+export interface ApplyPolicyInput {
+  bankLine: number;
+  ruleset?: PolicyRule[];
+  accountStates: AccountState[];
+}
+
+export interface Allocation {
+  accountId: string;
+  amount: number;
+  gate: GateState;
+}
+
+export interface ApplyPolicyResult {
+  allocations: Allocation[];
+  policyHash: string;
+  explain: string;
+}
+
+const DEFAULT_GATE: GateState = 'OPEN';
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+
+  return `{${entries.join(',')}}`;
+}
+
+function hash(value: unknown): string {
+  const text = stableStringify(value);
+  let acc = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    acc = (acc * 31 + text.charCodeAt(index)) >>> 0;
+  }
+
+  return acc.toString(16).padStart(8, '0');
+}
+
+function sanitiseBankLine(bankLine: number): number {
+  if (!Number.isFinite(bankLine) || bankLine <= 0) {
+    return 0;
+  }
+
+  return bankLine;
+}
+
+function normaliseRuleMap(ruleset: PolicyRule[] | undefined): Map<string, PolicyRule> {
+  const map = new Map<string, PolicyRule>();
+
+  if (!Array.isArray(ruleset)) {
+    return map;
+  }
+
+  for (const rule of ruleset) {
+    if (rule && typeof rule.accountId === 'string') {
+      map.set(rule.accountId, rule);
+    }
+  }
+
+  return map;
+}
+
+function determineGate(account: AccountState, rule?: PolicyRule): GateState {
+  const gate = rule?.gate ?? account.gate ?? DEFAULT_GATE;
+  return gate === 'CLOSED' ? 'CLOSED' : 'OPEN';
+}
+
+function determineWeight(account: AccountState, rule?: PolicyRule): number {
+  const raw = rule?.weight ?? account.weight ?? 1;
+
+  if (!Number.isFinite(raw) || raw < 0) {
+    return 0;
+  }
+
+  return raw;
+}
+
+export function applyPolicy({ bankLine, ruleset, accountStates }: ApplyPolicyInput): ApplyPolicyResult {
+  const safeBankLine = sanitiseBankLine(bankLine);
+  const ruleMap = normaliseRuleMap(ruleset);
+
+  const normalisedAccounts = accountStates.map((account) => {
+    const rule = account.accountId ? ruleMap.get(account.accountId) : undefined;
+    const gate = determineGate(account, rule);
+    const weight = determineWeight(account, rule);
+
+    return { accountId: account.accountId, gate, weight };
+  });
+
+  const openAccounts = normalisedAccounts.filter((account) => account.gate !== 'CLOSED');
+
+  const allocations: Allocation[] = normalisedAccounts.map((account) => ({
+    accountId: account.accountId,
+    amount: 0,
+    gate: account.gate,
+  }));
+
+  if (safeBankLine === 0 || openAccounts.length === 0) {
+    return {
+      allocations,
+      policyHash: hash({ bankLine: safeBankLine, normalisedAccounts }),
+      explain: 'No distributable bank line or all gates closed.',
+    };
+  }
+
+  let totalWeight = openAccounts.reduce((sum, account) => sum + account.weight, 0);
+
+  if (totalWeight <= 0) {
+    totalWeight = openAccounts.length;
+    openAccounts.forEach((account) => {
+      account.weight = 1;
+    });
+  }
+
+  let allocatedSoFar = 0;
+
+  openAccounts.forEach((account, index) => {
+    const allocation = allocations.find((item) => item.accountId === account.accountId);
+    if (!allocation) {
+      return;
+    }
+
+    const isLast = index === openAccounts.length - 1;
+    const rawAmount = isLast
+      ? safeBankLine - allocatedSoFar
+      : (safeBankLine * account.weight) / totalWeight;
+
+    const amount = Math.max(0, rawAmount);
+    allocation.amount = amount;
+    allocation.gate = account.gate;
+    allocatedSoFar += amount;
+  });
+
+  const totalAllocated = allocations.reduce((sum, current) => sum + current.amount, 0);
+  const discrepancy = safeBankLine - totalAllocated;
+
+  if (Math.abs(discrepancy) > Number.EPSILON) {
+    const adjustable = allocations.find((allocation) => allocation.gate !== 'CLOSED');
+    if (adjustable) {
+      adjustable.amount = Math.max(0, adjustable.amount + discrepancy);
+      allocatedSoFar = allocations.reduce((sum, current) => sum + current.amount, 0);
+    }
+  }
+
+  return {
+    allocations,
+    policyHash: hash({ bankLine: safeBankLine, allocations }),
+    explain: `Allocated ${allocatedSoFar.toFixed(2)} across ${openAccounts.length} open accounts from a bank line of ${safeBankLine.toFixed(2)}.`,
+  };
+}

--- a/apgms/tsconfig.json
+++ b/apgms/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
+      "@apgms/shared/policy-engine": ["shared/policy-engine/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   }


### PR DESCRIPTION
## Summary
- add a shared policy engine module that deterministically allocates bank lines while respecting account gates
- expose the policy engine from the shared package and wire up workspace config for typed imports
- add fast-check property tests in the API gateway service to cover conservation, non-negative allocations, and closed-gate behaviour

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f3be53d0048327840a75efd1a888f5