### PR TITLE
Add observability endpoints and graceful shutdown

### DIFF
--- a/apgms/docs/ops/runbook.md
+++ b/apgms/docs/ops/runbook.md
@@ -1,1 +1,65 @@
-﻿# Ops runbook
+# Ops runbook
+
+## On-call checklist
+
+- Confirm pager contactability in PagerDuty before a scheduled rotation.
+- Ensure access to production Kubernetes cluster and logging backends (Loki/Grafana or Cloud Logging).
+- Verify OTEL collector endpoint availability; if telemetry is disabled the service still functions but traces will be absent.
+
+## 1. Detection and triage
+
+1. **Alerts** – primary alerts originate from:
+   - Kubernetes readiness probe failures on `/readyz` (Pod transitions to `Unready`).
+   - Synthetic API checks reporting latency or error-rate regressions.
+   - Database connectivity alarms raised by Prisma error logs.
+2. **Immediate actions** – acknowledge the alert, open a shared incident document, and capture current timestamp.
+3. **Status** – post a preliminary incident note in `#on-call` and external status pages if customer-facing impact is confirmed.
+
+## 2. Diagnosis
+
+1. **Service health** – run:
+   ```sh
+   kubectl get pods -l app=api-gateway
+   kubectl describe pod <pod-name>
+   ```
+   Focus on readiness probe history and recent restarts.
+2. **Health endpoints** – from a bastion or port-forwarded terminal execute:
+   ```sh
+   curl -sf http://<pod-ip>:3000/healthz
+   curl -sf http://<pod-ip>:3000/readyz || echo "not ready"
+   ```
+   - `healthz` returning 200 indicates the process is alive.
+   - `readyz` returning 503 usually signals database connectivity issues or an in-progress shutdown.
+3. **Logs** – query centralized logging for the request ID referenced by probes:
+   - Structured logs now include `req_id`, `latency_ms`, and (when tracing is enabled) `trace_id`/`span_id` fields.
+   - Use filters such as `json.service="api-gateway" json.req_id="<value>"`.
+4. **Telemetry** – if OTEL is configured, open the tracing backend and search for `service.name = api-gateway` spans using the `trace_id` from logs.
+5. **Database** – check connectivity:
+   ```sh
+   pnpm --filter @apgms/api-gateway exec npx prisma db execute --stdin <<'SQL'
+   SELECT 1;
+   SQL
+   ```
+   Failures confirm a database outage blocking readiness.
+
+## 3. Mitigation
+
+1. **Roll pods** – when pods are wedged, drain gracefully:
+   ```sh
+   kubectl rollout restart deployment/api-gateway
+   ```
+   The deployment uses `/readyz` for readiness and a `preStop` hook plus 45s termination grace to honour the graceful shutdown handler.
+2. **Database outage** – coordinate with the database team; do not restart pods repeatedly. Once connectivity is restored pods will transition to Ready automatically.
+3. **Hotfix** – if application regression is suspected, use blue/green deployment by overriding `api_gateway_image` in Terraform and reapplying.
+
+## 4. Post-incident
+
+1. Capture a timeline with request IDs, trace IDs, and user impact.
+2. File a retrospective ticket within 24 hours with action items.
+3. Update this runbook if additional mitigation steps were required.
+
+## References
+
+- Deployment manifest: `infra/dev/kubernetes/api-gateway-deployment.yaml`
+- Terraform definition: `infra/iac/main.tf`
+- Telemetry configuration: environment variable `OTEL_EXPORTER_OTLP_ENDPOINT`

--- a/apgms/infra/dev/kubernetes/api-gateway-deployment.yaml
+++ b/apgms/infra/dev/kubernetes/api-gateway-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      terminationGracePeriodSeconds: 45
+      containers:
+        - name: api-gateway
+          image: ghcr.io/apgms/api-gateway:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep 5

