### PR TITLE
Add Zod reply validation for bank line routes

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test test/reply-validation.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,11 +9,36 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import { Prisma } from "@prisma/client";
+import type { BankLine as PrismaBankLine } from "@prisma/client";
 import { prisma } from "../../../shared/src/db";
+import replyValidationPlugin, { withValidatedReply } from "./plugins/reply-validate";
+import {
+  BankLine as BankLineSchema,
+  CreateRequest,
+  type BankLineResponse,
+  type ListResponsePayload,
+  ListResponse,
+} from "./schemas/bank-lines";
+import { ZodError } from "zod";
+
+const toBankLineResponse = (line: PrismaBankLine): BankLineResponse => {
+  const amountDecimal = new Prisma.Decimal(line.amount);
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amountCents: Number(amountDecimal.mul(100).toString()),
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+};
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await replyValidationPlugin(app);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -30,40 +55,49 @@ app.get("/users", async () => {
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
+app.get(
+  "/bank-lines",
+  withValidatedReply(ListResponse, async (req): Promise<ListResponsePayload> => {
+    const take = Number((req.query as Record<string, unknown> | undefined)?.take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return {
+      lines: lines.map(toBankLineResponse),
+    };
+  }),
+);
 
 // Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+app.post(
+  "/bank-lines",
+  withValidatedReply(BankLineSchema, async (req, rep): Promise<BankLineResponse | { error: string }> => {
+    try {
+      const body = CreateRequest.parse(req.body);
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: new Prisma.Decimal(body.amountCents).div(100),
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      rep.code(201);
+      return toBankLineResponse(created);
+    } catch (error) {
+      if (error instanceof ZodError) {
+        rep.code(400);
+        return { error: "bad_request" };
+      }
+
+      req.log.error(error);
+      rep.code(500);
+      return { error: "internal_server_error" };
+    }
+  }),
+);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +111,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/reply-validate.ts
+++ b/apgms/services/api-gateway/src/plugins/reply-validate.ts
@@ -1,0 +1,105 @@
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  RouteHandlerMethod,
+} from "fastify";
+import type { ZodTypeAny } from "zod";
+
+const REPLY_SCHEMA_SYMBOL = Symbol.for("reply-schema");
+
+interface ReplyWithSchema extends FastifyReply {
+  [REPLY_SCHEMA_SYMBOL]?: ZodTypeAny;
+}
+
+type Payload = unknown;
+
+type WithValidatedReply = <T extends RouteHandlerMethod>(schema: ZodTypeAny, handler: T) => T;
+
+const parsePayload = (payload: Payload): unknown => {
+  if (payload === null || payload === undefined) {
+    return payload;
+  }
+
+  if (Buffer.isBuffer(payload)) {
+    const text = payload.toString("utf8");
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  if (typeof payload === "string") {
+    try {
+      return JSON.parse(payload);
+    } catch {
+      return payload;
+    }
+  }
+
+  return payload;
+};
+
+const clearSchema = (reply: ReplyWithSchema) => {
+  delete reply[REPLY_SCHEMA_SYMBOL];
+};
+
+export const withValidatedReply: WithValidatedReply = (schema, handler) => {
+  const wrapped: RouteHandlerMethod = async function (this: FastifyInstance, request, reply) {
+    (reply as ReplyWithSchema)[REPLY_SCHEMA_SYMBOL] = schema;
+    try {
+      return await handler.apply(this, [request, reply]);
+    } finally {
+      // schema cleared in onSend hook
+    }
+  };
+
+  return Object.assign(wrapped, handler) as typeof handler;
+};
+
+const replyValidationPlugin = async (app: FastifyInstance) => {
+  app.addHook("onSend", async (request: FastifyRequest, reply: FastifyReply, payload) => {
+    const replyWithSchema = reply as ReplyWithSchema;
+    const schema = replyWithSchema[REPLY_SCHEMA_SYMBOL];
+
+    if (!schema) {
+      return payload;
+    }
+
+    if (reply.statusCode >= 400) {
+      clearSchema(replyWithSchema);
+      return payload;
+    }
+
+    const data = parsePayload(payload);
+    const result = schema.safeParse(data);
+
+    if (!result.success) {
+      request.log.error({ validationErrors: result.error.errors }, "reply validation failed");
+      clearSchema(replyWithSchema);
+      reply.code(500).type("application/json");
+
+      const responseBody =
+        process.env.NODE_ENV === "production"
+          ? { error: "internal_server_error" }
+          : { error: "invalid_response_payload", details: result.error.flatten() };
+
+      const serialized = reply.serialize(responseBody);
+      if (typeof serialized === "string" || Buffer.isBuffer(serialized)) {
+        return serialized;
+      }
+
+      if (serialized instanceof ArrayBuffer) {
+        return Buffer.from(serialized);
+      }
+
+      return JSON.stringify(responseBody);
+    }
+
+    clearSchema(replyWithSchema);
+    return payload;
+  });
+};
+
+export default replyValidationPlugin;

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const BankLine = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amountCents: z.number().int().nonnegative(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export const ListResponse = z.object({
+  lines: z.array(BankLine),
+});
+
+export const CreateRequest = z.object({
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amountCents: z.number().int(),
+  payee: z.string(),
+  desc: z.string(),
+});
+
+export type BankLineResponse = z.infer<typeof BankLine>;
+export type ListResponsePayload = z.infer<typeof ListResponse>;
+export type CreateRequestPayload = z.infer<typeof CreateRequest>;

--- a/apgms/services/api-gateway/test/reply-validation.spec.ts
+++ b/apgms/services/api-gateway/test/reply-validation.spec.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import replyValidationPlugin, { withValidatedReply } from "../src/plugins/reply-validate";
+import { ListResponse } from "../src/schemas/bank-lines";
+
+test("responds with 500 when reply payload violates schema", async () => {
+  const app = Fastify();
+  await replyValidationPlugin(app);
+  app.get(
+    "/broken",
+    withValidatedReply(ListResponse, async () => ({
+      lines: [
+        {
+          id: "line_1",
+          orgId: "org_1",
+          date: new Date().toISOString(),
+          amountCents: "1000" as unknown as number,
+          payee: "Acme",
+          desc: "Test",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    })),
+  );
+
+  await app.ready();
+  const response = await app.inject({ method: "GET", url: "/broken" });
+  assert.equal(response.statusCode, 500);
+  const body = response.json();
+  assert.equal(body.error, "invalid_response_payload");
+  assert.ok(body.details);
+
+  await app.close();
+});
+
+test("passes through when reply payload matches schema", async () => {
+  const app = Fastify();
+  await replyValidationPlugin(app);
+  app.get(
+    "/valid",
+    withValidatedReply(ListResponse, async () => ({
+      lines: [
+        {
+          id: "line_1",
+          orgId: "org_1",
+          date: new Date().toISOString(),
+          amountCents: 1000,
+          payee: "Acme",
+          desc: "Test",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    })),
+  );
+
+  await app.ready();
+  const response = await app.inject({ method: "GET", url: "/valid" });
+  assert.equal(response.statusCode, 200);
+  const body = response.json();
+  assert.equal(body.lines[0]?.amountCents, 1000);
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- add Zod reply schemas and a reusable reply validation helper
- wrap the /bank-lines endpoints with the validator and normalize decimal amounts
- cover the validator with contract tests exercising success and failure cases

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f42843c96483279c256a986946eb85