### PR TITLE
Add security log snapshot tests

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/security-log.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/security/logging.ts
+++ b/apgms/services/api-gateway/src/security/logging.ts
@@ -1,0 +1,106 @@
+export type SecurityDecision = "allow" | "deny";
+
+export interface SecurityPrincipal {
+  id: string;
+  roles?: string[];
+  type?: string;
+}
+
+export interface SecurityLogEntry {
+  event: string;
+  decision: SecurityDecision;
+  route: string;
+  orgId?: string;
+  principal?: SecurityPrincipal;
+  reason: string;
+  [key: string]: unknown;
+}
+
+export type SecurityLogWriter = (entry: SecurityLogEntry) => void;
+
+const noopWriter: SecurityLogWriter = () => {};
+
+let writer: SecurityLogWriter = noopWriter;
+
+export function setSecurityLogWriter(next: SecurityLogWriter) {
+  writer = next;
+}
+
+export function resetSecurityLogWriter() {
+  writer = noopWriter;
+}
+
+export function secLog(entry: SecurityLogEntry) {
+  writer(entry);
+}
+
+type MissingTokenParams = {
+  route: string;
+};
+
+type RoleMismatchParams = {
+  route: string;
+  orgId: string;
+  principalId: string;
+  principalRoles: string[];
+  requiredRoles: string[];
+};
+
+type ReplayRejectParams = {
+  route: string;
+  principalId: string;
+  orgId?: string;
+  expectedBodyHash: string;
+  receivedBodyHash: string;
+};
+
+export function logMissingToken({ route }: MissingTokenParams) {
+  secLog({
+    event: "auth.missing_token",
+    decision: "deny",
+    route,
+    reason: "missing_token",
+  });
+}
+
+export function logRoleMismatch({
+  route,
+  orgId,
+  principalId,
+  principalRoles,
+  requiredRoles,
+}: RoleMismatchParams) {
+  secLog({
+    event: "auth.role_mismatch",
+    decision: "deny",
+    route,
+    orgId,
+    principal: {
+      id: principalId,
+      roles: [...principalRoles],
+    },
+    reason: "role_mismatch",
+    requiredRoles: [...requiredRoles],
+  });
+}
+
+export function logReplayRejection({
+  route,
+  principalId,
+  orgId,
+  expectedBodyHash,
+  receivedBodyHash,
+}: ReplayRejectParams) {
+  secLog({
+    event: "auth.replay_rejected",
+    decision: "deny",
+    route,
+    orgId,
+    principal: {
+      id: principalId,
+    },
+    reason: "replay_body_mismatch",
+    expectedBodyHash,
+    receivedBodyHash,
+  });
+}

--- a/apgms/services/api-gateway/test/__snapshots__/security-log.snap.json
+++ b/apgms/services/api-gateway/test/__snapshots__/security-log.snap.json
@@ -1,0 +1,36 @@
+{
+  "missing-token-401": {
+    "decision": "deny",
+    "event": "auth.missing_token",
+    "reason": "missing_token",
+    "route": "/v1/secure/documents"
+  },
+  "role-mismatch-403": {
+    "decision": "deny",
+    "event": "auth.role_mismatch",
+    "orgId": "org_456",
+    "principal": {
+      "id": "user_123",
+      "roles": [
+        "viewer"
+      ]
+    },
+    "reason": "role_mismatch",
+    "requiredRoles": [
+      "admin"
+    ],
+    "route": "/v1/admin/reports"
+  },
+  "replay-reject": {
+    "decision": "deny",
+    "event": "auth.replay_rejected",
+    "expectedBodyHash": "sha256:expected",
+    "orgId": "org_654",
+    "principal": {
+      "id": "user_321"
+    },
+    "reason": "replay_body_mismatch",
+    "receivedBodyHash": "sha256:received",
+    "route": "/v1/secure/documents"
+  }
+}

