### PR TITLE
Add Zod schemas and response validation for API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/schemas.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,11 +7,51 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyReply } from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import type { ZodTypeAny, infer as ZodInfer } from "zod";
+import { dashboardResponseSchema } from "./schemas/dashboard";
+import {
+  createBankLineBodySchema,
+  createBankLineResponseSchema,
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+} from "./schemas/bank-lines";
+import { listUsersResponseSchema } from "./schemas/users";
 
 const app = Fastify({ logger: true });
+
+const isProduction = process.env.NODE_ENV === "production";
+
+declare module "fastify" {
+  interface FastifyReply {
+    withSchema<T extends ZodTypeAny>(schema: T): FastifyReply & {
+      send(payload: ZodInfer<T>): FastifyReply;
+    };
+  }
+}
+
+app.decorateReply("withSchema", function withSchema(this: FastifyReply, schema: ZodTypeAny) {
+  const reply = this;
+  const originalSend = reply.send.bind(reply);
+
+  reply.send = function sendWithSchema(payload: unknown) {
+    if (isProduction) {
+      try {
+        schema.parse(payload);
+      } catch (error) {
+        reply.log.error({ error, payload }, "Response schema validation failed");
+      }
+    } else {
+      schema.parse(payload);
+    }
+
+    return originalSend(payload);
+  };
+
+  return reply;
+});
 
 await app.register(cors, { origin: true });
 
@@ -21,48 +61,81 @@ app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
-app.get("/users", async () => {
+app.get("/users", async (_, reply) => {
   const users = await prisma.user.findMany({
     select: { email: true, orgId: true, createdAt: true },
     orderBy: { createdAt: "desc" },
   });
-  return { users };
+
+  const payload = {
+    users: users.map((user) => ({
+      email: user.email,
+      orgId: user.orgId,
+      createdAt: user.createdAt.toISOString(),
+    })),
+  };
+
+  return reply.withSchema(listUsersResponseSchema).send(payload);
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+app.get("/bank-lines", async (req, reply) => {
+  const parsedQuery = createBankLinesQuery(req.query as Record<string, unknown>);
+  const take = parsedQuery.take ?? 20;
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
     take: Math.min(Math.max(take, 1), 200),
   });
-  return { lines };
+
+  const payload = {
+    lines: lines.map((line) => serializeBankLine(line)),
+  };
+
+  return reply.withSchema(listBankLinesResponseSchema).send(payload);
 });
 
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
+    const body = createBankLineBodySchema.parse(req.body);
     const created = await prisma.bankLine.create({
       data: {
         orgId: body.orgId,
         date: new Date(body.date),
-        amount: body.amount as any,
+        amount: body.amount,
         payee: body.payee,
         desc: body.desc,
       },
     });
-    return rep.code(201).send(created);
+    const payload = serializeBankLine(created);
+    return rep.code(201).withSchema(createBankLineResponseSchema).send(payload);
   } catch (e) {
     req.log.error(e);
     return rep.code(400).send({ error: "bad_request" });
   }
+});
+
+app.get("/dashboard", async (_, reply) => {
+  const [userCount, bankLineCount, sum, recentBankLines] = await Promise.all([
+    prisma.user.count(),
+    prisma.bankLine.count(),
+    prisma.bankLine.aggregate({ _sum: { amount: true } }),
+    prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: 5,
+    }),
+  ]);
+
+  const payload = {
+    totals: {
+      users: userCount,
+      bankLines: bankLineCount,
+      balance: sum._sum.amount?.toString() ?? "0",
+    },
+    recentBankLines: recentBankLines.map((line) => serializeBankLine(line)),
+  };
+
+  return reply.withSchema(dashboardResponseSchema).send(payload);
 });
 
 // Print routes so we can SEE POST /bank-lines is registered
