### PR TITLE
Add OTEL instrumentation and sampling workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,12 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+      - name: Run OTEL sample
+        run: pnpm tsx scripts/otel-sample.ts
+      - name: Upload OTEL artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: otel-artifacts
+          path: |
+            evidence/otel-run.json
+            evidence/otel-summary.json

--- a/apgms/scripts/otel-sample.ts
+++ b/apgms/scripts/otel-sample.ts
@@ -1,0 +1,114 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { promises as fs } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, "..");
+
+async function waitForServer(url: string, timeoutMs = 15000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // ignore while waiting
+    }
+    await delay(250);
+  }
+  throw new Error(`Server did not become ready at ${url}`);
+}
+
+async function sendRequests(baseUrl: string): Promise<{ requestCount: number; errorCount: number; durationMinutes: number }> {
+  const total = 20;
+  let requestCount = 0;
+  let errorCount = 0;
+  const start = process.hrtime.bigint();
+
+  for (let i = 0; i < total; i++) {
+    const target = i % 3 === 0 ? "/users" : "/bank-lines";
+    const url = `${baseUrl}${target}`;
+    try {
+      let response;
+      if (target === "/bank-lines" && i % 2 === 1) {
+        response = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        });
+      } else {
+        response = await fetch(url);
+      }
+      requestCount += 1;
+      if (!response.ok) {
+        errorCount += 1;
+      }
+    } catch {
+      requestCount += 1;
+      errorCount += 1;
+    }
+  }
+
+  const end = process.hrtime.bigint();
+  const durationMinutes = Number(end - start) / 60000000000;
+  return { requestCount, errorCount, durationMinutes };
+}
+
+async function waitForFile(filePath: string, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await delay(200);
+    }
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function main(): Promise<void> {
+  const server = spawn("pnpm", ["--filter", "@apgms/api-gateway", "dev"], {
+    cwd: repoRoot,
+    env: { ...process.env, OTEL_ENABLED: "true" },
+    stdio: "inherit",
+  });
+
+  try {
+    await waitForServer("http://127.0.0.1:3000/health");
+    const { requestCount, errorCount, durationMinutes } = await sendRequests("http://127.0.0.1:3000");
+
+    const errorRatio = requestCount === 0 ? 0 : errorCount / requestCount;
+    const errorsPerMinute = durationMinutes === 0 ? (errorCount > 0 ? Infinity : 0) : errorCount / durationMinutes;
+    const summary = {
+      request_count: requestCount,
+      error_count: errorCount,
+      error_ratio: Number(errorRatio.toFixed(4)),
+      errors_per_minute: Number(errorsPerMinute.toFixed(4)),
+    };
+
+    const evidenceDir = resolve(repoRoot, "evidence");
+    await fs.mkdir(evidenceDir, { recursive: true });
+    await fs.writeFile(resolve(evidenceDir, "otel-summary.json"), JSON.stringify(summary, null, 2));
+  } finally {
+    if (!server.killed) {
+      server.kill("SIGTERM");
+    }
+    if (server.exitCode === null && server.signalCode === null) {
+      await once(server, "exit").catch(() => undefined);
+    }
+    const otelRunPath = resolve(repoRoot, "evidence/otel-run.json");
+    await waitForFile(otelRunPath, 5000).catch(() => undefined);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,8 +9,15 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/core": "^1.18.1",
+    "@opentelemetry/resources": "^1.18.1",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "@opentelemetry/sdk-trace-base": "^1.18.1",
+    "@opentelemetry/semantic-conventions": "^1.18.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "opentelemetry-instrumentation-pg": "^0.45.2",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -11,6 +11,11 @@ import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
+if (process.env.OTEL_ENABLED === "true") {
+  const { startOtel } = await import("./observability/otel.js");
+  await startOtel();
+}
+
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });

--- a/apgms/services/api-gateway/src/observability/otel.ts
+++ b/apgms/services/api-gateway/src/observability/otel.ts
@@ -1,0 +1,86 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promises as fs } from "node:fs";
+
+import { SpanKind } from "@opentelemetry/api";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { ExportResult, ExportResultCode, SpanExporter } from "@opentelemetry/core";
+import { ReadableSpan, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { PgInstrumentation } from "opentelemetry-instrumentation-pg";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+class JsonFileSpanExporter implements SpanExporter {
+  private readonly buffer: ReadableSpan[] = [];
+
+  constructor(private readonly filePath: string) {}
+
+  export(spans: ReadableSpan[], resultCallback: (result: ExportResult) => void): void {
+    this.buffer.push(...spans);
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  async shutdown(): Promise<void> {
+    await this.flush();
+  }
+
+  async forceFlush(): Promise<void> {
+    await this.flush();
+  }
+
+  private async flush(): Promise<void> {
+    if (this.buffer.length === 0) {
+      return;
+    }
+
+    const spans = this.buffer.map((span) => ({
+      traceId: span.spanContext().traceId,
+      spanId: span.spanContext().spanId,
+      parentSpanId: span.parentSpanId,
+      name: span.name,
+      kind: SpanKind[span.kind],
+      startTime: span.startTime,
+      endTime: span.endTime,
+      attributes: span.attributes,
+      status: span.status,
+      resource: span.resource.attributes,
+      events: span.events,
+      links: span.links,
+    }));
+
+    await fs.mkdir(dirname(this.filePath), { recursive: true });
+    await fs.writeFile(this.filePath, JSON.stringify(spans, null, 2));
+    this.buffer.length = 0;
+  }
+}
+
+export async function startOtel(): Promise<NodeSDK> {
+  const deploymentEnvironment = process.env.DEPLOYMENT_ENVIRONMENT ?? "development";
+  const evidencePath = resolve(__dirname, "../../../../evidence/otel-run.json");
+
+  const sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: "api-gateway",
+      [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: deploymentEnvironment,
+    }),
+    instrumentations: [
+      new PgInstrumentation(),
+    ],
+  });
+
+  sdk.addSpanProcessor(new SimpleSpanProcessor(new JsonFileSpanExporter(evidencePath)));
+
+  await sdk.start();
+
+  const shutdown = async () => {
+    await sdk.shutdown().catch(() => undefined);
+  };
+
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+
+  return sdk;
+}


### PR DESCRIPTION
## Summary
- add an OTEL bootstrap that enables PG tracing and writes spans to an evidence JSON file when OTEL is enabled
- add a sampling script that exercises the API gateway with mixed traffic, records an error summary, and ensures artifacts are captured
- update CI to execute the OTEL sampling script, upload the artifacts, and declare the new telemetry dependencies

## Testing
- ⚠️ `pnpm install` *(fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/@opentelemetry%2Fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68f432652b38832780b967eafce6cd2b