### PR TITLE
Implement anomaly detection alerts pipeline

### DIFF
--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,92 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import { auditBlobStore } from "@apgms/shared/audit-blobs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+type PrismaClientLike = {
+  user: { findMany: (args: unknown) => Promise<unknown[]> };
+  bankLine: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+    create: (args: unknown) => Promise<unknown>;
+  };
+};
+
+export interface BuildAppDependencies {
+  prisma?: PrismaClientLike;
+}
+
+export async function buildApp(
+  options: FastifyServerOptions = {},
+  deps: BuildAppDependencies = {}
+): Promise<FastifyInstance> {
+  const prisma =
+    deps.prisma ?? (await import("@apgms/shared/db")).prisma;
+
+  const app = Fastify({ logger: true, ...options });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as Record<string, string | undefined>).take ?? 20);
+    const safeTake = Math.min(Math.max(Number.isFinite(take) ? take : 20, 1), 200);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: safeTake,
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.get("/alerts", async (req) => {
+    const query = req.query as Record<string, string | undefined>;
+    const page = Math.max(parseInt(query.page ?? "1", 10) || 1, 1);
+    const pageSizeRaw = parseInt(query.pageSize ?? "20", 10);
+    const pageSize = Math.min(Math.max(pageSizeRaw || 20, 1), 200);
+    return auditBlobStore.listAlerts({ page, pageSize });
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,15 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+import { buildApp } from "./app";
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
+
+const app = await buildApp();
+
+app.ready(() => {
+  app.log.info(app.printRoutes());
+});
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/shared/src/audit-blobs.ts
+++ b/apgms/shared/src/audit-blobs.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+
+export type AuditBlobKind = "anomaly" | (string & {});
+
+export interface AuditBlobRecord {
+  id: string;
+  kind: AuditBlobKind;
+  payloadJson: string;
+  createdAt: Date;
+}
+
+export interface AuditAlertPayload {
+  rule: "amount_corridor_breach" | "burst_frequency" | "new_payee";
+  counterpartyId: string;
+  transactionId: string;
+  occurredAt: string;
+  summary: string;
+  context?: Record<string, unknown>;
+}
+
+export interface ListAlertsInput {
+  page: number;
+  pageSize: number;
+  kind?: AuditBlobKind;
+}
+
+export interface AlertsPage {
+  alerts: Array<{
+    id: string;
+    kind: AuditBlobKind;
+    payload: AuditAlertPayload;
+    createdAt: string;
+  }>;
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+class AuditBlobStore {
+  private blobs: AuditBlobRecord[] = [];
+
+  record(kind: AuditBlobKind, payload: unknown): AuditBlobRecord {
+    const entry: AuditBlobRecord = {
+      id: randomUUID(),
+      kind,
+      payloadJson: JSON.stringify(payload),
+      createdAt: new Date(),
+    };
+    this.blobs.push(entry);
+    return entry;
+  }
+
+  recordAnomaly(payload: AuditAlertPayload): AuditBlobRecord {
+    return this.record("anomaly", payload);
+  }
+
+  listAlerts({ page, pageSize, kind = "anomaly" }: ListAlertsInput): AlertsPage {
+    const safePage = Math.max(1, Math.floor(page) || 1);
+    const safePageSize = Math.max(1, Math.floor(pageSize) || 1);
+
+    const filtered = this.blobs
+      .filter((blob) => blob.kind === kind)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+    const total = filtered.length;
+    const start = (safePage - 1) * safePageSize;
+    const selected = filtered.slice(start, start + safePageSize);
+
+    return {
+      alerts: selected.map((blob) => ({
+        id: blob.id,
+        kind: blob.kind,
+        payload: JSON.parse(blob.payloadJson) as AuditAlertPayload,
+        createdAt: blob.createdAt.toISOString(),
+      })),
+      page: safePage,
+      pageSize: safePageSize,
+      total,
+    };
+  }
+
+  reset() {
+    this.blobs = [];
+  }
+}
+
+export const auditBlobStore = new AuditBlobStore();
+
+export function createAuditBlobStore(): AuditBlobStore {
+  return new AuditBlobStore();
+}
+
+export type AuditBlobWriter = Pick<AuditBlobStore, "record" | "recordAnomaly">;
+
+export { AuditBlobStore };

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./audit-blobs";
+export * from "./db";

--- a/apgms/tsconfig.json
+++ b/apgms/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared/*": ["shared/src/*"],
+      "@apgms/services/api-gateway/*": ["services/api-gateway/src/*"]
     }
   }
 }

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,10 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --project ../tsconfig.json",
+    "test": "tsx --test test/anomaly.spec.ts"
+  }
+}

--- a/apgms/worker/src/pipeline/anomaly.ts
+++ b/apgms/worker/src/pipeline/anomaly.ts
@@ -1,0 +1,106 @@
+import { auditBlobStore, AuditAlertPayload, AuditBlobWriter } from "@apgms/shared/audit-blobs";
+
+export interface BankLine {
+  id: string;
+  counterpartyId: string;
+  amount: number;
+  occurredAt: Date;
+  payee: string;
+}
+
+export interface AnomalyRuleConfig {
+  corridors?: Record<string, { min: number; max: number }>;
+  burst?: { threshold: number; windowMinutes: number };
+  payeeAllowlist?: Record<string, string[]>;
+}
+
+export interface ProcessAnomaliesOptions {
+  config: AnomalyRuleConfig;
+  store?: AuditBlobWriter;
+}
+
+interface BurstStateEntry {
+  occurredAt: Date;
+  transactionId: string;
+}
+
+export function processBankLineAnomalies(bankLines: BankLine[], options: ProcessAnomaliesOptions): AuditAlertPayload[] {
+  const { config, store = auditBlobStore } = options;
+
+  const sorted = [...bankLines].sort((a, b) => a.occurredAt.getTime() - b.occurredAt.getTime());
+  const anomalies: AuditAlertPayload[] = [];
+
+  const burstQueues = new Map<string, BurstStateEntry[]>();
+  const lastBurstAt = new Map<string, number>();
+  const burstWindowMs = config.burst ? config.burst.windowMinutes * 60 * 1000 : 0;
+
+  for (const line of sorted) {
+    const basePayload = {
+      counterpartyId: line.counterpartyId,
+      transactionId: line.id,
+      occurredAt: line.occurredAt.toISOString(),
+    };
+
+    // Amount corridor breach per counterparty
+    const corridor = config.corridors?.[line.counterpartyId];
+    if (corridor && (line.amount < corridor.min || line.amount > corridor.max)) {
+      const payload: AuditAlertPayload = {
+        ...basePayload,
+        rule: "amount_corridor_breach",
+        summary: `amount ${line.amount.toFixed(2)} outside corridor [${corridor.min.toFixed(2)}, ${corridor.max.toFixed(2)}]`,
+        context: {
+          observedAmount: line.amount,
+          corridor,
+        },
+      };
+      anomalies.push(payload);
+      store.recordAnomaly(payload);
+    }
+
+    // Burst frequency detection
+    if (config.burst) {
+      const queue = burstQueues.get(line.counterpartyId) ?? [];
+      queue.push({ occurredAt: line.occurredAt, transactionId: line.id });
+      while (queue.length > 0 && line.occurredAt.getTime() - queue[0].occurredAt.getTime() > burstWindowMs) {
+        queue.shift();
+      }
+      burstQueues.set(line.counterpartyId, queue);
+
+      if (queue.length >= config.burst.threshold) {
+        const lastTriggered = lastBurstAt.get(line.counterpartyId) ?? 0;
+        if (line.occurredAt.getTime() - lastTriggered >= burstWindowMs) {
+          const payload: AuditAlertPayload = {
+            ...basePayload,
+            rule: "burst_frequency",
+            summary: `burst of ${queue.length} payments detected within ${config.burst.windowMinutes} minutes`,
+            context: {
+              windowMinutes: config.burst.windowMinutes,
+              transactionIds: queue.map((entry) => entry.transactionId),
+            },
+          };
+          anomalies.push(payload);
+          store.recordAnomaly(payload);
+          lastBurstAt.set(line.counterpartyId, line.occurredAt.getTime());
+        }
+      }
+    }
+
+    // New payee outside allowlist
+    const allowlist = config.payeeAllowlist?.[line.counterpartyId];
+    if (allowlist && !allowlist.includes(line.payee)) {
+      const payload: AuditAlertPayload = {
+        ...basePayload,
+        rule: "new_payee",
+        summary: `payee ${line.payee} is not in allowlist`,
+        context: {
+          payee: line.payee,
+          allowlist,
+        },
+      };
+      anomalies.push(payload);
+      store.recordAnomaly(payload);
+    }
+  }
+
+  return anomalies;
+}

--- a/apgms/worker/test/anomaly.spec.ts
+++ b/apgms/worker/test/anomaly.spec.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { auditBlobStore } from "@apgms/shared/audit-blobs";
+import { processBankLineAnomalies, type BankLine } from "../src/pipeline/anomaly";
+import { buildApp } from "@apgms/services/api-gateway/app";
+
+const baseDate = new Date("2024-01-01T00:00:00Z");
+
+const minutesFromBase = (minutes: number) => new Date(baseDate.getTime() + minutes * 60 * 1000);
+
+describe("anomaly detection pipeline", () => {
+  afterEach(() => {
+    auditBlobStore.reset();
+  });
+
+  it("records anomalies and exposes them via /alerts", async () => {
+    const lines: BankLine[] = [
+      {
+        id: "t1",
+        counterpartyId: "cp-1",
+        amount: 20,
+        occurredAt: minutesFromBase(0),
+        payee: "acme-ops",
+      },
+      {
+        id: "t2",
+        counterpartyId: "cp-1",
+        amount: 150,
+        occurredAt: minutesFromBase(1),
+        payee: "acme-ops",
+      },
+      {
+        id: "t3",
+        counterpartyId: "cp-1",
+        amount: 155,
+        occurredAt: minutesFromBase(2),
+        payee: "acme-ops",
+      },
+      {
+        id: "t4",
+        counterpartyId: "cp-1",
+        amount: 160,
+        occurredAt: minutesFromBase(3),
+        payee: "acme-ops",
+      },
+      {
+        id: "t5",
+        counterpartyId: "cp-1",
+        amount: 180,
+        occurredAt: minutesFromBase(12),
+        payee: "rogue-payee",
+      },
+    ];
+
+    processBankLineAnomalies(lines, {
+      config: {
+        corridors: {
+          "cp-1": { min: 50, max: 170 },
+        },
+        burst: { threshold: 3, windowMinutes: 5 },
+        payeeAllowlist: {
+          "cp-1": ["acme-ops"],
+        },
+      },
+    });
+
+    const prismaStub = {
+      user: {
+        findMany: async () => [],
+      },
+      bankLine: {
+        findMany: async () => [],
+        create: async () => ({}),
+      },
+    };
+
+    const app = await buildApp({ logger: false }, { prisma: prismaStub });
+    const response = await app.inject({ method: "GET", url: "/alerts?page=1&pageSize=10" });
+    assert.equal(response.statusCode, 200);
+
+    const body = response.json();
+    assert.equal(body.total, 4);
+    assert.equal(body.alerts.length, 4);
+
+    const ruleCounts = body.alerts.reduce<Record<string, number>>((acc, alert: any) => {
+      acc[alert.payload.rule] = (acc[alert.payload.rule] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    assert.equal(ruleCounts["amount_corridor_breach"], 2);
+    assert.equal(ruleCounts["burst_frequency"], 1);
+    assert.equal(ruleCounts["new_payee"], 1);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared audit blob store used to persist anomaly alerts
- implement the worker anomaly detection pipeline to flag corridor, burst, and allowlist violations
- refactor the API gateway app builder to expose a paginated /alerts endpoint and cover it with a node:test suite

## Testing
- pnpm --filter @apgms/worker test

------
https://chatgpt.com/codex/tasks/task_e_68f4340f62908327b3ea38329adf0159