### PR TITLE
feat(webapp): implement dashboard shell and bank lines routes

### DIFF
--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en" class="bg-slate-50">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Birchal Operations Console</title>
+  </head>
+  <body class="min-h-screen">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,38 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check:a11y": "tsx scripts/check-a11y.ts"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.29.2",
+    "@tanstack/react-router": "^1.36.3",
+    "@tanstack/router-memory-history": "^1.36.3",
+    "axios": "^1.6.7",
+    "clsx": "^2.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.9.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.2.1",
+    "@types/axe-core": "^4.7.3",
+    "@types/jsdom": "^21.1.6",
+    "@types/react": "^18.2.46",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "axe-core": "^4.8.4",
+    "autoprefixer": "^10.4.16",
+    "jsdom": "^23.0.1",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.4"
+  }
+}

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apgms/webapp/scripts/check-a11y.ts
+++ b/apgms/webapp/scripts/check-a11y.ts
@@ -1,0 +1,166 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { createMemoryHistory } from '@tanstack/router-memory-history';
+import { cleanup, render } from '@testing-library/react';
+import axe from 'axe-core';
+import { JSDOM } from 'jsdom';
+import React from 'react';
+
+import { createAppRouter } from '../src/router';
+import { dashboardQueryOptions } from '../src/routes/index';
+import { bankLinesQueryOptions } from '../src/routes/bank-lines';
+import type { BankLinesResponse, DashboardResponse } from '../src/lib/api';
+
+const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+
+(globalThis as any).window = dom.window;
+(globalThis as any).document = dom.window.document;
+(globalThis as any).navigator = dom.window.navigator;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).Node = dom.window.Node;
+(globalThis as any).MutationObserver = dom.window.MutationObserver;
+(globalThis as any).requestAnimationFrame = (callback: FrameRequestCallback) => setTimeout(() => callback(Date.now()), 0);
+(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+(globalThis as any).matchMedia = globalThis.matchMedia ?? ((query: string) => ({
+  matches: query.includes('prefers-color-scheme: dark'),
+  media: query,
+  addListener: () => undefined,
+  removeListener: () => undefined,
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+  dispatchEvent: () => false
+}));
+
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+(globalThis as any).ResizeObserver = ResizeObserver;
+(globalThis as any).IntersectionObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+type Scenario = {
+  path: string;
+  seed: (client: QueryClient) => void;
+};
+
+const dashboardSample: DashboardResponse = {
+  asOf: new Date().toISOString(),
+  kpis: [
+    { id: 'cash', label: 'Available cash', value: 2350000, delta: 4.2, deltaDirection: 'up' },
+    { id: 'rpt', label: 'Ready to pay', value: 820000, delta: -1.3, deltaDirection: 'down' },
+    { id: 'payables', label: 'Payables', value: 310000, delta: 2.1, deltaDirection: 'up' },
+    { id: 'receivables', label: 'Receivables', value: 920000, delta: 0.8, deltaDirection: 'up' }
+  ],
+  cashTrend: Array.from({ length: 30 }).map((_, index) => ({
+    date: new Date(Date.now() - (29 - index) * 24 * 60 * 60 * 1000).toISOString(),
+    amount: 2000000 + Math.sin(index / 4) * 120000 + index * 1500
+  }))
+};
+
+const bankLinesSample: BankLinesResponse = {
+  data: [
+    {
+      id: 'fac-001',
+      facility: 'Growth Facility',
+      bank: 'ANZ',
+      limit: 1500000,
+      drawn: 825000,
+      utilisation: 55,
+      maturityDate: new Date(Date.now() + 220 * 24 * 60 * 60 * 1000).toISOString(),
+      costOfFundsBps: 245,
+      status: 'active'
+    },
+    {
+      id: 'fac-002',
+      facility: 'Acquisition Bridge',
+      bank: 'NAB',
+      limit: 2100000,
+      drawn: 1460000,
+      utilisation: 69.5,
+      maturityDate: new Date(Date.now() + 120 * 24 * 60 * 60 * 1000).toISOString(),
+      costOfFundsBps: 265,
+      status: 'review'
+    }
+  ],
+  pagination: {
+    page: 1,
+    perPage: 10,
+    total: 2
+  },
+  totals: {
+    aggregateLimit: 3600000,
+    aggregateDrawn: 2285000,
+    averageUtilisation: 62.3
+  }
+};
+
+const scenarios: Scenario[] = [
+  {
+    path: '/',
+    seed: (client) => {
+      client.setQueryData(dashboardQueryOptions.queryKey, dashboardSample);
+    }
+  },
+  {
+    path: '/bank-lines',
+    seed: (client) => {
+      client.setQueryData(bankLinesQueryOptions(1, 10).queryKey, bankLinesSample);
+    }
+  }
+];
+
+const runScenario = async ({ path, seed }: Scenario) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: Infinity,
+        retry: false
+      }
+    }
+  });
+
+  seed(queryClient);
+
+  const history = createMemoryHistory({ initialEntries: [path] });
+  const router = createAppRouter(queryClient, { history });
+  await router.load();
+
+  const { container, unmount } = render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+
+  const results = await axe.run(container, {
+    reporter: 'v2'
+  });
+
+  unmount();
+  cleanup();
+
+  if (results.violations.length) {
+    const formatted = results.violations
+      .map((violation) => `${violation.id}: ${violation.nodes.map((node) => node.target.join(' ')).join(', ')}`)
+      .join('\n');
+    throw new Error(`Accessibility violations detected on ${path}:\n${formatted}`);
+  }
+};
+
+const main = async () => {
+  for (const scenario of scenarios) {
+    await runScenario(scenario);
+  }
+
+  console.log('axe: no accessibility violations detected');
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-50 text-slate-900 dark:bg-slate-900 dark:text-slate-100 antialiased;
+}
+
+#root {
+  min-height: 100vh;
+}
+
+@layer utilities {
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.skip-link {
+  @apply sr-only focus:not-sr-only focus:fixed focus:z-50 focus:top-4 focus:left-4 focus:rounded-lg focus:bg-white focus:px-4 focus:py-2 focus:text-slate-900 shadow-focus;
+}

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,85 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
+  withCredentials: true
+});
+
+api.interceptors.request.use((config) => {
+  if (typeof window === 'undefined') {
+    return config;
+  }
+
+  const token = window.localStorage.getItem('dev:bearer-token');
+  if (token) {
+    config.headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  return config;
+});
+
+export interface DashboardKpi {
+  id: string;
+  label: string;
+  value: number;
+  delta?: number;
+  deltaDirection?: 'up' | 'down';
+}
+
+export interface DashboardTrendPoint {
+  date: string;
+  amount: number;
+}
+
+export interface DashboardResponse {
+  asOf: string;
+  kpis: DashboardKpi[];
+  cashTrend: DashboardTrendPoint[];
+}
+
+export interface BankLine {
+  id: string;
+  facility: string;
+  bank: string;
+  limit: number;
+  drawn: number;
+  utilisation: number;
+  maturityDate: string;
+  costOfFundsBps: number;
+  status: 'active' | 'pending' | 'review';
+}
+
+export interface BankLinesResponse {
+  data: BankLine[];
+  pagination: {
+    page: number;
+    perPage: number;
+    total: number;
+  };
+  totals: {
+    aggregateLimit: number;
+    aggregateDrawn: number;
+    averageUtilisation: number;
+  };
+}
+
+export const fetchDashboard = async (): Promise<DashboardResponse> => {
+  const { data } = await api.get<DashboardResponse>('/dashboard');
+  return data;
+};
+
+export const fetchBankLines = async (params: {
+  page: number;
+  perPage: number;
+}): Promise<BankLinesResponse> => {
+  const { data } = await api.get<BankLinesResponse>('/bank-lines', {
+    params
+  });
+  return data;
+};
+
+export const verifyRpt = async (facilityId: string): Promise<void> => {
+  await api.post(`/audit/rpt/${facilityId}`);
+};
+
+export { api };

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,38 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+
+import './index.css';
+import { createAppRouter } from './router';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false
+    }
+  }
+});
+
+const router = createAppRouter(queryClient);
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element missing');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/router.ts
+++ b/apgms/webapp/src/router.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { createRouter, type History } from '@tanstack/react-router';
+
+import { Route as rootRoute } from './routes/__root';
+import { Route as dashboardRoute } from './routes/index';
+import { Route as bankLinesRoute } from './routes/bank-lines';
+
+export type AppRouterContext = {
+  queryClient: QueryClient;
+};
+
+const routeTree = rootRoute.addChildren([dashboardRoute, bankLinesRoute]);
+
+export const createAppRouter = (
+  queryClient: QueryClient,
+  options?: { history?: History }
+) =>
+  createRouter<AppRouterContext>({
+    routeTree,
+    context: { queryClient },
+    history: options?.history,
+    defaultPreload: 'intent'
+  });
+
+export { routeTree };

