### PR TITLE
Add admin data deletion endpoint with audit logging

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test test/admin.data.delete.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerAdminDataRoutes } from "./routes/admin.data";
 
 const app = Fastify({ logger: true });
 
@@ -64,6 +65,8 @@ app.post("/bank-lines", async (req, rep) => {
     return rep.code(400).send({ error: "bad_request" });
   }
 });
+
+await registerAdminDataRoutes(app);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/routes/admin.data.ts
+++ b/apgms/services/api-gateway/src/routes/admin.data.ts
@@ -1,0 +1,190 @@
+import { createHash } from "node:crypto";
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import {
+  adminDataDeleteRequestSchema,
+  adminDataDeleteResponseSchema,
+  type AdminDataDeleteRequest,
+  type AdminDataDeleteResponse,
+} from "../schemas/admin.data";
+
+interface Principal {
+  id: string;
+  role: string;
+  orgId: string;
+  token: string;
+}
+
+export interface SecurityLogPayload {
+  event: "data_delete";
+  orgId: string;
+  principal: string;
+  subjectUserId: string;
+  mode: "anonymized" | "deleted";
+}
+
+const PASSWORD_PLACEHOLDER = "__deleted__";
+
+type SharedDbModule = typeof import("../../../../shared/src/db.js");
+type PrismaClientLike = Pick<SharedDbModule["prisma"], "user" | "bankLine">;
+
+interface AdminDataRouteDeps {
+  prisma?: PrismaClientLike;
+  secLog?: (payload: SecurityLogPayload) => Promise<void> | void;
+}
+
+export async function registerAdminDataRoutes(
+  app: FastifyInstance,
+  deps: AdminDataRouteDeps = {}
+) {
+  const prisma = deps.prisma ?? (await getDefaultPrisma());
+  const securityLogger =
+    deps.secLog ??
+    (async (payload: SecurityLogPayload) => {
+      app.log.info({ security: payload }, "security_event");
+    });
+
+  app.post("/admin/data/delete", async (request, reply) => {
+    const principal = parseAuthorization(request);
+    if (!principal) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    if (principal.role !== "admin") {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+
+    const body = parsed.data;
+
+    if (principal.orgId !== body.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const subject = await prisma.user.findFirst({
+      where: { orgId: body.orgId, email: body.email },
+    });
+
+    if (!subject) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const hasConstraintRisk = await detectForeignKeyRisk(
+      prisma,
+      subject.id,
+      subject.email,
+      subject.orgId
+    );
+
+    const occurredAt = new Date().toISOString();
+    let response: AdminDataDeleteResponse;
+
+    if (hasConstraintRisk) {
+      const anonymizedEmail = anonymizeEmail(subject.email, subject.id);
+      await prisma.user.update({
+        where: { id: subject.id },
+        data: {
+          email: anonymizedEmail,
+          password: PASSWORD_PLACEHOLDER,
+        },
+      });
+
+      response = adminDataDeleteResponseSchema.parse({
+        action: "anonymized",
+        userId: subject.id,
+        occurredAt,
+      });
+    } else {
+      await prisma.user.delete({ where: { id: subject.id } });
+      response = adminDataDeleteResponseSchema.parse({
+        action: "deleted",
+        userId: subject.id,
+        occurredAt,
+      });
+    }
+
+    await securityLogger({
+      event: "data_delete",
+      orgId: body.orgId,
+      principal: principal.id,
+      subjectUserId: subject.id,
+      mode: response.action,
+    });
+
+    return reply.code(202).send(response);
+  });
+}
+
+function parseAuthorization(request: FastifyRequest): Principal | null {
+  const header = request.headers["authorization"] ?? request.headers["Authorization" as keyof typeof request.headers];
+  if (!header || typeof header !== "string") {
+    return null;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1];
+  const [role, principalId, orgId] = token.split(":");
+  if (!role || !principalId || !orgId) {
+    return null;
+  }
+
+  return {
+    id: principalId,
+    role,
+    orgId,
+    token,
+  };
+}
+
+async function detectForeignKeyRisk(
+  prisma: PrismaClientLike,
+  userId: string,
+  email: string,
+  orgId: string
+): Promise<boolean> {
+  const relatedLines = await prisma.bankLine.count({
+    where: {
+      orgId,
+      payee: email,
+    },
+  });
+
+  if (relatedLines > 0) {
+    return true;
+  }
+
+  const otherRefs = await prisma.bankLine.count({
+    where: {
+      orgId,
+      desc: {
+        contains: userId,
+      },
+    },
+  });
+
+  return otherRefs > 0;
+}
+
+function anonymizeEmail(email: string, userId: string): string {
+  const hash = createHash("sha256").update(`${email}:${userId}`).digest("hex");
+  return `deleted+${hash.slice(0, 12)}@example.com`;
+}
+
+let cachedDefaultPrisma: PrismaClientLike | null = null;
+
+async function getDefaultPrisma(): Promise<PrismaClientLike> {
+  if (!cachedDefaultPrisma) {
+    const module = (await import("../../../../shared/src/db.js")) as SharedDbModule;
+    cachedDefaultPrisma = module.prisma;
+  }
+  return cachedDefaultPrisma;
+}
+
+export type { AdminDataDeleteRequest, AdminDataDeleteResponse };

--- a/apgms/services/api-gateway/src/schemas/admin.data.ts
+++ b/apgms/services/api-gateway/src/schemas/admin.data.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const adminDataDeleteRequestSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  email: z.string().email("email must be valid"),
+  confirm: z.literal("DELETE"),
+});
+
+export const adminDataDeleteResponseSchema = z.object({
+  action: z.union([z.literal("anonymized"), z.literal("deleted")]),
+  userId: z.string().min(1),
+  occurredAt: z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), {
+      message: "occurredAt must be ISO string",
+    }),
+});
+
+export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
+export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;

