### PR TITLE
Add webhook replay protection plugin

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+apgms/node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "apgms-birchal-webhook",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --import tsx --test test/webhook.spec.ts"
+  }
+}

--- a/src/plugins/webhook.ts
+++ b/src/plugins/webhook.ts
@@ -1,0 +1,115 @@
+import crypto from "node:crypto";
+import type { FastifyInstance } from "fastify";
+
+type RedisSetMode = "PX" | "EX" | undefined;
+
+type RedisLike = {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode?: RedisSetMode, ttl?: number): Promise<unknown>;
+};
+
+export interface WebhookPluginOptions {
+  /** Secret used to verify webhook signatures. Falls back to WEBHOOK_SECRET env var. */
+  secret?: string;
+  /** Redis instance used to store consumed nonces. */
+  redis: RedisLike;
+  /** Allowed clock skew window in milliseconds. Defaults to 5 minutes. */
+  windowMs?: number;
+}
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+
+const webhookPlugin = async (fastify: FastifyInstance, opts: WebhookPluginOptions) => {
+  const secret = opts.secret ?? process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    throw new Error("WEBHOOK_SECRET is required for webhook verification");
+  }
+
+  const windowMs = opts.windowMs ?? FIVE_MINUTES_MS;
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    const path = typeof request.url === "string" ? request.url : request.raw.url;
+    if (!path || !path.startsWith("/webhooks/")) {
+      return;
+    }
+
+    const signature = normalizeHeader(request.headers["x-signature"]);
+    const nonce = normalizeHeader(request.headers["x-nonce"]);
+    const timestampHeader = normalizeHeader(request.headers["x-timestamp"]);
+
+    if (!signature || !nonce || !timestampHeader) {
+      reply.code(401);
+      return reply.send({ error: "unauthorized" });
+    }
+
+    const timestamp = Number(timestampHeader);
+    if (!Number.isFinite(timestamp)) {
+      reply.code(401);
+      return reply.send({ error: "unauthorized" });
+    }
+
+    const now = Date.now();
+    if (Math.abs(now - timestamp) > windowMs) {
+      reply.code(409);
+      return reply.send({ error: "stale_timestamp" });
+    }
+
+    const bodyString = stringifyBody(request.body);
+    const expectedSignature = computeSignature(secret, timestampHeader, nonce, bodyString);
+
+    if (!timingSafeEqual(signature, expectedSignature)) {
+      reply.code(401);
+      return reply.send({ error: "invalid_signature" });
+    }
+
+    const nonceKey = `webhook:nonce:${nonce}`;
+    const existing = await opts.redis.get(nonceKey);
+    if (existing) {
+      reply.code(409);
+      return reply.send({ error: "nonce_reused" });
+    }
+
+    await opts.redis.set(nonceKey, String(timestamp), "PX", windowMs);
+  });
+};
+
+export default webhookPlugin;
+
+function normalizeHeader(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return value[0];
+  }
+  return null;
+}
+
+function stringifyBody(body: unknown): string {
+  if (body === undefined) {
+    return "";
+  }
+  if (typeof body === "string") {
+    return body;
+  }
+  if (Buffer.isBuffer(body)) {
+    return body.toString("utf8");
+  }
+  return JSON.stringify(body ?? null);
+}
+
+function computeSignature(secret: string, timestamp: string, nonce: string, body: string): string {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${nonce}.${body}`)
+    .digest("hex");
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a, "utf8");
+  const bBuffer = Buffer.from(b, "utf8");
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(aBuffer, bBuffer);
+}

--- a/test/webhook.spec.ts
+++ b/test/webhook.spec.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import test from "node:test";
+import Fastify from "fastify";
+import webhookPlugin from "../src/plugins/webhook.ts";
+
+class InMemoryRedis {
+  private store = new Map<string, { value: string; expiresAt?: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, mode?: "PX" | "EX", ttl?: number): Promise<string> {
+    let expiresAt: number | undefined;
+    if (mode === "PX" && typeof ttl === "number") {
+      expiresAt = Date.now() + ttl;
+    }
+    if (mode === "EX" && typeof ttl === "number") {
+      expiresAt = Date.now() + ttl * 1000;
+    }
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+const secret = "test-secret";
+const payload = { amount: 125.5, currency: "AUD" };
+
+function sign(nonce: string, timestamp: number, body = payload) {
+  const bodyString = JSON.stringify(body);
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${timestamp}.${nonce}.${bodyString}`)
+    .digest("hex");
+}
+
+async function createApp() {
+  const redis = new InMemoryRedis();
+  const app = Fastify();
+  await webhookPlugin(app, { secret, redis });
+  app.post("/webhooks/payto", async (_, reply) => reply.code(200).send({ ok: true }));
+  return { app, redis };
+}
+
+test("rejects requests with stale timestamps", async (t) => {
+  const { app, redis } = await createApp();
+  t.after(async () => {
+    await app.close();
+    await redis.clear();
+  });
+
+  const nonce = "stale-1";
+  const timestamp = Date.now() - 6 * 60 * 1000;
+  const signature = sign(nonce, timestamp);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+      "x-signature": signature,
+    },
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(response.json(), { error: "stale_timestamp" });
+});
+
+test("rejects requests that reuse a nonce", async (t) => {
+  const { app, redis } = await createApp();
+  t.after(async () => {
+    await app.close();
+    await redis.clear();
+  });
+
+  const nonce = "reuse-1";
+  const timestamp = Date.now();
+  const signature = sign(nonce, timestamp);
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+      "x-signature": signature,
+    },
+  });
+  assert.equal(first.statusCode, 200);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+      "x-signature": signature,
+    },
+  });
+
+  assert.equal(second.statusCode, 409);
+  assert.deepEqual(second.json(), { error: "nonce_reused" });
+});
+
+test("rejects requests with invalid signatures", async (t) => {
+  const { app, redis } = await createApp();
+  t.after(async () => {
+    await app.close();
+    await redis.clear();
+  });
+
+  const nonce = "bad-sig";
+  const timestamp = Date.now();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+      "x-signature": "not-valid",
+    },
+  });
+
+  assert.equal(response.statusCode, 401);
+  assert.deepEqual(response.json(), { error: "invalid_signature" });
+});
+
+test("accepts valid webhook requests", async (t) => {
+  const { app, redis } = await createApp();
+  t.after(async () => {
+    await app.close();
+    await redis.clear();
+  });
+
+  const nonce = "ok-1";
+  const timestamp = Date.now();
+  const signature = sign(nonce, timestamp);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+      "x-signature": signature,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ok: true });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- add a Fastify pre-handler that validates webhook signature, timestamp freshness, and nonce reuse with Redis-backed storage
- provide node:test coverage for stale timestamps, nonce reuse, invalid signatures, and valid webhook flows
- set up lightweight TypeScript config and test script to exercise the webhook verification

## Testing
- node --import tsx --test test/webhook.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f3be48be008327a2679e3b07c421f4