### PR TITLE
feat: enforce reply schema validation in api gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "NODE_ENV=test tsx --test test/reply-schema.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,243 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import cors from "@fastify/cors";
+import Fastify from "fastify";
+import { z } from "zod";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
+import { decorateReplyWithSchema } from "./plugins/reply-schema";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
+const healthSchema = z.object({
+  ok: z.boolean(),
+  service: z.string(),
 });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
+const userSummarySchema = z.object({
+  email: z.string().email(),
+  orgId: z.string(),
+  createdAt: z.string(),
 });
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
+const usersResponseSchema = z.object({
+  users: z.array(userSummarySchema),
+});
+
+const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string(),
+  amountCents: z.number().int().nonnegative(),
+  payee: z.string(),
+  description: z.string(),
+  createdAt: z.string(),
+});
+
+const bankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+type PrismaBankLineRecord = BankLineRecord & Record<string, unknown>;
+
+type PrismaClientLike = {
+  user: {
+    findMany: (args: {
+      select: { email: true; orgId: true; createdAt: true };
+      orderBy: { createdAt: "desc" };
+    }) => Promise<ReadonlyArray<UserRecord>>;
+  };
+  bankLine: {
+    findMany: (args: { orderBy: { date: "desc" }; take: number }) => Promise<
+      ReadonlyArray<PrismaBankLineRecord>
+    >;
+    create: (args: {
       data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+        orgId: string;
+        date: Date;
+        amount: unknown;
+        payee: string;
+        desc: string;
+      };
+    }) => Promise<PrismaBankLineRecord>;
+  };
+};
+
+export interface BuildAppOptions {
+  prisma?: PrismaClientLike;
+  logger?: boolean;
+}
+
+type UserRecord = {
+  email: string;
+  orgId: string;
+  createdAt: Date | string;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date | string;
+  amount: unknown;
+  payee: string;
+  desc: string;
+  createdAt: Date | string;
+};
+
+const toISOString = (value: Date | string) => {
+  if (value instanceof Date) {
+    return value.toISOString();
   }
+
+  if (typeof value === "string") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : date.toISOString();
+  }
+
+  throw new TypeError("Unsupported date value");
+};
+
+const toAmountCents = (amount: unknown) => {
+  if (typeof amount === "number") {
+    return Math.round(amount * 100);
+  }
+
+  if (typeof amount === "string") {
+    const numeric = Number(amount);
+    if (!Number.isFinite(numeric)) {
+      throw new TypeError("Invalid amount value");
+    }
+    return Math.round(numeric * 100);
+  }
+
+  if (amount && typeof amount === "object") {
+    const candidate = amount as { toNumber?: () => number; valueOf?: () => unknown };
+    if (typeof candidate.toNumber === "function") {
+      return Math.round(candidate.toNumber() * 100);
+    }
+    if (typeof candidate.valueOf === "function") {
+      const numeric = Number(candidate.valueOf());
+      if (!Number.isFinite(numeric)) {
+        throw new TypeError("Invalid amount value");
+      }
+      return Math.round(numeric * 100);
+    }
+  }
+
+  throw new TypeError("Unsupported amount type");
+};
+
+const mapUser = (user: UserRecord) => ({
+  email: user.email,
+  orgId: user.orgId,
+  createdAt: toISOString(user.createdAt),
 });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
+const mapBankLine = (line: BankLineRecord) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: toISOString(line.date),
+  amountCents: toAmountCents(line.amount),
+  payee: line.payee,
+  description: line.desc,
+  createdAt: toISOString(line.createdAt),
 });
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+export const buildApp = async (
+  { prisma, logger = true }: BuildAppOptions = {}
+) => {
+  const client =
+    prisma ??
+    ((await import("../../../shared/src/db")).prisma as PrismaClientLike);
+  const app = Fastify({ logger });
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  await app.register(cors, { origin: true });
+  decorateReplyWithSchema(app);
+
+  if (process.env.NODE_ENV !== "test") {
+    app.ready(() => {
+      app.log.info(app.printRoutes());
+    });
+  }
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async (_, reply) =>
+    reply.withSchema(healthSchema, { ok: true, service: "api-gateway" })
+  );
+
+  app.get("/users", async (_, reply) => {
+    const users = await client.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return reply.withSchema(usersResponseSchema, {
+      users: users.map(mapUser),
+    });
+  });
+
+  app.get("/bank-lines", async (req, reply) => {
+    const rawTake = Number(
+      (req.query as Record<string, unknown>).take ?? 20
+    );
+    const take = Number.isFinite(rawTake)
+      ? Math.min(Math.max(rawTake, 1), 200)
+      : 20;
+
+    const lines = await client.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    return reply.withSchema(bankLinesResponseSchema, {
+      lines: lines.map((line) => mapBankLine(line)),
+    });
+  });
+
+  app.post("/bank-lines", async (req, reply) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+
+      const created = await client.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      return reply.code(201).withSchema(bankLineSchema, mapBankLine(created));
+    } catch (error) {
+      req.log.error(error);
+      return reply.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  return app;
+};
+
+if (process.env.NODE_ENV !== "test") {
+  const app = await buildApp();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}
 

