### PR TITLE
Add idempotency cache and webhook anti-replay

### DIFF
--- a/apgms/eval/redteam/10_nonce_replay.json
+++ b/apgms/eval/redteam/10_nonce_replay.json
@@ -1,0 +1,1 @@
+{"attack":"nonce_replay","method":"POST","path":"/webhooks/payto","headers":["x-signature","x-nonce","x-timestamp"],"expected":409}

--- a/apgms/eval/redteam/11_stale_timestamp.json
+++ b/apgms/eval/redteam/11_stale_timestamp.json
@@ -1,0 +1,1 @@
+{"attack":"stale_timestamp","method":"POST","path":"/webhooks/payto","headers":["x-signature","x-nonce","x-timestamp"],"expected":400}

--- a/apgms/eval/redteam/12_bad_sig.json
+++ b/apgms/eval/redteam/12_bad_sig.json
@@ -1,0 +1,1 @@
+{"attack":"bad_signature","method":"POST","path":"/webhooks/payto","headers":["x-signature","x-nonce","x-timestamp"],"expected":401}

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,13 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/idempotency.spec.ts test/webhook-replay.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "ioredis": "^5.4.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import type { FastifyInstance, FastifyReply } from "fastify";
+import type { Redis } from "ioredis";
+
+const IDEMPOTENCY_HEADER = "idempotency-key";
+const IDEMPOTENCY_PREFIX = "idempotency:";
+const IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24;
+
+interface CachedEntry {
+  requestHash: string;
+  statusCode: number;
+  payload: string;
+  headers: Record<string, string>;
+}
+
+interface IdempotencyContext {
+  cacheKey: string;
+  requestHash: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    idempotencyContext: IdempotencyContext | null;
+  }
+}
+
+const serializeValue = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Buffer.isBuffer(value)) {
+    return value.toString("utf8");
+  }
+  return JSON.stringify(value);
+};
+
+const buildRequestHash = (method: string, url: string, body: unknown): string => {
+  const hash = createHash("sha256");
+  hash.update(method.toUpperCase());
+  hash.update("|");
+  hash.update(url);
+  hash.update("|");
+  hash.update(serializeValue(body));
+  return hash.digest("hex");
+};
+
+const extractHeaders = (reply: FastifyReply): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(reply.getHeaders())) {
+    if (typeof value === "string") {
+      const lower = name.toLowerCase();
+      if (lower === "content-length") {
+        continue;
+      }
+      headers[name] = value;
+    }
+  }
+  return headers;
+};
+
+const parseCachedEntry = (raw: string | null): CachedEntry | null => {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as CachedEntry;
+    if (
+      typeof parsed.requestHash === "string" &&
+      typeof parsed.statusCode === "number" &&
+      typeof parsed.payload === "string" &&
+      parsed.headers &&
+      typeof parsed.headers === "object"
+    ) {
+      return parsed;
+    }
+  } catch {}
+  return null;
+};
+
+export const applyIdempotency = async (
+  app: FastifyInstance,
+  redis: Redis,
+): Promise<void> => {
+  app.decorateRequest("idempotencyContext", null);
+
+  app.addHook("preHandler", async (request, reply) => {
+    const header = request.headers[IDEMPOTENCY_HEADER] ?? request.headers[IDEMPOTENCY_HEADER.toLowerCase()];
+    if (!header || typeof header !== "string" || header.trim() === "") {
+      request.idempotencyContext = null;
+      return;
+    }
+    const cacheKey = `${IDEMPOTENCY_PREFIX}${header}`;
+    const requestHash = buildRequestHash(request.method, request.url, request.body);
+    request.idempotencyContext = { cacheKey, requestHash };
+
+    const cached = parseCachedEntry(await redis.get(cacheKey));
+    if (!cached) {
+      return;
+    }
+    if (cached.requestHash !== requestHash) {
+      request.idempotencyContext = null;
+      reply.code(409);
+      return reply.send({ error: "idempotency_conflict" });
+    }
+    request.idempotencyContext = null;
+    for (const [name, value] of Object.entries(cached.headers)) {
+      reply.header(name, value);
+    }
+    reply.header("x-idempotent-replay", "true");
+    reply.code(200);
+    return reply.send(cached.payload);
+  });
+
+  app.addHook("onSend", async (request, reply, payload) => {
+    const context = request.idempotencyContext;
+    if (!context) {
+      return payload;
+    }
+    if (reply.statusCode >= 400) {
+      return payload;
+    }
+    const serializedPayload =
+      typeof payload === "string"
+        ? payload
+        : Buffer.isBuffer(payload)
+          ? payload.toString("utf8")
+          : serializeValue(payload);
+    const entry: CachedEntry = {
+      requestHash: context.requestHash,
+      statusCode: reply.statusCode,
+      payload: serializedPayload,
+      headers: extractHeaders(reply),
+    };
+    await redis.set(context.cacheKey, JSON.stringify(entry), "EX", IDEMPOTENCY_TTL_SECONDS, "NX");
+    return payload;
+  });
+};

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,85 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import type { Redis } from "ioredis";
+
+const HEADER_SIGNATURE = "x-signature";
+const HEADER_NONCE = "x-nonce";
+const HEADER_TIMESTAMP = "x-timestamp";
+const NONCE_PREFIX = "webhook:nonce:";
+const WINDOW_SECONDS = 60 * 5;
+
+const canonicalizePayload = (payload: unknown): string => {
+  if (payload === null || payload === undefined) {
+    return "";
+  }
+  if (typeof payload === "string") {
+    return payload;
+  }
+  if (Buffer.isBuffer(payload)) {
+    return payload.toString("utf8");
+  }
+  return JSON.stringify(payload);
+};
+
+const computeSignature = (secret: string, timestamp: number, nonce: string, payload: unknown): string => {
+  const canonical = `${timestamp}.${nonce}.${canonicalizePayload(payload)}`;
+  return createHmac("sha256", secret).update(canonical).digest("hex");
+};
+
+const isValidTimestamp = (timestamp: number): boolean => {
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+  const now = Math.floor(Date.now() / 1000);
+  return Math.abs(now - timestamp) <= WINDOW_SECONDS;
+};
+
+export const registerWebhookRoutes = (app: FastifyInstance, redis: Redis): void => {
+  app.post("/webhooks/payto", async (request, reply) => {
+    const secret = process.env.WEBHOOK_SECRET;
+    if (!secret) {
+      request.log.error("WEBHOOK_SECRET missing");
+      return reply.code(500).send({ error: "secret_not_configured" });
+    }
+
+    const signatureHeader = request.headers[HEADER_SIGNATURE];
+    const nonceHeader = request.headers[HEADER_NONCE];
+    const timestampHeader = request.headers[HEADER_TIMESTAMP];
+
+    if (typeof signatureHeader !== "string" || signatureHeader.length === 0) {
+      return reply.code(401).send({ error: "invalid_signature" });
+    }
+    if (typeof nonceHeader !== "string" || nonceHeader.length === 0) {
+      return reply.code(401).send({ error: "invalid_nonce" });
+    }
+    if (typeof timestampHeader !== "string" || timestampHeader.length === 0) {
+      return reply.code(400).send({ error: "invalid_timestamp" });
+    }
+
+    const timestamp = Number.parseInt(timestampHeader, 10);
+    if (!isValidTimestamp(timestamp)) {
+      return reply.code(400).send({ error: "stale_timestamp" });
+    }
+
+    const expectedSignature = computeSignature(secret, timestamp, nonceHeader, request.body);
+    let validSignature = false;
+    try {
+      const provided = Buffer.from(signatureHeader, "hex");
+      const expected = Buffer.from(expectedSignature, "hex");
+      validSignature = provided.length === expected.length && timingSafeEqual(provided, expected);
+    } catch {
+      validSignature = false;
+    }
+    if (!validSignature) {
+      return reply.code(401).send({ error: "invalid_signature" });
+    }
+
+    const nonceKey = `${NONCE_PREFIX}${nonceHeader}`;
+    const setResult = await redis.set(nonceKey, timestamp.toString(), "EX", WINDOW_SECONDS, "NX");
+    if (setResult === null) {
+      return reply.code(409).send({ error: "nonce_replay" });
+    }
+
+    return reply.code(202).send({ accepted: true });
+  });
+};

