### PR TITLE
feat: harden api gateway routes and rate limiting

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/route-registry.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,7 +9,8 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { registerSecurity } from "./plugins/security.js";
+import { registerRoutes } from "./routes/index.js";
 
 const app = Fastify({ logger: true });
 
@@ -18,52 +19,8 @@ await app.register(cors, { origin: true });
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+await registerSecurity(app);
+await registerRoutes(app);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,64 @@
+import type { FastifyInstance } from "fastify";
+
+const DEV_DEFAULT_RPM = 100;
+const PROD_DEFAULT_RPM = 60;
+const WINDOW_MS = 60_000;
+
+function resolveDefaultRateLimit(nodeEnv: string) {
+  return nodeEnv === "production" ? PROD_DEFAULT_RPM : DEV_DEFAULT_RPM;
+}
+
+export function resolveRateLimitRpm(env: NodeJS.ProcessEnv = process.env): number {
+  const nodeEnv = env.NODE_ENV?.toLowerCase() ?? "development";
+  const configured = env.RATE_LIMIT_RPM;
+
+  if (configured === undefined || configured === "") {
+    return resolveDefaultRateLimit(nodeEnv);
+  }
+
+  const parsed = Number.parseInt(configured, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid RATE_LIMIT_RPM value: ${configured}`);
+  }
+
+  return parsed;
+}
+
+class SlidingWindowLimiter {
+  #max: number;
+  #windowStart = Date.now();
+  #count = 0;
+
+  constructor(max: number) {
+    this.#max = max;
+  }
+
+  tryConsume(now = Date.now()): boolean {
+    if (now - this.#windowStart >= WINDOW_MS) {
+      this.#windowStart = now;
+      this.#count = 0;
+    }
+
+    if (this.#count >= this.#max) {
+      return false;
+    }
+
+    this.#count += 1;
+    return true;
+  }
+}
+
+export async function registerSecurity(app: FastifyInstance): Promise<void> {
+  const limiter = new SlidingWindowLimiter(resolveRateLimitRpm());
+
+  app.addHook("onRequest", async (_request, reply) => {
+    if (limiter.tryConsume()) {
+      return;
+    }
+
+    reply.code(429);
+    await reply.send({ error: "rate_limit_exceeded" });
+    return reply;
+  });
+}

--- a/apgms/services/api-gateway/src/routes/index.ts
+++ b/apgms/services/api-gateway/src/routes/index.ts
@@ -1,0 +1,109 @@
+import type { FastifyInstance, HTTPMethods } from "fastify";
+import type { prisma as PrismaInstance } from "../../../../shared/src/db";
+
+type RouteDependencies = {
+  prisma: typeof PrismaInstance;
+};
+
+type RouteRegistration = (app: FastifyInstance, deps: RouteDependencies) => void | Promise<void>;
+export type RouteIdentifier = `${Uppercase<HTTPMethods>} ${string}`;
+
+type RouteEntry = readonly [RouteIdentifier, RouteRegistration];
+
+const ROUTE_REGISTRY_ENTRIES: readonly RouteEntry[] = [
+  [
+    "GET /health",
+    (app) => {
+      app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+    },
+  ],
+  [
+    "GET /users",
+    (app, deps) => {
+      app.get("/users", async () => {
+        const users = await deps.prisma.user.findMany({
+          select: { email: true, orgId: true, createdAt: true },
+          orderBy: { createdAt: "desc" },
+        });
+        return { users };
+      });
+    },
+  ],
+  [
+    "GET /bank-lines",
+    (app, deps) => {
+      app.get("/bank-lines", async (req) => {
+        const take = Number((req.query as { take?: number | string }).take ?? 20);
+        const lines = await deps.prisma.bankLine.findMany({
+          orderBy: { date: "desc" },
+          take: Math.min(Math.max(take, 1), 200),
+        });
+        return { lines };
+      });
+    },
+  ],
+  [
+    "POST /bank-lines",
+    (app, deps) => {
+      app.post("/bank-lines", async (req, rep) => {
+        try {
+          const body = req.body as {
+            orgId: string;
+            date: string;
+            amount: number | string;
+            payee: string;
+            desc: string;
+          };
+          const created = await deps.prisma.bankLine.create({
+            data: {
+              orgId: body.orgId,
+              date: new Date(body.date),
+              amount: Number(body.amount),
+              payee: body.payee,
+              desc: body.desc,
+            },
+          });
+          return rep.code(201).send(created);
+        } catch (error) {
+          req.log.error(error);
+          return rep.code(400).send({ error: "bad_request" });
+        }
+      });
+    },
+  ],
+] as const;
+
+const ROUTE_REGISTRY = new Map<RouteIdentifier, RouteRegistration>(ROUTE_REGISTRY_ENTRIES);
+
+export const ROUTE_WHITELIST: readonly RouteIdentifier[] = ROUTE_REGISTRY_ENTRIES.map(([key]) => key);
+
+let cachedDependencies: RouteDependencies | null = null;
+
+async function resolveDependencies(provided?: RouteDependencies): Promise<RouteDependencies> {
+  if (provided) {
+    return provided;
+  }
+
+  if (!cachedDependencies) {
+    const module = await import("../../../../shared/src/db.js");
+    cachedDependencies = { prisma: module.prisma };
+  }
+
+  return cachedDependencies;
+}
+
+export async function registerRoutes(
+  app: FastifyInstance,
+  routes: readonly RouteIdentifier[] = ROUTE_WHITELIST,
+  deps?: RouteDependencies,
+): Promise<void> {
+  const resolvedDeps = await resolveDependencies(deps);
+
+  for (const route of routes) {
+    const register = ROUTE_REGISTRY.get(route);
+    if (!register) {
+      throw new Error(`Route not whitelisted: ${route}`);
+    }
+    await register(app, resolvedDeps);
+  }
+}

--- a/apgms/services/api-gateway/test/route-registry.spec.ts
+++ b/apgms/services/api-gateway/test/route-registry.spec.ts
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+
+import { registerRoutes, ROUTE_WHITELIST } from "../src/routes/index.js";
+
+function createPrismaMock() {
+  return {
+    user: {
+      findMany: async () => [],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async (data: unknown) => data,
+    },
+  };
+}
+
+test("registerRoutes mounts only whitelisted routes", async (t) => {
+  const app = Fastify();
+  t.after(() => app.close());
+
+  const deps = { prisma: createPrismaMock() } as const;
+
+  await registerRoutes(app, ROUTE_WHITELIST, deps);
+
+  for (const entry of ROUTE_WHITELIST) {
+    const [method, url] = entry.split(" ", 2) as [string, string];
+    assert.equal(
+      app.hasRoute({ method, url }),
+      true,
+      `Expected ${method} ${url} to be registered`,
+    );
+  }
+
+  assert.equal(app.hasRoute({ method: "GET", url: "/not-allowed" }), false);
+});
+
+test("registerRoutes rejects routes outside whitelist", async () => {
+  const app = Fastify();
+
+  const deps = { prisma: createPrismaMock() } as const;
+
+  await assert.rejects(
+    registerRoutes(app, [...ROUTE_WHITELIST, "POST /evil"], deps),
+    /not whitelisted/i,
+  );
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- add an env-configurable rate limiter plugin with per-environment defaults
- whitelist api gateway routes during registration to enforce deny-by-default
- cover the whitelist behaviour with automated tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f431c394288327b45a6b4df305abc6