### PR TITLE
feat(api-gateway): add auth and org scope guards

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/auth.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,72 +9,112 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import type { AuthUser } from "./plugins/auth.js";
+import { requireRole, verifyBearer } from "./plugins/auth.js";
+import { ensureOrgScope } from "./plugins/org-scope.js";
 
-const app = Fastify({ logger: true });
+type PrismaClientLike = {
+  user: {
+    findMany: (...args: any[]) => Promise<any>;
+  };
+  bankLine: {
+    findMany: (...args: any[]) => Promise<any>;
+    create: (...args: any[]) => Promise<any>;
+  };
+};
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+async function resolvePrisma(overrides?: { prisma?: PrismaClientLike }) {
+  if (overrides?.prisma) {
+    return overrides.prisma;
   }
-});
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  const module = await import("../../../shared/src/db");
+  return module.prisma as PrismaClientLike;
+}
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+export async function buildApp(overrides?: { prisma?: PrismaClientLike }) {
+  const db = await resolvePrisma(overrides);
+  const app = Fastify({ logger: true });
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  await app.register(cors, { origin: true });
 
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  await app.register(async (protectedApp) => {
+    protectedApp.decorateRequest("user", null as unknown as AuthUser);
+    protectedApp.addHook("onRequest", verifyBearer());
+    protectedApp.addHook("preHandler", ensureOrgScope());
+
+    protectedApp.get(
+      "/users",
+      { preHandler: [requireRole("admin")] },
+      async (request) => {
+        const users = await db.user.findMany({
+          where: { orgId: request.user.orgId },
+          select: { email: true, orgId: true, createdAt: true },
+          orderBy: { createdAt: "desc" },
+        });
+        return { users };
+      },
+    );
+
+    protectedApp.get("/bank-lines", async (request) => {
+      const query = request.query as { take?: number | string };
+      const take = Number(query?.take ?? 20);
+      const lines = await db.bankLine.findMany({
+        where: { orgId: request.user.orgId },
+        orderBy: { date: "desc" },
+        take: Math.min(Math.max(take, 1), 200),
+      });
+      return { lines };
+    });
+
+    protectedApp.post("/bank-lines", async (request, reply) => {
+      try {
+        const body = request.body as {
+          orgId: string;
+          date: string;
+          amount: number | string;
+          payee: string;
+          desc: string;
+        };
+        const created = await db.bankLine.create({
+          data: {
+            orgId: request.user.orgId,
+            date: new Date(body.date),
+            amount: body.amount as any,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+        return reply.code(201).send(created);
+      } catch (error) {
+        request.log.error(error);
+        return reply.code(400).send({ error: "bad_request" });
+      }
+    });
+  });
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  const app = await buildApp();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });
+}

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,151 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export type AuthUser = {
+  userId: string;
+  orgId: string;
+  roles: string[];
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user: AuthUser;
+  }
+}
+
+function parseRoles(input: unknown): string[] {
+  if (Array.isArray(input)) {
+    return input.map((role) => String(role)).filter(Boolean);
+  }
+
+  if (typeof input === "string") {
+    return input
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+function verifyJwtToken(
+  authorization: string,
+  request: FastifyRequest,
+  reply: FastifyReply,
+): FastifyReply | void {
+  const issuer = process.env.AUTH_ISSUER;
+  const audience = process.env.AUTH_AUDIENCE;
+  const secret = process.env.AUTH_SECRET;
+
+  if (!issuer || !audience || !secret) {
+    request.log.error("AUTH_ISSUER, AUTH_AUDIENCE, and AUTH_SECRET must be configured");
+    return reply.code(500).send({ error: "auth_not_configured" });
+  }
+
+  if (!authorization.toLowerCase().startsWith("bearer ")) {
+    return reply.code(401).send({ error: "unauthorized" });
+  }
+
+  const token = authorization.slice(7).trim();
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+
+  if (!encodedHeader || !encodedPayload || !encodedSignature) {
+    return reply.code(401).send({ error: "unauthorized" });
+  }
+
+  try {
+    const header = JSON.parse(Buffer.from(encodedHeader, "base64url").toString("utf8"));
+    if (header.alg !== "HS256") {
+      request.log.error({ alg: header.alg }, "Unsupported JWT algorithm");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    const payload = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+
+    const signature = Buffer.from(encodedSignature, "base64url");
+    const expectedSignature = createHmac("sha256", secret)
+      .update(`${encodedHeader}.${encodedPayload}`)
+      .digest();
+
+    if (signature.length !== expectedSignature.length || !timingSafeEqual(signature, expectedSignature)) {
+      request.log.error("JWT signature mismatch");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (typeof payload.exp === "number" && payload.exp < now) {
+      request.log.error({ exp: payload.exp, now }, "JWT expired");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    if (payload.iss !== issuer) {
+      request.log.error({ iss: payload.iss }, "JWT issuer mismatch");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    if (!audiences.some((aud) => aud === audience)) {
+      request.log.error({ aud: payload.aud }, "JWT audience mismatch");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    const userId = typeof payload.sub === "string" ? payload.sub : undefined;
+    const orgId = typeof payload.orgId === "string" ? payload.orgId : undefined;
+    const roles = parseRoles(payload.roles);
+
+    if (!userId || !orgId) {
+      request.log.error({ payload }, "JWT missing required claims");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    request.user = { userId, orgId, roles };
+  } catch (error) {
+    request.log.error({ error }, "JWT verification failed");
+    return reply.code(401).send({ error: "unauthorized" });
+  }
+}
+
+function verifyBypassHeaders(request: FastifyRequest, reply: FastifyReply) {
+  const devUser = request.headers["x-dev-user"];
+  const devOrg = request.headers["x-dev-org"];
+  const devRoles = request.headers["x-dev-roles"];
+
+  if (!devUser || !devOrg) {
+    return reply.code(401).send({ error: "unauthorized" });
+  }
+
+  request.user = {
+    userId: String(devUser),
+    orgId: String(devOrg),
+    roles: parseRoles(devRoles),
+  };
+}
+
+export function verifyBearer() {
+  return async function verify(request: FastifyRequest, reply: FastifyReply) {
+    if (process.env.AUTH_BYPASS === "true") {
+      return verifyBypassHeaders(request, reply);
+    }
+
+    const authorization = request.headers.authorization;
+
+    if (!authorization) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    return verifyJwtToken(authorization, request, reply);
+  };
+}
+
+export function requireRole(...roles: string[]) {
+  const required = new Set(roles);
+
+  return async function enforce(request: FastifyRequest, reply: FastifyReply) {
+    const userRoles = request.user?.roles ?? [];
+    const hasRole = userRoles.some((role) => required.has(role));
+
+    if (!hasRole) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+  };
+}

--- a/apgms/services/api-gateway/src/plugins/org-scope.ts
+++ b/apgms/services/api-gateway/src/plugins/org-scope.ts
@@ -1,0 +1,32 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+function resolveOrgId(request: FastifyRequest): string | undefined {
+  const fromQuery = (request.query as Record<string, unknown> | undefined)?.orgId;
+  if (typeof fromQuery === "string") {
+    return fromQuery;
+  }
+
+  const body = request.body as Record<string, unknown> | undefined;
+  const fromBody = body?.orgId;
+  if (typeof fromBody === "string") {
+    return fromBody;
+  }
+
+  const fromParams = (request.params as Record<string, unknown> | undefined)?.orgId;
+  if (typeof fromParams === "string") {
+    return fromParams;
+  }
+
+  return undefined;
+}
+
+export function ensureOrgScope() {
+  return async function enforce(request: FastifyRequest, reply: FastifyReply) {
+    const expectedOrgId = request.user?.orgId;
+    const scopedOrgId = resolveOrgId(request);
+
+    if (!expectedOrgId || !scopedOrgId || scopedOrgId !== expectedOrgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+  };
+}

--- a/apgms/services/api-gateway/test/auth.spec.ts
+++ b/apgms/services/api-gateway/test/auth.spec.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { buildApp } from "../src/index.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function createPrismaMock() {
+  return {
+    user: {
+      findMany: async () => [],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => ({ id: "bank-line" }),
+    },
+  };
+}
+
+function createToken(claims: { sub: string; orgId: string; roles?: unknown }) {
+  const secret = process.env.AUTH_SECRET ?? "";
+  const issuer = process.env.AUTH_ISSUER ?? "issuer";
+  const audience = process.env.AUTH_AUDIENCE ?? "audience";
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = {
+    alg: "HS256",
+    typ: "JWT",
+  };
+
+  const payload = {
+    iss: issuer,
+    aud: audience,
+    exp: now + 300,
+    sub: claims.sub,
+    orgId: claims.orgId,
+    roles: claims.roles ?? [],
+  };
+
+  const encodedHeader = Buffer.from(JSON.stringify(header)).toString("base64url");
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", secret)
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest("base64url");
+
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+describe("auth and org scope", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.AUTH_SECRET = "secret";
+    process.env.AUTH_ISSUER = "https://issuer";
+    process.env.AUTH_AUDIENCE = "api://aud";
+    process.env.AUTH_BYPASS = "false";
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("responds 401 when no credentials provided", async () => {
+    const prismaMock = createPrismaMock();
+    const app = await buildApp({ prisma: prismaMock });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/users?orgId=org-1",
+    });
+
+    assert.equal(response.statusCode, 401);
+    await app.close();
+  });
+
+  it("allows bypass mode with dev headers", async () => {
+    process.env.AUTH_BYPASS = "true";
+    const prismaMock = createPrismaMock();
+    const app = await buildApp({ prisma: prismaMock });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/users?orgId=org-1",
+      headers: {
+        "x-dev-user": "user-1",
+        "x-dev-org": "org-1",
+        "x-dev-roles": "admin",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    await app.close();
+  });
+
+  it("forbids access when org scope mismatches", async () => {
+    const prismaMock = createPrismaMock();
+    const token = createToken({ sub: "user-1", orgId: "org-1", roles: ["member"] });
+    const app = await buildApp({ prisma: prismaMock });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/bank-lines?orgId=org-2",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    await app.close();
+  });
+
+  it("allows access when org scope matches", async () => {
+    const prismaMock = createPrismaMock();
+    const token = createToken({ sub: "user-1", orgId: "org-1", roles: ["member"] });
+    const app = await buildApp({ prisma: prismaMock });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/bank-lines?orgId=org-1",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add bearer auth plugin with optional bypass headers and role enforcement
- enforce org scoped access for protected routes in the API gateway
- add node:test coverage for bypass mode, auth failures, and org scope checks

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f3bfdde0f883278a204902bf144a41