### PR TITLE
feat: add response schema validation to api gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/schemas.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,186 @@
+import Fastify, { FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import type { PrismaClient } from "@prisma/client";
+import replySchemaPlugin from "./plugins/reply-schema";
+import { listUsersResponseSchema, type ListUsersResponse } from "./schemas/users";
+import {
+  listBankLinesResponseSchema,
+  createBankLineResponseSchema,
+  createBankLineRequestSchema,
+  type ListBankLinesResponse,
+  type CreateBankLineResponse,
+  type CreateBankLineRequest,
+} from "./schemas/bank-lines";
+import { healthResponseSchema, type HealthResponse } from "./schemas/dashboard";
+
+type PrismaLike = Pick<PrismaClient, "user" | "bankLine">;
+
+let cachedPrisma: PrismaLike | null = null;
+
+async function resolvePrisma(): Promise<PrismaLike> {
+  if (!cachedPrisma) {
+    const module = await import("@apgms/shared/src/db");
+    cachedPrisma = module.prisma;
+  }
+  return cachedPrisma;
+}
+
+export interface BuildAppOptions {
+  prismaClient?: PrismaLike;
+  logger?: boolean;
+}
+
+const defaultOptions: Required<Omit<BuildAppOptions, "prismaClient">> = {
+  logger: true,
+};
+
+function toISOString(value: Date | string): string {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return new Date(value).toISOString();
+}
+
+function toAmountCents(value: unknown): number {
+  let numeric: number | null = null;
+
+  if (value && typeof value === "object") {
+    if ("toNumber" in value && typeof (value as any).toNumber === "function") {
+      numeric = (value as any).toNumber();
+    } else if ("toJSON" in value && typeof (value as any).toJSON === "function") {
+      const jsonValue = (value as any).toJSON();
+      if (typeof jsonValue === "number") {
+        numeric = jsonValue;
+      } else if (typeof jsonValue === "string") {
+        const parsed = Number(jsonValue);
+        if (Number.isFinite(parsed)) {
+          numeric = parsed;
+        }
+      }
+    }
+  }
+
+  if (numeric === null) {
+    if (typeof value === "number") {
+      numeric = value;
+    } else if (typeof value === "bigint") {
+      numeric = Number(value);
+    } else if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        numeric = parsed;
+      }
+    }
+  }
+
+  if (!Number.isFinite(numeric)) {
+    throw new TypeError("Unable to convert amount to cents");
+  }
+
+  return Math.trunc(numeric as number);
+}
+
+export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
+  const { logger } = { ...defaultOptions, ...options };
+  const prisma = options.prismaClient ?? (await resolvePrisma());
+
+  const app = Fastify({ logger });
+
+  await app.register(cors, { origin: true });
+  await app.register(replySchemaPlugin);
+
+  app.get("/health", async (_req, reply) => {
+    const payload: HealthResponse = { ok: true, service: "api-gateway" };
+    reply.withSchema(healthResponseSchema, payload);
+    return reply;
+  });
+
+  app.get("/users", async (_req, reply) => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const payload: ListUsersResponse = {
+      users: users.map((user) => ({
+        email: user.email,
+        orgId: user.orgId,
+        createdAt: toISOString(user.createdAt),
+      })),
+    };
+
+    reply.withSchema(listUsersResponseSchema, payload);
+    return reply;
+  });
+
+  app.get("/bank-lines", async (req, reply) => {
+    const query = req.query as { take?: number | string } | undefined;
+    const takeRaw = query?.take ?? 20;
+    const parsedTake = Number(takeRaw);
+    const safeTake = Number.isFinite(parsedTake) ? parsedTake : 20;
+    const take = Math.min(Math.max(Math.trunc(safeTake), 1), 200);
+
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    const payload: ListBankLinesResponse = {
+      lines: lines.map((line) => ({
+        id: line.id,
+        orgId: line.orgId,
+        date: toISOString(line.date),
+        amountCents: toAmountCents((line as any).amount ?? (line as never)),
+        payee: line.payee,
+        desc: line.desc,
+        createdAt: toISOString(line.createdAt),
+      })),
+    };
+
+    reply.withSchema(listBankLinesResponseSchema, payload);
+    return reply;
+  });
+
+  app.post("/bank-lines", async (req, reply) => {
+    const parseResult = createBankLineRequestSchema.safeParse(req.body);
+
+    if (!parseResult.success) {
+      req.log.error({ err: parseResult.error }, "invalid create bank line payload");
+      return reply.code(400).send({ error: "bad_request" });
+    }
+
+    const body: CreateBankLineRequest = parseResult.data;
+
+    try {
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amountCents,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      const payload: CreateBankLineResponse = {
+        id: created.id,
+        orgId: created.orgId,
+        date: toISOString(created.date),
+        amountCents: toAmountCents((created as any).amount ?? (created as never)),
+        payee: created.payee,
+        desc: created.desc,
+        createdAt: toISOString(created.createdAt),
+      };
+
+      reply.code(201);
+      reply.withSchema(createBankLineResponseSchema, payload);
+      return reply;
+    } catch (e) {
+      req.log.error({ err: e }, "failed to create bank line");
+      return reply.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  return app;
+}
+

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,71 +1,16 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { buildApp } from "./app";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+const app = await buildApp();
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
@@ -73,8 +18,9 @@ app.ready(() => {
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/src/plugins/reply-schema.ts
+++ b/apgms/services/api-gateway/src/plugins/reply-schema.ts
@@ -1,0 +1,39 @@
+import { FastifyPluginAsync, FastifyReply } from "fastify";
+import { ZodSchema } from "zod";
+
+const replySchemaPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateReply("withSchema", function withSchema<T>(
+    this: FastifyReply,
+    schema: ZodSchema<T>,
+    payload: unknown,
+  ): T {
+    const isProd = (process.env.NODE_ENV ?? "development") === "production" && process.env.CI !== "true";
+
+    if (!isProd) {
+      const parsed = schema.parse(payload);
+      this.send(parsed);
+      return parsed;
+    }
+
+    const result = schema.safeParse(payload);
+    if (!result.success) {
+      this.log.error({ err: result.error, payload }, "reply schema validation failed");
+      this.send(payload as T);
+      return payload as T;
+    }
+
+    this.send(result.data);
+    return result.data;
+  });
+};
+
+(replySchemaPlugin as any)[Symbol.for("skip-override")] = true;
+(replySchemaPlugin as any)[Symbol.for("fastify.display-name")] = "reply-schema";
+
+export default replySchemaPlugin;
+
+declare module "fastify" {
+  interface FastifyReply {
+    withSchema<T>(schema: ZodSchema<T>, payload: unknown): T;
+  }
+}

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { cuid, isoDate, moneyCents } from "./common";
+
+export const bankLineSchema = z.object({
+  id: cuid,
+  orgId: cuid,
+  date: isoDate,
+  amountCents: moneyCents,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+  createdAt: isoDate,
+});
+
+export const listBankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+export const createBankLineRequestSchema = z.object({
+  orgId: cuid,
+  date: isoDate,
+  amountCents: moneyCents,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const createBankLineResponseSchema = bankLineSchema;
+
+export type BankLine = z.infer<typeof bankLineSchema>;
+export type ListBankLinesResponse = z.infer<typeof listBankLinesResponseSchema>;
+export type CreateBankLineRequest = z.infer<typeof createBankLineRequestSchema>;
+export type CreateBankLineResponse = z.infer<typeof createBankLineResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const email = z.string().email();
+export const cuid = z.string().regex(/^c[0-9a-z]{24}$/i, "Invalid cuid");
+export const isoDate = z.string().datetime({ offset: true });
+export const moneyCents = z.number().int().nonnegative();

--- a/apgms/services/api-gateway/src/schemas/dashboard.ts
+++ b/apgms/services/api-gateway/src/schemas/dashboard.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const healthResponseSchema = z.object({
+  ok: z.literal(true),
+  service: z.literal("api-gateway"),
+});
+
+export type HealthResponse = z.infer<typeof healthResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/users.ts
+++ b/apgms/services/api-gateway/src/schemas/users.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { cuid, email, isoDate } from "./common";
+
+export const userSummarySchema = z.object({
+  email,
+  orgId: cuid,
+  createdAt: isoDate,
+});
+
+export const listUsersResponseSchema = z.object({
+  users: z.array(userSummarySchema),
+});
+
+export type UserSummary = z.infer<typeof userSummarySchema>;
+export type ListUsersResponse = z.infer<typeof listUsersResponseSchema>;

--- a/apgms/services/api-gateway/test/schemas.spec.ts
+++ b/apgms/services/api-gateway/test/schemas.spec.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import { z } from "zod";
+import replySchemaPlugin from "../src/plugins/reply-schema";
+import { buildApp } from "../src/app";
+import { healthResponseSchema } from "../src/schemas/dashboard";
+import { listUsersResponseSchema } from "../src/schemas/users";
+import {
+  listBankLinesResponseSchema,
+  createBankLineResponseSchema,
+  createBankLineRequestSchema,
+} from "../src/schemas/bank-lines";
+
+process.env.NODE_ENV = "test";
+
+const ORG_ID = "c123456789012345678901234";
+const BANK_LINE_ID = "caaaaaaaaaaaaaaaaaaaaaaaa";
+const SECOND_BANK_LINE_ID = "cbbbbbbbbbbbbbbbbbbbbbbbb";
+const CREATED_BANK_LINE_ID = "ccccccccccccccccccccccccc";
+
+const stubUsers = [
+  {
+    email: "user@example.com",
+    orgId: ORG_ID,
+    createdAt: new Date("2024-01-02T10:00:00.000Z"),
+  },
+  {
+    email: "another@example.com",
+    orgId: ORG_ID,
+    createdAt: new Date("2024-01-01T09:00:00.000Z"),
+  },
+];
+
+function buildPrismaStub() {
+  const bankLines = [
+    {
+      id: BANK_LINE_ID,
+      orgId: ORG_ID,
+      date: new Date("2024-01-03T12:00:00.000Z"),
+      amount: 25000,
+      payee: "Acme Corp",
+      desc: "Subscription",
+      createdAt: new Date("2024-01-03T13:00:00.000Z"),
+    },
+    {
+      id: SECOND_BANK_LINE_ID,
+      orgId: ORG_ID,
+      date: new Date("2024-01-02T12:00:00.000Z"),
+      amount: 5000,
+      payee: "Globex",
+      desc: "Consulting",
+      createdAt: new Date("2024-01-02T13:00:00.000Z"),
+    },
+  ];
+
+  return {
+    prisma: {
+      user: {
+        async findMany() {
+          return stubUsers;
+        },
+      },
+      bankLine: {
+        async findMany(args: { take?: number }) {
+          const take = args?.take ?? bankLines.length;
+          return bankLines.slice(0, take);
+        },
+        async create({ data }: { data: { orgId: string; date: Date; amount: number; payee: string; desc: string } }) {
+          const createdAt = new Date("2024-01-04T13:00:00.000Z");
+          const created = {
+            id: CREATED_BANK_LINE_ID,
+            orgId: data.orgId,
+            date: data.date,
+            amount: data.amount,
+            payee: data.payee,
+            desc: data.desc,
+            createdAt,
+          };
+          bankLines.unshift(created);
+          return created;
+        },
+      },
+    },
+    bankLines,
+  };
+}
+
+test("reply.withSchema throws on invalid payloads in development", async () => {
+  const app = Fastify({ logger: false });
+  await app.register(replySchemaPlugin);
+
+  app.get("/bad", async (_req, reply) => {
+    reply.withSchema(z.object({ ok: z.literal(true) }), { ok: false });
+  });
+
+  const response = await app.inject({ method: "GET", url: "/bad" });
+  assert.equal(response.statusCode, 500);
+  await app.close();
+});
+
+test("GET /health conforms to schema", async () => {
+  const { prisma } = buildPrismaStub();
+  const app = await buildApp({ prismaClient: prisma, logger: false });
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.statusCode, 200);
+  const parsed = healthResponseSchema.parse(response.json());
+  assert.deepEqual(parsed, { ok: true, service: "api-gateway" });
+
+  await app.close();
+});
+
+test("GET /users validates response", async () => {
+  const { prisma } = buildPrismaStub();
+  const app = await buildApp({ prismaClient: prisma, logger: false });
+
+  const response = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(response.statusCode, 200);
+  const parsed = listUsersResponseSchema.parse(response.json());
+  assert.equal(parsed.users.length, stubUsers.length);
+  assert.deepEqual(parsed.users[0], {
+    email: "user@example.com",
+    orgId: ORG_ID,
+    createdAt: stubUsers[0].createdAt.toISOString(),
+  });
+
+  await app.close();
+});
+
+test("GET /bank-lines validates list response", async () => {
+  const { prisma, bankLines } = buildPrismaStub();
+  const app = await buildApp({ prismaClient: prisma, logger: false });
+
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(response.statusCode, 200);
+  const parsed = listBankLinesResponseSchema.parse(response.json());
+  assert.equal(parsed.lines.length, bankLines.length);
+  assert.deepEqual(parsed.lines[0], {
+    id: BANK_LINE_ID,
+    orgId: ORG_ID,
+    date: bankLines[0].date.toISOString(),
+    amountCents: bankLines[0].amount,
+    payee: bankLines[0].payee,
+    desc: bankLines[0].desc,
+    createdAt: bankLines[0].createdAt.toISOString(),
+  });
+
+  await app.close();
+});
+
+test("POST /bank-lines validates response payload", async () => {
+  const { prisma } = buildPrismaStub();
+  const app = await buildApp({ prismaClient: prisma, logger: false });
+
+  const requestBody = {
+    orgId: ORG_ID,
+    date: new Date("2024-01-05T12:00:00.000Z").toISOString(),
+    amountCents: 1234,
+    payee: "Example",
+    desc: "Invoice",
+  } satisfies z.infer<typeof createBankLineRequestSchema>;
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: requestBody,
+  });
+
+  assert.equal(response.statusCode, 201);
+  const parsed = createBankLineResponseSchema.parse(response.json());
+  assert.equal(parsed.id, CREATED_BANK_LINE_ID);
+  assert.equal(parsed.amountCents, requestBody.amountCents);
+
+  await app.close();
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add a Fastify app builder that centralises route registration and schema-aware responses
- implement a reply.withSchema helper to validate payloads with Zod across environments
- define shared schemas and tests to cover user, bank line, and health responses

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f3bfef9a4c8327a5566018d6e0901b