--- a/apgms/services/api-gateway/test/admin.data.delete.spec.ts
+++ b/apgms/services/api-gateway/test/admin.data.delete.spec.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import cors from "@fastify/cors";
+import Fastify from "fastify";
+
+import {
+  registerAdminDataRoutes,
+  type SecurityLogPayload,
+} from "../src/routes/admin.data";
+import { adminDataDeleteResponseSchema } from "../src/schemas/admin.data";
+
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/test";
+process.env.SHADOW_DATABASE_URL ??= "postgresql://user:pass@localhost:5432/test-shadow";
+
+type PrismaUser = {
+  id: string;
+  email: string;
+  password: string | null;
+  createdAt: Date;
+  orgId: string;
+};
+
+describe("POST /admin/data/delete", () => {
+  let app: ReturnType<typeof Fastify>;
+  const prismaStub = {
+    user: {
+      findFirst: async () => null as PrismaUser | null,
+      update: async (_args: any) => null as PrismaUser | null,
+      delete: async (_args: any) => null as PrismaUser | null,
+    },
+    bankLine: {
+      count: async (_args: any) => 0,
+    },
+  };
+  let securityLogs: SecurityLogPayload[] = [];
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false });
+    await app.register(cors, { origin: true });
+    securityLogs = [];
+
+    prismaStub.user.findFirst = async () => null;
+    prismaStub.user.update = async () => null;
+    prismaStub.user.delete = async () => null;
+    prismaStub.bankLine.count = async () => 0;
+
+    await registerAdminDataRoutes(app, {
+      prisma: prismaStub as any,
+      secLog: async (payload) => {
+        securityLogs.push(payload);
+      },
+    });
+
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const buildToken = (role: string, orgId: string, principalId = "principal") =>
+    `Bearer ${role}:${principalId}:${orgId}`;
+
+  const defaultPayload = {
+    orgId: "org-123",
+    email: "user@example.com",
+    confirm: "DELETE",
+  } as const;
+
+  it("returns 401 without bearer token", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: defaultPayload,
+    });
+
+    assert.equal(response.statusCode, 401);
+  });
+
+  it("rejects non-admin principals", async () => {
+    let findCalled = false;
+    prismaStub.user.findFirst = (async (...args: any[]) => {
+      findCalled = true;
+      return null;
+    }) as typeof prismaStub.user.findFirst;
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: defaultPayload,
+      headers: {
+        authorization: buildToken("member", defaultPayload.orgId),
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(findCalled, false);
+  });
+
+  it("validates confirm token", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: { ...defaultPayload, confirm: "nope" },
+      headers: {
+        authorization: buildToken("admin", defaultPayload.orgId),
+      },
+    });
+
+    assert.equal(response.statusCode, 400);
+  });
+
+  it("returns 404 for unknown subject", async () => {
+    prismaStub.user.findFirst = async () => null;
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: defaultPayload,
+      headers: {
+        authorization: buildToken("admin", defaultPayload.orgId),
+      },
+    });
+
+    assert.equal(response.statusCode, 404);
+  });
+
+  it("anonymizes user with constraint risk", async () => {
+    const user: PrismaUser = {
+      id: "user-1",
+      email: defaultPayload.email,
+      password: "secret",
+      createdAt: new Date(),
+      orgId: defaultPayload.orgId,
+    };
+
+    let findCalls = 0;
+    prismaStub.user.findFirst = async () => {
+      findCalls += 1;
+      return user;
+    };
+
+    const countCalls: any[] = [];
+    prismaStub.bankLine.count = async (args: any) => {
+      countCalls.push(args);
+      if (countCalls.length === 1) {
+        return 1;
+      }
+      return 0;
+    };
+
+    const updateCalls: any[] = [];
+    prismaStub.user.update = async (args: any) => {
+      updateCalls.push(args);
+      return { ...user, email: "deleted" };
+    };
+
+    let deleteCalled = false;
+    prismaStub.user.delete = async () => {
+      deleteCalled = true;
+      return user;
+    };
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: defaultPayload,
+      headers: {
+        authorization: buildToken("admin", defaultPayload.orgId, "admin-1"),
+      },
+    });
+
+    assert.equal(response.statusCode, 202);
+    const body = response.json();
+    assert.doesNotThrow(() => adminDataDeleteResponseSchema.parse(body));
+    assert.equal(body.action, "anonymized");
+    assert.equal(body.userId, user.id);
+    assert.equal(typeof body.occurredAt, "string");
+
+    assert.equal(findCalls, 1);
+    assert.equal(countCalls.length, 1);
+    assert.equal(countCalls[0].where.payee, user.email);
+    assert.equal(deleteCalled, false);
+    assert.equal(updateCalls.length, 1);
+    const updateArgs = updateCalls[0];
+    assert.match(updateArgs.data.email, /^deleted\+[a-f0-9]{12}@example.com$/);
+    assert.equal(updateArgs.data.password, "__deleted__");
+
+    const lastLog = securityLogs.at(-1);
+    assert.deepEqual(lastLog, {
+      event: "data_delete",
+      orgId: defaultPayload.orgId,
+      principal: "admin-1",
+      subjectUserId: user.id,
+      mode: "anonymized",
+    });
+  });
+
+  it("hard deletes user when no constraint risk", async () => {
+    const user: PrismaUser = {
+      id: "user-2",
+      email: defaultPayload.email,
+      password: "secret",
+      createdAt: new Date(),
+      orgId: defaultPayload.orgId,
+    };
+
+    prismaStub.user.findFirst = async () => user;
+    prismaStub.bankLine.count = async () => 0;
+
+    let updateCalled = false;
+    prismaStub.user.update = async (args: any) => {
+      updateCalled = true;
+      return { ...user, email: args.data.email };
+    };
+
+    let deleteArgs: any = null;
+    prismaStub.user.delete = async (args: any) => {
+      deleteArgs = args;
+      return user;
+    };
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/data/delete",
+      payload: defaultPayload,
+      headers: {
+        authorization: buildToken("admin", defaultPayload.orgId),
+      },
+    });
+
+    assert.equal(response.statusCode, 202);
+    const body = response.json();
+    assert.doesNotThrow(() => adminDataDeleteResponseSchema.parse(body));
+    assert.equal(body.action, "deleted");
+    assert.equal(body.userId, user.id);
+
+    assert.equal(updateCalled, false);
+    assert.deepEqual(deleteArgs, { where: { id: user.id } });
+
+    const lastLog = securityLogs.at(-1);
+    assert.deepEqual(lastLog, {
+      event: "data_delete",
+      orgId: defaultPayload.orgId,
+      principal: "principal",
+      subjectUserId: user.id,
+      mode: "deleted",
+    });
+  });
+});

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,3 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 export const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- add an admin-gated data delete route that anonymizes or hard-deletes users and emits security logs
- define zod schemas for the delete request/response contracts and wire the route into the API gateway
- cover authorization, validation, anonymization, and deletion flows with node:test-based integration tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4206e534c8327a976ff17063f6e31