### PR TITLE
feat(api-gateway): centralize schemas and add reply validator

### DIFF
--- a/apgms/services/api-gateway/src/lib/replyValidate.ts
+++ b/apgms/services/api-gateway/src/lib/replyValidate.ts
@@ -1,0 +1,25 @@
+import type { FastifyReply } from "fastify";
+import type { ZodTypeAny, infer as ZodInfer } from "zod";
+
+interface ReplyValidator<Schema extends ZodTypeAny> {
+  code: (statusCode: number) => ReplyValidator<Schema>;
+  send: (payload: ZodInfer<Schema>) => FastifyReply;
+}
+
+export const replyValidate = <Schema extends ZodTypeAny>(
+  reply: FastifyReply,
+  schema: Schema,
+): ReplyValidator<Schema> => {
+  const builder: ReplyValidator<Schema> = {
+    code(statusCode) {
+      reply.code(statusCode);
+      return builder;
+    },
+    send(payload) {
+      const parsed = schema.parse(payload);
+      return reply.send(parsed);
+    },
+  };
+
+  return builder;
+};

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,69 @@
+import type { FastifyInstance } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+import { replyValidate } from "../lib/replyValidate";
+import {
+  bankLineCreateBodySchema,
+  bankLineCreateResponseSchema,
+  bankLineErrorSchema,
+  bankLineListQuerySchema,
+  bankLineListResponseSchema,
+} from "../schemas/bank-lines";
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: { toString(): string };
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+const serializeBankLine = (line: BankLineRecord) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amount: line.amount.toString(),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+export async function bankLinesRoutes(app: FastifyInstance) {
+  app.get("/bank-lines", async (req, rep) => {
+    const { take } = bankLineListQuerySchema.parse(req.query ?? {});
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    return replyValidate(rep, bankLineListResponseSchema).send({
+      lines: lines.map(serializeBankLine),
+    });
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = bankLineCreateBodySchema.parse(req.body);
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount:
+            typeof body.amount === "string" ? body.amount : body.amount.toString(),
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      return replyValidate(rep, bankLineCreateResponseSchema)
+        .code(201)
+        .send(serializeBankLine(created));
+    } catch (error) {
+      req.log.error(error);
+      return replyValidate(rep, bankLineErrorSchema)
+        .code(400)
+        .send({ error: "bad_request" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import {
+  cuidSchema,
+  isoDateTimeSchema,
+  moneyInputSchema,
+  moneyOutputSchema,
+} from "./common";
+
+export const allocationEntrySchema = z.object({
+  bankLineId: cuidSchema,
+  accountId: cuidSchema,
+  amount: moneyInputSchema,
+});
+
+export const allocationPreviewRequestSchema = z.object({
+  orgId: cuidSchema,
+  allocations: z.array(allocationEntrySchema).min(1),
+});
+
+export const allocationPreviewResponseSchema = z.object({
+  orgId: cuidSchema,
+  totalAllocated: moneyOutputSchema,
+  allocations: z.array(
+    allocationEntrySchema.extend({
+      amount: moneyOutputSchema,
+      remaining: moneyOutputSchema.optional(),
+    })
+  ),
+});
+
+export const allocationApplyRequestSchema = allocationPreviewRequestSchema.extend({
+  appliedBy: cuidSchema,
+});
+
+export const allocationApplyResponseSchema = z.object({
+  allocationBatchId: cuidSchema,
+  appliedAt: isoDateTimeSchema,
+  allocations: z.array(
+    allocationEntrySchema.extend({
+      amount: moneyOutputSchema,
+      status: z.enum(["applied", "failed"]),
+      message: z.string().optional(),
+    })
+  ),
+});
+
+export type AllocationEntry = z.infer<typeof allocationEntrySchema>;
+export type AllocationPreviewRequest = z.infer<typeof allocationPreviewRequestSchema>;
+export type AllocationPreviewResponse = z.infer<typeof allocationPreviewResponseSchema>;
+export type AllocationApplyRequest = z.infer<typeof allocationApplyRequestSchema>;
+export type AllocationApplyResponse = z.infer<typeof allocationApplyResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import {
+  apiErrorSchema,
+  cuidSchema,
+  isoDateTimeSchema,
+  moneyInputSchema,
+  moneyOutputSchema,
+  paginationQuerySchema,
+} from "./common";
+
+export const bankLineSchema = z.object({
+  id: cuidSchema,
+  orgId: cuidSchema,
+  date: isoDateTimeSchema,
+  amount: moneyOutputSchema,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+  createdAt: isoDateTimeSchema,
+});
+
+export const bankLineListQuerySchema = paginationQuerySchema.pick({ take: true });
+
+export const bankLineListResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+export const bankLineCreateBodySchema = z.object({
+  orgId: cuidSchema,
+  date: isoDateTimeSchema,
+  amount: moneyInputSchema,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const bankLineCreateResponseSchema = bankLineSchema;
+
+export const bankLineErrorSchema = apiErrorSchema;
+
+export type BankLine = z.infer<typeof bankLineSchema>;
+export type BankLineListQuery = z.infer<typeof bankLineListQuerySchema>;
+export type BankLineListResponse = z.infer<typeof bankLineListResponseSchema>;
+export type BankLineCreateBody = z.infer<typeof bankLineCreateBodySchema>;
+export type BankLineCreateResponse = z.infer<typeof bankLineCreateResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+
+const MONEY_REGEX = /^-?\d+(?:\.\d{1,})?$/;
+
+export const cuidSchema = z.string().cuid();
+export const uuidSchema = z.string().uuid();
+export const idSchema = z.union([cuidSchema, uuidSchema]);
+
+export const isoDateTimeSchema = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "Invalid ISO date",
+  });
+
+export const moneyInputSchema = z.union([
+  z.number(),
+  z
+    .string()
+    .regex(MONEY_REGEX, { message: "Invalid monetary amount" }),
+]);
+
+export const moneyOutputSchema = z
+  .string()
+  .regex(MONEY_REGEX, { message: "Invalid monetary amount" });
+
+export const paginationQuerySchema = z.object({
+  cursor: z.string().optional().nullable(),
+  take: z.coerce.number().int().min(1).max(200).default(20),
+});
+
+export const paginationMetaSchema = z.object({
+  hasNextPage: z.boolean(),
+  nextCursor: z.string().nullable(),
+});
+
+export const apiErrorSchema = z.object({
+  error: z.string(),
+  message: z.string().optional(),
+  statusCode: z.number().int().optional(),
+});
+
+export type Cuid = z.infer<typeof cuidSchema>;
+export type Uuid = z.infer<typeof uuidSchema>;
+export type Id = z.infer<typeof idSchema>;
+export type IsoDateTime = z.infer<typeof isoDateTimeSchema>;
+export type MoneyInput = z.infer<typeof moneyInputSchema>;
+export type MoneyOutput = z.infer<typeof moneyOutputSchema>;
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;
+export type PaginationMeta = z.infer<typeof paginationMetaSchema>;
+export type ApiError = z.infer<typeof apiErrorSchema>;

--- a/apgms/services/api-gateway/src/schemas/dashboard.ts
+++ b/apgms/services/api-gateway/src/schemas/dashboard.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { cuidSchema, moneyOutputSchema } from "./common";
+import { bankLineSchema } from "./bank-lines";
+import { rptSchema } from "./rpt";
+
+export const dashboardAccountSchema = z.object({
+  accountId: cuidSchema,
+  name: z.string().min(1),
+  balance: moneyOutputSchema,
+});
+
+export const dashboardResponseSchema = z.object({
+  org: z.object({
+    id: cuidSchema,
+    name: z.string().min(1),
+  }),
+  accounts: z.array(dashboardAccountSchema),
+  recentBankLines: z.array(bankLineSchema),
+  outstandingRpts: z.array(rptSchema),
+});
+
+export type DashboardAccount = z.infer<typeof dashboardAccountSchema>;
+export type DashboardResponse = z.infer<typeof dashboardResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { cuidSchema, isoDateTimeSchema, moneyOutputSchema } from "./common";
+
+export const rptStatusSchema = z.enum([
+  "pending",
+  "accepted",
+  "rejected",
+  "expired",
+]);
+
+export const rptSchema = z.object({
+  id: cuidSchema,
+  orgId: cuidSchema,
+  debtorName: z.string().min(1),
+  creditorName: z.string().min(1),
+  amount: moneyOutputSchema,
+  currency: z.string().length(3),
+  status: rptStatusSchema,
+  dueDate: isoDateTimeSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const rptListResponseSchema = z.object({
+  rpts: z.array(rptSchema),
+});
+
+export type RptStatus = z.infer<typeof rptStatusSchema>;
+export type Rpt = z.infer<typeof rptSchema>;
+export type RptListResponse = z.infer<typeof rptListResponseSchema>;


### PR DESCRIPTION
## Summary
- add shared schema definitions for common API data and downstream routes
- add a reply validation helper for Fastify responses
- refactor the bank-lines routes to consume the centralized schemas and helper

## Testing
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: Prisma engines download blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f41717ada88327a6399ce992fe68e3