### PR TITLE
Add readiness endpoints and graceful shutdown to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,89 @@
+import cors from "@fastify/cors";
+import Fastify, {
+  type FastifyInstance,
+  type FastifyServerOptions,
+} from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+export type DatabaseClient = {
+  $queryRaw: PrismaClient["$queryRaw"];
+  $disconnect: PrismaClient["$disconnect"];
+  user: Pick<PrismaClient["user"], "findMany">;
+  bankLine: Pick<PrismaClient["bankLine"], "findMany" | "create">;
+};
+
+export interface AppDependencies {
+  prisma: DatabaseClient;
+}
+
+export function buildApp(
+  options: FastifyServerOptions = {},
+  deps: AppDependencies,
+): FastifyInstance {
+  const app = Fastify({
+    logger: true,
+    ...options,
+  });
+
+  void app.register(cors, { origin: true });
+
+  app.get("/healthz", async () => ({ status: "ok", service: "api-gateway" }));
+
+  app.get("/readyz", async (_, reply) => {
+    try {
+      await deps.prisma.$queryRaw`SELECT 1`;
+      return { status: "ok" };
+    } catch (error) {
+      app.log.error({ err: error }, "database ping failed");
+      return reply.status(503).send({ status: "error", reason: "database_unreachable" });
+    }
+  });
+
+  app.get("/users", async () => {
+    const users = await deps.prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await deps.prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await deps.prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (error) {
+      req.log.error(error);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,74 +7,32 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { buildApp, type AppDependencies } from "./app";
+import { createShutdownHandler } from "./shutdown";
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
+const dependencies: AppDependencies = { prisma };
+const app = buildApp({}, dependencies);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
-
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+const shutdown = createShutdownHandler(app, dependencies);
+process.once("SIGTERM", shutdown);
+process.once("SIGINT", shutdown);
 
+try {
+  await app.listen({ port, host });
+  app.log.info({ port, host }, "api-gateway listening");
+} catch (error) {
+  app.log.error({ err: error }, "failed to start server");
+  try {
+    await prisma.$disconnect();
+  } catch (disconnectError) {
+    app.log.error({ err: disconnectError }, "failed to disconnect prisma during startup error");
+  }
+  process.exit(1);
+}

--- a/apgms/services/api-gateway/src/shutdown.ts
+++ b/apgms/services/api-gateway/src/shutdown.ts
@@ -1,0 +1,40 @@
+import type { FastifyInstance } from "fastify";
+import type { AppDependencies } from "./app";
+
+type ExitFunction = (code?: number) => void;
+
+export function createShutdownHandler(
+  app: FastifyInstance,
+  deps: AppDependencies,
+  exit: ExitFunction = process.exit,
+): (signal?: NodeJS.Signals) => Promise<void> {
+  let shuttingDown = false;
+
+  return async (signal?: NodeJS.Signals) => {
+    if (shuttingDown) {
+      app.log.info({ signal }, "shutdown already in progress");
+      return;
+    }
+    shuttingDown = true;
+
+    app.log.info({ signal }, "received shutdown signal");
+
+    let exitCode = 0;
+
+    try {
+      await app.close();
+    } catch (error) {
+      exitCode = 1;
+      app.log.error({ err: error }, "failed to close fastify instance");
+    }
+
+    try {
+      await deps.prisma.$disconnect();
+    } catch (error) {
+      exitCode = 1;
+      app.log.error({ err: error }, "failed to disconnect prisma");
+    }
+
+    exit(exitCode);
+  };
+}

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import type { FastifyInstance } from "fastify";
+import { buildApp, type AppDependencies, type DatabaseClient } from "../src/app";
+import { createShutdownHandler } from "../src/shutdown";
+
+function createPrismaStub(overrides: Partial<DatabaseClient> = {}): DatabaseClient {
+  const base: DatabaseClient = {
+    $queryRaw: async () => ({ ok: true }) as any,
+    $disconnect: async () => {},
+    user: {
+      findMany: async () => [],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async ({ data }) => ({ id: "bank_line_stub", ...data }),
+    },
+  };
+
+  const user = overrides.user
+    ? { ...base.user, ...overrides.user }
+    : base.user;
+  const bankLine = overrides.bankLine
+    ? { ...base.bankLine, ...overrides.bankLine }
+    : base.bankLine;
+
+  return {
+    ...base,
+    ...overrides,
+    user,
+    bankLine,
+  };
+}
+
+describe("health and readiness endpoints", () => {
+  test("/healthz always reports ok", async () => {
+    const prisma = createPrismaStub();
+    const app = buildApp({ logger: false }, { prisma });
+
+    const response = await app.inject({ method: "GET", url: "/healthz" });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), { status: "ok", service: "api-gateway" });
+
+    await app.close();
+    await prisma.$disconnect();
+  });
+
+  test("/readyz returns 503 when the database ping fails", async () => {
+    const error = new Error("db offline");
+    let calls = 0;
+    const prisma = createPrismaStub({
+      async $queryRaw() {
+        calls += 1;
+        throw error;
+      },
+    });
+    const app = buildApp({ logger: false }, { prisma });
+
+    const response = await app.inject({ method: "GET", url: "/readyz" });
+
+    assert.equal(response.statusCode, 503);
+    assert.deepEqual(response.json(), { status: "error", reason: "database_unreachable" });
+    assert.equal(calls, 1);
+
+    await app.close();
+    await prisma.$disconnect();
+  });
+});
+
+describe("graceful shutdown", () => {
+  test("handler drains fastify and disconnects prisma only once", async () => {
+    let closeCalls = 0;
+    const fakeApp = {
+      async close() {
+        closeCalls += 1;
+      },
+      log: {
+        info: () => {},
+        error: () => {},
+      },
+    } as unknown as FastifyInstance;
+
+    let disconnectCalls = 0;
+    const prisma = createPrismaStub({
+      async $disconnect() {
+        disconnectCalls += 1;
+      },
+    });
+
+    let exitCalls = 0;
+    let lastExitCode: number | undefined;
+    const exit = (code?: number) => {
+      exitCalls += 1;
+      lastExitCode = code;
+    };
+
+    const deps: AppDependencies = { prisma };
+    const handler = createShutdownHandler(fakeApp, deps, exit);
+
+    await handler("SIGTERM");
+
+    assert.equal(closeCalls, 1);
+    assert.equal(disconnectCalls, 1);
+    assert.equal(exitCalls, 1);
+    assert.equal(lastExitCode, 0);
+
+    await handler("SIGINT");
+
+    assert.equal(closeCalls, 1, "close should not be called again");
+    assert.equal(disconnectCalls, 1, "disconnect should not be called again");
+    assert.equal(exitCalls, 1, "exit should not run again");
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- refactor the API gateway into a reusable Fastify builder with /healthz and /readyz routes backed by a Prisma ping
- add a shutdown handler that drains Fastify and disconnects Prisma when SIGTERM or SIGINT is received
- cover health, readiness, and graceful shutdown logic with node:test and wire the service into the workspace test runner

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f433c848a883279c76b100b15f3527