### PR TITLE
feat: add api gateway middleware pack

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,8 +9,10 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/rate-limit": "^10.3.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "ioredis": "^5.4.2",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -8,12 +8,13 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerSecurity } from "./mw/security";
+import { registerBankLineRoutes } from "./routes/bank-lines";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await registerSecurity(app);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -30,40 +31,7 @@ app.get("/users", async () => {
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+await registerBankLineRoutes(app);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/lib/redis.ts
+++ b/apgms/services/api-gateway/src/lib/redis.ts
@@ -1,0 +1,58 @@
+import Redis from "ioredis";
+
+interface RedisLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode?: "PX" | "EX", ttl?: number): Promise<"OK" | null>;
+}
+
+class InMemoryRedis implements RedisLike {
+  private store = new Map<string, { value: string; expiresAt: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt !== 0 && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, mode?: "PX" | "EX", ttl?: number): Promise<"OK"> {
+    let expiresAt = 0;
+    if (mode && ttl) {
+      const duration = mode === "PX" ? ttl : ttl * 1000;
+      expiresAt = Date.now() + duration;
+    }
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+}
+
+let client: RedisLike | null = null;
+
+export const getRedis = (): RedisLike => {
+  if (client) {
+    return client;
+  }
+
+  const url = process.env.API_GATEWAY_REDIS_URL ?? process.env.REDIS_URL;
+  if (url) {
+    const redis = new Redis(url, { lazyConnect: true });
+    client = {
+      get: async (key: string) => redis.get(key),
+      set: async (key: string, value: string, mode?: "PX" | "EX", ttl?: number) => {
+        if (mode && ttl) {
+          return redis.set(key, value, mode, ttl);
+        }
+        return redis.set(key, value);
+      },
+    } satisfies RedisLike;
+  } else {
+    client = new InMemoryRedis();
+  }
+
+  return client;
+};

--- a/apgms/services/api-gateway/src/mw/auth.ts
+++ b/apgms/services/api-gateway/src/mw/auth.ts
@@ -1,0 +1,58 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export interface AuthenticatedUser {
+  id: string;
+  roles: string[];
+  orgId: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user?: AuthenticatedUser;
+  }
+}
+
+const parseToken = (token: string): AuthenticatedUser | null => {
+  const [id, orgId, roleSegment] = token.split(":");
+  if (!id || !orgId) {
+    return null;
+  }
+  const roles = roleSegment ? roleSegment.split(",").filter(Boolean) : [];
+  return { id, orgId, roles };
+};
+
+export const auth = () =>
+  async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const header = req.headers.authorization;
+    if (!header || !header.startsWith("Bearer ")) {
+      reply.code(401).send({ error: "unauthorized" });
+      return;
+    }
+
+    const token = header.slice("Bearer ".length).trim();
+    const user = parseToken(token);
+    if (!user) {
+      reply.code(401).send({ error: "unauthorized" });
+      return;
+    }
+
+    req.user = user;
+  };
+
+export const requireRole = (...roles: string[]) =>
+  async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    if (!req.user) {
+      reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+
+    if (roles.length === 0) {
+      return;
+    }
+
+    const hasRole = roles.some((role) => req.user?.roles.includes(role));
+    if (!hasRole) {
+      reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+  };

--- a/apgms/services/api-gateway/src/mw/idempotency.ts
+++ b/apgms/services/api-gateway/src/mw/idempotency.ts
@@ -1,0 +1,104 @@
+import crypto from "node:crypto";
+import { FastifyReply, FastifyRequest } from "fastify";
+import { getRedis } from "../lib/redis";
+
+interface StoredResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  hash: string;
+  isJson: boolean;
+}
+
+const isJsonContentType = (value: unknown): boolean => {
+  if (typeof value !== "string") {
+    return false;
+  }
+  return value.toLowerCase().includes("application/json");
+};
+
+const serializeHeaders = (headers: Record<string, unknown>): Record<string, string> => {
+  return Object.entries(headers).reduce<Record<string, string>>((acc, [key, value]) => {
+    if (typeof value === "string") {
+      acc[key] = value;
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      acc[key] = String(value);
+    }
+    return acc;
+  }, {});
+};
+
+export const idempotency = () => {
+  const redis = getRedis();
+
+  return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    if (req.method.toUpperCase() !== "POST") {
+      return;
+    }
+
+    const keyHeader = req.headers["idempotency-key"];
+    const idempotencyKey = Array.isArray(keyHeader) ? keyHeader[0] : keyHeader;
+    if (!idempotencyKey) {
+      return;
+    }
+
+    const bodyHash = crypto
+      .createHash("sha256")
+      .update(JSON.stringify(req.body ?? {}))
+      .digest("hex");
+
+    const cached = await redis.get(idempotencyKey);
+    if (cached) {
+      const payload = JSON.parse(cached) as StoredResponse;
+      if (payload.hash !== bodyHash) {
+        reply.code(409).send({ error: "idempotency_conflict" });
+        return;
+      }
+
+      reply.code(payload.statusCode);
+      for (const [header, value] of Object.entries(payload.headers)) {
+        reply.header(header, value);
+      }
+      if (payload.isJson) {
+        reply.send(JSON.parse(payload.body));
+      } else {
+        reply.send(payload.body);
+      }
+      return;
+    }
+
+    const originalSend = reply.send.bind(reply);
+    reply.send = ((responseBody: unknown) => {
+      const serializedBody =
+        typeof responseBody === "string"
+          ? responseBody
+          : JSON.stringify(responseBody ?? null) ?? "null";
+      const headers = serializeHeaders(reply.getHeaders() as Record<string, unknown>);
+      const isJson =
+        isJsonContentType(headers["content-type"]) || typeof responseBody !== "string";
+
+      void redis.set(
+        idempotencyKey,
+        JSON.stringify({
+          statusCode: reply.statusCode,
+          headers,
+          body: serializedBody,
+          hash: bodyHash,
+          isJson,
+        } satisfies StoredResponse),
+        "PX",
+        24 * 60 * 60 * 1000,
+      );
+
+      if (isJson && typeof responseBody === "string") {
+        try {
+          return originalSend(JSON.parse(responseBody));
+        } catch {
+          return originalSend(responseBody);
+        }
+      }
+
+      return originalSend(responseBody);
+    }) as typeof reply.send;
+  };
+};