--- a/apgms/services/api-gateway/test/security-log.spec.ts
+++ b/apgms/services/api-gateway/test/security-log.spec.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  logMissingToken,
+  logReplayRejection,
+  logRoleMismatch,
+  resetSecurityLogWriter,
+  setSecurityLogWriter,
+  type SecurityLogEntry,
+} from "../src/security/logging";
+
+type SnapshotMap = Record<string, unknown>;
+
+type TestCase = {
+  name: string;
+  fn: () => void;
+};
+
+const cases: TestCase[] = [];
+
+function test(name: string, fn: () => void) {
+  cases.push({ name, fn });
+}
+
+const snapshotPath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "__snapshots__",
+  "security-log.snap.json",
+);
+
+const snapshots = JSON.parse(
+  fs.readFileSync(snapshotPath, "utf-8"),
+) as SnapshotMap;
+
+function captureLog(action: () => void) {
+  const entries: SecurityLogEntry[] = [];
+  setSecurityLogWriter((entry) => {
+    entries.push(JSON.parse(JSON.stringify(entry)) as SecurityLogEntry);
+  });
+  try {
+    action();
+  } finally {
+    resetSecurityLogWriter();
+  }
+  return entries;
+}
+
+test("records 401 denial when token missing", () => {
+  const entries = captureLog(() => {
+    logMissingToken({ route: "/v1/secure/documents" });
+  });
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0]!;
+
+  assert.ok(entry.event, "event field present");
+  assert.ok(entry.decision, "decision field present");
+  assert.ok(entry.route, "route field present");
+  assert.ok(entry.reason, "reason field present");
+  assert.equal(entry.orgId, undefined);
+  assert.equal(entry.principal, undefined);
+
+  assert.deepStrictEqual(entry, snapshots["missing-token-401"]);
+});
+
+test("records 403 denial for role mismatch", () => {
+  const entries = captureLog(() => {
+    logRoleMismatch({
+      route: "/v1/admin/reports",
+      orgId: "org_456",
+      principalId: "user_123",
+      principalRoles: ["viewer"],
+      requiredRoles: ["admin"],
+    });
+  });
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0]!;
+
+  assert.ok(entry.event, "event field present");
+  assert.ok(entry.decision, "decision field present");
+  assert.ok(entry.route, "route field present");
+  assert.ok(entry.reason, "reason field present");
+  assert.equal(typeof entry.orgId, "string");
+  assert.equal(typeof entry.principal, "object");
+
+  assert.deepStrictEqual(entry, snapshots["role-mismatch-403"]);
+});
+
+test("records replay rejection when body hashes differ", () => {
+  const entries = captureLog(() => {
+    logReplayRejection({
+      route: "/v1/secure/documents",
+      principalId: "user_321",
+      orgId: "org_654",
+      expectedBodyHash: "sha256:expected",
+      receivedBodyHash: "sha256:received",
+    });
+  });
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0]!;
+
+  assert.ok(entry.event, "event field present");
+  assert.ok(entry.decision, "decision field present");
+  assert.ok(entry.route, "route field present");
+  assert.ok(entry.reason, "reason field present");
+  assert.equal(typeof entry.orgId, "string");
+  assert.equal(typeof entry.principal, "object");
+
+  assert.deepStrictEqual(entry, snapshots["replay-reject"]);
+});
+
+function run() {
+  let failed = 0;
+  for (const { name, fn } of cases) {
+    try {
+      fn();
+      console.log(`✓ ${name}`);
+    } catch (error) {
+      failed += 1;
+      console.error(`✗ ${name}`);
+      if (error instanceof Error) {
+        console.error(error.stack ?? error.message);
+      } else {
+        console.error(error);
+      }
+    }
+  }
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+run();

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add a security logging helper that centralises secLog invocations for authentication failures
- add snapshot-backed tests that cover missing token, role mismatch, and replay rejection scenarios
- wire the test runner to execute the security log suite

## Testing
- pnpm test --filter @apgms/api-gateway

------
https://chatgpt.com/codex/tasks/task_e_68f41a8e95708327b3f683a4e1cc921a