### PR TITLE
feat(api-gateway): implement RPT signing and audit verification

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,4 +1,6 @@
-﻿node_modules/
+node_modules/
+!services/api-gateway/node_modules/@noble/
+!services/api-gateway/node_modules/@noble/ed25519/
 dist/
 coverage/
 .env*

--- a/apgms/services/api-gateway/node_modules/@noble/ed25519/index.d.ts
+++ b/apgms/services/api-gateway/node_modules/@noble/ed25519/index.d.ts
@@ -1,0 +1,6 @@
+export declare const getPublicKey: (secretKey: Uint8Array) => Promise<Uint8Array>;
+export declare const sign: (message: Uint8Array, secretKey: Uint8Array) => Promise<Uint8Array>;
+export declare const verify: (signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array) => Promise<boolean>;
+export declare const utils: {
+  randomPrivateKey: () => Uint8Array;
+};

--- a/apgms/services/api-gateway/node_modules/@noble/ed25519/index.js
+++ b/apgms/services/api-gateway/node_modules/@noble/ed25519/index.js
@@ -1,0 +1,31 @@
+import { createPrivateKey, createPublicKey, randomBytes, sign as nodeSign, verify as nodeVerify } from "node:crypto";
+
+const PRIVATE_KEY_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const PUBLIC_KEY_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+const toBuffer = (value) => (Buffer.isBuffer(value) ? value : Buffer.from(value));
+
+const toPrivateKey = (secretKey) =>
+  createPrivateKey({ key: Buffer.concat([PRIVATE_KEY_PREFIX, toBuffer(secretKey)]), format: "der", type: "pkcs8" });
+
+const toPublicKey = (publicKey) =>
+  createPublicKey({ key: Buffer.concat([PUBLIC_KEY_PREFIX, toBuffer(publicKey)]), format: "der", type: "spki" });
+
+export const getPublicKey = async (secretKey) => {
+  const privateKey = toPrivateKey(secretKey);
+  const publicKey = createPublicKey(privateKey);
+  const der = publicKey.export({ format: "der", type: "spki" });
+  return new Uint8Array(der.slice(PUBLIC_KEY_PREFIX.length));
+};
+
+export const sign = async (message, secretKey) => {
+  const signature = nodeSign(null, toBuffer(message), toPrivateKey(secretKey));
+  return new Uint8Array(signature);
+};
+
+export const verify = async (signature, message, publicKey) =>
+  nodeVerify(null, toBuffer(message), toPublicKey(publicKey), toBuffer(signature));
+
+export const utils = {
+  randomPrivateKey: () => new Uint8Array(randomBytes(32)),
+};

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,210 @@
+import { createHash } from "node:crypto";
+import { verify as nobleVerify, getPublicKey } from "@noble/ed25519";
+
+export type RptAllocation = Record<string, unknown>;
+
+export interface RptBase {
+  rptId: string;
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: RptAllocation[];
+  prevHash?: string | null;
+  now: string | Date | number;
+}
+
+export interface SignedRpt extends Omit<RptBase, "now"> {
+  now: string;
+  hash: string;
+  sig: string;
+}
+
+export interface MintRptParams extends Omit<RptBase, "now"> {
+  now: Date | string | number;
+}
+
+export interface KmsSigner {
+  sign(data: Uint8Array): Promise<Uint8Array> | Uint8Array;
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const canonicalize = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  }
+  if (isObject(value)) {
+    const entries = Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalize((value as Record<string, unknown>)[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error("non_finite_number");
+    }
+    return value.toString(10);
+  }
+  if (typeof value === "bigint") {
+    return value.toString(10);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  throw new Error("unsupported_type");
+};
+
+export const canonicalAlloc = (allocation: RptAllocation): string => canonicalize(allocation);
+
+const normalizeNow = (value: Date | string | number): string => {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === "number") {
+    return new Date(value).toISOString();
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error("invalid_date");
+  }
+  return parsed.toISOString();
+};
+
+const toHashPayload = (rpt: RptBase | SignedRpt): Omit<SignedRpt, "hash" | "sig"> => ({
+  rptId: rpt.rptId,
+  orgId: rpt.orgId,
+  bankLineId: rpt.bankLineId,
+  policyHash: rpt.policyHash,
+  allocations: rpt.allocations,
+  prevHash: rpt.prevHash ?? null,
+  now: normalizeNow(rpt.now),
+});
+
+const toSortedCanonicalAllocations = (allocations: RptAllocation[]): string[] =>
+  allocations.map((allocation) => canonicalAlloc(allocation)).sort();
+
+export const hashRpt = (rpt: RptBase | SignedRpt): string => {
+  const base = toHashPayload(rpt);
+  const canonicalPayload = {
+    ...base,
+    allocations: toSortedCanonicalAllocations(base.allocations),
+  };
+  const canonical = canonicalize(canonicalPayload);
+  return createHash("sha256").update(canonical).digest("hex");
+};
+
+const hexToBytes = (hex: string): Uint8Array => {
+  if (hex.length % 2 !== 0) {
+    throw new Error("invalid_hex");
+  }
+  const result = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    const byte = Number.parseInt(hex.slice(i, i + 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new Error("invalid_hex");
+    }
+    result[i / 2] = byte;
+  }
+  return result;
+};
+
+const normalizeKey = (input: Uint8Array | string): Uint8Array => {
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const isHex = /^[0-9a-f]+$/i.test(trimmed) && trimmed.length >= 64 && trimmed.length % 2 === 0;
+    if (isHex) {
+      return hexToBytes(trimmed.toLowerCase());
+    }
+    return Uint8Array.from(Buffer.from(trimmed, "base64"));
+  }
+  return input;
+};
+
+const decodeSignature = (sig: string): Uint8Array => Uint8Array.from(Buffer.from(sig, "base64"));
+
+export const mintRpt = async (
+  { rptId, orgId, bankLineId, policyHash, allocations, prevHash, now }: MintRptParams,
+  kms: KmsSigner,
+): Promise<SignedRpt> => {
+  const normalizedNow = normalizeNow(now);
+  const base: Omit<SignedRpt, "hash" | "sig"> = {
+    rptId,
+    orgId,
+    bankLineId,
+    policyHash,
+    allocations: allocations.map((allocation) => ({ ...allocation })),
+    prevHash: prevHash ?? null,
+    now: normalizedNow,
+  };
+
+  const hash = hashRpt(base);
+  const message = hexToBytes(hash);
+  const signatureBytes = await kms.sign(message);
+  const sig = Buffer.from(signatureBytes).toString("base64");
+
+  return {
+    ...base,
+    hash,
+    sig,
+  };
+};
+
+export const verifyRpt = async (rpt: SignedRpt, pubkey: Uint8Array | string): Promise<boolean> => {
+  try {
+    const expectedHash = hashRpt(rpt);
+    if (expectedHash !== rpt.hash) {
+      return false;
+    }
+    const publicKeyBytes = normalizeKey(pubkey);
+    const signatureBytes = decodeSignature(rpt.sig);
+    return await nobleVerify(signatureBytes, hexToBytes(rpt.hash), publicKeyBytes);
+  } catch {
+    return false;
+  }
+};
+
+export const verifyChain = async (
+  headRptId: string,
+  loadPrev: (idOrHash: string) => Promise<SignedRpt | null | undefined>,
+): Promise<boolean> => {
+  let current = await loadPrev(headRptId);
+  if (!current) {
+    return false;
+  }
+  const visited = new Set<string>();
+
+  while (current) {
+    const recalculated = hashRpt(current);
+    if (recalculated !== current.hash) {
+      return false;
+    }
+    if (visited.has(current.hash)) {
+      return false;
+    }
+    visited.add(current.hash);
+
+    if (!current.prevHash) {
+      return true;
+    }
+
+    const previous = await loadPrev(current.prevHash);
+    if (!previous) {
+      return false;
+    }
+    if (previous.hash !== current.prevHash) {
+      return false;
+    }
+    current = previous;
+  }
+
+  return false;
+};
+
+export const derivePublicKey = async (secretKey: Uint8Array): Promise<Uint8Array> => getPublicKey(secretKey);

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from "fastify";
+import { verifyRpt, verifyChain, type SignedRpt } from "../lib/rpt.js";
+
+export interface AuditRouteOptions {
+  loadRpt: (idOrHash: string) => Promise<SignedRpt | null | undefined>;
+  loadPrev?: (idOrHash: string) => Promise<SignedRpt | null | undefined>;
+  pubkey: Uint8Array | string;
+}
+
+const auditRoutes = async (app: FastifyInstance, opts: AuditRouteOptions): Promise<void> => {
+  const { loadRpt, loadPrev, pubkey } = opts;
+  const resolve = loadPrev ?? loadRpt;
+
+  app.get("/audit/rpt/:id", async (req, rep) => {
+    const { id } = req.params as { id: string };
+    const head = await loadRpt(id);
+    if (!head) {
+      return rep.code(404).send({ ok: false, reason: "not_found" });
+    }
+
+    if (!(await verifyRpt(head, pubkey))) {
+      return rep.code(400).send({ ok: false, reason: "invalid_signature" });
+    }
+
+    const chainOk = await verifyChain(id, async (key) => {
+      if (key === id) {
+        return head;
+      }
+      return resolve(key) ?? null;
+    });
+
+    if (!chainOk) {
+      return rep.code(400).send({ ok: false, reason: "invalid_chain" });
+    }
+
+    return { ok: true, rpt: head };
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/test/rpt.spec.ts
+++ b/apgms/services/api-gateway/test/rpt.spec.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { utils, getPublicKey, sign } from "@noble/ed25519";
+import auditRoutes from "../src/routes/audit.js";
+import {
+  mintRpt,
+  verifyRpt,
+  verifyChain,
+  type SignedRpt,
+  type MintRptParams,
+} from "../src/lib/rpt.js";
+
+const createKms = (secretKey: Uint8Array) => ({
+  sign: async (data: Uint8Array) => sign(data, secretKey),
+});
+
+const baseAllocations = [
+  { accountId: "acct:1", amount: "100.00" },
+  { accountId: "acct:2", amount: "50.00" },
+];
+
+const baseParams = (overrides: Partial<MintRptParams> = {}): MintRptParams => ({
+  rptId: overrides.rptId ?? "rpt-1",
+  orgId: overrides.orgId ?? "org-1",
+  bankLineId: overrides.bankLineId ?? "bank-1",
+  policyHash: overrides.policyHash ?? "policy-1",
+  allocations: overrides.allocations ?? baseAllocations,
+  prevHash: overrides.prevHash ?? null,
+  now: overrides.now ?? new Date("2024-01-01T00:00:00.000Z"),
+});
+
+const setupKeys = async () => {
+  const secretKey = utils.randomPrivateKey();
+  const publicKey = await getPublicKey(secretKey);
+  return { secretKey, publicKey, kms: createKms(secretKey) };
+};
+
+const register = (store: Map<string, SignedRpt>) =>
+  async (idOrHash: string): Promise<SignedRpt | null> => store.get(idOrHash) ?? null;
+
+test("minted RPT verifies", async () => {
+  const { publicKey, kms } = await setupKeys();
+  const rpt = await mintRpt(baseParams(), kms);
+  assert.equal(await verifyRpt(rpt, Buffer.from(publicKey).toString("base64")), true);
+});
+
+test("tampered RPT fails verification", async () => {
+  const { publicKey, kms } = await setupKeys();
+  const rpt = await mintRpt(baseParams(), kms);
+  const tampered = {
+    ...rpt,
+    allocations: [{ accountId: "acct:1", amount: "999.00" }],
+  };
+  assert.equal(await verifyRpt(tampered, publicKey), false);
+});
+
+test("chain integrity succeeds and fails when broken", async () => {
+  const { kms } = await setupKeys();
+  const first = await mintRpt(baseParams({ rptId: "rpt-1" }), kms);
+  const second = await mintRpt(baseParams({ rptId: "rpt-2", prevHash: first.hash }), kms);
+  const third = await mintRpt(baseParams({ rptId: "rpt-3", prevHash: second.hash }), kms);
+
+  const store = new Map<string, SignedRpt>([
+    [first.hash, first],
+    [second.hash, second],
+    [third.hash, third],
+    [third.rptId, third],
+    [second.rptId, second],
+    [first.rptId, first],
+  ]);
+
+  assert.equal(await verifyChain(third.rptId, register(store)), true);
+
+  const broken = await mintRpt(baseParams({ rptId: "rpt-4", prevHash: "deadbeef" }), kms);
+  store.set(broken.hash, broken);
+  store.set(broken.rptId, broken);
+  assert.equal(await verifyChain(broken.rptId, register(store)), false);
+});
+
+test("audit endpoint returns verification result", async () => {
+  const { publicKey, kms } = await setupKeys();
+  const first = await mintRpt(baseParams({ rptId: "rpt-1" }), kms);
+  const second = await mintRpt(baseParams({ rptId: "rpt-2", prevHash: first.hash }), kms);
+
+  const store = new Map<string, SignedRpt>([
+    [first.hash, first],
+    [second.hash, second],
+    [first.rptId, first],
+    [second.rptId, second],
+  ]);
+
+  const app = Fastify();
+  await auditRoutes(app, {
+    loadRpt: register(store),
+    loadPrev: register(store),
+    pubkey: Buffer.from(publicKey).toString("base64"),
+  });
+
+  const okResponse = await app.inject({ method: "GET", url: `/audit/rpt/${second.rptId}` });
+  assert.equal(okResponse.statusCode, 200);
+  const parsedOk = okResponse.json() as { ok: boolean };
+  assert.equal(parsedOk.ok, true);
+
+  const broken = await mintRpt(baseParams({ rptId: "rpt-3", prevHash: "ffff" }), kms);
+  store.set(broken.hash, broken);
+  store.set(broken.rptId, broken);
+  const failResponse = await app.inject({ method: "GET", url: `/audit/rpt/${broken.rptId}` });
+  assert.equal(failResponse.statusCode, 400);
+  const parsedFail = failResponse.json() as { ok: boolean; reason: string };
+  assert.equal(parsedFail.ok, false);
+  assert.equal(parsedFail.reason, "invalid_chain");
+});


### PR DESCRIPTION
## Summary
- add deterministic RPT serialization helpers plus mint/verify/chain utilities built on Ed25519
- expose an audit endpoint that validates signature and chain integrity before returning the record
- cover signing, tampering, chain breaks, endpoint responses, and ship a local Ed25519 shim for offline runs

## Testing
- pnpm exec tsx --test services/api-gateway/test/rpt.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f4285e4fcc8327a2d38de0aeadf4d9