--- a/apgms/services/api-gateway/src/mw/org-scope.ts
+++ b/apgms/services/api-gateway/src/mw/org-scope.ts
@@ -1,0 +1,22 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export const orgScope = () =>
+  async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const userOrgId = req.user?.orgId;
+    const requestOrgId = (() => {
+      const queryOrgId = (req.query as Record<string, unknown> | undefined)?.orgId;
+      if (typeof queryOrgId === "string" && queryOrgId) {
+        return queryOrgId;
+      }
+      const bodyOrgId = (req.body as Record<string, unknown> | undefined)?.orgId;
+      if (typeof bodyOrgId === "string" && bodyOrgId) {
+        return bodyOrgId;
+      }
+      return null;
+    })();
+
+    if (!userOrgId || !requestOrgId || requestOrgId !== userOrgId) {
+      reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+  };

--- a/apgms/services/api-gateway/src/mw/security.ts
+++ b/apgms/services/api-gateway/src/mw/security.ts
@@ -1,0 +1,45 @@
+import cors from "@fastify/cors";
+import rateLimit from "@fastify/rate-limit";
+import { FastifyInstance } from "fastify";
+
+const parseList = (value: string | undefined): string[] =>
+  value
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean) ?? [];
+
+const defaultOrigins = ["http://localhost:3000"];
+
+export const registerSecurity = async (app: FastifyInstance): Promise<void> => {
+  const allowedOrigins = parseList(
+    process.env.API_GATEWAY_CORS_ALLOWLIST ?? process.env.CORS_ALLOWLIST,
+  );
+  const origins = allowedOrigins.length > 0 ? allowedOrigins : defaultOrigins;
+
+  await app.register(cors, {
+    origin: (origin, callback) => {
+      if (!origin || origins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error("origin_not_allowed"), false);
+    },
+    credentials: true,
+  });
+
+  const max = Number(process.env.API_GATEWAY_RATE_LIMIT_RPM ?? process.env.RATE_LIMIT_RPM ?? 100);
+  const allowList = parseList(process.env.API_GATEWAY_RATE_LIMIT_ALLOWLIST);
+
+  await app.register(rateLimit, {
+    max,
+    timeWindow: "1 minute",
+    allowList: allowList.length > 0 ? allowList : undefined,
+  });
+
+  const bodyLimit = Number(process.env.API_GATEWAY_BODY_LIMIT ?? 512 * 1024);
+  app.addHook("onRoute", (routeOptions) => {
+    if (routeOptions.bodyLimit === undefined) {
+      routeOptions.bodyLimit = bodyLimit;
+    }
+  });
+};

