### PR TITLE
Add security plugin to API gateway

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -8,12 +8,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import security from "./plugins/security";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(security);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,132 @@
+import cors from "@fastify/cors";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+const ONE_MINUTE_MS = 60_000;
+const DEFAULT_DEV_ORIGIN = "http://localhost:3000";
+
+const parsePositiveInteger = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+};
+
+const parseAllowedOrigins = (envValue: string | undefined, nodeEnv: string): string[] => {
+  if (envValue && envValue.trim().length > 0) {
+    return envValue
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0);
+  }
+
+  if (nodeEnv !== "production") {
+    return [DEFAULT_DEV_ORIGIN];
+  }
+
+  return [];
+};
+
+const isPayloadTooLarge = (request: FastifyRequest, bodyLimit: number): boolean => {
+  if (bodyLimit <= 0) {
+    return false;
+  }
+
+  const contentLengthHeader = request.headers["content-length"];
+  if (!contentLengthHeader) {
+    return false;
+  }
+
+  const length = Number.parseInt(Array.isArray(contentLengthHeader) ? contentLengthHeader[0] : contentLengthHeader, 10);
+
+  return Number.isFinite(length) && length > bodyLimit;
+};
+
+const applyRateLimit = (
+  rateLimitState: Map<string, { count: number; resetAt: number }>,
+  request: FastifyRequest,
+  limit: number,
+): boolean => {
+  if (limit <= 0) {
+    return false;
+  }
+
+  const now = Date.now();
+  const ip = request.ip;
+  const existing = rateLimitState.get(ip);
+
+  if (!existing || existing.resetAt <= now) {
+    rateLimitState.set(ip, { count: 1, resetAt: now + ONE_MINUTE_MS });
+    return false;
+  }
+
+  if (existing.count + 1 > limit) {
+    return true;
+  }
+
+  existing.count += 1;
+  rateLimitState.set(ip, existing);
+
+  if (rateLimitState.size > 1000) {
+    for (const [key, value] of rateLimitState) {
+      if (value.resetAt <= now) {
+        rateLimitState.delete(key);
+      }
+    }
+  }
+
+  return false;
+};
+
+const denyRequest = (reply: FastifyReply, statusCode: number, error: string) => {
+  return reply.code(statusCode).send({ error });
+};
+
+const security = async (app: FastifyInstance) => {
+  const nodeEnv = process.env.NODE_ENV ?? "development";
+  const allowedOrigins = parseAllowedOrigins(process.env.ALLOWED_ORIGINS, nodeEnv);
+  const rateLimitRpm = parsePositiveInteger(process.env.RATE_LIMIT_RPM, 100);
+  const bodyLimitBytes = parsePositiveInteger(process.env.BODY_LIMIT_BYTES, 512 * 1024);
+  const rateLimitState = new Map<string, { count: number; resetAt: number }>();
+
+  await app.register(cors, {
+    preflight: true,
+    credentials: true,
+    origin(origin, callback) {
+      if (!origin) {
+        callback(null, true);
+        return;
+      }
+
+      if (allowedOrigins.length === 0) {
+        callback(null, false);
+        return;
+      }
+
+      const isAllowed = allowedOrigins.some((allowed) => allowed === "*" || allowed === origin);
+      callback(null, isAllowed);
+    },
+  });
+
+  app.addHook("onRequest", async (request, reply) => {
+    if (isPayloadTooLarge(request, bodyLimitBytes)) {
+      return denyRequest(reply, 413, "payload_too_large");
+    }
+
+    if (applyRateLimit(rateLimitState, request, rateLimitRpm)) {
+      return denyRequest(reply, 429, "rate_limit_exceeded");
+    }
+
+    return undefined;
+  });
+
+  app.addHook("onClose", () => {
+    rateLimitState.clear();
+  });
+};
+
+(security as any)[Symbol.for("skip-override")] = true;
+(security as any)[Symbol.for("skip-encapsulation")] = true;
+
+export default security;

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+import Fastify from "fastify";
+import security from "../src/plugins/security";
+
+const originalEnv = { ...process.env };
+
+const resetEnv = () => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+
+  Object.assign(process.env, originalEnv);
+};
+
+const buildApp = async () => {
+  const app = Fastify({ logger: false });
+  await app.register(security);
+  app.get("/ping", async () => ({ ok: true }));
+  app.post("/echo", async (request) => request.body);
+  await app.ready();
+  return app;
+};
+
+beforeEach(() => {
+  resetEnv();
+});
+
+test("CORS preflight from disallowed origin is blocked", async (t) => {
+  process.env.NODE_ENV = "production";
+  process.env.ALLOWED_ORIGINS = "https://allowed.example";
+
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/ping",
+    headers: {
+      origin: "https://evil.example",
+      "access-control-request-method": "GET",
+    },
+  });
+
+  assert.ok(response.statusCode >= 400);
+  assert.equal(response.headers["access-control-allow-origin"], undefined);
+});
+
+test("requests beyond the configured limit receive 429", async (t) => {
+  process.env.RATE_LIMIT_RPM = "2";
+
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const first = await app.inject({ method: "GET", url: "/ping" });
+  const second = await app.inject({ method: "GET", url: "/ping" });
+  const third = await app.inject({ method: "GET", url: "/ping" });
+
+  assert.equal(first.statusCode, 200);
+  assert.equal(second.statusCode, 200);
+  assert.equal(third.statusCode, 429);
+  assert.deepEqual(JSON.parse(third.payload), { error: "rate_limit_exceeded" });
+});
+
+test("payloads larger than the configured limit receive 413", async (t) => {
+  process.env.BODY_LIMIT_BYTES = "10";
+
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/echo",
+    payload: "a".repeat(32),
+    headers: { "content-type": "text/plain" },
+  });
+
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(JSON.parse(response.payload), { error: "payload_too_large" });
+});


### PR DESCRIPTION
## Summary
- add a security plugin that enforces CORS allowlists, per-IP rate limiting, and payload size limits based on environment configuration
- register the security plugin before API routes so protections apply globally
- add end-to-end tests covering CORS preflight rejection, rate limiting, and payload-size enforcement

## Testing
- pnpm exec tsx test/security.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f410898d2883279ca19c05458e46a2