### PR TITLE
feat: add health and readiness endpoints to api-gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,27 @@
+import type { FastifyPluginAsync, FastifyInstance } from "fastify";
+
+type PrismaLike = {
+  $queryRaw: (...args: unknown[]) => Promise<unknown>;
+  $disconnect: () => Promise<void>;
+};
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  const prisma = (app as FastifyInstance & { prisma: PrismaLike }).prisma;
+
+  app.get("/healthz", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/readyz", async (_, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return { ready: true };
+    } catch {
+      return reply.status(503).send({ ready: false, reason: "db_unreachable" });
+    }
+  });
+
+  app.addHook("onClose", async () => {
+    await prisma.$disconnect();
+  });
+};
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import Fastify from "fastify";
+import healthRoutes from "../src/routes/health";
+
+const prismaStub = {
+  $queryRaw: async (..._args: unknown[]) => Promise.resolve(1),
+  $disconnect: async () => Promise.resolve(),
+};
+
+test("readyz reflects database availability", { concurrency: false }, async (t) => {
+  await t.test("returns 200 when the database is reachable", async () => {
+    prismaStub.$queryRaw = async (..._args: unknown[]) => Promise.resolve(1);
+
+    const app = Fastify();
+    app.decorate("prisma", prismaStub);
+    await app.register(healthRoutes);
+    await app.ready();
+
+    const response = await app.inject({ method: "GET", url: "/readyz" });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { ready: true });
+
+    await app.close();
+  });
+
+  await t.test("returns 503 when the database is unreachable", async () => {
+    prismaStub.$queryRaw = async (..._args: unknown[]) => {
+      throw new Error("db down");
+    };
+
+    const app = Fastify();
+    app.decorate("prisma", prismaStub);
+    await app.register(healthRoutes);
+    await app.ready();
+
+    const response = await app.inject({ method: "GET", url: "/readyz" });
+    assert.equal(response.statusCode, 503);
+    assert.deepEqual(response.json(), { ready: false, reason: "db_unreachable" });
+
+    await app.close();
+  });
+
+  await t.test("healthz always responds with service status", async () => {
+    prismaStub.$queryRaw = async (..._args: unknown[]) => Promise.resolve(1);
+
+    const app = Fastify();
+    app.decorate("prisma", prismaStub);
+    await app.register(healthRoutes);
+    await app.ready();
+
+    const response = await app.inject({ method: "GET", url: "/healthz" });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { ok: true, service: "api-gateway" });
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add Fastify plugin exposing /healthz and /readyz routes with database readiness checks
- register the health routes, decorate Prisma on the app instance, and close gracefully on SIGINT/SIGTERM
- add node:test coverage and script for exercising the health endpoints

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f42868e4648327981ca21b364eaac4