### PR TITLE
Add KMS signer provider for API gateway

### DIFF
--- a/apgms/docs/KEY_MGMT.md
+++ b/apgms/docs/KEY_MGMT.md
@@ -1,0 +1,26 @@
+# Key Management Strategy
+
+## Custody Model
+- The default `dev` signer keeps ephemeral RSA keys in memory for local development.
+- Production and staging environments must set `SIGNER_PROVIDER=kms` so request payment tokens (RPTs) are signed by AWS KMS keys (`KMS_KEY_ID`).
+- KMS provides hardware-backed custody; application hosts never receive private key material, only signatures.
+
+## Rotation Policy
+- Rotate the active `KMS_KEY_ID` at least every 90 days or when mandated by compliance requirements.
+- Use AWS KMS key aliases to stage new keys, then update `KMS_KEY_ID` through infrastructure configuration.
+- After rotation, verify new signatures end-to-end and decommission prior keys only after dependent services confirm acceptance.
+
+## Separation of Duties (SoD)
+- Platform engineers provision and manage the AWS KMS key and IAM policies.
+- Application operators configure deployment secrets (environment variables) without access to modify KMS policies.
+- Security teams audit key usage through CloudTrail and the `/evidence/keys/provider.json` artifact emitted at service boot.
+
+## Emergency Key Revocation
+- Disable the compromised KMS key in AWS immediately to prevent further signatures.
+- Update service configuration to point to an alternate standby key, redeploy, and confirm signatures verify as expected.
+- Document the incident, purge dependent caches, and notify relying parties that prior signatures should be considered untrusted.
+
+## Change Control
+- All changes to signing configuration require code review and change management approval.
+- Evidence files written to `evidence/keys/provider.json` capture the active provider, key ID, region, and timestamp for audit trails.
+- Tests cover both dev and KMS providers to ensure safe deployments when toggling the `SIGNER_PROVIDER` flag.

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,10 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
+    "@aws-sdk/client-kms": "^3.674.0",
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -10,6 +10,9 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { getSignerProviderFromEnv } from "./lib/kms";
+
+await getSignerProviderFromEnv();
 
 const app = Fastify({ logger: true });
 
