### PR TITLE
Add deterministic policy engine with property tests

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/policy-engine.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/test/fast-check.ts
+++ b/apgms/services/api-gateway/test/fast-check.ts
@@ -1,0 +1,226 @@
+/*
+ * Minimal deterministic property testing utilities providing a subset of the fast-check API
+ * required by the policy engine tests. This implementation focuses on deterministic generation
+ * to ensure reproducible property runs within constrained environments.
+ */
+
+type CompareFn<T> = (a: T, b: T) => boolean;
+
+type NilOption<T> = { nil?: T };
+
+type ArbitraryGenerator<T> = (rng: Random) => T;
+
+class Arbitrary<T> {
+  constructor(private readonly generator: ArbitraryGenerator<T>) {}
+
+  generate(rng: Random): T {
+    return this.generator(rng);
+  }
+
+  map<U>(mapper: (value: T) => U): Arbitrary<U> {
+    return new Arbitrary<U>((rng) => mapper(this.generate(rng)));
+  }
+
+  chain<U>(mapper: (value: T) => Arbitrary<U>): Arbitrary<U> {
+    return new Arbitrary<U>((rng) => mapper(this.generate(rng)).generate(rng));
+  }
+}
+
+class Random {
+  private state: bigint;
+
+  constructor(seed: bigint) {
+    this.state = seed & ((1n << 64n) - 1n);
+    if (this.state === 0n) {
+      this.state = 1n;
+    }
+  }
+
+  next(): bigint {
+    let x = this.state;
+    x ^= x << 13n;
+    x ^= x >> 7n;
+    x ^= x << 17n;
+    this.state = x & ((1n << 64n) - 1n);
+    return this.state;
+  }
+
+  nextInt(min: number, max: number): number {
+    if (max < min) {
+      throw new Error(`Invalid range ${min}-${max}`);
+    }
+    const range = BigInt(max - min + 1);
+    const value = this.next() % range;
+    return min + Number(value);
+  }
+
+  nextBigInt(maxExclusive: bigint): bigint {
+    if (maxExclusive <= 0n) {
+      return 0n;
+    }
+    const bits = maxExclusive.toString(2).length;
+    let candidate = 0n;
+    do {
+      candidate = 0n;
+      let produced = 0;
+      while (produced < bits) {
+        candidate = (candidate << 16n) | (this.next() & 0xffffn);
+        produced += 16;
+      }
+      candidate %= maxExclusive;
+    } while (candidate >= maxExclusive);
+    return candidate;
+  }
+}
+
+interface AssertOptions {
+  numRuns?: number;
+}
+
+interface SetOptions<T> {
+  minLength?: number;
+  maxLength?: number;
+  compare?: CompareFn<T>;
+}
+
+interface OptionOptions<T> {
+  nil?: T;
+}
+
+interface HexaStringConstraints {
+  minLength?: number;
+  maxLength?: number;
+}
+
+interface IntegerConstraints {
+  min?: number;
+  max?: number;
+}
+
+const DEFAULT_SEED = 0x1a2b3c4d5e6f7801n;
+
+class Property<T> {
+  constructor(public readonly arbitrary: Arbitrary<T>, public readonly predicate: (value: T) => boolean) {}
+}
+
+function constantFrom<T>(...values: T[]): Arbitrary<T> {
+  if (values.length === 0) {
+    throw new Error('constantFrom requires at least one value');
+  }
+  return new Arbitrary<T>((rng) => values[rng.nextInt(0, values.length - 1)]);
+}
+
+function integer(constraints: IntegerConstraints): Arbitrary<number> {
+  const min = constraints.min ?? Number.MIN_SAFE_INTEGER;
+  const max = constraints.max ?? Number.MAX_SAFE_INTEGER;
+  return new Arbitrary<number>((rng) => rng.nextInt(min, max));
+}
+
+function bigUintN(bits: number): Arbitrary<bigint> {
+  if (bits <= 0) {
+    return new Arbitrary(() => 0n);
+  }
+  return new Arbitrary<bigint>((rng) => {
+    const max = 1n << BigInt(bits);
+    return rng.nextBigInt(max);
+  });
+}
+
+function tuple<A, B>(arbA: Arbitrary<A>, arbB: Arbitrary<B>): Arbitrary<[A, B]>;
+function tuple<T>(...arbs: Arbitrary<T>[]): Arbitrary<T[]>;
+function tuple<T>(...arbs: Arbitrary<T>[]): Arbitrary<T[]> {
+  return new Arbitrary<T[]>((rng) => arbs.map((arb) => arb.generate(rng)));
+}
+
+function option<T>(arb: Arbitrary<T>, options: OptionOptions<T> & NilOption<T> = {}): Arbitrary<T | undefined> {
+  const nilValue = options.nil as T | undefined;
+  return new Arbitrary<T | undefined>((rng) => {
+    const choice = rng.nextInt(0, 1);
+    if (choice === 0) {
+      return nilValue;
+    }
+    return arb.generate(rng);
+  });
+}
+
+function set<T>(arb: Arbitrary<T>, options: SetOptions<T> = {}): Arbitrary<T[]> {
+  const min = options.minLength ?? 0;
+  const max = options.maxLength ?? min;
+  const compare = options.compare ?? ((a: T, b: T) => a === b);
+  return new Arbitrary<T[]>((rng) => {
+    const target = max === min ? max : rng.nextInt(min, max);
+    const result: T[] = [];
+    const maxAttempts = target === 0 ? 1 : target * 10;
+    let attempts = 0;
+    while (result.length < target && attempts < maxAttempts) {
+      attempts += 1;
+      const candidate = arb.generate(rng);
+      if (!result.some((existing) => compare(existing, candidate))) {
+        result.push(candidate);
+      }
+    }
+    while (result.length < min) {
+      const candidate = arb.generate(rng);
+      if (!result.some((existing) => compare(existing, candidate))) {
+        result.push(candidate);
+      }
+    }
+    return result;
+  });
+}
+
+function record<TRecord extends Record<string, Arbitrary<any>>>(schema: TRecord): Arbitrary<{ [K in keyof TRecord]: ReturnType<TRecord[K]['generate']> }> {
+  return new Arbitrary((rng) => {
+    const result: Record<string, unknown> = {};
+    for (const [key, arb] of Object.entries(schema)) {
+      result[key] = (arb as Arbitrary<unknown>).generate(rng);
+    }
+    return result as { [K in keyof TRecord]: ReturnType<TRecord[K]['generate']> };
+  });
+}
+
+function hexaString(constraints: HexaStringConstraints = {}): Arbitrary<string> {
+  const min = constraints.minLength ?? 0;
+  const max = constraints.maxLength ?? Math.max(min, 16);
+  const chars = '0123456789abcdef';
+  return new Arbitrary<string>((rng) => {
+    const length = max === min ? max : rng.nextInt(min, max);
+    let output = '';
+    for (let index = 0; index < length; index += 1) {
+      output += chars[rng.nextInt(0, chars.length - 1)];
+    }
+    return output;
+  });
+}
+
+function property<T>(arb: Arbitrary<T>, predicate: (value: T) => boolean): Property<T> {
+  return new Property(arb, predicate);
+}
+
+function assert<T>(prop: Property<T>, options: AssertOptions = {}): void {
+  const runs = options.numRuns ?? 100;
+  const rng = new Random(DEFAULT_SEED);
+  for (let run = 0; run < runs; run += 1) {
+    const value = prop.arbitrary.generate(rng);
+    const passed = prop.predicate(value);
+    if (!passed) {
+      throw new Error(`Property failed on run ${run}`);
+    }
+  }
+}
+
+const fc = {
+  constantFrom,
+  integer,
+  bigUintN,
+  tuple,
+  option,
+  set,
+  record,
+  hexaString,
+  property,
+  assert,
+};
+
+export default fc;
+export type { Property };

