### PR TITLE
Add RPT minting and verification endpoints

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx src/lib/rpt.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,16 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { allocationsRequestSchema } from "./lib/schemas/allocations";
+import {
+  deriveLedgerEntries,
+  getStoredLedger,
+  getStoredRpt,
+  mintRpt,
+  storeRptToken,
+  verifyChain,
+  verifyRpt,
+} from "./lib/rpt";
 
 const app = Fastify({ logger: true });
 
@@ -37,6 +47,60 @@ app.get("/bank-lines", async (req) => {
     take: Math.min(Math.max(take, 1), 200),
   });
   return { lines };
+});
+
+app.post("/allocations/preview", async (req, rep) => {
+  try {
+    const body = allocationsRequestSchema.parse(req.body ?? {});
+    const rpt = await mintRpt(body);
+    const ledger = deriveLedgerEntries(rpt.payload, rpt.hash);
+    return rep.send({ rpt, ledger });
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(400).send({ error: "invalid_request" });
+  }
+});
+
+app.post("/allocations/apply", async (req, rep) => {
+  try {
+    const body = allocationsRequestSchema.parse(req.body ?? {});
+    if (body.prevHash) {
+      const prev = getStoredRpt(body.prevHash);
+      if (!prev) {
+        return rep.code(409).send({ error: "invalid_prev_hash" });
+      }
+    }
+
+    const rpt = await mintRpt(body);
+    const ledger = deriveLedgerEntries(rpt.payload, rpt.hash);
+    storeRptToken(rpt, ledger);
+
+    return rep.code(201).send({ id: rpt.hash });
+  } catch (error) {
+    req.log.error(error);
+    return rep.code(400).send({ error: "invalid_request" });
+  }
+});
+
+app.get("/audit/rpt/:id", async (req, rep) => {
+  const { id } = req.params as { id: string };
+  const rpt = getStoredRpt(id);
+
+  if (!rpt) {
+    return rep.code(404).send({ error: "not_found" });
+  }
+
+  const isValid = await verifyRpt(rpt);
+  if (!isValid) {
+    return rep.code(409).send({ error: "invalid_signature" });
+  }
+
+  const chainValid = await verifyChain(id);
+  if (!chainValid) {
+    return rep.code(409).send({ error: "invalid_chain" });
+  }
+
+  return rep.send({ rpt, ledger: getStoredLedger(id) ?? [] });
 });
 
 // Create a bank line

