### PR TITLE
Implement RPT minting and verification chain

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/*.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -19,3 +20,4 @@
     "typescript": "^5.9.3"
   }
 }
+

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,8 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import allocationsRoutes from "./routes/allocations.js";
+import auditRoutes from "./routes/audit.js";
 
 const app = Fastify({ logger: true });
 
@@ -64,6 +66,9 @@ app.post("/bank-lines", async (req, rep) => {
     return rep.code(400).send({ error: "bad_request" });
   }
 });
+
+await app.register(allocationsRoutes);
+await app.register(auditRoutes);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/lib/kmsLike.ts
+++ b/apgms/services/api-gateway/src/lib/kmsLike.ts
@@ -1,0 +1,46 @@
+import { generateKeyPairSync, sign as edSign, verify as edVerify } from "node:crypto";
+
+export type KmsLikeBytes = Uint8Array | Buffer | string;
+
+const kmsLike = (() => {
+  let keyPair: ReturnType<typeof generateKeyPairSync> | null = null;
+
+  const getKeyPair = () => {
+    if (!keyPair) {
+      keyPair = generateKeyPairSync("ed25519");
+    }
+    return keyPair;
+  };
+
+  const toBuffer = (value: KmsLikeBytes | Buffer): Buffer => {
+    if (typeof value === "string") {
+      return Buffer.from(value, "utf-8");
+    }
+    if (Buffer.isBuffer(value)) {
+      return value;
+    }
+    return Buffer.from(value);
+  };
+
+  return {
+    sign(data: KmsLikeBytes): string {
+      const { privateKey } = getKeyPair();
+      const buffer = toBuffer(data);
+      return edSign(null, buffer, privateKey).toString("base64");
+    },
+    verify(data: KmsLikeBytes, signature: string | Uint8Array | Buffer): boolean {
+      const { publicKey } = getKeyPair();
+      const buffer = toBuffer(data);
+      const signatureBuffer = typeof signature === "string" ? Buffer.from(signature, "base64") : toBuffer(signature);
+      return edVerify(null, buffer, publicKey, signatureBuffer);
+    },
+    pubkey(): string {
+      const { publicKey } = getKeyPair();
+      return publicKey.export({ format: "der", type: "spki" }).toString("base64");
+    },
+  };
+})();
+
+export type KmsLike = typeof kmsLike;
+
+export { kmsLike };

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,288 @@
+import { createHash, randomUUID } from "node:crypto";
+import { kmsLike } from "./kmsLike.js";
+
+export type RptAllocation = {
+  allocationId: string;
+  amountCents: number;
+  memo?: string;
+};
+
+export type RptToken = {
+  rptId: string;
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: RptAllocation[];
+  prevHash: string | null;
+  sig: string;
+  timestamp: string;
+};
+
+export type MintRptInput = {
+  rptId: string;
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: RptAllocation[];
+  prevHash?: string | null;
+  timestamp?: string;
+};
+
+export type MintedRpt = {
+  token: RptToken;
+  hash: string;
+  canonical: string;
+};
+
+export type VerifyRptResult = {
+  ok: boolean;
+  hash: string;
+  canonical: string;
+  reason?: string;
+};
+
+export type VerifyChainSuccess = {
+  ok: true;
+  verified: true;
+  length: number;
+  headHash: string;
+};
+
+export type VerifyChainFailure = {
+  ok: false;
+  verified: false;
+  reason: string;
+  rptId: string;
+  details?: Record<string, unknown>;
+};
+
+export type VerifyChainResult = VerifyChainSuccess | VerifyChainFailure;
+
+export type LedgerEntry = {
+  id: string;
+  rptId: string;
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: RptAllocation[];
+  prevHash: string | null;
+  createdAt: string;
+};
+
+const rptTokensById = new Map<string, MintedRpt>();
+const rptIdsByHash = new Map<string, string>();
+const latestRptByOrg = new Map<string, string>();
+const ledgerEntries = new Map<string, LedgerEntry>();
+
+const normalizeStructuredData = (input: unknown): unknown => {
+  if (Array.isArray(input)) {
+    return input.map((value) => normalizeStructuredData(value));
+  }
+  if (input && typeof input === "object" && Object.getPrototypeOf(input) === Object.prototype) {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(input).sort()) {
+      result[key] = normalizeStructuredData((input as Record<string, unknown>)[key]);
+    }
+    return result;
+  }
+  return input;
+};
+
+export const canonicalize = (value: unknown): string => {
+  return JSON.stringify(normalizeStructuredData(value));
+};
+
+export const hashCanonical = (value: unknown): { canonical: string; hash: string } => {
+  const canonical = canonicalize(value);
+  const digest = createHash("sha256").update(canonical).digest("hex");
+  return { canonical, hash: digest };
+};
+
+const cloneAllocations = (allocations: RptAllocation[]): RptAllocation[] => {
+  return allocations.map((allocation) => ({ ...allocation }));
+};
+
+const buildRptPayload = (input: MintRptInput, timestamp: string, prevHash: string | null) => {
+  return {
+    rptId: input.rptId,
+    orgId: input.orgId,
+    bankLineId: input.bankLineId,
+    policyHash: input.policyHash,
+    allocations: cloneAllocations(input.allocations),
+    prevHash,
+    timestamp,
+  };
+};
+
+export const mintRpt = (input: MintRptInput): MintedRpt => {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const prevHash = input.prevHash ?? null;
+  const payload = buildRptPayload(input, timestamp, prevHash);
+  const canonical = canonicalize(payload);
+  const digest = createHash("sha256").update(canonical).digest();
+  const hash = digest.toString("hex");
+  const sig = kmsLike.sign(digest);
+  const token: RptToken = {
+    ...payload,
+    sig,
+  };
+  return { token, hash, canonical };
+};
+
+export const verifyRpt = (token: RptToken): VerifyRptResult => {
+  const payload = {
+    rptId: token.rptId,
+    orgId: token.orgId,
+    bankLineId: token.bankLineId,
+    policyHash: token.policyHash,
+    allocations: cloneAllocations(token.allocations),
+    prevHash: token.prevHash ?? null,
+    timestamp: token.timestamp,
+  };
+  const canonical = canonicalize(payload);
+  const digest = createHash("sha256").update(canonical).digest();
+  const hash = digest.toString("hex");
+  const ok = kmsLike.verify(digest, token.sig);
+  if (!ok) {
+    return { ok: false, reason: "invalid_signature", hash, canonical };
+  }
+  return { ok: true, hash, canonical };
+};
+
+export const persistRpt = (minted: MintedRpt): MintedRpt => {
+  const stored = {
+    token: {
+      ...minted.token,
+      allocations: cloneAllocations(minted.token.allocations),
+      prevHash: minted.token.prevHash ?? null,
+    },
+    hash: minted.hash,
+    canonical: minted.canonical,
+  };
+  rptTokensById.set(stored.token.rptId, stored);
+  rptIdsByHash.set(stored.hash, stored.token.rptId);
+  latestRptByOrg.set(stored.token.orgId, stored.token.rptId);
+  return stored;
+};
+
+export const getRpt = (rptId: string): MintedRpt | undefined => {
+  return rptTokensById.get(rptId);
+};
+
+export const getRptByHash = (hash: string): MintedRpt | undefined => {
+  const rptId = rptIdsByHash.get(hash);
+  return rptId ? rptTokensById.get(rptId) : undefined;
+};
+
+export const getLatestRptForOrg = (orgId: string): MintedRpt | undefined => {
+  const rptId = latestRptByOrg.get(orgId);
+  return rptId ? rptTokensById.get(rptId) : undefined;
+};
+
+export const persistLedgerEntry = (entry: Omit<LedgerEntry, "id"> & { id?: string }): LedgerEntry => {
+  const id = entry.id ?? randomUUID();
+  const stored: LedgerEntry = {
+    id,
+    rptId: entry.rptId,
+    orgId: entry.orgId,
+    bankLineId: entry.bankLineId,
+    policyHash: entry.policyHash,
+    allocations: cloneAllocations(entry.allocations),
+    prevHash: entry.prevHash ?? null,
+    createdAt: entry.createdAt,
+  };
+  ledgerEntries.set(id, stored);
+  return stored;
+};
+
+export const listLedgerEntries = (): LedgerEntry[] => Array.from(ledgerEntries.values());
+
+export const verifyChain = (headRptId: string): VerifyChainResult => {
+  const visited = new Set<string>();
+  let currentId: string | undefined = headRptId;
+  let expectedHash: string | null = null;
+  let childId: string | null = null;
+  let steps = 0;
+
+  while (currentId) {
+    if (visited.has(currentId)) {
+      return {
+        ok: false,
+        verified: false,
+        reason: "cycle_detected",
+        rptId: currentId,
+      };
+    }
+    visited.add(currentId);
+    const record = rptTokensById.get(currentId);
+    if (!record) {
+      return {
+        ok: false,
+        verified: false,
+        reason: "missing_token",
+        rptId: childId ?? currentId,
+      };
+    }
+
+    const verification = verifyRpt(record.token);
+    if (!verification.ok) {
+      return {
+        ok: false,
+        verified: false,
+        reason: verification.reason ?? "invalid_signature",
+        rptId: currentId,
+      };
+    }
+
+    if (expectedHash && verification.hash !== expectedHash) {
+      return {
+        ok: false,
+        verified: false,
+        reason: "prev_hash_mismatch",
+        rptId: childId ?? currentId,
+        details: { expectedHash, actualHash: verification.hash },
+      };
+    }
+
+    steps += 1;
+
+    const prevHash = record.token.prevHash;
+    if (!prevHash) {
+      return {
+        ok: true,
+        verified: true,
+        length: steps,
+        headHash: verification.hash,
+      };
+    }
+
+    const prevId = rptIdsByHash.get(prevHash);
+    if (!prevId) {
+      return {
+        ok: false,
+        verified: false,
+        reason: "prev_hash_not_found",
+        rptId: record.token.rptId,
+        details: { missingHash: prevHash },
+      };
+    }
+
+    expectedHash = prevHash;
+    childId = record.token.rptId;
+    currentId = prevId;
+  }
+
+  return {
+    ok: false,
+    verified: false,
+    reason: "chain_incomplete",
+    rptId: headRptId,
+  };
+};
+
+export const resetRptStore = (): void => {
+  rptTokensById.clear();
+  rptIdsByHash.clear();
+  latestRptByOrg.clear();
+  ledgerEntries.clear();
+};

--- a/apgms/services/api-gateway/src/routes/allocations.ts
+++ b/apgms/services/api-gateway/src/routes/allocations.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from "node:crypto";
+import { FastifyInstance } from "fastify";
+import {
+  applyAllocationsRequestSchema,
+  applyAllocationsResponseSchema,
+  previewAllocationsRequestSchema,
+  previewAllocationsResponseSchema,
+} from "../schemas/allocations.js";
+import { hashCanonical, mintRpt, persistLedgerEntry, persistRpt, getLatestRptForOrg } from "../lib/rpt.js";
+
+const formatExplain = (orgId: string, allocationCount: number, totalCents: number): string => {
+  const dollars = (totalCents / 100).toFixed(2);
+  return `Preview for org ${orgId}: ${allocationCount} allocations totaling $${dollars}`;
+};
+
+export const allocationsRoutes = async (app: FastifyInstance) => {
+  app.post("/allocations/preview", async (request, reply) => {
+    const parsed = previewAllocationsRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ ok: false, reason: parsed.error.message });
+    }
+
+    const { orgId, bankLineId, policy, allocations } = parsed.data;
+    const { hash: policyHash } = hashCanonical({ orgId, bankLineId, policy });
+    const totalCents = allocations.reduce((acc, item) => acc + item.amountCents, 0);
+    const explain = formatExplain(orgId, allocations.length, totalCents);
+
+    return reply.send(
+      previewAllocationsResponseSchema.parse({
+        ok: true,
+        policyHash,
+        allocations,
+        explain,
+      }),
+    );
+  });
+
+  app.post("/allocations/apply", async (request, reply) => {
+    const parsed = applyAllocationsRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ ok: false, reason: parsed.error.message });
+    }
+
+    const { rptId, orgId, bankLineId, policy, allocations, timestamp } = parsed.data;
+    const { hash: policyHash } = hashCanonical({ orgId, bankLineId, policy });
+    const prev = getLatestRptForOrg(orgId);
+    const prevHash = prev?.hash ?? null;
+    const minted = mintRpt({
+      rptId,
+      orgId,
+      bankLineId,
+      policyHash,
+      allocations,
+      prevHash,
+      timestamp,
+    });
+
+    const storedRpt = persistRpt(minted);
+    persistLedgerEntry({
+      rptId: storedRpt.token.rptId,
+      orgId: storedRpt.token.orgId,
+      bankLineId: storedRpt.token.bankLineId,
+      policyHash: storedRpt.token.policyHash,
+      allocations: storedRpt.token.allocations,
+      prevHash: storedRpt.token.prevHash,
+      createdAt: storedRpt.token.timestamp,
+      id: randomUUID(),
+    });
+
+    return reply.code(201).send(
+      applyAllocationsResponseSchema.parse({
+        ok: true,
+        policyHash,
+        rpt: storedRpt,
+      }),
+    );
+  });
+};
+
+export default allocationsRoutes;

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,26 @@
+import { FastifyInstance } from "fastify";
+import { getRpt, verifyChain, verifyRpt } from "../lib/rpt.js";
+
+export const auditRoutes = async (app: FastifyInstance) => {
+  app.get("/audit/rpt/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const record = getRpt(id);
+    if (!record) {
+      return reply.code(404).send({ ok: false, reason: "not_found" });
+    }
+
+    const verification = verifyRpt(record.token);
+    if (!verification.ok) {
+      return reply.code(400).send({ ok: false, reason: verification.reason ?? "invalid_signature" });
+    }
+
+    const chain = verifyChain(id);
+    if (!chain.ok) {
+      return reply.code(400).send({ ok: false, reason: chain.reason, rptId: chain.rptId, details: chain.details });
+    }
+
+    return reply.send({ ok: true, verified: true, hash: verification.hash, rpt: record.token });
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/src/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { rptAllocationSchema, rptTokenSchema } from "./rpt.js";
+
+export const previewAllocationsRequestSchema = z.object({
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policy: z.unknown().default({}),
+  allocations: z.array(rptAllocationSchema).min(1),
+});
+
+export const previewAllocationsResponseSchema = z.object({
+  ok: z.literal(true),
+  policyHash: z.string(),
+  allocations: z.array(rptAllocationSchema),
+  explain: z.string(),
+});
+
+export const applyAllocationsRequestSchema = previewAllocationsRequestSchema.extend({
+  rptId: z.string(),
+  timestamp: z.string().optional(),
+});
+
+export const applyAllocationsResponseSchema = z.object({
+  ok: z.literal(true),
+  policyHash: z.string(),
+  rpt: z.object({
+    token: rptTokenSchema,
+    hash: z.string(),
+    canonical: z.string(),
+  }),
+});
+
+export type PreviewAllocationsRequest = z.infer<typeof previewAllocationsRequestSchema>;
+export type ApplyAllocationsRequest = z.infer<typeof applyAllocationsRequestSchema>;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const rptAllocationSchema = z.object({
+  allocationId: z.string(),
+  amountCents: z.number().int(),
+  memo: z.string().optional(),
+});
+
+export const rptTokenSchema = z.object({
+  rptId: z.string(),
+  orgId: z.string(),
+  bankLineId: z.string(),
+  policyHash: z.string(),
+  allocations: z.array(rptAllocationSchema),
+  prevHash: z.string().nullable(),
+  sig: z.string(),
+  timestamp: z.string(),
+});
+
+export const verifyRptResponseSchema = z.object({
+  ok: z.boolean(),
+  verified: z.boolean().optional(),
+  hash: z.string().optional(),
+  reason: z.string().optional(),
+});
+
+export type RptAllocationInput = z.infer<typeof rptAllocationSchema>;
+export type RptTokenInput = z.infer<typeof rptTokenSchema>;

--- a/apgms/services/api-gateway/test/rpt.spec.ts
+++ b/apgms/services/api-gateway/test/rpt.spec.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import {
+  mintRpt,
+  persistRpt,
+  resetRptStore,
+  verifyChain,
+  verifyRpt,
+} from "../src/lib/rpt.js";
+
+const sampleAllocations = [
+  { allocationId: "alloc-1", amountCents: 2500, memo: "primary" },
+  { allocationId: "alloc-2", amountCents: 5000 },
+];
+
+const mintSampleRpt = (overrides: Partial<Parameters<typeof mintRpt>[0]> = {}) => {
+  return mintRpt({
+    rptId: overrides.rptId ?? `rpt-${randomUUID()}`,
+    orgId: overrides.orgId ?? "org-1",
+    bankLineId: overrides.bankLineId ?? "bank-line-1",
+    policyHash: overrides.policyHash ?? "policy-1",
+    allocations: overrides.allocations ?? sampleAllocations,
+    prevHash: overrides.prevHash ?? null,
+    timestamp: overrides.timestamp,
+  });
+};
+
+test("mint and verify RPT token", () => {
+  resetRptStore();
+  const minted = mintSampleRpt({ rptId: "rpt-1" });
+  persistRpt(minted);
+
+  const verification = verifyRpt(minted.token);
+  assert.equal(verification.ok, true);
+  assert.equal(verification.hash, minted.hash);
+});
+
+test("tampering allocations fails verification", () => {
+  resetRptStore();
+  const minted = mintSampleRpt({ rptId: "rpt-2" });
+  persistRpt(minted);
+
+  const tampered = {
+    ...minted.token,
+    allocations: minted.token.allocations.map((allocation, index) =>
+      index === 0 ? { ...allocation, amountCents: allocation.amountCents + 1 } : allocation,
+    ),
+  };
+
+  const verification = verifyRpt(tampered);
+  assert.equal(verification.ok, false);
+  assert.equal(verification.reason, "invalid_signature");
+});
+
+test("verifyChain detects prevHash mismatch", () => {
+  resetRptStore();
+  const first = mintSampleRpt({ rptId: "rpt-3" });
+  const storedFirst = persistRpt(first);
+
+  const second = mintSampleRpt({
+    rptId: "rpt-4",
+    prevHash: storedFirst.hash,
+    bankLineId: "bank-line-2",
+  });
+  const storedSecond = persistRpt(second);
+
+  const chainOk = verifyChain(storedSecond.token.rptId);
+  assert.equal(chainOk.ok, true);
+
+  const badLink = mintSampleRpt({
+    rptId: "rpt-5",
+    prevHash: "bogus-prev",
+    bankLineId: "bank-line-3",
+  });
+  persistRpt(badLink);
+
+  const broken = verifyChain(badLink.token.rptId);
+  assert.equal(broken.ok, false);
+  assert.equal(broken.rptId, badLink.token.rptId);
+  assert.equal(broken.reason, "prev_hash_not_found");
+});


### PR DESCRIPTION
## Summary
- add an in-memory Ed25519 KMS helper for signing and verifying RPT payloads
- implement RPT minting, verification, and chain validation with persistence helpers and schemas
- expose allocation preview/apply and audit routes plus regression tests for happy path, tampering, and chain failures

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4109be63c83278297afebcc7d832b