@@ -77,4 +80,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/lib/kms.ts
+++ b/apgms/services/api-gateway/src/lib/kms.ts
@@ -1,0 +1,241 @@
+import { createSign, createVerify, generateKeyPairSync, KeyObject } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface SignerProvider {
+  readonly keyId?: string;
+  readonly region?: string;
+  sign(payload: Uint8Array): Promise<Uint8Array>;
+  verify(payload: Uint8Array, signature: Uint8Array): Promise<boolean>;
+}
+
+export class DevMemorySigner implements SignerProvider {
+  private readonly privateKey: KeyObject;
+  private readonly publicKey: KeyObject;
+
+  constructor() {
+    const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      publicExponent: 0x10001,
+    });
+    this.privateKey = privateKey;
+    this.publicKey = publicKey;
+  }
+
+  async sign(payload: Uint8Array): Promise<Uint8Array> {
+    const signer = createSign("RSA-SHA256");
+    signer.update(payload);
+    signer.end();
+    const signature = signer.sign(this.privateKey);
+    return new Uint8Array(signature);
+  }
+
+  async verify(payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(payload);
+    verifier.end();
+    return verifier.verify(this.publicKey, Buffer.from(signature));
+  }
+}
+
+export type KmsLikeClient = {
+  send(command: unknown): Promise<any>;
+};
+
+type SignCommandInput = {
+  KeyId: string;
+  Message: Uint8Array;
+  SigningAlgorithm: string;
+  MessageType?: string;
+};
+
+type VerifyCommandInput = {
+  KeyId: string;
+  Message: Uint8Array;
+  Signature: Uint8Array;
+  SigningAlgorithm: string;
+  MessageType?: string;
+};
+
+type SignCommandConstructor = new (input: SignCommandInput) => { input: SignCommandInput };
+type VerifyCommandConstructor = new (input: VerifyCommandInput) => { input: VerifyCommandInput };
+
+export interface AwsKmsSignerOptions {
+  keyId: string;
+  region: string;
+  client?: KmsLikeClient;
+  signCommand?: SignCommandConstructor;
+  verifyCommand?: VerifyCommandConstructor;
+  signingAlgorithm?:
+    | "RSASSA_PSS_SHA_256"
+    | "RSASSA_PSS_SHA_384"
+    | "RSASSA_PSS_SHA_512"
+    | "RSASSA_PKCS1_V1_5_SHA_256"
+    | "RSASSA_PKCS1_V1_5_SHA_384"
+    | "RSASSA_PKCS1_V1_5_SHA_512";
+}
+
+export class AwsKmsSigner implements SignerProvider {
+  private client?: KmsLikeClient;
+  private signCommandCtor?: SignCommandConstructor;
+  private verifyCommandCtor?: VerifyCommandConstructor;
+  private readonly initializePromise: Promise<void>;
+
+  readonly keyId: string;
+  readonly region: string;
+  private readonly signingAlgorithm: NonNullable<AwsKmsSignerOptions["signingAlgorithm"]>;
+
+  constructor(options: AwsKmsSignerOptions) {
+    this.keyId = options.keyId;
+    this.region = options.region;
+    this.signingAlgorithm = options.signingAlgorithm ?? "RSASSA_PSS_SHA_256";
+    this.client = options.client;
+    this.signCommandCtor = options.signCommand;
+    this.verifyCommandCtor = options.verifyCommand;
+    this.initializePromise = this.ensureAwsSdkLoaded();
+  }
+
+  private async ensureAwsSdkLoaded(): Promise<void> {
+    if (this.client && this.signCommandCtor && this.verifyCommandCtor) {
+      return;
+    }
+
+    try {
+      const mod = await import("@aws-sdk/client-kms");
+      this.client = this.client ?? new mod.KMSClient({ region: this.region });
+      this.signCommandCtor = this.signCommandCtor ?? mod.SignCommand;
+      this.verifyCommandCtor = this.verifyCommandCtor ?? mod.VerifyCommand;
+    } catch (error) {
+      throw new Error(
+        "Failed to load @aws-sdk/client-kms. Ensure the dependency is installed when using the KMS signer.",
+      );
+    }
+  }
+
+  private async ready(): Promise<void> {
+    await this.initializePromise;
+    if (!this.client || !this.signCommandCtor || !this.verifyCommandCtor) {
+      throw new Error("AWS KMS signer was not initialized correctly");
+    }
+  }
+
+  async sign(payload: Uint8Array): Promise<Uint8Array> {
+    await this.ready();
+    const SignCommand = this.signCommandCtor!;
+    const command = new SignCommand({
+      KeyId: this.keyId,
+      Message: payload,
+      SigningAlgorithm: this.signingAlgorithm,
+      MessageType: "RAW",
+    });
+
+    const response = await this.client!.send(command);
+    if (!response || !response.Signature) {
+      throw new Error("KMS did not return a signature");
+    }
+
+    return new Uint8Array(response.Signature);
+  }
+
+  async verify(payload: Uint8Array, signature: Uint8Array): Promise<boolean> {
+    await this.ready();
+    const VerifyCommand = this.verifyCommandCtor!;
+    const command = new VerifyCommand({
+      KeyId: this.keyId,
+      Message: payload,
+      Signature: signature,
+      SigningAlgorithm: this.signingAlgorithm,
+      MessageType: "RAW",
+    });
+
+    const response = await this.client!.send(command);
+    return Boolean(response?.SignatureValid);
+  }
+}
+
+export interface SignerProviderFactoryOptions {
+  evidenceRoot?: string;
+  kmsClient?: KmsLikeClient;
+  signCommand?: SignCommandConstructor;
+  verifyCommand?: VerifyCommandConstructor;
+  now?: () => Date;
+}
+
+let defaultProviderPromise: Promise<SignerProvider> | undefined;
+
+export function getSignerProviderFromEnv(
+  options: SignerProviderFactoryOptions = {},
+): Promise<SignerProvider> {
+  const hasOverrides = Boolean(
+    options.evidenceRoot || options.kmsClient || options.signCommand || options.verifyCommand || options.now,
+  );
+  if (!hasOverrides) {
+    if (!defaultProviderPromise) {
+      defaultProviderPromise = createSignerProviderFromEnv({});
+    }
+    return defaultProviderPromise;
+  }
+
+  return createSignerProviderFromEnv(options);
+}
+
+async function createSignerProviderFromEnv(
+  options: SignerProviderFactoryOptions,
+): Promise<SignerProvider> {
+  const provider = (process.env.SIGNER_PROVIDER ?? "dev").toLowerCase();
+
+  if (provider === "kms") {
+    const keyId = process.env.KMS_KEY_ID;
+    const region = process.env.AWS_REGION;
+    if (!keyId) {
+      throw new Error("KMS_KEY_ID must be set when SIGNER_PROVIDER=kms");
+    }
+    if (!region) {
+      throw new Error("AWS_REGION must be set when SIGNER_PROVIDER=kms");
+    }
+
+    const signer = new AwsKmsSigner({
+      keyId,
+      region,
+      client: options.kmsClient,
+      signCommand: options.signCommand,
+      verifyCommand: options.verifyCommand,
+    });
+
+    await writeEvidence({
+      provider: "kms",
+      keyId,
+      region,
+      now: options.now,
+      evidenceRoot: options.evidenceRoot,
+    });
+
+    return signer;
+  }
+
+  return new DevMemorySigner();
+}
+
+interface EvidenceOptions {
+  provider: string;
+  keyId: string;
+  region: string;
+  now?: () => Date;
+  evidenceRoot?: string;
+}
+
+async function writeEvidence(options: EvidenceOptions): Promise<void> {
+  const { provider, keyId, region } = options;
+  const evidenceRoot =
+    options.evidenceRoot ?? process.env.EVIDENCE_ROOT ?? path.resolve(process.cwd(), "evidence");
+  const filePath = path.join(evidenceRoot, "keys", "provider.json");
+  const payload = {
+    provider,
+    keyId,
+    region,
+    ts: (options.now ? options.now() : new Date()).toISOString(),
+  };
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
+}

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,52 @@
+import { SignerProvider, getSignerProviderFromEnv } from "./kms";
+
+export interface RptToken<T = Record<string, unknown>> {
+  payload: T;
+  signature: string;
+}
+
+export async function signRpt<T = Record<string, unknown>>(
+  payload: T,
+  provider?: SignerProvider,
+): Promise<RptToken<T>> {
+  const signer = provider ?? (await getSignerProviderFromEnv());
+  const message = serializePayload(payload);
+  const signature = await signer.sign(message);
+
+  return {
+    payload,
+    signature: Buffer.from(signature).toString("base64"),
+  };
+}
+
+export async function verifyRpt<T = Record<string, unknown>>(
+  token: RptToken<T>,
+  provider?: SignerProvider,
+): Promise<boolean> {
+  const signer = provider ?? (await getSignerProviderFromEnv());
+  const message = serializePayload(token.payload);
+  const signature = Buffer.from(token.signature, "base64");
+  return signer.verify(message, signature);
+}
+
+function serializePayload(payload: unknown): Uint8Array {
+  const canonical = canonicalize(payload);
+  return new Uint8Array(Buffer.from(JSON.stringify(canonical)));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = canonicalize((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+}

--- a/apgms/services/api-gateway/test/kms.spec.ts
+++ b/apgms/services/api-gateway/test/kms.spec.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { promises as fs, mkdtempSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  AwsKmsSigner,
+  DevMemorySigner,
+  getSignerProviderFromEnv,
+} from "../src/lib/kms";
+import { signRpt, verifyRpt } from "../src/lib/rpt";
+
+class FakeSignCommand {
+  readonly input;
+
+  constructor(input: any) {
+    this.input = input;
+  }
+}
+
+class FakeVerifyCommand {
+  readonly input;
+
+  constructor(input: any) {
+    this.input = input;
+  }
+}
+
+describe("Signer providers", () => {
+  afterEach(() => {
+    delete process.env.SIGNER_PROVIDER;
+    delete process.env.KMS_KEY_ID;
+    delete process.env.AWS_REGION;
+  });
+
+  it("signs and verifies RPTs using the dev memory signer", async () => {
+    const payload = { sub: "user-123", scope: ["read"] };
+    const signer = new DevMemorySigner();
+
+    const token = await signRpt(payload, signer);
+    const verified = await verifyRpt(token, signer);
+
+    assert.equal(typeof token.signature, "string");
+    assert.equal(verified, true);
+  });
+
+  it("signs and verifies using AWS KMS", async () => {
+    const signature = new Uint8Array(Buffer.from("signed"));
+    const send = async (command: any) => {
+      if (command instanceof FakeSignCommand) {
+        assert.equal(command.input.SigningAlgorithm, "RSASSA_PSS_SHA_256");
+        assert.equal(command.input.KeyId, "kms-key-id");
+        assert.ok(command.input.Message instanceof Uint8Array);
+        return { Signature: signature };
+      }
+
+      if (command instanceof FakeVerifyCommand) {
+        assert.deepEqual(new Uint8Array(command.input.Signature), signature);
+        assert.equal(command.input.KeyId, "kms-key-id");
+        return { SignatureValid: true };
+      }
+
+      throw new Error("Unexpected command");
+    };
+
+    const signer = new AwsKmsSigner({
+      keyId: "kms-key-id",
+      region: "ap-southeast-2",
+      client: { send },
+      signCommand: FakeSignCommand,
+      verifyCommand: FakeVerifyCommand,
+    });
+
+    const payload = { transactionId: "abc", amount: 100 };
+    const token = await signRpt(payload, signer);
+    assert.equal(token.signature, Buffer.from(signature).toString("base64"));
+
+    const verified = await verifyRpt(token, signer);
+    assert.equal(verified, true);
+  });
+
+  it("creates evidence when KMS is selected from the environment", async () => {
+    const evidenceRoot = mkdtempSync(path.join(tmpdir(), "evidence-"));
+    process.env.SIGNER_PROVIDER = "kms";
+    process.env.KMS_KEY_ID = "arn:aws:kms:region:acct:key/123";
+    process.env.AWS_REGION = "us-east-1";
+
+    const provider = await getSignerProviderFromEnv({
+      evidenceRoot,
+      kmsClient: { send: async () => ({ Signature: new Uint8Array([1]) }) },
+      signCommand: FakeSignCommand,
+      verifyCommand: FakeVerifyCommand,
+      now: () => new Date("2024-01-02T03:04:05.000Z"),
+    });
+
+    assert.ok(provider instanceof AwsKmsSigner);
+
+    const filePath = path.join(evidenceRoot, "keys", "provider.json");
+    const content = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(content);
+
+    assert.deepEqual(parsed, {
+      provider: "kms",
+      keyId: "arn:aws:kms:region:acct:key/123",
+      region: "us-east-1",
+      ts: "2024-01-02T03:04:05.000Z",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a signer provider abstraction with in-memory and AWS KMS-backed implementations, including evidence emission
- update the RPT utilities and API gateway bootstrap to resolve the provider via environment configuration
- add key management documentation and automated tests covering dev and KMS signing flows

## Testing
- pnpm test
- pnpm exec tsx --test test/kms.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f414889a0083278a0bfeb945a5bdb3