### PR TITLE
Add nightly PII redaction job and retention schema updates

### DIFF
--- a/apgms/shared/prisma/migrations/20251010140000_add_retention_columns/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010140000_add_retention_columns/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN     "deletedAt" TIMESTAMP(3),
+  ALTER COLUMN "email" DROP NOT NULL,
+  ALTER COLUMN "password" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "BankLine"
+  ADD COLUMN     "deletedAt" TIMESTAMP(3),
+  ALTER COLUMN "payee" DROP NOT NULL,
+  ALTER COLUMN "desc" DROP NOT NULL;
+
+-- CreateTable
+CREATE TABLE "AuditBlob" (
+    "id" TEXT NOT NULL,
+    "event" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "redactedAt" TIMESTAMP(3),
+    CONSTRAINT "AuditBlob_pkey" PRIMARY KEY ("id")
+);

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,36 +1,47 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
 model Org {
-  id        String   @id @default(cuid())
+  id        String     @id @default(cuid())
   name      String
-  createdAt DateTime @default(now())
+  createdAt DateTime   @default(now())
   users     User[]
   lines     BankLine[]
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  id        String    @id @default(cuid())
+  email     String?   @unique
+  password  String?
+  createdAt DateTime  @default(now())
+  deletedAt DateTime?
+  org       Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
 }
 
 model BankLine {
-  id        String   @id @default(cuid())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  id        String    @id @default(cuid())
+  org       Org       @relation(fields: [orgId], references: [id], onDelete: Cascade)
   orgId     String
   date      DateTime
   amount    Decimal
-  payee     String
-  desc      String
-  createdAt DateTime @default(now())
+  payee     String?
+  desc      String?
+  createdAt DateTime  @default(now())
+  deletedAt DateTime?
+}
+
+model AuditBlob {
+  id         String   @id @default(cuid())
+  event      String
+  payload    Json
+  createdAt  DateTime @default(now())
+  redactedAt DateTime?
 }

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,10 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "tsx test/redact.spec.ts"
+  }
+}

--- a/apgms/worker/src/index.ts
+++ b/apgms/worker/src/index.ts
@@ -1,1 +1,1 @@
-﻿console.log('worker');
+export * from "./jobs/redact.js";