@@ -77,4 +150,23 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
+
+type BankLine = Awaited<ReturnType<typeof prisma.bankLine.findFirst>>;
+
+function serializeBankLine(line: NonNullable<BankLine>) {
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amount: String(line.amount),
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+}
+
+function createBankLinesQuery(query: Record<string, unknown> | undefined) {
+  const parsed = listBankLinesQuerySchema.safeParse(query ?? {});
+  return parsed.success ? parsed.data : {};
+}
 

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const decimalString = z
+  .string()
+  .regex(/^-?\d+(\.\d+)?$/, "Invalid decimal format");
+
+export const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amount: decimalString,
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export const listBankLinesQuerySchema = z
+  .object({
+    take: z
+      .union([z.string(), z.number()])
+      .transform((value) => Number(value))
+      .pipe(z.number().int().positive().max(200))
+      .optional(),
+  })
+  .strict(false);
+
+export const listBankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+export const createBankLineBodySchema = z.object({
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amount: z.union([z.number(), decimalString]).transform((value) =>
+    typeof value === "number" ? value.toString() : value,
+  ),
+  payee: z.string(),
+  desc: z.string(),
+});
+
+export const createBankLineResponseSchema = bankLineSchema;
+
+export type ListBankLinesResponse = z.infer<typeof listBankLinesResponseSchema>;
+export type CreateBankLineBody = z.infer<typeof createBankLineBodySchema>;
+export type CreateBankLineResponse = z.infer<typeof createBankLineResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/dashboard.ts
+++ b/apgms/services/api-gateway/src/schemas/dashboard.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { bankLineSchema } from "./bank-lines";
+
+export const dashboardResponseSchema = z.object({
+  totals: z.object({
+    users: z.number().int().nonnegative(),
+    bankLines: z.number().int().nonnegative(),
+    balance: z.string(),
+  }),
+  recentBankLines: z.array(bankLineSchema),
+});
+
+export type DashboardResponse = z.infer<typeof dashboardResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/users.ts
+++ b/apgms/services/api-gateway/src/schemas/users.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const userSummarySchema = z.object({
+  email: z.string().email(),
+  orgId: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export const listUsersResponseSchema = z.object({
+  users: z.array(userSummarySchema),
+});
+
+export type ListUsersResponse = z.infer<typeof listUsersResponseSchema>;

--- a/apgms/services/api-gateway/test/schemas.spec.ts
+++ b/apgms/services/api-gateway/test/schemas.spec.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { dashboardResponseSchema } from "../src/schemas/dashboard";
+import {
+  createBankLineBodySchema,
+  createBankLineResponseSchema,
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+} from "../src/schemas/bank-lines";
+import { listUsersResponseSchema } from "../src/schemas/users";
+
+const iso = () => new Date().toISOString();
+
+describe("users schema", () => {
+  it("accepts a valid response", () => {
+    const payload = {
+      users: [
+        {
+          email: "founder@example.com",
+          orgId: "org-123",
+          createdAt: iso(),
+        },
+      ],
+    };
+
+    assert.doesNotThrow(() => listUsersResponseSchema.parse(payload));
+  });
+
+  it("rejects an invalid response", () => {
+    const payload = {
+      users: [
+        {
+          email: "not-an-email",
+          orgId: "org-123",
+          createdAt: "yesterday",
+        },
+      ],
+    };
+
+    assert.throws(() => listUsersResponseSchema.parse(payload));
+  });
+});
+
+describe("bank line schemas", () => {
+  it("parses take from query", () => {
+    const query = listBankLinesQuerySchema.parse({ take: "50" });
+    assert.equal(query.take, 50);
+  });
+
+  it("accepts valid list response", () => {
+    const payload = {
+      lines: [
+        {
+          id: "line-1",
+          orgId: "org-1",
+          date: iso(),
+          amount: "1250.40",
+          payee: "Acme",
+          desc: "Office fit-out",
+          createdAt: iso(),
+        },
+      ],
+    };
+
+    assert.doesNotThrow(() => listBankLinesResponseSchema.parse(payload));
+  });
+
+  it("rejects invalid list response", () => {
+    const payload = {
+      lines: [
+        {
+          id: "line-1",
+          orgId: "org-1",
+          date: "invalid",
+          amount: "oops",
+          payee: "Acme",
+          desc: "Office fit-out",
+          createdAt: iso(),
+        },
+      ],
+    };
+
+    assert.throws(() => listBankLinesResponseSchema.parse(payload));
+  });
+
+  it("coerces amount when creating", () => {
+    const payload = {
+      orgId: "org-1",
+      date: iso(),
+      amount: 1250.4,
+      payee: "Acme",
+      desc: "Office fit-out",
+    };
+
+    const parsed = createBankLineBodySchema.parse(payload);
+    assert.equal(parsed.amount, "1250.4");
+  });
+
+  it("rejects invalid create payload", () => {
+    const payload = {
+      orgId: "org-1",
+      date: "not-a-date",
+      amount: "abc",
+      payee: "Acme",
+      desc: "Office fit-out",
+    };
+
+    assert.throws(() => createBankLineBodySchema.parse(payload));
+  });
+
+  it("validates create response", () => {
+    const payload = {
+      id: "line-2",
+      orgId: "org-1",
+      date: iso(),
+      amount: "10.00",
+      payee: "CloudCo",
+      desc: "Subscription",
+      createdAt: iso(),
+    };
+
+    assert.doesNotThrow(() => createBankLineResponseSchema.parse(payload));
+  });
+});
+
+describe("dashboard schema", () => {
+  it("accepts a valid payload", () => {
+    const payload = {
+      totals: {
+        users: 10,
+        bankLines: 25,
+        balance: "1200.00",
+      },
+      recentBankLines: [
+        {
+          id: "line-1",
+          orgId: "org-1",
+          date: iso(),
+          amount: "100.00",
+          payee: "Acme",
+          desc: "Office fit-out",
+          createdAt: iso(),
+        },
+      ],
+    };
+
+    assert.doesNotThrow(() => dashboardResponseSchema.parse(payload));
+  });
+
+  it("rejects an invalid payload", () => {
+    const payload = {
+      totals: {
+        users: -1,
+        bankLines: 2,
+        balance: "abc",
+      },
+      recentBankLines: [],
+    };
+
+    assert.throws(() => dashboardResponseSchema.parse(payload));
+  });
+});


### PR DESCRIPTION
## Summary
- add Zod response schemas for users, bank line, and dashboard routes
- wrap Fastify replies with schema-aware send validation outside production and log mismatches on prod
- normalize route payloads, add dashboard aggregate route, and cover schemas with node:test cases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3be30654083278ebc5eb01946bbc0