### PR TITLE
feat: add security headers plugin

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,11 +9,13 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import headersPlugin from "./plugins/headers";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(headersPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/headers.ts
+++ b/apgms/services/api-gateway/src/plugins/headers.ts
@@ -1,0 +1,28 @@
+import { FastifyPluginAsync } from "fastify";
+
+const SECURITY_HEADERS = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "no-referrer",
+  "Permissions-Policy": "interest-cohort=()",
+} as const;
+
+const CSP_VALUE =
+  "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:3000";
+
+const headersPlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.addHook("onSend", async (_request, reply, payload) => {
+    for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      reply.header(header, value);
+    }
+
+    const contentType = reply.getHeader("content-type");
+    if (typeof contentType === "string" && contentType.includes("text/html")) {
+      reply.header("Content-Security-Policy", CSP_VALUE);
+    }
+
+    return payload;
+  });
+};
+
+export default headersPlugin;

--- a/apgms/services/api-gateway/test/headers.spec.ts
+++ b/apgms/services/api-gateway/test/headers.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import headersPlugin from "../src/plugins/headers";
+
+const SECURITY_HEADERS = {
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+  "referrer-policy": "no-referrer",
+  "permissions-policy": "interest-cohort=()",
+} as const;
+
+const CSP_HEADER =
+  "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:3000";
+
+describe("headers plugin", () => {
+  it("applies security headers to api responses", async () => {
+    const app = Fastify();
+    await app.register(headersPlugin);
+
+    app.get("/healthz", async () => ({ ok: true }));
+
+    const response = await app.inject({ method: "GET", url: "/healthz" });
+
+    assert.equal(response.statusCode, 200);
+    for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      assert.equal(response.headers[header], value);
+    }
+    assert.equal(response.headers["content-security-policy"], undefined);
+  });
+
+  it("sets csp for web routes", async () => {
+    const app = Fastify();
+    await app.register(headersPlugin);
+
+    app.get("/app", async (_request, reply) => {
+      reply.type("text/html");
+      return "<html></html>";
+    });
+
+    const response = await app.inject({ method: "GET", url: "/app" });
+
+    assert.equal(response.statusCode, 200);
+    for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      assert.equal(response.headers[header], value);
+    }
+    assert.equal(response.headers["content-security-policy"], CSP_HEADER);
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add a Fastify plugin that attaches strict security headers and CSP to HTML responses
- register the plugin with the API gateway and expose a test script
- cover the plugin behaviour with node:test specs

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f431ac4e6c8327b4b1d4db2d82b874