### PR TITLE
feat(sbr): scaffold AS4 client with artifact persistence

### DIFF
--- a/apgms/services/sbr/src/as4.ts
+++ b/apgms/services/sbr/src/as4.ts
@@ -1,0 +1,134 @@
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface As4Config {
+  service: string;
+  action: string;
+  from: string;
+  to: string;
+  messageIdSeed?: string;
+  createdAt?: string;
+}
+
+export interface As4Envelope {
+  messageId: string;
+  service: string;
+  action: string;
+  parties: {
+    from: string;
+    to: string;
+  };
+  payload: unknown;
+  payloadDigest: string;
+  createdAt: string;
+}
+
+export interface As4Receipt {
+  messageId: string;
+  signature: string;
+  algorithm: 'sha256';
+  keyId: string;
+}
+
+const DEFAULT_TIMESTAMP = '1970-01-01T00:00:00.000Z';
+
+const normalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalize);
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return entries
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .reduce<Record<string, unknown>>((acc, [key, val]) => {
+        acc[key] = normalize(val);
+        return acc;
+      }, {});
+  }
+
+  return value;
+};
+
+const stableStringify = (value: unknown): string => JSON.stringify(normalize(value));
+
+const createHashFrom = (...parts: string[]): string => {
+  const hash = createHash('sha256');
+  for (const part of parts) {
+    hash.update(part);
+  }
+  return hash.digest('hex');
+};
+
+export const buildEnvelope = (payload: unknown, cfg: As4Config): As4Envelope => {
+  const payloadRepresentation = stableStringify(payload);
+  const payloadDigest = createHashFrom(payloadRepresentation);
+  const messageIdSource = cfg.messageIdSeed ?? `${cfg.service}:${cfg.action}:${cfg.from}:${cfg.to}:${payloadDigest}`;
+  const messageId = `as4-${createHashFrom(messageIdSource)}`;
+
+  return {
+    messageId,
+    service: cfg.service,
+    action: cfg.action,
+    parties: {
+      from: cfg.from,
+      to: cfg.to,
+    },
+    payload,
+    payloadDigest,
+    createdAt: cfg.createdAt ?? DEFAULT_TIMESTAMP,
+  };
+};
+
+export const signEnvelope = (envelope: As4Envelope, key: string): As4Receipt => {
+  const envelopeSummary = stableStringify({
+    messageId: envelope.messageId,
+    service: envelope.service,
+    action: envelope.action,
+    parties: envelope.parties,
+    payloadDigest: envelope.payloadDigest,
+  });
+
+  const signature = createHashFrom(envelopeSummary, key);
+  const keyId = createHashFrom(key).slice(0, 16);
+
+  return {
+    messageId: envelope.messageId,
+    signature,
+    algorithm: 'sha256',
+    keyId,
+  };
+};
+
+type PersistArtifactsInput = {
+  envelope: As4Envelope;
+  receipt: As4Receipt;
+  directory?: string;
+};
+
+type PersistArtifactsResult = {
+  envelopePath: string;
+  receiptPath: string;
+};
+
+const defaultDirectory = path.resolve(process.cwd(), 'tmp');
+
+const safeBasename = (messageId: string): string => messageId.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+export const persistArtifacts = async ({
+  envelope,
+  receipt,
+  directory = defaultDirectory,
+}: PersistArtifactsInput): Promise<PersistArtifactsResult> => {
+  await fs.mkdir(directory, { recursive: true });
+
+  const base = safeBasename(envelope.messageId);
+  const envelopePath = path.join(directory, `${base}-envelope.json`);
+  const receiptPath = path.join(directory, `${base}-receipt.json`);
+
+  await fs.writeFile(envelopePath, JSON.stringify(envelope, null, 2), 'utf-8');
+  await fs.writeFile(receiptPath, JSON.stringify(receipt, null, 2), 'utf-8');
+
+  return { envelopePath, receiptPath };
+};

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,8 @@
-﻿console.log('sbr service');
+import { buildEnvelope, persistArtifacts, signEnvelope } from './as4.js';
+
+console.log('[sbr] service bootstrapped with AS4 stubs');
+
+// TODO: Wire AS4 client into message dispatcher
+// TODO: Replace stubbed signing with hardware-backed implementation
+
+export { buildEnvelope, signEnvelope, persistArtifacts };

--- a/apgms/services/sbr/test/as4.spec.ts
+++ b/apgms/services/sbr/test/as4.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+
+import { buildEnvelope, persistArtifacts, signEnvelope } from '../src/index.js';
+
+const tmpDir = path.resolve(process.cwd(), 'tmp');
+
+const samplePayload = {
+  amount: 42,
+  currency: 'AUD',
+  meta: { purpose: 'testing', tags: ['alpha', 'beta'] },
+};
+
+const baseConfig = {
+  service: 'BusinessRegistry',
+  action: 'SubmitDocument',
+  from: 'APGMS',
+  to: 'SBR',
+} as const;
+
+describe('AS4 client scaffold', () => {
+  beforeEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('builds deterministic envelopes for the same payload and config', () => {
+    const first = buildEnvelope(samplePayload, baseConfig);
+    const second = buildEnvelope(samplePayload, baseConfig);
+
+    assert.deepStrictEqual(first, second);
+    assert.match(first.messageId, /^as4-[a-f0-9]{64}$/);
+    assert.equal(first.parties.from, baseConfig.from);
+    assert.equal(first.parties.to, baseConfig.to);
+  });
+
+  it('persists envelope and receipt artifacts to tmp/ with message ID naming', async () => {
+    const envelope = buildEnvelope(samplePayload, baseConfig);
+    const receipt = signEnvelope(envelope, 'stub-key');
+
+    const { envelopePath, receiptPath } = await persistArtifacts({ envelope, receipt });
+
+    assert.equal(path.dirname(envelopePath), tmpDir);
+    assert.equal(path.dirname(receiptPath), tmpDir);
+    assert.equal(path.basename(envelopePath), `${envelope.messageId}-envelope.json`);
+    assert.equal(path.basename(receiptPath), `${envelope.messageId}-receipt.json`);
+
+    const storedEnvelope = JSON.parse(await fs.readFile(envelopePath, 'utf-8'));
+    const storedReceipt = JSON.parse(await fs.readFile(receiptPath, 'utf-8'));
+
+    assert.deepStrictEqual(storedEnvelope, envelope);
+    assert.deepStrictEqual(storedReceipt, receipt);
+  });
+});


### PR DESCRIPTION
## Summary
- add an AS4 envelope builder, signer, and persistence helpers for the SBR service
- expose the AS4 stubs from the service entrypoint with startup logging and TODO markers
- add coverage that enforces deterministic envelopes and persisted artifacts in tmp/

## Testing
- pnpm exec tsx --test services/sbr/test/as4.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f428810ee483278b1280c5cc539037