### PR TITLE
Add security plugin with CORS, rate limiting, and body limits

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/security.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,12 +8,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import securityPlugin from "./plugins/security.js";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await securityPlugin(app);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -77,4 +77,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,142 @@
+import cors from "@fastify/cors";
+import type { FastifyPluginAsync, RouteOptions } from "fastify";
+
+const defaultBodyLimit = 512 * 1024;
+const defaultRateLimitMax = 100;
+const defaultRateLimitWindowMs = 60_000;
+
+const normalizePositiveNumber = (
+  value: string | number | undefined,
+  fallback: number,
+): number => {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return Math.floor(parsed);
+};
+
+const securityPlugin: FastifyPluginAsync = async (fastify) => {
+  const env = (process.env.NODE_ENV ?? "").toLowerCase();
+  const isProduction = env === "production";
+
+  const allowedOriginsCsv = process.env.ALLOWED_ORIGINS;
+  const allowedOrigins = allowedOriginsCsv
+    ?.split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  const allowAllOrigins = !allowedOrigins && !isProduction;
+  const allowedOriginSet = new Set(allowedOrigins ?? []);
+
+  const isOriginAllowed = (originHeader?: string): boolean => {
+    if (!originHeader) {
+      return true;
+    }
+
+    if (allowAllOrigins) {
+      return true;
+    }
+
+    return allowedOriginSet.has(originHeader);
+  };
+
+  await fastify.register(cors, {
+    origin(origin, cb) {
+      cb(null, isOriginAllowed(origin ?? undefined));
+    },
+  });
+
+  const bodyLimit = normalizePositiveNumber(
+    process.env.BODY_LIMIT_BYTES,
+    defaultBodyLimit,
+  );
+
+  fastify.addHook("onRoute", (routeOptions: RouteOptions) => {
+    const methodList = Array.isArray(routeOptions.method)
+      ? routeOptions.method
+      : [routeOptions.method];
+
+    const shouldApplyLimit = methodList.some((method) => {
+      if (!method) {
+        return false;
+      }
+
+      const upper = method.toUpperCase();
+      return upper !== "GET" && upper !== "HEAD" && upper !== "OPTIONS";
+    });
+
+    if (!shouldApplyLimit) {
+      return;
+    }
+
+    routeOptions.config = {
+      ...(routeOptions.config ?? {}),
+      bodyLimit,
+    };
+
+    (routeOptions as RouteOptions & { bodyLimit?: number }).bodyLimit = bodyLimit;
+  });
+
+  const rateLimitMax = normalizePositiveNumber(
+    process.env.RATE_LIMIT_MAX,
+    defaultRateLimitMax,
+  );
+  const rateLimitWindowMs = normalizePositiveNumber(
+    process.env.RATE_LIMIT_WINDOW_MS,
+    defaultRateLimitWindowMs,
+  );
+
+  const buckets = new Map<string, { count: number; reset: number }>();
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const now = Date.now();
+    const ip = request.ip || request.socket.remoteAddress || "unknown";
+    const existing = buckets.get(ip);
+
+    if (!existing || now >= existing.reset) {
+      buckets.set(ip, { count: 1, reset: now + rateLimitWindowMs });
+    } else if (existing.count >= rateLimitMax) {
+      const retryAfterSeconds = Math.max(
+        1,
+        Math.ceil((existing.reset - now) / 1000),
+      );
+
+      return reply
+        .header("Retry-After", retryAfterSeconds.toString())
+        .code(429)
+        .send({ error: "too_many_requests" });
+    } else {
+      existing.count += 1;
+    }
+
+    if (!isOriginAllowed(request.headers.origin ?? undefined)) {
+      return reply.code(403).send({ error: "origin_not_allowed" });
+    }
+
+    const method = request.method.toUpperCase();
+    if (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") {
+      const contentLengthHeader = request.headers["content-length"];
+      if (Array.isArray(contentLengthHeader)) {
+        const parsed = contentLengthHeader
+          .map((value) => Number(value))
+          .find((value) => Number.isFinite(value));
+        if (parsed !== undefined && parsed > bodyLimit) {
+          return reply.code(413).send({ error: "payload_too_large" });
+        }
+      } else if (contentLengthHeader) {
+        const parsed = Number(contentLengthHeader);
+        if (Number.isFinite(parsed) && parsed > bodyLimit) {
+          return reply.code(413).send({ error: "payload_too_large" });
+        }
+      }
+    }
+  });
+};
+
+export default securityPlugin;

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import securityPlugin from "../src/plugins/security.js";
+
+type EnvOverrides = Record<string, string | undefined>;
+
+type RouteRegistrar = (instance: FastifyInstance) => void | Promise<void>;
+
+const previousEnv = new Map<string, string | undefined>();
+
+const applyEnv = (overrides: EnvOverrides) => {
+  previousEnv.clear();
+  for (const [key, value] of Object.entries(overrides)) {
+    previousEnv.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+};
+
+afterEach(() => {
+  for (const [key, value] of previousEnv.entries()) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  previousEnv.clear();
+});
+
+const buildServer = async (registerRoutes: RouteRegistrar) => {
+  const app = Fastify({ logger: false });
+  await securityPlugin(app);
+  await registerRoutes(app);
+  await app.ready();
+  return app;
+};
+
+test("preflight from disallowed origin is blocked", async () => {
+  applyEnv({
+    NODE_ENV: "production",
+    ALLOWED_ORIGINS: "https://allowed.example.com",
+  });
+
+  const app = await buildServer(async (instance) => {
+    instance.options("/preflight", async () => ({ ok: true }));
+  });
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/preflight",
+    headers: {
+      origin: "https://evil.example.com",
+      "access-control-request-method": "POST",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+});
+
+test("requests larger than the configured body limit are rejected", async () => {
+  applyEnv({
+    BODY_LIMIT_BYTES: String(512 * 1024),
+  });
+
+  const app = await buildServer(async (instance) => {
+    instance.post("/echo", async (request) => request.body);
+  });
+
+  const payload = JSON.stringify({ data: "a".repeat(512 * 1024) });
+  const response = await app.inject({
+    method: "POST",
+    url: "/echo",
+    payload,
+    headers: { "content-type": "application/json" },
+  });
+
+  assert.equal(response.statusCode, 413);
+});
+
+test("repeated requests over the limit yield 429", async () => {
+  applyEnv({
+    RATE_LIMIT_MAX: "3",
+    RATE_LIMIT_WINDOW_MS: "60000",
+  });
+
+  const app = await buildServer(async (instance) => {
+    instance.get("/limited", async () => ({ ok: true }));
+  });
+
+  for (let i = 0; i < 3; i += 1) {
+    const okResponse = await app.inject({
+      method: "GET",
+      url: "/limited",
+      remoteAddress: "203.0.113.42",
+    });
+    assert.equal(okResponse.statusCode, 200);
+  }
+
+  const limitedResponse = await app.inject({
+    method: "GET",
+    url: "/limited",
+    remoteAddress: "203.0.113.42",
+  });
+
+  assert.equal(limitedResponse.statusCode, 429);
+});


### PR DESCRIPTION
## Summary
- add a security plugin to centralize CORS, rate limiting, and request body limits
- register the plugin in the API gateway bootstrap path and expose a test runner script
- cover security behaviours with node:test cases for preflight, payload size, and rate limiting

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3be220f2483278314961b1a8e8aea