### PR TITLE
feat: scaffold SBR AS4 artifact endpoints

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@apgms/sbr",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx --test test/sbr.spec.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.6.1"
+  }
+}

--- a/apgms/services/sbr/src/as4.ts
+++ b/apgms/services/sbr/src/as4.ts
@@ -1,0 +1,205 @@
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const ARTIFACT_ROOT = path.resolve(process.cwd(), 'tmp/as4-artifacts');
+const SIGNING_SECRET = 'apgms-sbr-signing-key';
+const SERVICE_NAME = 'APGMS-SBR';
+
+export type ArtifactName = 'envelope' | 'digest' | 'receipt' | 'messageId' | 'signature';
+
+const ARTIFACT_FILENAMES: Record<ArtifactName, string> = {
+  envelope: 'envelope.xml',
+  digest: 'digest.txt',
+  receipt: 'receipt.json',
+  messageId: 'message-id.txt',
+  signature: 'signature.txt',
+};
+
+const ARTIFACT_CONTENT_TYPES: Record<ArtifactName, string> = {
+  envelope: 'application/xml',
+  digest: 'text/plain',
+  receipt: 'application/json',
+  messageId: 'text/plain',
+  signature: 'text/plain',
+};
+
+export interface As4EnvelopeOptions {
+  messageId?: string;
+  payload: unknown;
+  createdAt?: string;
+  service?: string;
+}
+
+export interface Receipt {
+  messageId: string;
+  digest: string;
+  signature: string;
+  createdAt: string;
+  service: string;
+  status: 'RECEIVED';
+}
+
+export interface PersistArtifactsOptions {
+  messageId: string;
+  envelope: string;
+  digest: string;
+  receipt: Receipt;
+  signature: string;
+}
+
+export type ArtifactRecord = Record<ArtifactName, string>;
+
+export const ensureArtifactRoot = async () => {
+  await fs.mkdir(ARTIFACT_ROOT, { recursive: true });
+};
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+
+export const canonicalizePayload = (value: unknown): string => {
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return JSON.stringify(String(value));
+    }
+
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalizePayload(item)).join(',')}]`;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    const canonicalEntries = entries.map(
+      ([key, val]) => `${JSON.stringify(key)}:${canonicalizePayload(val)}`,
+    );
+    return `{${canonicalEntries.join(',')}}`;
+  }
+
+  return 'null';
+};
+
+export const buildAs4Envelope = ({
+  messageId = `msg-${randomUUID()}`,
+  payload,
+  createdAt = new Date().toISOString(),
+  service = SERVICE_NAME,
+}: As4EnvelopeOptions): { messageId: string; envelope: string; createdAt: string } => {
+  const canonicalPayload = canonicalizePayload(payload);
+  const encodedPayload = Buffer.from(canonicalPayload).toString('base64');
+
+  const envelope = [
+    '<AS4Envelope>',
+    '  <Header>',
+    `    <MessageId>${escapeXml(messageId)}</MessageId>`,
+    `    <Timestamp>${escapeXml(createdAt)}</Timestamp>`,
+    `    <Service>${escapeXml(service)}</Service>`,
+    '  </Header>',
+    `  <Payload>${encodedPayload}</Payload>`,
+    '</AS4Envelope>',
+  ].join('\n');
+
+  return { messageId, envelope, createdAt };
+};
+
+export const computeCanonicalHash = (envelope: string): string =>
+  createHash('sha256').update(envelope).digest('hex');
+
+export const signDigest = (digest: string): string =>
+  createHmac('sha256', SIGNING_SECRET).update(digest).digest('hex');
+
+export const createReceipt = ({
+  messageId,
+  digest,
+  signature,
+  createdAt,
+  service = SERVICE_NAME,
+}: {
+  messageId: string;
+  digest: string;
+  signature: string;
+  createdAt: string;
+  service?: string;
+}): Receipt => ({
+  messageId,
+  digest,
+  signature,
+  createdAt,
+  service,
+  status: 'RECEIVED',
+});
+
+export const artifactIdToPath = (artifactId: string): { path: string; name: ArtifactName } => {
+  const [messageId, name] = artifactId.split('--');
+  if (!messageId || !name) {
+    throw new Error('Invalid artifact id');
+  }
+
+  if (!/^[a-zA-Z0-9-]+$/.test(messageId)) {
+    throw new Error('Invalid artifact id');
+  }
+
+  if (!Object.hasOwn(ARTIFACT_FILENAMES, name)) {
+    throw new Error('Invalid artifact id');
+  }
+
+  const artifactName = name as ArtifactName;
+  const resolvedPath = path.resolve(ARTIFACT_ROOT, messageId, ARTIFACT_FILENAMES[artifactName]);
+
+  if (!resolvedPath.startsWith(path.resolve(ARTIFACT_ROOT))) {
+    throw new Error('Invalid artifact path');
+  }
+
+  return { path: resolvedPath, name: artifactName };
+};
+
+export const persistArtifacts = async ({
+  messageId,
+  envelope,
+  digest,
+  receipt,
+  signature,
+}: PersistArtifactsOptions): Promise<ArtifactRecord> => {
+  await ensureArtifactRoot();
+  const messageDir = path.resolve(ARTIFACT_ROOT, messageId);
+  await fs.mkdir(messageDir, { recursive: true });
+
+  const files: Array<[ArtifactName, string]> = [
+    ['envelope', envelope],
+    ['digest', `${digest}\n`],
+    ['receipt', `${JSON.stringify(receipt, null, 2)}\n`],
+    ['messageId', `${messageId}\n`],
+    ['signature', `${signature}\n`],
+  ];
+
+  await Promise.all(
+    files.map(async ([name, content]) => {
+      const filePath = path.join(messageDir, ARTIFACT_FILENAMES[name]);
+      await fs.writeFile(filePath, content, 'utf-8');
+    }),
+  );
+
+  return files.reduce<ArtifactRecord>((acc, [name]) => {
+    acc[name] = `${messageId}--${name}`;
+    return acc;
+  }, {} as ArtifactRecord);
+};
+
+export const getArtifactContentType = (name: ArtifactName): string => ARTIFACT_CONTENT_TYPES[name];

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,12 @@
-﻿console.log('sbr service');
+export { buildSbrServer } from './server';
+export {
+  ARTIFACT_ROOT,
+  artifactIdToPath,
+  buildAs4Envelope,
+  canonicalizePayload,
+  computeCanonicalHash,
+  createReceipt,
+  getArtifactContentType,
+  persistArtifacts,
+  signDigest,
+} from './as4';

--- a/apgms/services/sbr/src/server.ts
+++ b/apgms/services/sbr/src/server.ts
@@ -1,0 +1,67 @@
+import Fastify, { FastifyInstance } from 'fastify';
+import { promises as fs } from 'node:fs';
+
+import {
+  ARTIFACT_ROOT,
+  artifactIdToPath,
+  buildAs4Envelope,
+  computeCanonicalHash,
+  createReceipt,
+  getArtifactContentType,
+  persistArtifacts,
+  signDigest,
+} from './as4';
+
+interface SendRequestBody {
+  payload?: unknown;
+}
+
+export const buildSbrServer = async (): Promise<FastifyInstance> => {
+  const app = Fastify({ logger: false });
+
+  app.post<{ Body: SendRequestBody }>('/sbr/send', async (request, reply) => {
+    const input = request.body ?? {};
+    const { payload = null } = input;
+
+    const { messageId, envelope, createdAt } = buildAs4Envelope({ payload });
+    const digest = computeCanonicalHash(envelope);
+    const signature = signDigest(digest);
+    const receipt = createReceipt({ messageId, digest, signature, createdAt });
+
+    const artifacts = await persistArtifacts({
+      messageId,
+      envelope,
+      digest,
+      receipt,
+      signature,
+    });
+
+    reply.code(201).send({
+      messageId,
+      digest,
+      signature,
+      artifacts,
+      artifactRoot: ARTIFACT_ROOT,
+    });
+  });
+
+  app.get<{ Params: { id: string } }>('/sbr/artifact/:id', async (request, reply) => {
+    const { id } = request.params;
+
+    try {
+      const { path: artifactPath, name } = artifactIdToPath(id);
+      const payload = await fs.readFile(artifactPath);
+      reply.type(getArtifactContentType(name));
+      reply.send(payload);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        reply.code(404).send({ message: 'Artifact not found' });
+        return;
+      }
+
+      reply.code(400).send({ message: 'Invalid artifact id' });
+    }
+  });
+
+  return app;
+};

--- a/apgms/services/sbr/test/sbr.spec.ts
+++ b/apgms/services/sbr/test/sbr.spec.ts
@@ -1,0 +1,121 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+
+import {
+  ARTIFACT_ROOT,
+  artifactIdToPath,
+  buildAs4Envelope,
+  buildSbrServer,
+  canonicalizePayload,
+  computeCanonicalHash,
+  createReceipt,
+  persistArtifacts,
+} from '../src/index.js';
+
+const removeArtifacts = async () => {
+  await fs.rm(ARTIFACT_ROOT, { recursive: true, force: true });
+};
+
+test('SBR AS4 envelope scaffolding', async (t) => {
+  t.beforeEach(removeArtifacts);
+  t.afterEach(removeArtifacts);
+
+  await t.test('creates artifacts on send and exposes retrieval endpoint', async () => {
+    const app = await buildSbrServer();
+
+    const sendResponse = await app.inject({
+      method: 'POST',
+      url: '/sbr/send',
+      payload: { payload: { b: 2, a: 1 } },
+    });
+
+    assert.equal(sendResponse.statusCode, 201);
+
+    const body = sendResponse.json() as {
+      messageId: string;
+      artifacts: Record<string, string>;
+    };
+
+    const artifactIds = body.artifacts;
+    const artifactNames = ['envelope', 'digest', 'receipt', 'messageId', 'signature'] as const;
+
+    for (const name of artifactNames) {
+      assert.ok(artifactIds[name]);
+      const { path: artifactPath } = artifactIdToPath(artifactIds[name]);
+      const exists = await fs
+        .access(artifactPath)
+        .then(() => true)
+        .catch(() => false);
+      assert.ok(exists);
+    }
+
+    const digestResponse = await app.inject({
+      method: 'GET',
+      url: `/sbr/artifact/${artifactIds.digest}`,
+    });
+
+    assert.equal(digestResponse.statusCode, 200);
+    const digestContent = digestResponse.body.trim();
+
+    const { path: envelopePath } = artifactIdToPath(artifactIds.envelope);
+    const storedEnvelope = await fs.readFile(envelopePath, 'utf-8');
+    assert.equal(digestContent, computeCanonicalHash(storedEnvelope));
+  });
+
+  await t.test('produces deterministic canonical hashes for equivalent payloads', async () => {
+    const createdAt = '2024-01-01T00:00:00.000Z';
+    const messageId = 'msg-test-id';
+
+    const first = buildAs4Envelope({
+      messageId,
+      payload: { b: 2, a: 1, nested: { z: 3, y: 2 } },
+      createdAt,
+    });
+
+    const second = buildAs4Envelope({
+      messageId,
+      payload: { nested: { y: 2, z: 3 }, a: 1, b: 2 },
+      createdAt,
+    });
+
+    assert.equal(first.envelope, second.envelope);
+
+    const digest = computeCanonicalHash(first.envelope);
+    assert.equal(digest, computeCanonicalHash(second.envelope));
+  });
+
+  await t.test('creates a signed receipt with persisted digest and message id', async () => {
+    const messageId = 'msg-receipt-test';
+    const createdAt = '2024-01-01T00:00:00.000Z';
+    const { envelope } = buildAs4Envelope({ messageId, payload: { value: 1 }, createdAt });
+    const digest = computeCanonicalHash(envelope);
+    const receipt = createReceipt({
+      messageId,
+      digest,
+      signature: 'stub-signature',
+      createdAt,
+    });
+
+    const artifacts = await persistArtifacts({
+      messageId,
+      envelope,
+      digest,
+      receipt,
+      signature: 'stub-signature',
+    });
+
+    const receiptArtifact = artifacts.receipt;
+    const { path: receiptPath } = artifactIdToPath(receiptArtifact);
+    const storedReceipt = JSON.parse(await fs.readFile(receiptPath, 'utf-8'));
+    assert.equal(storedReceipt.messageId, messageId);
+    assert.equal(storedReceipt.digest, digest);
+    assert.equal(storedReceipt.signature, 'stub-signature');
+  });
+
+  await t.test('canonicalizes payload structures consistently', () => {
+    const payload = { z: 1, y: [3, 2, { b: 2, a: 1 }], x: 'value' };
+    const canonical = canonicalizePayload(payload);
+    assert.equal(canonical, '{"x":"value","y":[3,2,{"a":1,"b":2}],"z":1}');
+  });
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "types": ["node"],
+    "rootDir": "src"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- implement deterministic AS4 envelope builder with artifact persistence and signing stubs
- expose Fastify endpoints to send AS4 messages and fetch stored artifacts
- add node-based tests to verify artifact creation and canonical hash stability

## Testing
- pnpm --filter @apgms/sbr test

------
https://chatgpt.com/codex/tasks/task_e_68f4342395488327a8bc150184a3b522