--- a/apgms/worker/src/jobs/redact.ts
+++ b/apgms/worker/src/jobs/redact.ts
@@ -1,0 +1,184 @@
+import { createHash } from "node:crypto";
+
+type UserRecord = {
+  id: string;
+  email: string | null;
+  password: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: unknown;
+  payee: string | null;
+  desc: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+};
+
+type AuditBlobRecord = {
+  id?: string;
+  event: string;
+  payload: unknown;
+  redactedAt?: Date;
+};
+
+type FindManyArgs = { where: { createdAt: { lt: Date }; deletedAt: null } };
+type UpdateArgs<T> = { where: { id: string }; data: Partial<T> };
+type CreateArgs<T> = { data: T };
+
+export interface RedactionClient {
+  user: {
+    findMany(args: FindManyArgs): Promise<UserRecord[]>;
+    update(args: UpdateArgs<UserRecord>): Promise<UserRecord>;
+  };
+  bankLine: {
+    findMany(args: FindManyArgs): Promise<BankLineRecord[]>;
+    update(args: UpdateArgs<BankLineRecord>): Promise<BankLineRecord>;
+  };
+  auditBlob: {
+    create(args: CreateArgs<AuditBlobRecord>): Promise<unknown>;
+  };
+}
+
+export interface RedactJobOptions {
+  prisma: RedactionClient;
+  retentionDays?: number;
+  dryRun?: boolean;
+  now?: Date;
+  log?: (message: string) => void;
+}
+
+type HashedUser = {
+  id: string;
+  emailHash: string | null;
+  passwordHash: string | null;
+};
+
+type HashedBankLine = {
+  id: string;
+  payeeHash: string | null;
+  descHash: string | null;
+};
+
+export interface RedactJobSummary {
+  dryRun: boolean;
+  retentionDays: number;
+  cutoff: string;
+  users: {
+    total: number;
+    hashed: HashedUser[];
+  };
+  bankLines: {
+    total: number;
+    hashed: HashedBankLine[];
+  };
+}
+
+const DEFAULT_RETENTION_DAYS = 365;
+
+const envRetention = Number.parseInt(process.env.RETENTION_DAYS_PII ?? "", 10);
+
+export const RETENTION_DAYS_PII = Number.isFinite(envRetention) && envRetention > 0
+  ? envRetention
+  : DEFAULT_RETENTION_DAYS;
+
+export async function runRedactionJob({
+  prisma,
+  retentionDays = RETENTION_DAYS_PII,
+  dryRun = false,
+  now = new Date(),
+  log = console.log,
+}: RedactJobOptions): Promise<RedactJobSummary> {
+  const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+
+  const [staleUsers, staleBankLines] = await Promise.all([
+    prisma.user.findMany({
+      where: {
+        createdAt: { lt: cutoff },
+        deletedAt: null,
+      },
+    }),
+    prisma.bankLine.findMany({
+      where: {
+        createdAt: { lt: cutoff },
+        deletedAt: null,
+      },
+    }),
+  ]);
+
+  const hashedUsers = staleUsers.map<HashedUser>((user) => ({
+    id: user.id,
+    emailHash: hashValue(user.email),
+    passwordHash: hashValue(user.password),
+  }));
+
+  const hashedBankLines = staleBankLines.map<HashedBankLine>((line) => ({
+    id: line.id,
+    payeeHash: hashValue(line.payee),
+    descHash: hashValue(line.desc),
+  }));
+
+  if (!dryRun) {
+    await Promise.all([
+      ...staleUsers.map((user) =>
+        prisma.user.update({
+          where: { id: user.id },
+          data: { email: null, password: null, deletedAt: now },
+        })
+      ),
+      ...staleBankLines.map((line) =>
+        prisma.bankLine.update({
+          where: { id: line.id },
+          data: { payee: null, desc: null, deletedAt: now },
+        })
+      ),
+    ]);
+
+    if (staleUsers.length > 0 || staleBankLines.length > 0) {
+      await prisma.auditBlob.create({
+        data: {
+          event: "pii.redacted",
+          payload: {
+            retentionDays,
+            cutoff: cutoff.toISOString(),
+            users: hashedUsers,
+            bankLines: hashedBankLines,
+          },
+          redactedAt: now,
+        },
+      });
+    }
+  }
+
+  const summary: RedactJobSummary = {
+    dryRun,
+    retentionDays,
+    cutoff: cutoff.toISOString(),
+    users: {
+      total: staleUsers.length,
+      hashed: hashedUsers,
+    },
+    bankLines: {
+      total: staleBankLines.length,
+      hashed: hashedBankLines,
+    },
+  };
+
+  if (dryRun) {
+    log(JSON.stringify(summary));
+  }
+
+  return summary;
+}
+
+function hashValue(value: string | null): string | null {
+  if (value == null) {
+    return null;
+  }
+
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apgms/worker/test/redact.spec.ts
+++ b/apgms/worker/test/redact.spec.ts
@@ -1,0 +1,176 @@
+import { strict as assert } from "node:assert";
+import { createHash } from "node:crypto";
+
+import { runRedactionJob } from "../src/jobs/redact.js";
+
+type UserRecord = {
+  id: string;
+  email: string | null;
+  password: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string | null;
+  desc: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+};
+
+type AuditBlobRecord = {
+  event: string;
+  payload: unknown;
+  redactedAt?: Date;
+};
+
+function createPrismaStub({ now }: { now: Date }) {
+  const users = new Map<string, UserRecord>();
+  const bankLines = new Map<string, BankLineRecord>();
+  const auditBlobs: AuditBlobRecord[] = [];
+
+  const staleUser: UserRecord = {
+    id: "user-stale",
+    email: "stale@example.com",
+    password: "hunter2",
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    deletedAt: null,
+  };
+
+  const freshUser: UserRecord = {
+    id: "user-fresh",
+    email: "fresh@example.com",
+    password: "secret",
+    createdAt: new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000),
+    deletedAt: null,
+  };
+
+  users.set(staleUser.id, staleUser);
+  users.set(freshUser.id, freshUser);
+
+  const staleLine: BankLineRecord = {
+    id: "line-stale",
+    orgId: "org-1",
+    date: new Date("2024-01-05T00:00:00.000Z"),
+    amount: 100,
+    payee: "Past Vendor",
+    desc: "Subscription",
+    createdAt: new Date("2024-01-05T00:00:00.000Z"),
+    deletedAt: null,
+  };
+
+  const freshLine: BankLineRecord = {
+    id: "line-fresh",
+    orgId: "org-1",
+    date: now,
+    amount: 42,
+    payee: "Current Vendor",
+    desc: "Services",
+    createdAt: now,
+    deletedAt: null,
+  };
+
+  bankLines.set(staleLine.id, staleLine);
+  bankLines.set(freshLine.id, freshLine);
+
+  return {
+    user: {
+      async findMany({ where }: { where: { createdAt: { lt: Date }; deletedAt: null } }) {
+        return Array.from(users.values()).filter(
+          (user) => user.createdAt < where.createdAt.lt && user.deletedAt === null
+        );
+      },
+      async update({ where, data }: { where: { id: string }; data: Partial<UserRecord> }) {
+        const current = users.get(where.id);
+        assert(current, `user ${where.id} not found`);
+        Object.assign(current, data);
+        return current;
+      },
+    },
+    bankLine: {
+      async findMany({ where }: { where: { createdAt: { lt: Date }; deletedAt: null } }) {
+        return Array.from(bankLines.values()).filter(
+          (line) => line.createdAt < where.createdAt.lt && line.deletedAt === null
+        );
+      },
+      async update({ where, data }: { where: { id: string }; data: Partial<BankLineRecord> }) {
+        const current = bankLines.get(where.id);
+        assert(current, `bank line ${where.id} not found`);
+        Object.assign(current, data);
+        return current;
+      },
+    },
+    auditBlob: {
+      async create({ data }: { data: AuditBlobRecord }) {
+        auditBlobs.push(data);
+        return data;
+      },
+    },
+    data: {
+      users,
+      bankLines,
+      auditBlobs,
+    },
+  };
+}
+
+function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+(async () => {
+  const now = new Date("2025-01-01T00:00:00.000Z");
+  const retentionDays = 30;
+  const prisma = createPrismaStub({ now });
+
+  const summary = await runRedactionJob({ prisma, retentionDays, now });
+
+  assert.equal(summary.dryRun, false);
+  assert.equal(summary.retentionDays, retentionDays);
+  assert.equal(summary.users.total, 1);
+  assert.equal(summary.bankLines.total, 1);
+  assert.equal(summary.users.hashed[0].emailHash, hash("stale@example.com"));
+  assert.equal(summary.bankLines.hashed[0].payeeHash, hash("Past Vendor"));
+  assert.equal(summary.bankLines.hashed[0].descHash, hash("Subscription"));
+
+  const staleUser = prisma.data.users.get("user-stale");
+  assert(staleUser);
+  assert.equal(staleUser.email, null);
+  assert.equal(staleUser.password, null);
+  assert(staleUser.deletedAt instanceof Date);
+  assert.equal(staleUser.deletedAt?.toISOString(), now.toISOString());
+
+  const freshUser = prisma.data.users.get("user-fresh");
+  assert(freshUser);
+  assert.equal(freshUser.email, "fresh@example.com");
+  assert.equal(freshUser.deletedAt, null);
+
+  const staleLine = prisma.data.bankLines.get("line-stale");
+  assert(staleLine);
+  assert.equal(staleLine.payee, null);
+  assert.equal(staleLine.desc, null);
+  assert(staleLine.deletedAt instanceof Date);
+  assert.equal(staleLine.deletedAt?.toISOString(), now.toISOString());
+
+  const freshLine = prisma.data.bankLines.get("line-fresh");
+  assert(freshLine);
+  assert.equal(freshLine.payee, "Current Vendor");
+  assert.equal(freshLine.deletedAt, null);
+
+  assert.equal(prisma.data.auditBlobs.length, 1);
+  const audit = prisma.data.auditBlobs[0];
+  assert.equal(audit.event, "pii.redacted");
+  assert(audit.redactedAt instanceof Date);
+  assert.equal(audit.redactedAt?.toISOString(), now.toISOString());
+  const auditPayload = audit.payload as Record<string, unknown>;
+  assert.equal(auditPayload?.retentionDays, retentionDays);
+
+  const hashedUsers = Array.isArray((auditPayload as any)?.users) ? (auditPayload as any).users : [];
+  assert.equal(hashedUsers[0]?.id, "user-stale");
+
+  console.log("redact.spec.ts ok");
+})();


### PR DESCRIPTION
## Summary
- add retention metadata columns and AuditBlob support in the Prisma schema
- implement a configurable redaction job that hashes and clears PII, and writes audit events
- configure the worker workspace with a test covering PII redaction behaviour

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f431d4d804832792407cad22b1c3b6