--- a/apgms/services/api-gateway/test/idempotency.spec.ts
+++ b/apgms/services/api-gateway/test/idempotency.spec.ts
@@ -1,0 +1,88 @@
+import { strictEqual } from "node:assert/strict";
+import { test } from "node:test";
+import Fastify from "fastify";
+import type { Redis } from "ioredis";
+import { applyIdempotency } from "../src/plugins/idempotency";
+
+class FakeRedis {
+  private store = new Map<string, { value: string; expiresAt?: number }>();
+
+  private getEntry(key: string) {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.getEntry(key);
+    return entry ? entry.value : null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<"OK" | null> {
+    let ttlSeconds: number | undefined;
+    let nx = false;
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i];
+      if (typeof arg === "string") {
+        const upper = arg.toUpperCase();
+        if (upper === "EX") {
+          ttlSeconds = Number(args[i + 1]);
+          i += 1;
+        } else if (upper === "NX") {
+          nx = true;
+        }
+      }
+    }
+    const existing = this.getEntry(key);
+    if (nx && existing) {
+      return null;
+    }
+    const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined;
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+}
+
+test("idempotent replay returns cached response", async () => {
+  const redis = new FakeRedis();
+  const app = Fastify();
+  await applyIdempotency(app, redis as unknown as Redis);
+
+  let counter = 0;
+  app.post("/echo", async () => {
+    counter += 1;
+    return { counter };
+  });
+
+  await app.ready();
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/echo",
+    payload: { value: "one" },
+    headers: { "idempotency-key": "abc" },
+  });
+  strictEqual(first.statusCode, 200);
+  strictEqual(counter, 1);
+  const cachedBody = first.json() as { counter: number };
+  strictEqual(cachedBody.counter, 1);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/echo",
+    payload: { value: "one" },
+    headers: { "idempotency-key": "abc" },
+  });
+  strictEqual(second.statusCode, 200);
+  strictEqual(counter, 1);
+  strictEqual(second.headers["x-idempotent-replay"], "true");
+  strictEqual(second.payload, first.payload);
+
+  await app.close();
+});

