### PR TITLE
Add AS4 hello-world evidence stub scaffolding

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "as4:stub": "SBR_AS4_DEV=1 tsx services/sbr/src/as4/dev-stub.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/sbr/src/as4/dev-stub.ts
+++ b/apgms/services/sbr/src/as4/dev-stub.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+type Artifact = {
+  filename: string;
+  content: string;
+};
+
+const evidenceDir = path.resolve(__dirname, '../../../../../evidence/as4');
+
+const artifacts: Artifact[] = [
+  {
+    filename: 'request.json',
+    content: JSON.stringify(
+      {
+        devStub: true,
+        description: 'AS4 hello-world request placeholder',
+        messageInfo: {
+          messageId: 'urn:uuid:00000000-0000-0000-0000-000000000000',
+          timestamp: '2025-01-01T00:00:00Z',
+        },
+        payload: {
+          profile: 'hello-world',
+          note: 'Populate with the real business document payload in production',
+        },
+      },
+      null,
+      2,
+    ).concat('\n'),
+  },
+  {
+    filename: 'receipt.json',
+    content: JSON.stringify(
+      {
+        devStub: true,
+        description: 'AS4 hello-world receipt placeholder',
+        messageInfo: {
+          refToMessageId: 'urn:uuid:00000000-0000-0000-0000-000000000000',
+          timestamp: '2025-01-01T00:00:10Z',
+        },
+        receipt: {
+          status: 'ACCEPTED',
+          note: 'Replace with the signed receipt returned by the gateway',
+        },
+      },
+      null,
+      2,
+    ).concat('\n'),
+  },
+  {
+    filename: 'signature.xml',
+    content: `<?xml version="1.0" encoding="UTF-8"?>\n` +
+      `<!-- Dev stub signature placeholder -->\n` +
+      `<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">\n` +
+      `  <SignedInfo>\n` +
+      `    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />\n` +
+      `    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />\n` +
+      `    <Reference URI="#as4-request">\n` +
+      `      <Transforms>\n` +
+      `        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />\n` +
+      `      </Transforms>\n` +
+      `      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />\n` +
+      `      <DigestValue>REPLACE_WITH_REAL_DIGEST==</DigestValue>\n` +
+      `    </Reference>\n` +
+      `  </SignedInfo>\n` +
+      `  <SignatureValue>REPLACE_WITH_REAL_SIGNATURE==</SignatureValue>\n` +
+      `  <KeyInfo>\n` +
+      `    <KeyName>DEV-STUB-KEY</KeyName>\n` +
+      `  </KeyInfo>\n` +
+      `</Signature>\n`,
+  },
+];
+
+function isDevEnabled(): boolean {
+  return process.env.SBR_AS4_DEV === '1';
+}
+
+async function persistArtifacts(): Promise<void> {
+  if (!isDevEnabled()) {
+    console.log('SBR_AS4_DEV is not set to 1; skipping AS4 stub generation.');
+    return;
+  }
+
+  await fs.mkdir(evidenceDir, { recursive: true });
+
+  await Promise.all(
+    artifacts.map(async ({ filename, content }) => {
+      const filePath = path.join(evidenceDir, filename);
+      await fs.writeFile(filePath, content, 'utf8');
+      console.log(`Wrote ${filePath}`);
+    }),
+  );
+}
+
+persistArtifacts().catch((error) => {
+  console.error('Failed to persist AS4 evidence stubs:', error);
+  process.exitCode = 1;
+});

--- a/evidence/as4/README.md
+++ b/evidence/as4/README.md
@@ -1,0 +1,22 @@
+# AS4 Evidence Bundle (Dev Stub)
+
+This directory contains development stub assets that simulate an AS4 evidence bundle. They are intended to unblock integration work until the real exchange implementation is available.
+
+## Flow Overview
+
+1. Generate an AS4 request payload representing the message sent to the gateway.
+2. Capture the corresponding receipt returned by the gateway.
+3. Record the detached XML signature that binds the request/receipt pair.
+4. Persist the artifacts to `evidence/as4/` so they can be published as CI artifacts for traceability.
+
+## Profiles Covered
+
+- **Hello World / Connectivity Check** – minimal AS4 exchange used only for validating plumbing between systems.
+- **Dev Stub** – placeholder payloads that document the expected structure without containing real data.
+
+## Next Steps
+
+- Replace the stub generator in `services/sbr/src/as4/dev-stub.ts` with the real integration logic once the gateway is available.
+- Expand the payload structures to match the mandated AS4 profile (headers, payload parts, security tokens).
+- Automate validation of receipts/signatures against production certificate chains.
+- Remove the `SBR_AS4_DEV` guard when production-grade evidence is ready.

--- a/evidence/as4/receipt.json
+++ b/evidence/as4/receipt.json
@@ -1,0 +1,12 @@
+{
+  "devStub": true,
+  "description": "AS4 hello-world receipt placeholder",
+  "messageInfo": {
+    "refToMessageId": "urn:uuid:00000000-0000-0000-0000-000000000000",
+    "timestamp": "2025-01-01T00:00:10Z"
+  },
+  "receipt": {
+    "status": "ACCEPTED",
+    "note": "Replace with the signed receipt returned by the gateway"
+  }
+}

--- a/evidence/as4/request.json
+++ b/evidence/as4/request.json
@@ -1,0 +1,12 @@
+{
+  "devStub": true,
+  "description": "AS4 hello-world request placeholder",
+  "messageInfo": {
+    "messageId": "urn:uuid:00000000-0000-0000-0000-000000000000",
+    "timestamp": "2025-01-01T00:00:00Z"
+  },
+  "payload": {
+    "profile": "hello-world",
+    "note": "Populate with the real business document payload in production"
+  }
+}

--- a/evidence/as4/signature.xml
+++ b/evidence/as4/signature.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Dev stub signature placeholder -->
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+    <Reference URI="#as4-request">
+      <Transforms>
+        <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+      </Transforms>
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+      <DigestValue>REPLACE_WITH_REAL_DIGEST==</DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>REPLACE_WITH_REAL_SIGNATURE==</SignatureValue>
+  <KeyInfo>
+    <KeyName>DEV-STUB-KEY</KeyName>
+  </KeyInfo>
+</Signature>


### PR DESCRIPTION
## Summary
- add a development stub generator that writes AS4 evidence bundle artifacts when SBR_AS4_DEV=1
- scaffold placeholder hello-world request, receipt, and signature evidence along with documentation

## Testing
- npm run as4:stub

------
https://chatgpt.com/codex/tasks/task_e_68f414d5e99083279350fcc67930d36c