### PR TITLE
Add secret scanning and license guard to CI

### DIFF
--- a/LICENSE-ALLOWLIST.txt
+++ b/LICENSE-ALLOWLIST.txt
@@ -1,0 +1,5 @@
+MIT
+Apache-2.0
+BSD-2-Clause
+BSD-3-Clause
+ISC

--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,24 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  sec-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --redact --source .
+      - name: License check
+        uses: pilosus/action-pip-license-checker@v1
+        if: false
+      - name: Node license guard
+        uses: mheap/github-action-allow-list-licenses@v2
+        with:
+          path: apgms/pnpm-lock.yaml
+          allow: |
+            MIT
+            Apache-2.0
+            BSD-2-Clause
+            BSD-3-Clause
+            ISC


### PR DESCRIPTION
## Summary
- add a security and license job to CI with gitleaks scanning
- enforce the allowed SPDX identifiers for pnpm dependencies
- add a shared license allowlist file for reuse

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f4318b78148327a975b5c7262d2b44