--- a/apgms/services/api-gateway/test/policy-engine.spec.ts
+++ b/apgms/services/api-gateway/test/policy-engine.spec.ts
@@ -1,0 +1,196 @@
+import fc from 'fast-check';
+import {
+  applyPolicy,
+  bankersRound,
+  type AccountState,
+  type ApplyPolicyInput,
+  type PolicyBucketRule,
+  type PolicyRuleset,
+} from '@apgms/policy-engine';
+
+type GateState = 'OPEN' | 'CLOSED';
+
+const RUNS = 10_000;
+
+const gateArb = fc.constantFrom<GateState>('OPEN', 'CLOSED');
+
+const corridorArb = fc
+  .tuple(fc.integer({ min: 0, max: 10_000 }), fc.integer({ min: 0, max: 10_000 }))
+  .map(([a, b]) => ({
+    minBps: Math.min(a, b),
+    maxBps: Math.max(a, b),
+  }));
+
+const allowListArb = fc.option(
+  fc.set(fc.hexaString({ minLength: 2, maxLength: 6 }), { minLength: 1, maxLength: 4 }),
+  { nil: undefined },
+);
+
+const denyListArb = fc.option(
+  fc.set(fc.hexaString({ minLength: 2, maxLength: 6 }), { minLength: 1, maxLength: 4 }),
+  { nil: undefined },
+);
+
+const bucketRuleArb = fc
+  .record({
+    bucketId: fc.hexaString({ minLength: 3, maxLength: 8 }),
+    corridor: corridorArb,
+    counterpartyAllow: allowListArb,
+    counterpartyDeny: denyListArb,
+    gate: fc.option(gateArb, { nil: undefined }),
+  })
+  .map((rule) => ({
+    ...rule,
+    corridor: {
+      minBps: rule.corridor.minBps,
+      maxBps: Math.max(rule.corridor.minBps, rule.corridor.maxBps),
+    },
+  } satisfies PolicyBucketRule));
+
+const rulesetArb = fc.set(bucketRuleArb, {
+  minLength: 1,
+  maxLength: 4,
+  compare: (a, b) => a.bucketId === b.bucketId,
+});
+
+const accountStatesArb = (bucketIds: string[]) =>
+  fc.set(
+    fc.record({
+      accountId: fc.hexaString({ minLength: 4, maxLength: 10 }),
+      bucketId: fc.constantFrom(...bucketIds),
+      requestedCents: fc.bigUintN(40).map((value) => BigInt(value)),
+      counterpartyId: fc.hexaString({ minLength: 3, maxLength: 8 }),
+      gate: fc.option(gateArb, { nil: undefined }),
+    }),
+    { minLength: 0, maxLength: 12, compare: (a, b) => a.accountId === b.accountId },
+  );
+
+const bankLineArb = fc.record({
+  availableCents: fc.bigUintN(44).map((value) => BigInt(value)),
+  gate: fc.option(gateArb, { nil: undefined }),
+});
+
+const policyInputArb = rulesetArb.chain((bucketRules) => {
+  const ruleset: PolicyRuleset = { buckets: bucketRules };
+  const buckets = bucketRules.map((rule) => rule.bucketId);
+  return fc
+    .tuple(bankLineArb, accountStatesArb(buckets))
+    .map(([bankLine, accountStates]) => ({
+      bankLine,
+      ruleset,
+      accountStates,
+    } satisfies ApplyPolicyInput));
+});
+
+function computeEligibleRequests(
+  rule: PolicyBucketRule,
+  accounts: AccountState[],
+  bankLineGate: GateState,
+): bigint {
+  if ((rule.gate ?? 'OPEN') === 'CLOSED' || bankLineGate === 'CLOSED') {
+    return 0n;
+  }
+  return accounts.reduce<bigint>((total, account) => {
+    if ((account.gate ?? 'OPEN') === 'CLOSED') {
+      return total;
+    }
+    if (rule.counterpartyAllow && rule.counterpartyAllow.length > 0 && !rule.counterpartyAllow.includes(account.counterpartyId)) {
+      return total;
+    }
+    if (rule.counterpartyDeny && rule.counterpartyDeny.includes(account.counterpartyId)) {
+      return total;
+    }
+    return total + (account.requestedCents < 0n ? 0n : account.requestedCents);
+  }, 0n);
+}
+
+function groupAllocationsByBucket(result: ReturnType<typeof applyPolicy>) {
+  const map = new Map<string, bigint>();
+  for (const allocation of result.allocations) {
+    map.set(allocation.bucketId, (map.get(allocation.bucketId) ?? 0n) + allocation.allocatedCents);
+  }
+  return map;
+}
+
+fc.assert(
+  fc.property(policyInputArb, ({ bankLine, ruleset, accountStates }) => {
+    const result = applyPolicy({ bankLine, ruleset, accountStates });
+    const totalAllocated = result.allocations.reduce((sum, item) => sum + item.allocatedCents, 0n);
+    const eligibleRequested = ruleset.buckets.reduce((sum, bucketRule) => {
+      const bucketAccounts = accountStates.filter((account) => account.bucketId === bucketRule.bucketId);
+      return sum + computeEligibleRequests(bucketRule, bucketAccounts, bankLine.gate ?? 'OPEN');
+    }, 0n);
+    if (bankLine.gate === 'CLOSED') {
+      return totalAllocated === 0n;
+    }
+    return totalAllocated <= bankLine.availableCents && totalAllocated <= eligibleRequested;
+  }),
+  { numRuns: RUNS },
+);
+
+fc.assert(
+  fc.property(policyInputArb, ({ bankLine, ruleset, accountStates }) => {
+    const result = applyPolicy({ bankLine, ruleset, accountStates });
+    return result.allocations.every((allocation) => allocation.allocatedCents >= 0n);
+  }),
+  { numRuns: RUNS },
+);
+
+function toComparableAllocations(result: ReturnType<typeof applyPolicy>): string[] {
+  return result.allocations.map(
+    (allocation) => `${allocation.accountId}:${allocation.bucketId}:${allocation.allocatedCents.toString()}`,
+  );
+}
+
+fc.assert(
+  fc.property(policyInputArb, ({ bankLine, ruleset, accountStates }) => {
+    const first = applyPolicy({ bankLine, ruleset, accountStates });
+    const second = applyPolicy({ bankLine, ruleset, accountStates });
+    return (
+      toComparableAllocations(first).join('|') === toComparableAllocations(second).join('|') &&
+      first.policyHash === second.policyHash &&
+      first.explain === second.explain
+    );
+  }),
+  { numRuns: RUNS },
+);
+
+fc.assert(
+  fc.property(policyInputArb, ({ bankLine, ruleset, accountStates }) => {
+    const result = applyPolicy({ bankLine, ruleset, accountStates });
+    const allocationsByBucket = groupAllocationsByBucket(result);
+    const total = bankLine.availableCents < 0n ? 0n : bankLine.availableCents;
+    const bankLineGate = bankLine.gate ?? 'OPEN';
+    const minFeasibleTotal = ruleset.buckets.reduce((sum, bucketRule) => {
+      const bucketAccounts = accountStates.filter((account) => account.bucketId === bucketRule.bucketId);
+      const requested = computeEligibleRequests(bucketRule, bucketAccounts, bankLineGate);
+      const minBound = bankersRound(total * BigInt(bucketRule.corridor.minBps), 10_000n);
+      const minRequired = requested >= minBound ? minBound : requested;
+      return sum + minRequired;
+    }, 0n);
+    for (const bucketRule of ruleset.buckets) {
+      const bucketAccounts = accountStates.filter((account) => account.bucketId === bucketRule.bucketId);
+      const requested = computeEligibleRequests(bucketRule, bucketAccounts, bankLineGate);
+      const allocated = allocationsByBucket.get(bucketRule.bucketId) ?? 0n;
+      const minBound = bankersRound(total * BigInt(bucketRule.corridor.minBps), 10_000n);
+      const maxBound = bankersRound(total * BigInt(bucketRule.corridor.maxBps), 10_000n);
+      if (requested < minBound || minFeasibleTotal > total) {
+        if (allocated > requested) {
+          return false;
+        }
+      } else if (bankLineGate === 'OPEN') {
+        if (allocated < minBound) {
+          return false;
+        }
+      }
+      if (allocated > maxBound) {
+        return false;
+      }
+      if (allocated > requested) {
+        return false;
+      }
+    }
+    return true;
+  }),
+  { numRuns: RUNS },
+);

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,8 +9,10 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared/*": ["shared/src/*"],
+      "@apgms/policy-engine": ["shared/policy-engine/index.ts"],
+      "fast-check": ["services/api-gateway/test/fast-check.ts"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/policy-engine/index.ts
+++ b/apgms/shared/policy-engine/index.ts
@@ -1,0 +1,339 @@
+import { createHash } from 'node:crypto';
+
+type GateState = 'OPEN' | 'CLOSED';
+
+export interface BankLine {
+  availableCents: bigint;
+  gate?: GateState;
+}
+
+export interface Corridor {
+  /** Basis points (0-10000) */
+  minBps: number;
+  /** Basis points (0-10000) */
+  maxBps: number;
+}
+
+export interface PolicyBucketRule {
+  bucketId: string;
+  corridor: Corridor;
+  counterpartyAllow?: string[];
+  counterpartyDeny?: string[];
+  gate?: GateState;
+}
+
+export interface PolicyRuleset {
+  buckets: PolicyBucketRule[];
+}
+
+export interface AccountState {
+  accountId: string;
+  bucketId: string;
+  requestedCents: bigint;
+  counterpartyId: string;
+  gate?: GateState;
+}
+
+export interface Allocation {
+  accountId: string;
+  bucketId: string;
+  allocatedCents: bigint;
+}
+
+export interface ApplyPolicyInput {
+  bankLine: BankLine;
+  ruleset: PolicyRuleset;
+  accountStates: AccountState[];
+}
+
+export interface ApplyPolicyOutput {
+  allocations: Allocation[];
+  policyHash: string;
+  explain: string;
+}
+
+interface BucketComputation {
+  rule: PolicyBucketRule;
+  requested: bigint;
+  minBound: bigint;
+  maxBound: bigint;
+  minRequired: bigint;
+  accounts: AccountState[];
+  allocation: bigint;
+}
+
+const BASIS_POINT_SCALE = 10_000n;
+
+export function bankersRound(dividend: bigint, divisor: bigint): bigint {
+  if (divisor === 0n) {
+    throw new Error('Division by zero in bankersRound');
+  }
+  const quotient = dividend / divisor;
+  const remainder = dividend % divisor;
+  const doubled = remainder * 2n;
+  if (doubled < divisor) {
+    return quotient;
+  }
+  if (doubled > divisor) {
+    return quotient + 1n;
+  }
+  return quotient % 2n === 0n ? quotient : quotient + 1n;
+}
+
+function canonicalRuleset(ruleset: PolicyRuleset): string {
+  const canonicalBuckets = [...ruleset.buckets]
+    .map((bucket) => ({
+      bucketId: bucket.bucketId,
+      corridor: {
+        minBps: bucket.corridor.minBps,
+        maxBps: bucket.corridor.maxBps,
+      },
+      allow: bucket.counterpartyAllow ? [...bucket.counterpartyAllow].sort() : [],
+      deny: bucket.counterpartyDeny ? [...bucket.counterpartyDeny].sort() : [],
+      gate: bucket.gate ?? 'OPEN',
+    }))
+    .sort((a, b) => a.bucketId.localeCompare(b.bucketId));
+  return JSON.stringify({ buckets: canonicalBuckets });
+}
+
+function withinAllowList(allow: string[] | undefined, counterpartyId: string): boolean {
+  if (!allow || allow.length === 0) {
+    return true;
+  }
+  return allow.includes(counterpartyId);
+}
+
+function withinDenyList(deny: string[] | undefined, counterpartyId: string): boolean {
+  if (!deny || deny.length === 0) {
+    return true;
+  }
+  return !deny.includes(counterpartyId);
+}
+
+function computeBounds(total: bigint, rule: PolicyBucketRule): { min: bigint; max: bigint } {
+  const min = bankersRound(total * BigInt(rule.corridor.minBps), BASIS_POINT_SCALE);
+  const max = bankersRound(total * BigInt(rule.corridor.maxBps), BASIS_POINT_SCALE);
+  return {
+    min: min < 0n ? 0n : min,
+    max: max < 0n ? 0n : max,
+  };
+}
+
+function filterEligibleAccounts(
+  accounts: AccountState[],
+  rule: PolicyBucketRule,
+  bankLineGate: GateState,
+): AccountState[] {
+  if (bankLineGate === 'CLOSED' || (rule.gate ?? 'OPEN') === 'CLOSED') {
+    return [];
+  }
+  return accounts.filter((account) => {
+    if ((account.gate ?? 'OPEN') === 'CLOSED') {
+      return false;
+    }
+    if (!withinAllowList(rule.counterpartyAllow, account.counterpartyId)) {
+      return false;
+    }
+    if (!withinDenyList(rule.counterpartyDeny, account.counterpartyId)) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function distributeToAccounts(
+  bucket: BucketComputation,
+  existingAllocations: Map<string, Allocation>,
+): void {
+  const { accounts, allocation, requested } = bucket;
+  if (accounts.length === 0 || allocation === 0n) {
+    return;
+  }
+  const sortedAccounts = [...accounts].sort((a, b) => a.accountId.localeCompare(b.accountId));
+  const totalRequested = requested === 0n ? 1n : requested;
+  let remaining = allocation;
+  for (let index = 0; index < sortedAccounts.length; index += 1) {
+    const account = sortedAccounts[index];
+    const isLast = index === sortedAccounts.length - 1;
+    let share: bigint;
+    if (isLast) {
+      share = remaining;
+    } else {
+      const rawShare = allocation * account.requestedCents;
+      const rounded = bankersRound(rawShare, totalRequested);
+      share = rounded;
+    }
+    if (share > account.requestedCents) {
+      share = account.requestedCents;
+    }
+    if (share > remaining) {
+      share = remaining;
+    }
+    remaining -= share;
+    const prior = existingAllocations.get(account.accountId);
+    if (!prior) {
+      existingAllocations.set(account.accountId, {
+        accountId: account.accountId,
+        bucketId: account.bucketId,
+        allocatedCents: share,
+      });
+    } else {
+      prior.allocatedCents += share;
+    }
+  }
+}
+
+function ensureAllocationMap(
+  map: Map<string, Allocation>,
+  accounts: AccountState[],
+): void {
+  for (const account of accounts) {
+    if (!map.has(account.accountId)) {
+      map.set(account.accountId, {
+        accountId: account.accountId,
+        bucketId: account.bucketId,
+        allocatedCents: 0n,
+      });
+    }
+  }
+}
+
+export function applyPolicy({ bankLine, ruleset, accountStates }: ApplyPolicyInput): ApplyPolicyOutput {
+  const available = bankLine.availableCents < 0n ? 0n : bankLine.availableCents;
+  const bankLineGate = bankLine.gate ?? 'OPEN';
+  const policyHash = createHash('sha256').update(canonicalRuleset(ruleset)).digest('hex');
+  const allocationsMap = new Map<string, Allocation>();
+  ensureAllocationMap(allocationsMap, accountStates);
+
+  if (available === 0n || bankLineGate === 'CLOSED') {
+    return {
+      allocations: [...allocationsMap.values()],
+      policyHash,
+      explain: bankLineGate === 'CLOSED' ? 'gate:CLOSED;total:0' : 'gate:OPEN;total:0',
+    };
+  }
+
+  const bucketOrder = [...ruleset.buckets]
+    .map((rule) => rule.bucketId)
+    .sort((a, b) => a.localeCompare(b));
+
+  const ruleByBucket = new Map<string, PolicyBucketRule>();
+  for (const bucketRule of ruleset.buckets) {
+    ruleByBucket.set(bucketRule.bucketId, bucketRule);
+  }
+
+  const accountsByBucket = new Map<string, AccountState[]>();
+  for (const account of accountStates) {
+    const list = accountsByBucket.get(account.bucketId) ?? [];
+    list.push(account);
+    accountsByBucket.set(account.bucketId, list);
+  }
+
+  const bucketComputations: BucketComputation[] = bucketOrder.map((bucketId) => {
+    const rule = ruleByBucket.get(bucketId);
+    if (!rule) {
+      throw new Error(`Missing rule for bucket ${bucketId}`);
+    }
+    const relevantAccounts = accountsByBucket.get(bucketId) ?? [];
+    const eligibleAccounts = filterEligibleAccounts(relevantAccounts, rule, bankLineGate);
+    const requested = eligibleAccounts.reduce<bigint>((sum, account) => {
+      const value = account.requestedCents < 0n ? 0n : account.requestedCents;
+      return sum + value;
+    }, 0n);
+    const { min: minBound, max: maxBound } = computeBounds(available, rule);
+    const cappedRequested = requested > maxBound ? maxBound : requested;
+    const minRequired = requested >= minBound ? (minBound < requested ? minBound : requested) : requested;
+    return {
+      rule,
+      accounts: eligibleAccounts,
+      requested,
+      minBound,
+      maxBound,
+      minRequired,
+      allocation: cappedRequested,
+    };
+  });
+
+  let totalAllocated = bucketComputations.reduce((sum, bucket) => sum + bucket.allocation, 0n);
+  if (totalAllocated > available) {
+    let excess = totalAllocated - available;
+    for (const bucket of bucketComputations) {
+      if (excess === 0n) {
+        break;
+      }
+      const reducible = bucket.allocation - bucket.minRequired;
+      if (reducible <= 0n) {
+        continue;
+      }
+      const delta = reducible >= excess ? excess : reducible;
+      bucket.allocation -= delta;
+      excess -= delta;
+    }
+    if (excess > 0n) {
+      for (const bucket of bucketComputations) {
+        if (excess === 0n) {
+          break;
+        }
+        const reducible = bucket.allocation;
+        if (reducible <= 0n) {
+          continue;
+        }
+        const delta = reducible >= excess ? excess : reducible;
+        bucket.allocation -= delta;
+        excess -= delta;
+      }
+    }
+    totalAllocated = bucketComputations.reduce((sum, bucket) => sum + bucket.allocation, 0n);
+  }
+
+  let leftover = available - totalAllocated;
+  if (leftover > 0n) {
+    for (const bucket of bucketComputations) {
+      if (leftover === 0n) {
+        break;
+      }
+      if (bucket.minRequired > bucket.allocation) {
+        const desired = bucket.minRequired - bucket.allocation;
+        const possible = bucket.requested - bucket.allocation;
+        const increment = desired < possible ? desired : possible;
+        if (increment > 0n) {
+          const delta = increment >= leftover ? leftover : increment;
+          bucket.allocation += delta;
+          leftover -= delta;
+        }
+      }
+    }
+    if (leftover > 0n) {
+      for (const bucket of bucketComputations) {
+        if (leftover === 0n) {
+          break;
+        }
+        const capacityByMax = bucket.maxBound - bucket.allocation;
+        const capacityByRequest = bucket.requested - bucket.allocation;
+        const capacity = capacityByMax < capacityByRequest ? capacityByMax : capacityByRequest;
+        if (capacity <= 0n) {
+          continue;
+        }
+        const delta = capacity >= leftover ? leftover : capacity;
+        bucket.allocation += delta;
+        leftover -= delta;
+      }
+    }
+  }
+
+  for (const bucket of bucketComputations) {
+    distributeToAccounts(bucket, allocationsMap);
+  }
+
+  const explainParts = bucketComputations.map((bucket) => {
+    const allocated = bucket.allocation;
+    return `${bucket.rule.bucketId}:${allocated.toString()}/${bucket.requested.toString()}`;
+  });
+  const explain = `gate:${bankLineGate};buckets:${explainParts.join(',')};leftover:${leftover.toString()}`;
+
+  return {
+    allocations: [...allocationsMap.values()].sort((a, b) => a.accountId.localeCompare(b.accountId)),
+    policyHash,
+    explain,
+  };
+}


### PR DESCRIPTION
## Summary
- implement a shared policy engine with deterministic allocation, corridor enforcement, and canonical hashing
- add property-based coverage exercising conservation, non-negative, stability, and corridor limits with a local fast-check shim
- wire an api-gateway test script to execute the policy engine property tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f43366062c83278015a59942012a24