### PR TITLE
Add Playwright accessibility audit for webapp

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,22 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  web-a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: pnpm --filter @apgms/webapp exec playwright install --with-deps
+      - run: pnpm --filter @apgms/webapp exec playwright test tests
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: webapp-a11y-report
+          path: apgms/reports/a11y.json

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,13 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^5.0.0",
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/apgms/webapp/tests/a11y.spec.ts
+++ b/apgms/webapp/tests/a11y.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+import { analyzePage, initializeReport, writeReport } from './axe';
+
+const baseURL = process.env.WEBAPP_BASE_URL ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173';
+
+function resolveUrl(pathname: string) {
+  return new URL(pathname, baseURL).toString();
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  await initializeReport();
+});
+
+test.afterAll(async () => {
+  await writeReport();
+});
+
+test('home page has no accessibility violations', async ({ page }) => {
+  await page.goto(resolveUrl('/'));
+  const results = await analyzePage(page);
+  expect(results.violations).toHaveLength(0);
+});
+
+test('bank lines page has no accessibility violations', async ({ page }) => {
+  await page.goto(resolveUrl('/bank-lines'));
+  const results = await analyzePage(page);
+  expect(results.violations).toHaveLength(0);
+});

--- a/apgms/webapp/tests/axe.ts
+++ b/apgms/webapp/tests/axe.ts
@@ -1,0 +1,24 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import AxeBuilder from '@axe-core/playwright';
+import type { AxeResults } from 'axe-core';
+import type { Page } from '@playwright/test';
+
+const results: Array<{ url: string; results: AxeResults }> = [];
+const reportPath = path.resolve(__dirname, '..', '..', 'reports', 'a11y.json');
+
+export async function initializeReport() {
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  results.length = 0;
+}
+
+export async function analyzePage(page: Page) {
+  const analysis = await new AxeBuilder({ page }).analyze();
+  results.push({ url: page.url(), results: analysis });
+  return analysis;
+}
+
+export async function writeReport() {
+  await fs.writeFile(reportPath, JSON.stringify(results, null, 2));
+}


### PR DESCRIPTION
## Summary
- add a11y Playwright spec for the home and bank lines routes that records Axe results
- provide a shared helper to initialize, execute, and persist axe scans to reports/a11y.json
- extend CI with a dedicated Web a11y job that runs the new spec and uploads the generated report

## Testing
- pnpm install *(fails in local container: npm registry returned 403 for @playwright/test)*

------
https://chatgpt.com/codex/tasks/task_e_68f41a9a8a3c8327bafa3f197776c153