### PR TITLE
Add security hardening plugin to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/security.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -8,12 +8,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import securityPlugin from "./plugins/security.js";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(securityPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,103 @@
+import cors from "@fastify/cors";
+import type { FastifyPluginAsync } from "fastify";
+
+const DEV_DEFAULT_ORIGINS = ["http://localhost:3000"];
+
+const parseCsvList = (value?: string): string[] =>
+  value
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean) ?? [];
+
+const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return fallback;
+};
+
+const securityPlugin: FastifyPluginAsync = async (fastify) => {
+  const env = process.env.NODE_ENV ?? "development";
+  let allowedOrigins = parseCsvList(process.env.ALLOWED_ORIGINS);
+
+  if (env === "production" && allowedOrigins.length === 0) {
+    throw new Error("ALLOWED_ORIGINS must be provided in production");
+  }
+
+  if (allowedOrigins.length === 0) {
+    allowedOrigins = DEV_DEFAULT_ORIGINS;
+  }
+
+  const allowList = new Set(allowedOrigins);
+
+  const maxRequestsPerMinute = parsePositiveInteger(process.env.RATE_LIMIT_RPM, 100);
+  const timeWindowMs = 60_000;
+  const buckets = new Map<string, { count: number; resetAt: number }>();
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const originHeader = request.headers.origin;
+    if (originHeader && !allowList.has(originHeader)) {
+      await reply.code(403).send({ error: "forbidden_origin" });
+      return reply;
+    }
+
+    if (maxRequestsPerMinute <= 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const ip = request.ip || request.socket.remoteAddress || "unknown";
+    const bucket = buckets.get(ip);
+
+    if (!bucket || bucket.resetAt <= now) {
+      buckets.set(ip, { count: 1, resetAt: now + timeWindowMs });
+      return;
+    }
+
+    bucket.count += 1;
+    if (bucket.count > maxRequestsPerMinute) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      reply.header("retry-after", retryAfterSeconds);
+      await reply.code(429).send({ error: "rate_limit_exceeded" });
+      return reply;
+    }
+  });
+
+  fastify.addHook("onClose", () => {
+    buckets.clear();
+  });
+
+  await fastify.register(cors, {
+    origin(origin, cb) {
+      if (!origin) {
+        cb(null, true);
+        return;
+      }
+
+      if (allowList.has(origin)) {
+        cb(null, true);
+        return;
+      }
+
+      const error = new Error("Origin not allowed");
+      (error as Error & { statusCode?: number }).statusCode = 403;
+      cb(error);
+    },
+  });
+
+  const bodyLimit = parsePositiveInteger(process.env.BODY_LIMIT_BYTES, 512 * 1024);
+
+  fastify.removeContentTypeParser("application/json");
+  fastify.removeContentTypeParser("application/json; charset=utf-8");
+
+  fastify.addContentTypeParser(
+    /^application\/(.+\+)?json$/,
+    { parseAs: "string", bodyLimit },
+    fastify.getDefaultJsonParser("error", "ignore"),
+  );
+};
+
+(securityPlugin as Record<string | symbol, unknown>)[Symbol.for("skip-override")] = true;
+
+export default securityPlugin;

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import securityPlugin from "../src/plugins/security.js";
+
+type EnvOverrides = Record<string, string | undefined>;
+
+const withEnv = (overrides: EnvOverrides) => {
+  const previous = new Map<string, string | undefined>();
+
+  for (const [key, value] of Object.entries(overrides)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  return () => {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+};
+
+test("Preflight from disallowed origin fails", async (t) => {
+  const restoreEnv = withEnv({ NODE_ENV: "development", ALLOWED_ORIGINS: "" });
+  t.after(restoreEnv);
+
+  const app = Fastify({ logger: false });
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.register(securityPlugin);
+  app.options("/resource", async () => ({ ok: true }));
+  await app.ready();
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/resource",
+    headers: {
+      origin: "https://malicious.example",
+      "access-control-request-method": "POST",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+});
+
+test("Exceeding the configured RPM returns 429", async (t) => {
+  const restoreEnv = withEnv({ NODE_ENV: "development", ALLOWED_ORIGINS: "", RATE_LIMIT_RPM: "2" });
+  t.after(restoreEnv);
+
+  const app = Fastify({ logger: false });
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.register(securityPlugin);
+  app.get("/limited", async () => ({ ok: true }));
+  await app.ready();
+
+  const first = await app.inject({ method: "GET", url: "/limited" });
+  const second = await app.inject({ method: "GET", url: "/limited" });
+  const third = await app.inject({ method: "GET", url: "/limited" });
+
+  assert.equal(first.statusCode, 200);
+  assert.equal(second.statusCode, 200);
+  assert.equal(third.statusCode, 429);
+});
+
+test("Requests exceeding the body limit return 413", async (t) => {
+  const restoreEnv = withEnv({
+    NODE_ENV: "development",
+    ALLOWED_ORIGINS: "",
+    BODY_LIMIT_BYTES: "32",
+  });
+  t.after(restoreEnv);
+
+  const app = Fastify({ logger: false });
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.register(securityPlugin);
+  app.post("/body", async () => ({ ok: true }));
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/body",
+    headers: { "content-type": "application/json" },
+    payload: JSON.stringify({ message: "x".repeat(64) }),
+  });
+
+  assert.equal(response.statusCode, 413);
+});


### PR DESCRIPTION
## Summary
- add a Fastify security plugin that enforces an allow-listed CORS policy, rate limits, and request body caps based on environment variables
- wire the plugin into the API gateway server and expose a package script for running the new tests
- cover the new behavior with integration-style tests for origin blocking, rate limiting, and payload limits

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f3bfe6dc508327bd183fa0ec1cb15c