--- a/apgms/services/api-gateway/src/lib/rpt.spec.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.spec.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  deriveLedgerEntries,
+  mintRpt,
+  resetRptState,
+  storeRptToken,
+  verifyChain,
+  verifyRpt,
+} from "./rpt";
+
+const baseRequest = {
+  orgId: "org-1",
+  bankLineId: "bank-1",
+  policyHash: "policy-1",
+  allocations: [
+    { accountId: "acct-1", amount: 100 },
+    { accountId: "acct-2", amount: -100 },
+  ],
+  now: "2024-01-01T00:00:00.000Z",
+} as const;
+
+test.beforeEach(() => {
+  resetRptState();
+});
+
+test("minted RPT verifies", async () => {
+  const rpt = await mintRpt(baseRequest);
+  assert.equal(await verifyRpt(rpt), true);
+});
+
+test("tampering invalidates signature", async () => {
+  const rpt = await mintRpt(baseRequest);
+  const tampered = {
+    ...rpt,
+    payload: {
+      ...rpt.payload,
+      allocations: rpt.payload.allocations.map((allocation, index) =>
+        index === 0
+          ? { ...allocation, amount: allocation.amount + 1 }
+          : allocation,
+      ),
+    },
+  };
+
+  assert.equal(await verifyRpt(tampered), false);
+});
+
+test("chain verification succeeds and fails when broken", async () => {
+  const first = await mintRpt(baseRequest);
+  storeRptToken(first, deriveLedgerEntries(first.payload, first.hash));
+
+  const second = await mintRpt({
+    ...baseRequest,
+    bankLineId: "bank-2",
+    prevHash: first.hash,
+    now: "2024-01-01T01:00:00.000Z",
+  });
+  storeRptToken(second, deriveLedgerEntries(second.payload, second.hash));
+
+  assert.equal(await verifyChain(second.hash), true);
+
+  const orphan = await mintRpt({
+    ...baseRequest,
+    bankLineId: "bank-3",
+    prevHash: "missing-hash",
+    now: "2024-01-01T02:00:00.000Z",
+  });
+  storeRptToken(orphan, deriveLedgerEntries(orphan.payload, orphan.hash));
+
+  assert.equal(await verifyChain(orphan.hash), false);
+});

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,175 @@
+import {
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as signMessage,
+  verify as verifySignature,
+} from "node:crypto";
+import { TextEncoder } from "node:util";
+import {
+  allocationsRequestSchema,
+  type Allocation,
+  type AllocationsRequest,
+} from "./schemas/allocations";
+import { rptPayloadSchema, rptTokenSchema, type RptPayload, type RptToken } from "./schemas/rpt";
+
+const encoder = new TextEncoder();
+
+interface MintRptArgs extends AllocationsRequest {}
+
+export interface LedgerEntry {
+  orgId: string;
+  bankLineId: string;
+  accountId: string;
+  amount: number;
+  memo?: string;
+  policyHash: string;
+  rptHash: string;
+  timestamp: string;
+}
+
+const kmsKeyPair = createKeyPair();
+const rptStore = new Map<string, RptToken>();
+const ledgerStore = new Map<string, LedgerEntry[]>();
+
+function createKeyPair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const publicKeyDer = publicKey.export({ format: "der", type: "spki" });
+  return { publicKey, privateKey, publicKeyDer: Buffer.from(publicKeyDer) };
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    return `{${entries
+      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalize(val)}`)
+      .join(",")}}`;
+  }
+  throw new TypeError(`Unsupported value in canonicalizer: ${typeof value}`);
+}
+
+function hashCanonicalPayload(canonicalPayload: string): string {
+  return createHash("sha256").update(canonicalPayload).digest("hex");
+}
+
+function normalizeAllocationsRequest(args: MintRptArgs): RptPayload {
+  const parsed = allocationsRequestSchema.parse(args);
+  return rptPayloadSchema.parse(parsed);
+}
+
+function encodeCanonicalPayload(payload: RptPayload): { canonical: string; bytes: Uint8Array } {
+  const canonical = canonicalize(payload);
+  return { canonical, bytes: encoder.encode(canonical) };
+}
+
+function encodeBase64(data: Uint8Array | Buffer): string {
+  return Buffer.from(data).toString("base64");
+}
+
+function decodeBase64(data: string): Buffer {
+  return Buffer.from(data, "base64");
+}
+
+export async function mintRpt(args: MintRptArgs): Promise<RptToken> {
+  const payload = normalizeAllocationsRequest({ ...args, now: args.now ?? new Date().toISOString() });
+  const { canonical, bytes } = encodeCanonicalPayload(payload);
+  const signature = signMessage(null, bytes, kmsKeyPair.privateKey);
+  const hash = hashCanonicalPayload(canonical);
+
+  const token: RptToken = {
+    hash,
+    payload,
+    signature: encodeBase64(signature),
+    publicKey: encodeBase64(kmsKeyPair.publicKeyDer),
+  };
+
+  return token;
+}
+
+export function deriveLedgerEntries(payload: RptPayload, rptHash: string): LedgerEntry[] {
+  return payload.allocations.map((allocation) => mapToLedgerEntry(payload, allocation, rptHash));
+}
+
+function mapToLedgerEntry(payload: RptPayload, allocation: Allocation, rptHash: string): LedgerEntry {
+  return {
+    orgId: payload.orgId,
+    bankLineId: payload.bankLineId,
+    accountId: allocation.accountId,
+    amount: allocation.amount,
+    memo: allocation.memo,
+    policyHash: payload.policyHash,
+    rptHash,
+    timestamp: payload.now,
+  };
+}
+
+export function storeRptToken(token: RptToken, ledgerEntries: LedgerEntry[]): void {
+  rptStore.set(token.hash, rptTokenSchema.parse(token));
+  ledgerStore.set(token.hash, ledgerEntries);
+}
+
+export function getStoredRpt(hash: string): RptToken | undefined {
+  return rptStore.get(hash);
+}
+
+export function getStoredLedger(hash: string): LedgerEntry[] | undefined {
+  return ledgerStore.get(hash);
+}
+
+export function resetRptState(): void {
+  rptStore.clear();
+  ledgerStore.clear();
+}
+
+export async function verifyRpt(token: RptToken): Promise<boolean> {
+  try {
+    const parsed = rptTokenSchema.parse(token);
+    const { canonical, bytes } = encodeCanonicalPayload(parsed.payload);
+    const expectedHash = hashCanonicalPayload(canonical);
+    if (expectedHash !== parsed.hash) {
+      return false;
+    }
+    const publicKey = createPublicKey({ key: decodeBase64(parsed.publicKey), format: "der", type: "spki" });
+    const signature = decodeBase64(parsed.signature);
+    return verifySignature(null, bytes, publicKey, signature);
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyChain(headHash: string): Promise<boolean> {
+  const visited = new Set<string>();
+  let currentHash: string | null = headHash;
+
+  while (currentHash) {
+    if (visited.has(currentHash)) {
+      return false;
+    }
+    visited.add(currentHash);
+
+    const currentToken = rptStore.get(currentHash);
+    if (!currentToken) {
+      return false;
+    }
+
+    const valid = await verifyRpt(currentToken);
+    if (!valid) {
+      return false;
+    }
+
+    currentHash = currentToken.payload.prevHash;
+  }
+
+  return true;
+}

--- a/apgms/services/api-gateway/src/lib/schemas/allocations.ts
+++ b/apgms/services/api-gateway/src/lib/schemas/allocations.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const allocationSchema = z.object({
+  accountId: z.string().min(1, "accountId required"),
+  amount: z.number().finite(),
+  memo: z.string().min(1).optional(),
+});
+
+export const allocationsRequestSchema = z.object({
+  orgId: z.string().min(1, "orgId required"),
+  bankLineId: z.string().min(1, "bankLineId required"),
+  policyHash: z.string().min(1, "policyHash required"),
+  allocations: z.array(allocationSchema).min(1, "allocations required"),
+  prevHash: z.string().min(1).nullable().optional(),
+  now: z.string().datetime().optional(),
+});
+
+export type Allocation = z.infer<typeof allocationSchema>;
+export type AllocationsRequest = z.infer<typeof allocationsRequestSchema>;

--- a/apgms/services/api-gateway/src/lib/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/schemas/rpt.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { allocationsRequestSchema } from "./allocations";
+
+export const rptPayloadSchema = allocationsRequestSchema
+  .extend({
+    now: allocationsRequestSchema.shape.now.default(() => new Date().toISOString()),
+  })
+  .transform((payload) => ({
+    ...payload,
+    prevHash: payload.prevHash ?? null,
+  }));
+
+export const rptTokenSchema = z.object({
+  hash: z.string().min(1),
+  payload: rptPayloadSchema,
+  signature: z.string().min(1),
+  publicKey: z.string().min(1),
+});
+
+export type RptPayload = z.infer<typeof rptPayloadSchema>;
+export type RptToken = z.infer<typeof rptTokenSchema>;


### PR DESCRIPTION
## Summary
- implement Ed25519-backed RPT minting, storage, and chain verification utilities
- define allocation and RPT schemas plus ledger derivation helpers for the API gateway
- expose allocations preview/apply/audit routes and cover tampering and chain validation in tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f433786df4832797b03931b0c4c147