### PR TITLE
Add reply validation to API gateway responses

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/reply-contract.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,179 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { z } from "zod";
+import type { FastifyServerOptions } from "fastify";
+import { replyValidate } from "./lib/replyValidate";
+
+const healthReply = replyValidate(
+  z.object({
+    ok: z.literal(true),
+    service: z.literal("api-gateway"),
+  })
+);
+
+const usersReply = replyValidate(
+  z.object({
+    users: z.array(
+      z.object({
+        email: z.string().email(),
+        orgId: z.string(),
+        createdAt: z.string(),
+      })
+    ),
+  })
+);
+
+const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string(),
+  amount: z.string(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string(),
+});
+
+const bankLinesReply = replyValidate(
+  z.object({
+    lines: z.array(bankLineSchema),
+  })
+);
+
+const bankLineReply = replyValidate(bankLineSchema);
+
+const errorReply = replyValidate(
+  z.object({
+    error: z.string(),
+  })
+);
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: { toString(): string } | string | number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+type Dependencies = {
+  prisma: {
+    user: {
+      findMany: (...args: any[]) => Promise<Array<{ email?: string; orgId: string; createdAt: Date }>>;
+    };
+    bankLine: {
+      findMany: (...args: any[]) => Promise<BankLineRecord[]>;
+      create: (...args: any[]) => Promise<BankLineRecord>;
+    };
+  };
+};
+
+const bankLineToReply = (line: BankLineRecord) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amount: typeof line.amount === "object" && line.amount !== null && "toString" in line.amount
+    ? line.amount.toString()
+    : String(line.amount),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+const resolvePrisma = async (deps?: Dependencies) => {
+  if (deps) {
+    return deps.prisma;
+  }
+
+  const { prisma } = await import("../../../shared/src/db");
+  return prisma as Dependencies["prisma"];
+};
+
+export const buildApp = async (
+  options: FastifyServerOptions = { logger: true },
+  deps?: Dependencies
+) => {
+  const db = await resolvePrisma(deps);
+
+  const app = Fastify(options);
+
+  await app.register(cors, { origin: true });
+
+  app.get("/health", async () => healthReply({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await db.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return usersReply({
+      users: users.map(({ email, orgId, createdAt }) => ({
+        email: email ?? "",
+        orgId,
+        createdAt: createdAt.toISOString(),
+      })),
+    });
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const takeParam = Number((req.query as { take?: string | number }).take ?? 20);
+    const take = Number.isFinite(takeParam) ? takeParam : 20;
+
+    const lines = await db.bankLine.findMany({
+      select: {
+        id: true,
+        orgId: true,
+        date: true,
+        amount: true,
+        payee: true,
+        desc: true,
+        createdAt: true,
+      },
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+
+    return bankLinesReply({
+      lines: lines.map(bankLineToReply),
+    });
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await db.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+        select: {
+          id: true,
+          orgId: true,
+          date: true,
+          amount: true,
+          payee: true,
+          desc: true,
+          createdAt: true,
+        },
+      });
+
+      return rep.code(201).send(bankLineReply(bankLineToReply(created)));
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send(errorReply({ error: "bad_request" }));
+    }
+  });
+
+  return app;
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,71 +1,17 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { buildApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await buildApp();
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
@@ -73,8 +19,9 @@ app.ready(() => {
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/src/lib/replyValidate.ts
+++ b/apgms/services/api-gateway/src/lib/replyValidate.ts
@@ -1,0 +1,5 @@
+import type { ZodTypeAny } from "zod";
+
+export const replyValidate = <Schema extends ZodTypeAny>(schema: Schema) => {
+  return (payload: unknown): ReturnType<Schema["parse"]> => schema.parse(payload);
+};

--- a/apgms/services/api-gateway/test/reply-contract.spec.ts
+++ b/apgms/services/api-gateway/test/reply-contract.spec.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildApp } from "../src/app";
+
+test("GET /users enforces reply schema", async (t) => {
+  const stubbedPrisma = {
+    user: {
+      findMany: async () => [
+        {
+          orgId: "org_123",
+          createdAt: new Date("2023-01-01T00:00:00.000Z"),
+        },
+      ],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => ({
+        id: "line_123",
+        orgId: "org_123",
+        date: new Date("2023-01-01T00:00:00.000Z"),
+        amount: { toString: () => "0" },
+        payee: "",
+        desc: "",
+        createdAt: new Date("2023-01-01T00:00:00.000Z"),
+      }),
+    },
+  } as any;
+
+  const app = await buildApp({ logger: false }, { prisma: stubbedPrisma });
+  await app.ready();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({ method: "GET", url: "/users" });
+
+  assert.equal(response.statusCode, 500);
+});


### PR DESCRIPTION
## Summary
- refactor the API gateway to build the Fastify app through a reusable helper that validates every route reply
- add a reusable reply validation utility, wire the entry point through the new builder, and expose a test script
- cover the `/users` reply contract with a new test that stubs Prisma data to ensure validation failures surface

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f41a72e04883279ce3184e89233af1