--- a/apgms/services/api-gateway/test/webhook-replay.spec.ts
+++ b/apgms/services/api-gateway/test/webhook-replay.spec.ts
@@ -1,0 +1,183 @@
+import { strictEqual } from "node:assert/strict";
+import { test } from "node:test";
+import { createHmac } from "node:crypto";
+import Fastify from "fastify";
+import type { Redis } from "ioredis";
+import { registerWebhookRoutes } from "../src/routes/webhooks";
+
+class FakeRedis {
+  private store = new Map<string, { value: string; expiresAt?: number }>();
+
+  private getEntry(key: string) {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry;
+  }
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.getEntry(key);
+    return entry ? entry.value : null;
+  }
+
+  async set(key: string, value: string, ...args: Array<string | number>): Promise<"OK" | null> {
+    let ttlSeconds: number | undefined;
+    let nx = false;
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i];
+      if (typeof arg === "string") {
+        const upper = arg.toUpperCase();
+        if (upper === "EX") {
+          ttlSeconds = Number(args[i + 1]);
+          i += 1;
+        } else if (upper === "NX") {
+          nx = true;
+        }
+      }
+    }
+    const existing = this.getEntry(key);
+    if (nx && existing) {
+      return null;
+    }
+    const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : undefined;
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+}
+
+const payload = { amount: 42 };
+const secret = "test-secret";
+
+const sign = (timestamp: number, nonce: string) =>
+  createHmac("sha256", secret).update(`${timestamp}.${nonce}.${JSON.stringify(payload)}`).digest("hex");
+
+test("stale timestamp is rejected", async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  const redis = new FakeRedis();
+  const app = Fastify();
+  registerWebhookRoutes(app, redis as unknown as Redis);
+  await app.ready();
+
+  const timestamp = Math.floor(Date.now() / 1000) - 600;
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": sign(timestamp, "nonce-stale"),
+      "x-nonce": "nonce-stale",
+      "x-timestamp": String(timestamp),
+    },
+  });
+
+  strictEqual(response.statusCode, 400);
+  const body = response.json() as { error: string };
+  strictEqual(body.error, "stale_timestamp");
+
+  await app.close();
+});
+
+test("invalid signature returns unauthorized", async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  const redis = new FakeRedis();
+  const app = Fastify();
+  registerWebhookRoutes(app, redis as unknown as Redis);
+  await app.ready();
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": "deadbeef",
+      "x-nonce": "nonce-bad",
+      "x-timestamp": String(timestamp),
+    },
+  });
+
+  strictEqual(response.statusCode, 401);
+  const body = response.json() as { error: string };
+  strictEqual(body.error, "invalid_signature");
+
+  await app.close();
+});
+
+test("nonce replay is rejected", async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  const redis = new FakeRedis();
+  const app = Fastify();
+  registerWebhookRoutes(app, redis as unknown as Redis);
+  await app.ready();
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = "nonce-replay";
+  const signature = sign(timestamp, nonce);
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+    },
+  });
+  strictEqual(first.statusCode, 202);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+    },
+  });
+  strictEqual(second.statusCode, 409);
+  const body = second.json() as { error: string };
+  strictEqual(body.error, "nonce_replay");
+
+  await app.close();
+});
+
+test("valid webhook returns accepted", async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  const redis = new FakeRedis();
+  const app = Fastify();
+  registerWebhookRoutes(app, redis as unknown as Redis);
+  await app.ready();
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = "nonce-ok";
+  const signature = sign(timestamp, nonce);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers: {
+      "content-type": "application/json",
+      "x-signature": signature,
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+    },
+  });
+
+  strictEqual(response.statusCode, 202);
+  const body = response.json() as { accepted: boolean };
+  strictEqual(body.accepted, true);
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- add a Redis-backed idempotency middleware that caches request/response pairs for 24 hours
- implement the payto webhook endpoint with HMAC verification, timestamp checks, and nonce replay protection
- cover idempotency and webhook replay logic with node:test suites and provide replay/stale/signature red-team cases

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f428529cc48327af8e379dd57dca9a