### PR TITLE
feat: add admin privacy endpoints

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test test/privacy.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Fastify, { FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import dotenv from "dotenv";
+import adminPrivacyRoutes from "./routes/admin-privacy";
+
+type BuildAppDeps = {
+  prisma?: any;
+};
+
+let cachedPrisma: any;
+
+const loadPrisma = async () => {
+  if (!cachedPrisma) {
+    const mod = await import("../../../shared/src/db");
+    cachedPrisma = mod.prisma;
+  }
+  return cachedPrisma;
+};
+
+export async function buildApp(deps: BuildAppDeps = {}): Promise<FastifyInstance> {
+  const prisma = (deps.prisma ?? (await loadPrisma())) as any;
+
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+  const app = Fastify({ logger: true });
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  await app.register(adminPrivacyRoutes, { prisma });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,11 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+import { buildApp } from "./app";
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
+
+const app = await buildApp();
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/routes/admin-privacy.ts
+++ b/apgms/services/api-gateway/src/routes/admin-privacy.ts
@@ -1,0 +1,120 @@
+import crypto from "node:crypto";
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+type AdminPrivacyOptions = {
+  prisma: any;
+};
+
+type AdminRequest = FastifyRequest & {
+  headers: FastifyRequest["headers"] & { "x-role"?: string; "x-actor"?: string };
+};
+
+const adminOnly = async (req: AdminRequest, rep: FastifyReply) => {
+  if (req.headers["x-role"] !== "admin") {
+    return rep.code(403).send({ error: "forbidden" });
+  }
+};
+
+const getQuerySchema = z.object({ orgId: z.string().min(1) });
+const deleteBodySchema = z.object({ orgId: z.string().min(1), hard: z.boolean().optional() });
+
+const hashValue = (value: string) =>
+  crypto.createHash("sha256").update(value).digest("hex");
+
+const adminPrivacyRoutes: FastifyPluginAsync<AdminPrivacyOptions> = async (
+  app,
+  { prisma }
+) => {
+  app.get("/admin/export", { preHandler: adminOnly }, async (req, rep) => {
+    const { orgId } = getQuerySchema.parse(req.query);
+
+    const org = await prisma.org.findUnique({ where: { id: orgId } });
+    if (!org) {
+      return rep.code(404).send({ error: "not_found" });
+    }
+
+    const [users, bankLines, rpts] = await Promise.all([
+      prisma.user.findMany({ where: { orgId } }),
+      prisma.bankLine.findMany({ where: { orgId } }),
+      prisma.rpt.findMany({ where: { orgId } }),
+    ]);
+
+    return rep.send({ org, users, bankLines, rpts });
+  });
+
+  app.post("/admin/delete", { preHandler: adminOnly }, async (req, rep) => {
+    const { orgId, hard } = deleteBodySchema.parse(req.body);
+    const now = new Date();
+
+    const org = await prisma.org.findUnique({ where: { id: orgId } });
+    if (!org) {
+      return rep.code(404).send({ error: "not_found" });
+    }
+
+    if (hard) {
+      await prisma.org.update({ where: { id: orgId }, data: { name: hashValue(org.name), deletedAt: now } });
+
+      const users = await prisma.user.findMany({ where: { orgId } });
+      await Promise.all(
+        users.map((user) =>
+          prisma.user.update({
+            where: { id: user.id },
+            data: {
+              email: hashValue(user.email),
+              password: hashValue(user.password),
+              deletedAt: now,
+            },
+          })
+        )
+      );
+
+      const lines = await prisma.bankLine.findMany({ where: { orgId } });
+      await Promise.all(
+        lines.map((line) =>
+          prisma.bankLine.update({
+            where: { id: line.id },
+            data: {
+              payee: hashValue(line.payee),
+              desc: hashValue(line.desc),
+              deletedAt: now,
+            },
+          })
+        )
+      );
+
+      const reports = await prisma.rpt.findMany({ where: { orgId } });
+      await Promise.all(
+        reports.map((report) =>
+          prisma.rpt.update({
+            where: { id: report.id },
+            data: {
+              kind: hashValue(report.kind),
+              payloadHash: hashValue(report.payloadHash),
+              deletedAt: now,
+            },
+          })
+        )
+      );
+    } else {
+      await Promise.all([
+        prisma.org.update({ where: { id: orgId }, data: { deletedAt: now } }),
+        prisma.user.updateMany({ where: { orgId }, data: { deletedAt: now } }),
+        prisma.bankLine.updateMany({ where: { orgId }, data: { deletedAt: now } }),
+        prisma.rpt.updateMany({ where: { orgId }, data: { deletedAt: now } }),
+      ]);
+    }
+
+    await prisma.auditEvent.create({
+      data: {
+        orgId,
+        action: hard ? "org.delete.hard" : "org.delete.soft",
+        actor: req.headers["x-actor"] ?? "system",
+        payload: { hard: Boolean(hard) },
+      },
+    });
+
+    return rep.send({ ok: true });
+  });
+};
+
+export default adminPrivacyRoutes;

--- a/apgms/services/api-gateway/test/privacy.spec.ts
+++ b/apgms/services/api-gateway/test/privacy.spec.ts
@@ -1,0 +1,244 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "../src/app";
+
+type Org = {
+  id: string;
+  name: string;
+  createdAt: Date;
+  deletedAt?: Date | null;
+};
+
+type User = {
+  id: string;
+  orgId: string;
+  email: string;
+  password: string;
+  deletedAt?: Date | null;
+};
+
+type BankLine = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  deletedAt?: Date | null;
+};
+
+type Rpt = {
+  id: string;
+  orgId: string;
+  kind: string;
+  payloadHash: string;
+  deletedAt?: Date | null;
+};
+
+type AuditEvent = {
+  id: string;
+  orgId: string;
+  action: string;
+  actor: string;
+  payload: Record<string, unknown>;
+};
+
+type MockState = {
+  orgs: Org[];
+  users: User[];
+  bankLines: BankLine[];
+  rpts: Rpt[];
+  audits: AuditEvent[];
+};
+
+type UpdateArgs<T> = { where: { id: string }; data: Partial<T> };
+
+type UpdateManyArgs<T> = { where: { orgId: string }; data: Partial<T> };
+
+type FindManyArgs = { where?: { orgId?: string } };
+
+type CreateArgs<T> = { data: T };
+
+type MockPrisma = {
+  org: {
+    findUnique: ({ where }: { where: { id: string } }) => Promise<Org | null>;
+    update: (args: UpdateArgs<Org>) => Promise<Org>;
+  };
+  user: {
+    findMany: (args: FindManyArgs) => Promise<User[]>;
+    updateMany: (args: UpdateManyArgs<User>) => Promise<{ count: number }>;
+    update: (args: UpdateArgs<User>) => Promise<User>;
+  };
+  bankLine: {
+    findMany: (args: FindManyArgs) => Promise<BankLine[]>;
+    updateMany: (args: UpdateManyArgs<BankLine>) => Promise<{ count: number }>;
+    update: (args: UpdateArgs<BankLine>) => Promise<BankLine>;
+  };
+  rpt: {
+    findMany: (args: FindManyArgs) => Promise<Rpt[]>;
+    updateMany: (args: UpdateManyArgs<Rpt>) => Promise<{ count: number }>;
+    update: (args: UpdateArgs<Rpt>) => Promise<Rpt>;
+  };
+  auditEvent: {
+    create: (args: CreateArgs<Omit<AuditEvent, "id">>) => Promise<AuditEvent>;
+  };
+};
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const applyUpdate = <T extends { id: string }>(collection: T[], args: UpdateArgs<T>): T => {
+  const target = collection.find((item) => item.id === args.where.id);
+  if (!target) {
+    throw new Error("not found");
+  }
+  Object.assign(target, args.data);
+  return target;
+};
+
+const applyUpdateMany = <T extends { orgId: string }>(
+  collection: T[],
+  args: UpdateManyArgs<T>
+): { count: number } => {
+  const targets = collection.filter((item) => item.orgId === args.where.orgId);
+  for (const item of targets) {
+    Object.assign(item, args.data);
+  }
+  return { count: targets.length };
+};
+
+const applyFindMany = <T extends { orgId: string }>(
+  collection: T[],
+  args: FindManyArgs
+): T[] => {
+  if (!args.where?.orgId) {
+    return collection.map(clone);
+  }
+  return collection.filter((item) => item.orgId === args.where?.orgId).map(clone);
+};
+
+const createMockPrisma = () => {
+  const state: MockState = {
+    orgs: [
+      { id: "org-1", name: "Org One", createdAt: new Date("2024-01-01T00:00:00Z") },
+    ],
+    users: [
+      {
+        id: "user-1",
+        orgId: "org-1",
+        email: "user1@example.com",
+        password: "secret",
+      },
+      {
+        id: "user-2",
+        orgId: "org-1",
+        email: "user2@example.com",
+        password: "secret",
+      },
+    ],
+    bankLines: [
+      {
+        id: "line-1",
+        orgId: "org-1",
+        date: new Date("2024-01-10T00:00:00Z"),
+        amount: 100,
+        payee: "Vendor",
+        desc: "Payment",
+      },
+    ],
+    rpts: [
+      { id: "rpt-1", orgId: "org-1", kind: "summary", payloadHash: "hash" },
+    ],
+    audits: [],
+  };
+
+  const prisma: MockPrisma = {
+    org: {
+      findUnique: async ({ where }) =>
+        state.orgs.find((org) => org.id === where.id) ?? null,
+      update: async (args) => applyUpdate(state.orgs, args),
+    },
+    user: {
+      findMany: async (args) => applyFindMany(state.users, args),
+      updateMany: async (args) => applyUpdateMany(state.users, args),
+      update: async (args) => applyUpdate(state.users, args),
+    },
+    bankLine: {
+      findMany: async (args) => applyFindMany(state.bankLines, args),
+      updateMany: async (args) => applyUpdateMany(state.bankLines, args),
+      update: async (args) => applyUpdate(state.bankLines, args),
+    },
+    rpt: {
+      findMany: async (args) => applyFindMany(state.rpts, args),
+      updateMany: async (args) => applyUpdateMany(state.rpts, args),
+      update: async (args) => applyUpdate(state.rpts, args),
+    },
+    auditEvent: {
+      create: async ({ data }) => {
+        const event: AuditEvent = {
+          id: `audit-${state.audits.length + 1}`,
+          ...clone(data),
+        };
+        state.audits.push(event);
+        return event;
+      },
+    },
+  };
+
+  return { prisma, state };
+};
+
+test("admin privacy routes", async (t) => {
+  await t.test("rejects non-admin access", async () => {
+    const { prisma } = createMockPrisma();
+    const app = await buildApp({ prisma });
+    const response = await app.inject({
+      method: "GET",
+      url: "/admin/export?orgId=org-1",
+    });
+
+    assert.equal(response.statusCode, 403);
+  });
+
+  await t.test("exports org bundle for admin", async () => {
+    const { prisma } = createMockPrisma();
+    const app = await buildApp({ prisma });
+    const response = await app.inject({
+      method: "GET",
+      url: "/admin/export?orgId=org-1",
+      headers: { "x-role": "admin" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    const payload = response.json();
+    assert.equal(payload.org.id, "org-1");
+    assert.equal(payload.users.length, 2);
+    assert.equal(payload.bankLines.length, 1);
+    assert.equal(payload.rpts.length, 1);
+  });
+
+  await t.test("soft deletes org data and logs audit", async () => {
+    const { prisma, state } = createMockPrisma();
+    const app = await buildApp({ prisma });
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/delete",
+      headers: { "x-role": "admin", "x-actor": "tester" },
+      payload: { orgId: "org-1" },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.ok(state.orgs[0].deletedAt instanceof Date);
+    assert.equal(state.orgs[0].name, "Org One");
+    assert.ok(state.users.every((user) => user.deletedAt instanceof Date));
+    assert.ok(state.bankLines.every((line) => line.deletedAt instanceof Date));
+    assert.ok(state.rpts.every((report) => report.deletedAt instanceof Date));
+    assert.equal(state.audits.length, 1);
+    assert.deepEqual(state.audits[0], {
+      id: "audit-1",
+      orgId: "org-1",
+      action: "org.delete.soft",
+      actor: "tester",
+      payload: { hard: false },
+    });
+  });
+});

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
@@ -8,11 +9,14 @@ datasource db {
 }
 
 model Org {
-  id        String   @id @default(cuid())
+  id        String      @id @default(cuid())
   name      String
-  createdAt DateTime @default(now())
+  createdAt DateTime    @default(now())
+  deletedAt DateTime?
   users     User[]
   lines     BankLine[]
+  reports   Rpt[]
+  audits    AuditEvent[]
 }
 
 model User {
@@ -20,6 +24,7 @@ model User {
   email     String   @unique
   password  String
   createdAt DateTime @default(now())
+  deletedAt DateTime?
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
 }
@@ -32,5 +37,26 @@ model BankLine {
   amount    Decimal
   payee     String
   desc      String
+  createdAt DateTime @default(now())
+  deletedAt DateTime?
+}
+
+model Rpt {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  kind        String
+  payloadHash String
+  createdAt   DateTime @default(now())
+  deletedAt   DateTime?
+}
+
+model AuditEvent {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  action    String
+  actor     String
+  payload   Json
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- add admin-only export and delete routes that stream org data, support soft/hard deletion, and log audits
- refactor Fastify bootstrap into a reusable builder for dependency injection
- extend Prisma models for soft-delete metadata, reports, and audit events plus add node:test coverage

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4288df58c832783c00f3fefde08d1