### PR TITLE
Add golden and red-team gates to CI workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,15 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+      - name: Golden tests
+        run: npm run golden
+      - name: Red-team checks
+        run: npm run redteam
+      - name: Upload evaluation reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-reports
+          path: |
+            eval/golden-report.json
+            eval/redteam-report.json


### PR DESCRIPTION
## Summary
- add golden and red-team checks to the CI workflow after the recursive tests
- upload the golden and red-team evaluation reports as artifacts

## Testing
- not run (CI only)

------
https://chatgpt.com/codex/tasks/task_e_68f428b0979c8327b337f82dd62d23d3