--- a/apgms/webapp/src/routes/__root.tsx
+++ b/apgms/webapp/src/routes/__root.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from '@tanstack/react-router';
+import { createRootRoute } from '@tanstack/react-router';
+
+import { AppShell } from '../shell/AppShell';
+
+const RootComponent = () => (
+  <AppShell>
+    <Outlet />
+  </AppShell>
+);
+
+export const Route = createRootRoute({
+  component: RootComponent
+});

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,459 @@
+import { createRoute, useNavigate } from '@tanstack/react-router';
+import {
+  keepPreviousData,
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query';
+import clsx from 'clsx';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import {
+  fetchBankLines,
+  verifyRpt,
+  type BankLine,
+  type BankLinesResponse
+} from '../lib/api';
+import { AppRouterContext } from '../router';
+import { DateText } from '../ui/Date';
+import { Money } from '../ui/Money';
+import { Route as rootRoute } from './__root';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PAGE_SIZE = 10;
+
+const bankLinesQueryOptions = (page: number, perPage: number) =>
+  queryOptions<BankLinesResponse>({
+    queryKey: ['bank-lines', { page, perPage }],
+    queryFn: () => fetchBankLines({ page, perPage }),
+    staleTime: 60 * 1000
+  });
+
+const parsePositiveInteger = (value: unknown, fallback: number) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.floor(parsed);
+};
+
+const allowedPageSizes = [10, 25, 50];
+
+const normaliseSearch = (search: Record<string, unknown>): { page: number; perPage: number } => {
+  const page = parsePositiveInteger(search.page, DEFAULT_PAGE);
+  const perPageCandidate = parsePositiveInteger(search.perPage, DEFAULT_PAGE_SIZE);
+  const perPage = allowedPageSizes.includes(perPageCandidate) ? perPageCandidate : DEFAULT_PAGE_SIZE;
+  return { page, perPage };
+};
+
+const BankLinesPage = () => {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.id });
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<BankLine | null>(null);
+  const [statusMessage, setStatusMessage] = useState('');
+
+  const query = useQuery({
+    ...bankLinesQueryOptions(search.page, search.perPage),
+    placeholderData: keepPreviousData
+  });
+
+  const verifyMutation = useMutation({
+    mutationFn: (facilityId: string) => verifyRpt(facilityId),
+    onMutate: (facilityId) => {
+      setStatusMessage(`Starting RPT verification for facility ${facilityId}.`);
+    },
+    onSuccess: async (_, facilityId) => {
+      await queryClient.invalidateQueries({ queryKey: ['bank-lines'] });
+      setStatusMessage(`RPT verification started for facility ${facilityId}.`);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Unable to start verification right now.';
+      setStatusMessage(message);
+    }
+  });
+
+  const data = query.data;
+
+  const totalPages = useMemo(() => {
+    if (!data) {
+      return 1;
+    }
+    return Math.max(1, Math.ceil(data.pagination.total / data.pagination.perPage));
+  }, [data]);
+
+  const goToPage = (page: number) => {
+    navigate({
+      search: (current) => ({
+        ...current,
+        page
+      })
+    });
+  };
+
+  const changePageSize = (perPage: number) => {
+    navigate({
+      search: (current) => ({
+        ...current,
+        page: DEFAULT_PAGE,
+        perPage
+      })
+    });
+  };
+
+  useEffect(() => {
+    if (!selected) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setSelected(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [selected]);
+
+  if (!data) {
+    return null;
+  }
+
+  if (!data.data.length) {
+    return <BankLinesEmpty />;
+  }
+
+  const { pagination, totals } = data;
+  const firstItem = (pagination.page - 1) * pagination.perPage + 1;
+  const lastItem = Math.min(pagination.page * pagination.perPage, pagination.total);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">Bank lines</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Facility utilisation, maturities and rapid verification entry points.
+          </p>
+        </div>
+        <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+          Showing {firstItem}-{lastItem} of {pagination.total} facilities
+        </div>
+      </header>
+
+      <section aria-labelledby="summary-heading" className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <h2 id="summary-heading" className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+          Totals
+        </h2>
+        <dl className="mt-3 grid gap-4 sm:grid-cols-3">
+          <SummaryItem label="Aggregate limit">
+            <Money value={totals.aggregateLimit} />
+          </SummaryItem>
+          <SummaryItem label="Aggregate drawn">
+            <Money value={totals.aggregateDrawn} />
+          </SummaryItem>
+          <SummaryItem label="Average utilisation">
+            <span className="tabular-nums text-lg font-semibold text-slate-900 dark:text-white">
+              {totals.averageUtilisation.toFixed(1)}%
+            </span>
+          </SummaryItem>
+        </dl>
+      </section>
+
+      <section aria-labelledby="table-heading">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h2 id="table-heading" className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+            Facilities
+          </h2>
+          <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+            <span>Rows per page</span>
+            <div className="relative">
+              <select
+                className="appearance-none rounded-md border border-slate-200 bg-white px-3 py-1.5 pr-8 text-sm font-medium text-slate-700 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                value={pagination.perPage}
+                onChange={(event) => changePageSize(Number(event.target.value))}
+                aria-label="Rows per page"
+              >
+                {allowedPageSizes.map((size) => (
+                  <option key={size} value={size}>
+                    {size}
+                  </option>
+                ))}
+              </select>
+              <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-slate-400" aria-hidden>
+                ▾
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="mt-3 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-300">
+            <caption className="sr-only">Bank line facilities and utilisation</caption>
+            <thead className="bg-slate-50/70 dark:bg-slate-800">
+              <tr>
+                <SortableHeading label="Facility" />
+                <SortableHeading label="Bank" />
+                <SortableHeading label="Limit" numeric />
+                <SortableHeading label="Drawn" numeric />
+                <SortableHeading label="Utilisation" numeric />
+                <SortableHeading label="Maturity" />
+                <th scope="col" className="px-3 py-3 text-right font-medium">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800" aria-busy={query.isFetching}>
+              {data.data.map((line) => (
+                <tr key={line.id} className="hover:bg-slate-50/60 dark:hover:bg-slate-800/70">
+                  <th scope="row" className="px-3 py-3 text-sm font-semibold text-slate-900 dark:text-white">
+                    {line.facility}
+                  </th>
+                  <td className="px-3 py-3 text-sm">{line.bank}</td>
+                  <td className="px-3 py-3 text-sm">
+                    <Money value={line.limit} />
+                  </td>
+                  <td className="px-3 py-3 text-sm">
+                    <Money value={line.drawn} />
+                  </td>
+                  <td className="px-3 py-3 text-sm">
+                    <span className="tabular-nums">{line.utilisation.toFixed(1)}%</span>
+                  </td>
+                  <td className="px-3 py-3 text-sm">
+                    <DateText value={line.maturityDate} />
+                  </td>
+                  <td className="px-3 py-3 text-right text-sm">
+                    <button
+                      type="button"
+                      className="rounded-md border border-slate-200 px-3 py-1.5 font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+                      onClick={() => {
+                        setSelected(line);
+                        setStatusMessage('');
+                      }}
+                    >
+                      Inspect
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <footer className="flex flex-col gap-3 border-t border-slate-200 bg-slate-50/70 p-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => goToPage(Math.max(1, pagination.page - 1))}
+                disabled={pagination.page <= 1}
+                className="rounded-md border border-slate-200 px-3 py-1.5 font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => goToPage(Math.min(totalPages, pagination.page + 1))}
+                disabled={pagination.page >= totalPages}
+                className="rounded-md border border-slate-200 px-3 py-1.5 font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+              >
+                Next
+              </button>
+            </div>
+            <div>
+              Page {pagination.page} of {totalPages}
+            </div>
+          </footer>
+        </div>
+      </section>
+
+      <div aria-live="polite" className="sr-only">
+        {query.isFetching ? 'Loading facilities' : statusMessage}
+      </div>
+
+      {selected && (
+        <Drawer onClose={() => setSelected(null)} titleId={`facility-${selected.id}-title`}>
+          <DrawerHeader title={selected.facility} titleId={`facility-${selected.id}-title`} onClose={() => setSelected(null)} />
+          <div className="space-y-6">
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Facility details</h3>
+              <dl className="mt-3 grid gap-4 sm:grid-cols-2">
+                <DetailItem label="Bank">{selected.bank}</DetailItem>
+                <DetailItem label="Limit">
+                  <Money value={selected.limit} />
+                </DetailItem>
+                <DetailItem label="Drawn">
+                  <Money value={selected.drawn} />
+                </DetailItem>
+                <DetailItem label="Utilisation">
+                  <span className="tabular-nums font-semibold">{selected.utilisation.toFixed(1)}%</span>
+                </DetailItem>
+                <DetailItem label="Maturity">
+                  <DateText value={selected.maturityDate} />
+                </DetailItem>
+                <DetailItem label="Cost of funds">
+                  <span className="tabular-nums font-semibold">{selected.costOfFundsBps.toFixed(0)} bps</span>
+                </DetailItem>
+                <DetailItem label="Status">
+                  <StatusPill status={selected.status} />
+                </DetailItem>
+              </dl>
+            </section>
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Rapid tests</h3>
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Trigger a real-time RPT verification for this facility. We will record the request and update the audit trail automatically.
+              </p>
+              <button
+                type="button"
+                onClick={() => verifyMutation.mutate(selected.id)}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500 disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-slate-900"
+                disabled={verifyMutation.isPending}
+              >
+                {verifyMutation.isPending ? 'Verifying…' : 'RPT Verify'}
+              </button>
+              {verifyMutation.isError && (
+                <p role="alert" className="text-sm text-rose-500">
+                  {verifyMutation.error instanceof Error
+                    ? verifyMutation.error.message
+                    : 'Unable to start verification right now.'}
+                </p>
+              )}
+            </section>
+          </div>
+        </Drawer>
+      )}
+    </div>
+  );
+};
+
+const SummaryItem = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="space-y-1">
+    <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+    <dd className="text-lg font-semibold text-slate-900 dark:text-white">{children}</dd>
+  </div>
+);
+
+const DetailItem = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="space-y-1">
+    <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</dt>
+    <dd className="text-sm text-slate-700 dark:text-slate-200">{children}</dd>
+  </div>
+);
+
+const SortableHeading = ({ label, numeric }: { label: string; numeric?: boolean }) => (
+  <th
+    scope="col"
+    className={clsx('px-3 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500', numeric ? 'text-right' : 'text-left')}
+  >
+    {label}
+  </th>
+);
+
+const StatusPill = ({ status }: { status: BankLine['status'] }) => {
+  const copy = {
+    active: { label: 'Active', className: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-200' },
+    pending: { label: 'Pending', className: 'bg-amber-100 text-amber-700 dark:bg-amber-400/20 dark:text-amber-200' },
+    review: { label: 'Under review', className: 'bg-sky-100 text-sky-700 dark:bg-sky-400/20 dark:text-sky-200' }
+  }[status];
+
+  if (!copy) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-slate-200 px-2 py-1 text-xs font-semibold text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+        Unknown
+      </span>
+    );
+  }
+
+  return <span className={clsx('inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold', copy.className)}>{copy.label}</span>;
+};
+
+const Drawer = ({ children, onClose, titleId }: { children: ReactNode; onClose: () => void; titleId: string }) => (
+  <div className="fixed inset-0 z-50 flex items-end justify-end bg-slate-900/40 backdrop-blur-sm">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="h-full w-full max-w-md overflow-y-auto border-l border-slate-200 bg-white p-6 shadow-2xl transition dark:border-slate-800 dark:bg-slate-900"
+    >
+      {children}
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-6 w-full rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+      >
+        Close
+      </button>
+    </div>
+    <button
+      type="button"
+      className="absolute inset-0 h-full w-full cursor-pointer"
+      aria-hidden="true"
+      tabIndex={-1}
+      onClick={onClose}
+    />
+  </div>
+);
+
+const DrawerHeader = ({ title, onClose, titleId }: { title: string; onClose: () => void; titleId: string }) => (
+  <header className="flex items-start justify-between gap-4">
+    <div>
+      <h2 id={titleId} className="text-xl font-semibold text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400">Facility insights and verification controls.</p>
+    </div>
+    <button
+      type="button"
+      onClick={onClose}
+      className="rounded-full border border-slate-200 p-1 text-slate-500 transition hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+      aria-label="Close drawer"
+    >
+      ×
+    </button>
+  </header>
+);
+
+const BankLinesEmpty = () => (
+  <div className="flex h-full flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white/70 p-10 text-center dark:border-slate-700 dark:bg-slate-900/60">
+    <div className="text-4xl" aria-hidden>
+      🏦
+    </div>
+    <div>
+      <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">No bank lines configured</h2>
+      <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Add a facility to see utilisation, maturities and audit controls in one place.
+      </p>
+    </div>
+  </div>
+);
+
+const BankLinesSkeleton = () => (
+  <div className="space-y-6">
+    <div className="h-8 w-48 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+    <div className="h-28 animate-pulse rounded-2xl bg-slate-200/70 dark:bg-slate-700/70" />
+    <div className="h-96 animate-pulse rounded-2xl bg-slate-200/70 dark:bg-slate-700/70" />
+  </div>
+);
+
+const BankLinesError = ({ error }: { error: unknown }) => (
+  <div role="alert" className="rounded-xl border border-rose-200 bg-rose-50 p-6 text-rose-700 dark:border-rose-400/40 dark:bg-rose-500/10 dark:text-rose-200">
+    <h2 className="text-lg font-semibold">Unable to load bank lines</h2>
+    <p className="mt-2 text-sm">
+      {error instanceof Error ? error.message : 'An unexpected error occurred. Please try again shortly.'}
+    </p>
+  </div>
+);
+
+export const Route = createRoute<AppRouterContext>({
+  getParentRoute: () => rootRoute,
+  path: '/bank-lines',
+  validateSearch: normaliseSearch,
+  loader: async ({ context, search }) => {
+    await context.queryClient.ensureQueryData(bankLinesQueryOptions(search.page, search.perPage));
+    return {};
+  },
+  component: BankLinesPage,
+  pendingComponent: BankLinesSkeleton,
+  errorComponent: BankLinesError
+});
+
+export { bankLinesQueryOptions };

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,233 @@
+import { createRoute, Link } from '@tanstack/react-router';
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import clsx from 'clsx';
+
+import { fetchDashboard, type DashboardResponse } from '../lib/api';
+import { AppRouterContext } from '../router';
+import { Money } from '../ui/Money';
+import { DateText } from '../ui/Date';
+import { Route as rootRoute } from './__root';
+
+const dashboardQueryOptions = queryOptions<DashboardResponse>({
+  queryKey: ['dashboard'],
+  queryFn: fetchDashboard,
+  staleTime: 5 * 60 * 1000
+});
+
+const DashboardPage = () => {
+  const { data } = useQuery(dashboardQueryOptions);
+
+  if (!data?.kpis.length && !data?.cashTrend.length) {
+    return <EmptyState />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">Operating dashboard</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Snapshot of cash, facilities and utilisation for the past month.
+          </p>
+        </div>
+        {data?.asOf && (
+          <div className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+            Updated <DateText value={data.asOf} className="ml-1" />
+          </div>
+        )}
+      </header>
+
+      <section aria-labelledby="kpi-heading" className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 id="kpi-heading" className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+            Key indicators
+          </h2>
+          <Link
+            to="/bank-lines"
+            prefetch="intent"
+            className="rounded-md border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:text-slate-200"
+          >
+            Manage bank lines
+          </Link>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {data?.kpis.map((kpi) => (
+            <article
+              key={kpi.id}
+              className="rounded-xl border border-slate-200 bg-white/80 p-4 shadow-sm transition hover:border-slate-300 focus-within:border-slate-300 dark:border-slate-800 dark:bg-slate-900/70"
+            >
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="text-sm font-medium text-slate-600 dark:text-slate-300">{kpi.label}</h3>
+                  <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">
+                    <Money value={kpi.value} />
+                  </p>
+                </div>
+                {typeof kpi.delta === 'number' && kpi.deltaDirection && (
+                  <Delta value={kpi.delta} direction={kpi.deltaDirection} />
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="trend-heading" className="space-y-4">
+        <div>
+          <h2 id="trend-heading" className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+            30 day cash trend
+          </h2>
+          <p className="sr-only" id="trend-description">
+            Cash balance plotted for the previous 30 days.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+          <div role="img" aria-labelledby="trend-heading trend-description" className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data?.cashTrend ?? []} margin={{ top: 8, right: 24, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#CBD5F5" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(value) => new Intl.DateTimeFormat('en-AU', { month: 'short', day: 'numeric' }).format(new Date(value))}
+                  stroke="#94A3B8"
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  stroke="#94A3B8"
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(value) =>
+                    new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 }).format(value)
+                  }
+                />
+                <Tooltip content={<TrendTooltip />} />
+                <Line type="monotone" dataKey="amount" stroke="#0EA5E9" strokeWidth={2.5} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+          <TrendTable data={data?.cashTrend ?? []} />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const TrendTooltip = ({ active, payload, label }: any) => {
+  if (!active || !payload?.length) {
+    return null;
+  }
+
+  const point = payload[0];
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-lg">
+      <div className="font-medium">
+        {new Intl.DateTimeFormat('en-AU', { dateStyle: 'medium' }).format(new Date(label))}
+      </div>
+      <div>
+        {new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD' }).format(point.value as number)}
+      </div>
+    </div>
+  );
+};
+
+const TrendTable = ({ data }: { data: DashboardResponse['cashTrend'] }) => (
+  <div className="mt-4 overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+    <table className="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-300">
+      <caption className="sr-only">Tabular representation of the cash trend</caption>
+      <thead className="bg-slate-50/70 dark:bg-slate-800">
+        <tr>
+          <th scope="col" className="px-3 py-2 font-medium">Date</th>
+          <th scope="col" className="px-3 py-2 font-medium">Balance</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+        {data.map((point) => (
+          <tr key={point.date}>
+            <td className="px-3 py-2">
+              <DateText value={point.date} />
+            </td>
+            <td className="px-3 py-2">
+              <Money value={point.amount} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+const Delta = ({ value, direction }: { value: number; direction: 'up' | 'down' }) => {
+  const positive = direction === 'up';
+  return (
+    <p
+      className={clsx(
+        'flex items-center gap-1 rounded-full px-2 py-1 text-xs font-semibold',
+        positive ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-200' : 'bg-rose-100 text-rose-700 dark:bg-rose-400/20 dark:text-rose-200'
+      )}
+    >
+      <span aria-hidden>{positive ? '▲' : '▼'}</span>
+      <span>
+        {value}% {positive ? 'increase' : 'decrease'}
+      </span>
+    </p>
+  );
+};
+
+const EmptyState = () => (
+  <div className="flex h-full flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-slate-300 bg-white/70 p-10 text-center dark:border-slate-700 dark:bg-slate-900/60">
+    <div className="text-4xl" aria-hidden>
+      📈
+    </div>
+    <div>
+      <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">No dashboard data yet</h2>
+      <p className="mt-2 max-w-md text-sm text-slate-500 dark:text-slate-400">
+        Connect a bank feed or import statements to populate the dashboard.
+      </p>
+    </div>
+  </div>
+);
+
+const DashboardSkeleton = () => (
+  <div className="space-y-8">
+    <div className="h-8 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+    <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div key={index} className="h-32 animate-pulse rounded-xl bg-slate-200/70 dark:bg-slate-700/70" />
+      ))}
+    </div>
+    <div className="h-80 animate-pulse rounded-2xl bg-slate-200/70 dark:bg-slate-700/70" />
+  </div>
+);
+
+const DashboardError = ({ error }: { error: unknown }) => (
+  <div role="alert" className="rounded-xl border border-rose-200 bg-rose-50 p-6 text-rose-700 dark:border-rose-400/40 dark:bg-rose-500/10 dark:text-rose-200">
+    <h2 className="text-lg font-semibold">Unable to load dashboard</h2>
+    <p className="mt-2 text-sm">
+      {error instanceof Error ? error.message : 'An unexpected error occurred. Please try again shortly.'}
+    </p>
+  </div>
+);
+
+export const Route = createRoute<AppRouterContext>({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData(dashboardQueryOptions);
+    return {};
+  },
+  component: DashboardPage,
+  pendingComponent: DashboardSkeleton,
+  errorComponent: DashboardError
+});
+
+export { dashboardQueryOptions };

--- a/apgms/webapp/src/shell/AppShell.tsx
+++ b/apgms/webapp/src/shell/AppShell.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState, type ReactNode } from 'react';
+import { Link, useRouterState } from '@tanstack/react-router';
+import clsx from 'clsx';
+
+const NAV_ITEMS = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/bank-lines', label: 'Bank lines' }
+];
+
+type Theme = 'light' | 'dark';
+
+const resolveInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem('apgms:theme');
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  const prefersDark = window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+};
+
+const applyTheme = (theme: Theme) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.dataset.theme = theme;
+};
+
+export const AppShell = ({ children }: { children: ReactNode }) => {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [theme, setTheme] = useState<Theme>(() => resolveInitialTheme());
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+
+  useEffect(() => {
+    applyTheme(theme);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('apgms:theme', theme);
+    }
+  }, [theme]);
+
+  useEffect(() => {
+    if (!mobileNavOpen) {
+      return;
+    }
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setMobileNavOpen(false);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [mobileNavOpen]);
+
+  const toggleTheme = () => {
+    setTheme((current) => (current === 'light' ? 'dark' : 'light'));
+  };
+
+  const closeOnNavigate = () => setMobileNavOpen(false);
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 transition-colors dark:bg-slate-900 dark:text-slate-100">
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
+      <div className="flex min-h-screen">
+        <aside
+          className={clsx(
+            'fixed inset-y-0 z-40 w-64 border-r border-slate-200 bg-white/95 backdrop-blur dark:border-slate-800 dark:bg-slate-900/90 md:static md:translate-x-0 md:bg-white/95 md:dark:bg-slate-900/90',
+            mobileNavOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
+          )}
+        >
+          <div className="flex h-16 items-center justify-between px-6">
+            <span className="text-lg font-semibold tracking-tight">Birchal Ops</span>
+            <button
+              type="button"
+              onClick={() => setMobileNavOpen(false)}
+              className="rounded-md p-2 text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 md:hidden"
+              aria-label="Close navigation"
+            >
+              <span aria-hidden>×</span>
+            </button>
+          </div>
+          <nav aria-label="Primary" className="mt-4 space-y-1 px-2">
+            {NAV_ITEMS.map((item) => {
+              const active = pathname === item.to;
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  prefetch="intent"
+                  className={clsx(
+                    'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500',
+                    active
+                      ? 'bg-sky-500 text-white shadow-sm'
+                      : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800/70'
+                  )}
+                  onClick={closeOnNavigate}
+                >
+                  <span aria-hidden className="text-base">
+                    {item.label === 'Dashboard' ? '📊' : '🏦'}
+                  </span>
+                  <span>{item.label}</span>
+                </Link>
+              );
+            })}
+          </nav>
+        </aside>
+        <div className="flex flex-1 flex-col">
+          <header className="sticky top-0 z-30 border-b border-slate-200 bg-white/70 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+            <div className="flex h-16 items-center justify-between px-4 md:px-8">
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setMobileNavOpen(true)}
+                  className="rounded-md p-2 text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 md:hidden"
+                  aria-label="Open navigation"
+                >
+                  <span aria-hidden>☰</span>
+                </button>
+                <span className="text-base font-semibold text-slate-700 dark:text-slate-200">
+                  Control centre
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={toggleTheme}
+                className="flex items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                aria-pressed={theme === 'dark'}
+                aria-label="Toggle color scheme"
+              >
+                <span aria-hidden>{theme === 'dark' ? '🌙' : '☀️'}</span>
+                <span>{theme === 'dark' ? 'Dark' : 'Light'}</span>
+              </button>
+            </div>
+          </header>
+          <main id="main-content" className="flex-1 px-4 py-6 md:px-8 md:py-10" tabIndex={-1}>
+            {children}
+          </main>
+        </div>
+      </div>
+      {mobileNavOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-slate-900/40 backdrop-blur-sm md:hidden"
+          aria-hidden="true"
+          onClick={() => setMobileNavOpen(false)}
+        />
+      )}
+    </div>
+  );
+};