--- a/apgms/infra/iac/main.tf
+++ b/apgms/infra/iac/main.tf
@@ -1,1 +1,75 @@
-﻿# terraform root
+resource "kubernetes_deployment" "api_gateway" {
+  metadata {
+    name = "api-gateway"
+    labels = {
+      app = "api-gateway"
+    }
+  }
+
+  spec {
+    replicas = 2
+
+    selector {
+      match_labels = {
+        app = "api-gateway"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "api-gateway"
+        }
+      }
+
+      spec {
+        termination_grace_period_seconds = 45
+
+        container {
+          name  = "api-gateway"
+          image = var.api_gateway_image
+
+          port {
+            name           = "http"
+            container_port = 3000
+          }
+
+          env {
+            name  = "PORT"
+            value = "3000"
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 5
+            period_seconds        = 5
+            timeout_seconds       = 2
+
+            http_get {
+              path = "/readyz"
+              port = 3000
+            }
+          }
+
+          liveness_probe {
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 2
+
+            http_get {
+              path = "/healthz"
+              port = 3000
+            }
+          }
+
+          lifecycle {
+            pre_stop {
+              exec {
+                command = ["/bin/sh", "-c", "sleep 5"]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apgms/infra/iac/outputs.tf
+++ b/apgms/infra/iac/outputs.tf
@@ -1,1 +1,7 @@
-﻿
+output "api_gateway_probe_paths" {
+  description = "HTTP paths used for Kubernetes probes"
+  value = {
+    readiness = "/readyz"
+    liveness  = "/healthz"
+  }
+}

--- a/apgms/infra/iac/variables.tf
+++ b/apgms/infra/iac/variables.tf
@@ -1,1 +1,5 @@
-﻿
+variable "api_gateway_image" {
+  description = "Container image for the API gateway deployment"
+  type        = string
+  default     = "ghcr.io/apgms/api-gateway:latest"
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,5 @@
-﻿import path from "node:path";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,20 +8,91 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import Fastify from "fastify";
+import {
+  childLogger,
+  createServiceLogger,
+  getActiveTraceContext,
+  prisma,
+  shutdownTelemetry,
+  startTelemetry,
+} from "../../../shared/src";
 
-const app = Fastify({ logger: true });
+const baseLogger = createServiceLogger("api-gateway");
+
+const telemetry = await startTelemetry({ serviceName: "api-gateway" }, baseLogger);
+
+try {
+  await prisma.$connect();
+  baseLogger.info("database connected");
+} catch (err) {
+  baseLogger.error({ err }, "failed to connect to database");
+  await shutdownTelemetry(telemetry, baseLogger);
+  process.exit(1);
+}
+
+let shuttingDown = false;
+let serverReady = false;
+
+const app = Fastify({
+  logger: baseLogger,
+  disableRequestLogging: true,
+  genReqId: (req) => req.headers["x-request-id"]?.toString() ?? randomUUID(),
+  requestIdHeader: "x-request-id",
+  requestIdLogLabel: "req_id",
+});
 
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.addHook("onRequest", async (req, reply) => {
+  reply.header("x-request-id", req.id);
+  (req as any).startTime = process.hrtime.bigint();
+});
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+app.addHook("onResponse", async (req, reply) => {
+  const start = (req as any).startTime as bigint | undefined;
+  const durationNs = start ? process.hrtime.bigint() - start : undefined;
+  const latencyMs = durationNs ? Number(durationNs) / 1_000_000 : undefined;
+  const traceContext = getActiveTraceContext();
 
-// List users (email + org)
+  const requestLogger = childLogger(req.log, {
+    method: req.method,
+    url: req.url,
+    statusCode: reply.statusCode,
+    latency_ms: latencyMs,
+    trace_id: traceContext?.traceId,
+    span_id: traceContext?.spanId,
+  });
+  requestLogger.info("request completed");
+});
+
+app.setErrorHandler((error, request, reply) => {
+  const traceContext = getActiveTraceContext();
+  const errorLogger = childLogger(request.log, {
+    trace_id: traceContext?.traceId,
+    span_id: traceContext?.spanId,
+  });
+  errorLogger.error({ err: error }, "request failed");
+  const statusCode = "statusCode" in error && typeof error.statusCode === "number" ? error.statusCode : 500;
+  reply.status(statusCode).send({ error: "internal_server_error" });
+});
+
+app.get("/healthz", async () => ({ status: "ok", service: "api-gateway" }));
+
+app.get("/readyz", async (req, reply) => {
+  if (!serverReady || shuttingDown) {
+    return reply.status(503).send({ status: "starting" });
+  }
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return { status: "ok" };
+  } catch (err) {
+    req.log.error({ err }, "readiness check failed");
+    return reply.status(503).send({ status: "db_unavailable" });
+  }
+});
+
 app.get("/users", async () => {
   const users = await prisma.user.findMany({
     select: { email: true, orgId: true, createdAt: true },
@@ -29,7 +101,6 @@ app.get("/users", async () => {
   return { users };
 });
 
-// List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
   const take = Number((req.query as any).take ?? 20);
   const lines = await prisma.bankLine.findMany({
@@ -39,7 +110,6 @@ app.get("/bank-lines", async (req) => {
   return { lines };
 });
 
-// Create a bank line
 app.post("/bank-lines", async (req, rep) => {
   try {
     const body = req.body as {
@@ -60,21 +130,56 @@ app.post("/bank-lines", async (req, rep) => {
     });
     return rep.code(201).send(created);
   } catch (e) {
-    req.log.error(e);
+    req.log.error({ err: e }, "failed to create bank line");
     return rep.code(400).send({ error: "bad_request" });
   }
 });
 
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
-  app.log.info(app.printRoutes());
+  app.log.info({ routes: app.printRoutes() }, "routes registered");
 });
+
+async function shutdown(signal: NodeJS.Signals) {
+  if (shuttingDown) {
+    return;
+  }
+  shuttingDown = true;
+  serverReady = false;
+  baseLogger.info({ signal }, "received shutdown signal");
+  try {
+    await app.close();
+    baseLogger.info("fastify server closed");
+  } catch (err) {
+    baseLogger.error({ err }, "failed to close fastify");
+  }
+  try {
+    await prisma.$disconnect();
+    baseLogger.info("prisma disconnected");
+  } catch (err) {
+    baseLogger.error({ err }, "failed to disconnect prisma");
+  }
+  await shutdownTelemetry(telemetry, baseLogger);
+  baseLogger.info("shutdown complete");
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
+try {
+  await app.listen({ port, host });
+  serverReady = true;
+  baseLogger.info({ port, host }, "api-gateway listening");
+} catch (err) {
+  baseLogger.error({ err }, "failed to start server");
+  try {
+    await prisma.$disconnect();
+  } catch (disconnectErr) {
+    baseLogger.error({ err: disconnectErr }, "failed to disconnect prisma during startup");
+  }
+  await shutdownTelemetry(telemetry, baseLogger);
   process.exit(1);
-});
-
+}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,7 +8,14 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.53.1",
+    "@opentelemetry/resources": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "@opentelemetry/semantic-conventions": "^1.26.0",
+    "@prisma/client": "6.17.1",
+    "pino": "^9.5.0"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,25 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { Prisma, PrismaClient } from "@prisma/client";
+import type { LevelWithSilent } from "pino";
+import { createServiceLogger } from "./logger";
+
+const prismaLogLevel = ((process.env.PRISMA_LOG_LEVEL ?? process.env.LOG_LEVEL) ?? "info") as LevelWithSilent;
+
+const prismaLogger = createServiceLogger("prisma", {
+  level: prismaLogLevel,
+});
+
+export const prisma = new PrismaClient({
+  log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+});
+
+prisma.$on("warn", (event: Prisma.LogEvent) => {
+  prismaLogger.warn({ target: event.target, message: event.message }, "prisma warning");
+});
+
+prisma.$on("error", (event: Prisma.LogEvent) => {
+  prismaLogger.error({ target: event.target, message: event.message }, "prisma error");
+});
+
+prisma.$on("beforeExit", () => {
+  prismaLogger.info("prisma beforeExit");
+});

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,3 @@
-﻿// shared
+export * from "./db";
+export * from "./logger";
+export * from "./telemetry";

--- a/apgms/shared/src/logger.ts
+++ b/apgms/shared/src/logger.ts
@@ -1,0 +1,30 @@
+import pino, { stdTimeFunctions, type LevelWithSilent, type Logger, type LoggerOptions } from "pino";
+
+const baseLevel = (process.env.LOG_LEVEL ?? "info") as LevelWithSilent;
+
+const defaultOptions: LoggerOptions = {
+  level: baseLevel,
+  timestamp: stdTimeFunctions.isoTime,
+  formatters: {
+    level(label: string) {
+      return { level: label };
+    },
+  },
+};
+
+export type { Logger } from "pino";
+
+export function createLogger(options: LoggerOptions = {}): Logger {
+  return pino({ ...defaultOptions, ...options, base: { ...(defaultOptions.base ?? {}), ...(options.base ?? {}) } });
+}
+
+export function createServiceLogger(serviceName: string, options: LoggerOptions = {}): Logger {
+  return createLogger({ ...options, base: { service: serviceName, ...(options.base ?? {}) } });
+}
+
+export function childLogger<T extends { child(bindings: Record<string, unknown>): T }>(
+  logger: T,
+  context: Record<string, unknown>,
+): T {
+  return logger.child(context);
+}

--- a/apgms/shared/src/telemetry.ts
+++ b/apgms/shared/src/telemetry.ts
@@ -1,0 +1,74 @@
+import { context, trace } from "@opentelemetry/api";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { Resource } from "@opentelemetry/resources";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import type { Logger } from "./logger";
+
+export interface TelemetryConfig {
+  serviceName: string;
+  otlpEndpoint?: string;
+}
+
+export type TelemetrySDK = NodeSDK;
+
+export async function startTelemetry(
+  config: TelemetryConfig,
+  logger?: Logger,
+): Promise<TelemetrySDK | undefined> {
+  const endpoint = config.otlpEndpoint ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (!endpoint) {
+    logger?.debug({ service: config.serviceName }, "telemetry disabled");
+    return undefined;
+  }
+
+  const sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: config.serviceName,
+    }),
+    traceExporter: new OTLPTraceExporter({ url: endpoint }),
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
+
+  try {
+    await sdk.start();
+    logger?.info({ endpoint }, "telemetry started");
+    return sdk;
+  } catch (err) {
+    logger?.error({ err }, "failed to start telemetry");
+    return undefined;
+  }
+}
+
+export async function shutdownTelemetry(sdk: TelemetrySDK | undefined, logger?: Logger): Promise<void> {
+  if (!sdk) {
+    return;
+  }
+  try {
+    await sdk.shutdown();
+    logger?.info("telemetry stopped");
+  } catch (err) {
+    logger?.error({ err }, "failed to shutdown telemetry");
+  }
+}
+
+export interface TraceContext {
+  traceId: string;
+  spanId: string;
+}
+
+export function getActiveTraceContext(): TraceContext | undefined {
+  const span = trace.getSpan(context.active());
+  if (!span) {
+    return undefined;
+  }
+  const spanContext = span.spanContext();
+  if (!spanContext || !spanContext.traceId || !spanContext.spanId) {
+    return undefined;
+  }
+  return {
+    traceId: spanContext.traceId,
+    spanId: spanContext.spanId,
+  };
+}


### PR DESCRIPTION
## Summary
- add `/healthz` and `/readyz` endpoints backed by Prisma checks, structured logging, and graceful shutdown handling in the API gateway
- centralize logging, Prisma instrumentation, and OpenTelemetry startup/shutdown helpers in the shared workspace
- document incident response steps and wire readiness/liveness probes plus termination behaviour into the infrastructure manifests

## Testing
- `pnpm --filter @apgms/api-gateway exec tsc --noEmit` *(fails: missing generated Prisma client and OpenTelemetry packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3c92c35ac8327b4597e6210ea63ee