--- a/apgms/services/api-gateway/src/plugins/reply-schema.ts
+++ b/apgms/services/api-gateway/src/plugins/reply-schema.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from "fastify";
+import type { ZodTypeAny, input } from "zod";
+
+declare module "fastify" {
+  interface FastifyReply {
+    withSchema<T extends ZodTypeAny>(
+      schema: T,
+      payload: input<T>
+    ): FastifyReply;
+  }
+}
+
+const isProduction = () => process.env.NODE_ENV === "production";
+
+export const decorateReplyWithSchema = (app: FastifyInstance) => {
+  app.decorateReply(
+    "withSchema",
+    function withSchema<T extends ZodTypeAny>(schema: T, payload: input<T>) {
+      const result = schema.safeParse(payload);
+
+      if (!result.success) {
+        if (isProduction()) {
+          this.log.error(
+            { issues: result.error.issues },
+            "Reply schema validation failed"
+          );
+          return this.send(payload);
+        }
+
+        const error = new Error("Reply schema validation failed");
+        (error as any).cause = result.error;
+        (error as any).issues = result.error.issues;
+        throw error;
+      }
+
+      return this.send(result.data);
+    }
+  );
+};
+

--- a/apgms/services/api-gateway/test/reply-schema.spec.ts
+++ b/apgms/services/api-gateway/test/reply-schema.spec.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import Fastify from "fastify";
+import { z } from "zod";
+
+import { decorateReplyWithSchema } from "../src/plugins/reply-schema";
+import { buildApp } from "../src/index";
+
+const restoreNodeEnv = (value: string | undefined) => {
+  if (value === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = value;
+  }
+};
+
+test("reply.withSchema throws on invalid payloads in dev", async (t) => {
+  const originalEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "development";
+
+  const app = Fastify({ logger: false });
+  decorateReplyWithSchema(app);
+
+  app.get("/invalid", async (_, reply) =>
+    reply.withSchema(
+      z.object({ amountCents: z.number().int() }),
+      { amountCents: "not-a-number" } as unknown as { amountCents: number }
+    )
+  );
+
+  await app.ready();
+
+  t.after(async () => {
+    await app.close();
+    restoreNodeEnv(originalEnv);
+  });
+
+  const response = await app.inject({ method: "GET", url: "/invalid" });
+
+  assert.equal(response.statusCode, 500);
+  const body = JSON.parse(response.body);
+  assert.equal(body.message, "Reply schema validation failed");
+});
+
+test("route replies satisfy their schemas", async (t) => {
+  const originalEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "test";
+
+  const userCreatedAt = new Date("2024-01-01T00:00:00.000Z");
+  const bankLine = {
+    id: "line-1",
+    orgId: "org-1",
+    date: new Date("2024-01-02T00:00:00.000Z"),
+    amount: 123.45,
+    payee: "Test Payee",
+    desc: "Test description",
+    createdAt: new Date("2024-01-03T00:00:00.000Z"),
+  } as const;
+
+  const prismaStub = {
+    user: {
+      findMany: async () => [
+        {
+          email: "user@example.com",
+          orgId: "org-1",
+          createdAt: userCreatedAt,
+        },
+      ],
+    },
+    bankLine: {
+      findMany: async () => [bankLine],
+      create: async ({ data }: { data: any }) => ({
+        id: "line-created",
+        orgId: data.orgId,
+        date: new Date(data.date),
+        amount: data.amount,
+        payee: data.payee,
+        desc: data.desc,
+        createdAt: new Date("2024-01-04T00:00:00.000Z"),
+      }),
+    },
+  } as const;
+
+  const app = await buildApp({ prisma: prismaStub as any, logger: false });
+  await app.ready();
+
+  t.after(async () => {
+    await app.close();
+    restoreNodeEnv(originalEnv);
+  });
+
+  const usersResponse = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(usersResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(usersResponse.body), {
+    users: [
+      {
+        email: "user@example.com",
+        orgId: "org-1",
+        createdAt: userCreatedAt.toISOString(),
+      },
+    ],
+  });
+
+  const bankLinesResponse = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+  });
+  assert.equal(bankLinesResponse.statusCode, 200);
+
+  const bankLinesBody = JSON.parse(bankLinesResponse.body);
+  assert.equal(bankLinesBody.lines.length, 1);
+  assert.equal(bankLinesBody.lines[0].amountCents, 12345);
+  assert.equal(bankLinesBody.lines[0].description, "Test description");
+  assert.equal(bankLinesBody.lines[0].payee, "Test Payee");
+  assert.equal(bankLinesBody.lines[0].orgId, "org-1");
+  assert.equal(bankLinesBody.lines[0].date, bankLine.date.toISOString());
+  assert.equal(
+    bankLinesBody.lines[0].createdAt,
+    bankLine.createdAt.toISOString()
+  );
+});
+

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add a Fastify reply.withSchema helper that validates payloads with Zod
- wrap api gateway responses with schemas for health, user list, and bank line endpoints
- add contract tests covering validation failures and happy paths using a Prisma stub

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4107cc69c8327854133a68e9c949f