--- a/apgms/services/api-gateway/src/mw/validate.ts
+++ b/apgms/services/api-gateway/src/mw/validate.ts
@@ -1,0 +1,47 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+import { ZodTypeAny, z } from "zod";
+
+const buildValidator = <T extends ZodTypeAny>(
+  schema: T,
+  read: (req: FastifyRequest) => unknown,
+  write: (req: FastifyRequest, value: z.infer<T>) => void,
+) =>
+  async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const result = schema.safeParse(read(req));
+    if (!result.success) {
+      reply.code(400).send({
+        error: "validation_error",
+        details: result.error.flatten(),
+      });
+      return;
+    }
+
+    write(req, result.data);
+  };
+
+export const validateBody = <T extends ZodTypeAny>(schema: T) =>
+  buildValidator(
+    schema,
+    (req) => req.body,
+    (req, value) => {
+      (req as FastifyRequest<{ Body: z.infer<T> }>).body = value;
+    },
+  );
+
+export const validateQuery = <T extends ZodTypeAny>(schema: T) =>
+  buildValidator(
+    schema,
+    (req) => req.query,
+    (req, value) => {
+      (req as FastifyRequest<{ Querystring: z.infer<T> }>).query = value;
+    },
+  );
+
+export const validateParams = <T extends ZodTypeAny>(schema: T) =>
+  buildValidator(
+    schema,
+    (req) => req.params,
+    (req, value) => {
+      (req as FastifyRequest<{ Params: z.infer<T> }>).params = value;
+    },
+  );

--- a/apgms/services/api-gateway/src/routes/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/bank-lines.ts
@@ -1,0 +1,52 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+import { prisma } from "../../../../shared/src/db";
+import { auth } from "../mw/auth";
+import { idempotency } from "../mw/idempotency";
+import { orgScope } from "../mw/org-scope";
+import { validateBody } from "../mw/validate";
+
+const bankLineBodySchema = z.object({
+  orgId: z.string().min(1),
+  date: z.string().min(1),
+  amount: z.union([z.number(), z.string().min(1)]),
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+type BankLineBody = z.infer<typeof bankLineBodySchema>;
+
+export const registerBankLineRoutes = async (app: FastifyInstance): Promise<void> => {
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as Record<string, unknown>)?.take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post<{
+    Body: BankLineBody;
+  }>(
+    "/bank-lines",
+    {
+      preHandler: [auth(), orgScope(), validateBody(bankLineBodySchema), idempotency()],
+    },
+    async (req: FastifyRequest<{ Body: BankLineBody }>, reply: FastifyReply) => {
+      const body = req.body;
+
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      reply.code(201).send(created);
+    },
+  );
+};


### PR DESCRIPTION
## Summary
- add reusable auth, org scope, idempotency, security, and validation middleware for the API gateway
- provide a redis client with in-memory fallback for idempotent request caching
- update bank line routes to use the consolidated middleware and register tightened security defaults

## Testing
- `pnpm --filter @apgms/api-gateway exec tsc --noEmit` *(fails: missing registry credentials for @fastify/rate-limit, ioredis, and @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68f4171d9b948327a0e364ec2f7ac07a