### PR TITLE
feat: implement audit logging plugin for API gateway

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,6 +1,7 @@
-﻿node_modules/
+node_modules/
 dist/
 coverage/
+artifacts/
 .env*
 .DS_Store
 .vscode/

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/audit-log.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,11 +9,13 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import auditLogPlugin from "./plugins/audit-log";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(auditLogPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/audit-log.ts
+++ b/apgms/services/api-gateway/src/plugins/audit-log.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, createWriteStream } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { Writable } from "node:stream";
+import type { FastifyPluginAsync } from "fastify";
+
+type Decision = "ALLOW" | "DENY" | "UNKNOWN";
+
+type AuditBaseEvent = {
+  ts: string;
+};
+
+type PolicyDecisionEvent = AuditBaseEvent & {
+  type: "policy-decision";
+  decision: "ALLOW" | "DENY";
+  reason?: string;
+  policy_id?: string;
+};
+
+type RptMintEvent = AuditBaseEvent & {
+  type: "rpt-mint";
+  rpt_id: string;
+  policy_id?: string;
+};
+
+type AuditEvent = PolicyDecisionEvent | RptMintEvent;
+
+type HashedAuditEvent = AuditEvent & {
+  prev_hash: string;
+  hash: string;
+};
+
+type AuditActor = {
+  userId?: string;
+  orgId?: string;
+};
+
+type AuditContext = {
+  recordDecision: (
+    decision: "ALLOW" | "DENY",
+    opts?: { reason?: string; policyId?: string }
+  ) => void;
+  recordRptMint: (rptId: string, opts?: { policyId?: string }) => void;
+  setActor: (actor: AuditActor) => void;
+  decision?: Decision;
+  reason?: string;
+  getEvents: () => HashedAuditEvent[];
+  getActor: () => AuditActor;
+};
+
+type Clock = () => Date;
+
+type AuditLogPluginOptions = {
+  stream?: Writable;
+  clock?: Clock;
+  outputPath?: string;
+};
+
+const ZERO_HASH = "0".repeat(64);
+const DEFAULT_OUTPUT = resolve(process.cwd(), "artifacts/audit-sample.ndjson");
+const startTimeSymbol = Symbol("auditStartTime");
+
+const sanitizeValue = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const text = String(value);
+  if (/^[^@]+@[^@]+\.[^@]+$/.test(text)) {
+    return "[REDACTED]";
+  }
+  if (/\b\d{6,}\b/.test(text)) {
+    return "[REDACTED]";
+  }
+  return text;
+};
+
+const sanitizeRoute = (route?: string): string => {
+  if (!route) {
+    return "unknown";
+  }
+  if (route.includes(":")) {
+    return route;
+  }
+  return route
+    .split("?")[0]
+    .split("/")
+    .map((segment) => {
+      if (!segment) return segment;
+      if (/^[a-zA-Z-]+$/.test(segment)) {
+        return segment;
+      }
+      return ":param";
+    })
+    .join("/");
+};
+
+const ensureStream = (options?: AuditLogPluginOptions): Writable => {
+  if (options?.stream) {
+    return options.stream;
+  }
+  const outputPath = options?.outputPath ?? DEFAULT_OUTPUT;
+  mkdirSync(dirname(outputPath), { recursive: true });
+  return createWriteStream(outputPath, { flags: "a" });
+};
+
+const hashEvent = (event: AuditEvent, prevHash: string): HashedAuditEvent => {
+  const base = { ...event };
+  const hash = createHash("sha256")
+    .update(prevHash)
+    .update(JSON.stringify(base))
+    .digest("hex");
+  return { ...base, prev_hash: prevHash, hash };
+};
+
+const createAuditContext = (clock: Clock): AuditContext => {
+  let lastHash = ZERO_HASH;
+  const events: HashedAuditEvent[] = [];
+  let decision: Decision | undefined;
+  let reason: string | undefined;
+  let actor: AuditActor = {};
+
+  return {
+    recordDecision: (nextDecision, opts) => {
+      decision = nextDecision;
+      reason = sanitizeValue(opts?.reason) ?? undefined;
+      const event: PolicyDecisionEvent = {
+        type: "policy-decision",
+        decision: nextDecision,
+        reason,
+        policy_id: sanitizeValue(opts?.policyId),
+        ts: clock().toISOString(),
+      };
+      const hashed = hashEvent(event, lastHash);
+      lastHash = hashed.hash;
+      events.push(hashed);
+    },
+    recordRptMint: (rptId, opts) => {
+      const event: RptMintEvent = {
+        type: "rpt-mint",
+        rpt_id: sanitizeValue(rptId) ?? "[REDACTED]",
+        policy_id: sanitizeValue(opts?.policyId),
+        ts: clock().toISOString(),
+      };
+      const hashed = hashEvent(event, lastHash);
+      lastHash = hashed.hash;
+      events.push(hashed);
+    },
+    setActor: (nextActor) => {
+      actor = {
+        userId: sanitizeValue(nextActor.userId),
+        orgId: sanitizeValue(nextActor.orgId),
+      };
+    },
+    getEvents: () => [...events],
+    getActor: () => ({ ...actor }),
+    get decision() {
+      return decision;
+    },
+    get reason() {
+      return reason;
+    },
+  };
+};
+
+const auditLogPlugin: FastifyPluginAsync<AuditLogPluginOptions> = async (
+  fastify,
+  options
+) => {
+  const stream = ensureStream(options);
+  const clock = options?.clock ?? (() => new Date());
+
+  fastify.decorateRequest("audit", null);
+
+  fastify.addHook("onRequest", async (request) => {
+    const audit = createAuditContext(clock);
+    request.audit = audit;
+    (request as any)[startTimeSymbol] = process.hrtime.bigint();
+    const userIdHeader = request.headers["x-user-id"];
+    const orgIdHeader = request.headers["x-org-id"];
+    if (userIdHeader || orgIdHeader) {
+      audit.setActor({
+        userId: userIdHeader as string | undefined,
+        orgId: orgIdHeader as string | undefined,
+      });
+    }
+  });
+
+  fastify.addHook("onResponse", async (request, reply) => {
+    const endTime = process.hrtime.bigint();
+    const startTime = (request as any)[startTimeSymbol] as bigint | undefined;
+    const latencyMs = startTime
+      ? Number((endTime - startTime) / BigInt(1_000_000))
+      : undefined;
+
+    const actor = request.audit?.getActor?.() ?? {};
+
+    const resolvedDecision =
+      request.audit?.decision ?? (reply.statusCode >= 400 ? "DENY" : "ALLOW");
+
+    const payload = {
+      ts: clock().toISOString(),
+      req_id: request.id,
+      user_id: actor.userId ?? sanitizeValue((request as any).user?.id),
+      org_id: actor.orgId ?? sanitizeValue((request as any).user?.orgId),
+      route: sanitizeRoute(
+        request.routeOptions?.url ?? request.routerPath ?? request.raw.url
+      ),
+      status: reply.statusCode,
+      latency_ms: latencyMs ?? null,
+      decision: resolvedDecision,
+      reason: request.audit?.reason ?? null,
+      audit_blob: request.audit?.getEvents() ?? [],
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      stream.write(`${JSON.stringify(payload)}\n`, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    audit: AuditContext;
+    [startTimeSymbol]?: bigint;
+  }
+}
+
+export type { AuditLogPluginOptions, AuditContext, HashedAuditEvent };
+(auditLogPlugin as any)[Symbol.for("skip-override")] = true;
+(auditLogPlugin as any)[Symbol.for("fastify.display-name")] = "audit-log-plugin";
+export default auditLogPlugin;

--- a/apgms/services/api-gateway/test/audit-log.spec.ts
+++ b/apgms/services/api-gateway/test/audit-log.spec.ts
@@ -1,0 +1,107 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { Writable } from "node:stream";
+import { readFileSync, rmSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import auditLogPlugin from "../src/plugins/audit-log";
+
+type Line = ReturnType<typeof JSON.parse>;
+
+class ArrayWritable extends Writable {
+  public readonly lines: string[] = [];
+
+  _write(chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.lines.push(chunk.toString());
+    callback();
+  }
+}
+
+const createDeterministicClock = () => {
+  const base = Date.parse("2024-01-01T00:00:00.000Z");
+  let tick = 0;
+  return () => new Date(base + tick++);
+};
+
+test("records allow and deny decisions with sanitized output", async () => {
+  const stream = new ArrayWritable();
+  const clock = createDeterministicClock();
+  const app = Fastify();
+  await app.register(auditLogPlugin, { stream, clock });
+
+  app.get("/users/:userId", async (request) => {
+    request.audit.setActor({ userId: "user-123", orgId: "org-789" });
+    request.audit.recordRptMint("rpt-1", { policyId: "policy-1" });
+    request.audit.recordDecision("ALLOW", { reason: "policy:allow", policyId: "policy-1" });
+    return { ok: true };
+  });
+
+  app.post("/tenants/:tenantId/policies", async (request, reply) => {
+    request.audit.setActor({ userId: "user-321", orgId: "org-111" });
+    request.audit.recordDecision("DENY", { reason: "user@example.com", policyId: "policy-2" });
+    reply.code(403).send({ error: "denied" });
+  });
+
+  await app.ready();
+
+  const allowResponse = await app.inject({ method: "GET", url: "/users/999?email=test@example.com" });
+  assert.equal(allowResponse.statusCode, 200);
+  const denyResponse = await app.inject({ method: "POST", url: "/tenants/000000001/policies" });
+  assert.equal(denyResponse.statusCode, 403);
+
+  assert.equal(stream.lines.length, 2);
+
+  const allowLog = JSON.parse(stream.lines[0]) as Line;
+  assert.equal(allowLog.decision, "ALLOW");
+  assert.equal(allowLog.reason, "policy:allow");
+  assert.equal(allowLog.route, "/users/:userId");
+  assert.equal(allowLog.user_id, "user-123");
+  assert.equal(allowLog.org_id, "org-789");
+  assert.equal(Array.isArray(allowLog.audit_blob), true);
+  assert.equal(allowLog.audit_blob.length, 2);
+  assert.equal(allowLog.audit_blob[0].type, "rpt-mint");
+  assert.equal(allowLog.audit_blob[1].type, "policy-decision");
+  assert.equal(allowLog.audit_blob[1].prev_hash, allowLog.audit_blob[0].hash);
+  assert.ok(!JSON.stringify(allowLog).includes("test@example.com"));
+
+  const denyLog = JSON.parse(stream.lines[1]) as Line;
+  assert.equal(denyLog.decision, "DENY");
+  assert.equal(denyLog.reason, "[REDACTED]");
+  assert.equal(denyLog.status, 403);
+  assert.equal(denyLog.route, "/tenants/:tenantId/policies");
+  assert.ok(!JSON.stringify(denyLog).includes("000000001"));
+
+  await app.close();
+});
+
+test("writes audit artifact file", async () => {
+  const artifactPath = resolve(process.cwd(), "artifacts/audit-sample.ndjson");
+  if (existsSync(artifactPath)) {
+    rmSync(artifactPath, { force: true });
+  }
+
+  const clock = createDeterministicClock();
+  const app = Fastify();
+  await app.register(auditLogPlugin, { clock });
+
+  app.get("/health", async (request) => {
+    request.audit.recordDecision("ALLOW", { reason: "ok" });
+    return { ok: true };
+  });
+
+  await app.ready();
+
+  const healthResponse = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(healthResponse.statusCode, 200);
+  await app.close();
+  await new Promise((resolve) => setTimeout(resolve, 25));
+
+  assert.equal(existsSync(artifactPath), true);
+
+  const contents = readFileSync(artifactPath, "utf-8").trim();
+  assert.notEqual(contents.length, 0);
+  const [line] = contents.split("\n");
+  const payload = JSON.parse(line) as Line;
+  assert.equal(payload.route, "/health");
+  assert.equal(payload.decision, "ALLOW");
+});


### PR DESCRIPTION
## Summary
- add a Fastify audit logging plugin that emits sanitized per-request JSON lines and chained audit blobs for RPT mint and policy decisions
- register the audit logging plugin in the API gateway and ensure generated audit artifacts stay ignored
- cover the new logging behaviour with node:test specs that validate allow/deny decisions and artifact creation

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f433e5cda08327a370c30f8d9b5e75