--- a/apgms/webapp/src/ui/Date.tsx
+++ b/apgms/webapp/src/ui/Date.tsx
@@ -1,0 +1,21 @@
+import clsx from 'clsx';
+
+export type DateTextProps = {
+  value: string | Date;
+  options?: Intl.DateTimeFormatOptions;
+  className?: string;
+};
+
+const defaultOptions: Intl.DateTimeFormatOptions = {
+  dateStyle: 'medium'
+};
+
+const getFormatter = (options?: Intl.DateTimeFormatOptions) =>
+  new Intl.DateTimeFormat('en-AU', options ?? defaultOptions);
+
+const ensureDate = (value: string | Date) => (value instanceof Date ? value : new Date(value));
+
+export const DateText = ({ value, options, className }: DateTextProps) => {
+  const formatter = getFormatter(options);
+  return <span className={clsx('tabular-nums text-sm text-slate-500', className)}>{formatter.format(ensureDate(value))}</span>;
+};

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,47 @@
+import clsx from 'clsx';
+
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+export type MoneyProps = {
+  value: number;
+  currency?: string;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  signDisplay?: 'auto' | 'always' | 'never' | 'exceptZero';
+  className?: string;
+};
+
+const getFormatter = (
+  currency: string,
+  minimumFractionDigits: number | undefined,
+  maximumFractionDigits: number | undefined,
+  signDisplay: MoneyProps['signDisplay']
+) => {
+  const key = [currency, minimumFractionDigits, maximumFractionDigits, signDisplay].join(':');
+  const existing = formatterCache.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const formatter = new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    signDisplay
+  });
+  formatterCache.set(key, formatter);
+  return formatter;
+};
+
+export const Money = ({
+  value,
+  currency = 'AUD',
+  minimumFractionDigits,
+  maximumFractionDigits,
+  signDisplay = 'auto',
+  className
+}: MoneyProps) => {
+  const formatter = getFormatter(currency, minimumFractionDigits, maximumFractionDigits, signDisplay);
+  return <span className={clsx('tabular-nums', className)}>{formatter.format(value)}</span>;
+};

--- a/apgms/webapp/tailwind.config.cjs
+++ b/apgms/webapp/tailwind.config.cjs
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif']
+      },
+      boxShadow: {
+        focus: '0 0 0 3px rgba(59,130,246,0.45)'
+      }
+    }
+  }
+};

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "baseUrl": "./src",
+    "paths": {}
+  },
+  "include": ["src", "vite.config.ts", "scripts"],
+  "references": []
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  css: {
+    postcss: './postcss.config.cjs'
+  }
+});


### PR DESCRIPTION
## Summary
- add Vite/Tailwind setup with application shell powered by TanStack Router
- implement dashboard and bank line routes with KPI cards, charts, and drawers
- wire axios client utilities and ship an axe-based accessibility regression script

## Testing
- not run (dependencies unavailable in sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68f428c178c88327b3df9866c6ecdeb3