### PR TITLE
feat: enforce idempotency and webhook replay protections

### DIFF
--- a/apgms/services/api-gateway/eval/redteam/nonce.json
+++ b/apgms/services/api-gateway/eval/redteam/nonce.json
@@ -1,0 +1,18 @@
+{
+  "name": "missing-nonce-header",
+  "request": {
+    "method": "POST",
+    "url": "/webhooks/payto",
+    "headers": {
+      "X-Timestamp": "{{timestamp}}",
+      "X-Signature": "{{signature}}"
+    },
+    "body": {
+      "id": "rt-missing-nonce"
+    }
+  },
+  "expect": {
+    "status": 400,
+    "body": { "error": "missing_webhook_headers" }
+  }
+}

--- a/apgms/services/api-gateway/eval/redteam/replay.json
+++ b/apgms/services/api-gateway/eval/redteam/replay.json
@@ -1,0 +1,21 @@
+{
+  "name": "webhook-replay",
+  "request": {
+    "method": "POST",
+    "url": "/webhooks/payto",
+    "headers": {
+      "X-Nonce": "redteam-nonce",
+      "X-Timestamp": "{{timestamp}}",
+      "X-Signature": "{{signature}}"
+    },
+    "body": {
+      "id": "rt-replay",
+      "amount": 100
+    }
+  },
+  "replay": true,
+  "expect": {
+    "status": 409,
+    "body": { "error": "replayed_nonce" }
+  }
+}

--- a/apgms/services/api-gateway/eval/redteam/stale.json
+++ b/apgms/services/api-gateway/eval/redteam/stale.json
@@ -1,0 +1,20 @@
+{
+  "name": "webhook-stale-timestamp",
+  "request": {
+    "method": "POST",
+    "url": "/webhooks/payto",
+    "headers": {
+      "X-Nonce": "redteam-stale",
+      "X-Timestamp": "{{past_timestamp}}",
+      "X-Signature": "{{signature}}"
+    },
+    "body": {
+      "id": "rt-stale",
+      "amount": 55
+    }
+  },
+  "expect": {
+    "status": 409,
+    "body": { "error": "stale_timestamp" }
+  }
+}

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --import tsx --test test/idempotency.spec.ts test/webhook-replay.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,66 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { prisma } from "../../../shared/src/db";
+import idempotencyPlugin from "./plugins/idempotency";
+import webhooksRoutes from "./routes/webhooks";
+
+export async function buildApp() {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+  await idempotencyPlugin(app);
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  await webhooksRoutes(app, { prefix: "/webhooks" });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,74 +1,13 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { buildApp } from "./app";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await buildApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
@@ -77,4 +16,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,89 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { redis, IDEMPOTENCY_PREFIX } from "../redis";
+
+const REPLAY_HEADER = "x-idempotent-replay";
+const DEFAULT_TTL_SECONDS = 60 * 60 * 24;
+
+declare module "fastify" {
+  interface FastifyRequest {
+    idempotencyKey?: string;
+  }
+}
+
+async function handleReplay(reply: FastifyReply, cached: string) {
+  try {
+    const record = JSON.parse(cached) as {
+      body: string;
+      contentType?: string;
+    };
+    if (record.contentType) {
+      reply.header("content-type", record.contentType);
+    }
+    reply.header(REPLAY_HEADER, "1");
+    reply.code(200);
+    await reply.send(record.body);
+  } catch {
+    await reply.code(500).send({ error: "idempotency_store_corrupt" });
+  }
+}
+
+async function saveResponse(request: FastifyRequest, reply: FastifyReply, payload: any) {
+  const key = request.idempotencyKey;
+  if (!key) {
+    return payload;
+  }
+  const redisKey = `${IDEMPOTENCY_PREFIX}${key}`;
+  const body = typeof payload === "string" ? payload : payload ? payload.toString() : "";
+  const record = JSON.stringify({
+    body,
+    contentType: reply.getHeader("content-type")?.toString(),
+  });
+  try {
+    await redis.set(redisKey, record, "NX", "EX", DEFAULT_TTL_SECONDS);
+  } catch (err) {
+    request.log.error({ err }, "failed to persist idempotent response");
+  }
+  return payload;
+}
+
+export default async function idempotencyPlugin(fastify: FastifyInstance) {
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (request.method !== "POST") {
+      return;
+    }
+    const header = request.headers["idempotency-key"];
+    if (!header || (Array.isArray(header) && header.length === 0)) {
+      await reply.code(400).send({ error: "missing_idempotency_key" });
+      return;
+    }
+    const key = Array.isArray(header) ? header[0] : header;
+    if (!key.trim()) {
+      await reply.code(400).send({ error: "invalid_idempotency_key" });
+      return;
+    }
+    request.idempotencyKey = key;
+    const redisKey = `${IDEMPOTENCY_PREFIX}${key}`;
+    try {
+      const cached = await redis.get(redisKey);
+      if (cached) {
+        await handleReplay(reply, cached);
+        return;
+      }
+    } catch (err) {
+      request.log.error({ err }, "failed to retrieve idempotent response");
+    }
+  });
+
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    if (request.method !== "POST") {
+      return payload;
+    }
+    if (!request.idempotencyKey) {
+      return payload;
+    }
+    if (reply.getHeader(REPLAY_HEADER)) {
+      return payload;
+    }
+    return saveResponse(request, reply, payload);
+  });
+}

--- a/apgms/services/api-gateway/src/redis.ts
+++ b/apgms/services/api-gateway/src/redis.ts
@@ -1,0 +1,41 @@
+interface StoredValue {
+  value: string;
+  expiresAt?: number;
+}
+
+class InMemoryRedis {
+  private store = new Map<string, StoredValue>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, mode?: string, ex?: string, ttlSeconds?: number): Promise<"OK" | null> {
+    if (mode === "NX") {
+      const existing = await this.get(key);
+      if (existing !== null) {
+        return null;
+      }
+    }
+    const expiresAt = ex === "EX" && typeof ttlSeconds === "number" ? Date.now() + ttlSeconds * 1000 : undefined;
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+
+  async flushall(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+export const redis = new InMemoryRedis();
+
+export const IDEMPOTENCY_PREFIX = "idempotency:";
+export const NONCE_PREFIX = "webhook:nonce:";

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,99 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import { redis, NONCE_PREFIX } from "../redis";
+
+const WINDOW_SECONDS = 300;
+const NONCE_TTL_SECONDS = 600;
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .map(([key, val]) => [key, canonicalize(val)] as const)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return Object.fromEntries(entries);
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function verifySignature(secret: string, payload: string, signature: string) {
+  const hmac = createHmac("sha256", secret);
+  const digest = hmac.update(payload).digest();
+  const provided = Buffer.from(signature, "hex");
+  if (provided.length !== digest.length) {
+    return false;
+  }
+  return timingSafeEqual(provided, digest);
+}
+
+export default async function webhooksRoutes(
+  app: FastifyInstance,
+  opts: { prefix?: string } = {}
+) {
+  const route = `${opts.prefix ?? ""}/payto`;
+  app.post<{ Body: Record<string, unknown> }>(route, async (request, reply) => {
+    const signatureHeader = request.headers["x-signature"];
+    const nonceHeader = request.headers["x-nonce"];
+    const timestampHeader = request.headers["x-timestamp"];
+
+    if (
+      !signatureHeader ||
+      !nonceHeader ||
+      !timestampHeader ||
+      Array.isArray(signatureHeader) ||
+      Array.isArray(nonceHeader) ||
+      Array.isArray(timestampHeader)
+    ) {
+      reply.code(400);
+      return reply.send({ error: "missing_webhook_headers" });
+    }
+
+    const timestamp = Number(timestampHeader);
+    if (!Number.isFinite(timestamp)) {
+      reply.code(400);
+      return reply.send({ error: "invalid_timestamp" });
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - timestamp) > WINDOW_SECONDS) {
+      reply.code(409);
+      return reply.send({ error: "stale_timestamp" });
+    }
+
+    const secret = process.env.WEBHOOK_SECRET;
+    if (!secret) {
+      request.log.error("WEBHOOK_SECRET not configured");
+      reply.code(500);
+      return reply.send({ error: "webhook_secret_missing" });
+    }
+
+    const canonicalBody = canonicalJson(request.body ?? {});
+    const expected = verifySignature(secret, canonicalBody, signatureHeader);
+    if (!expected) {
+      reply.code(401);
+      return reply.send({ error: "invalid_signature" });
+    }
+
+    const nonceKey = `${NONCE_PREFIX}${nonceHeader}`;
+    try {
+      const stored = await redis.set(nonceKey, String(timestamp), "NX", "EX", NONCE_TTL_SECONDS);
+      if (stored !== "OK") {
+        reply.code(409);
+        return reply.send({ error: "replayed_nonce" });
+      }
+    } catch (err) {
+      request.log.error({ err }, "failed to store nonce");
+      reply.code(500);
+      return reply.send({ error: "nonce_storage_failed" });
+    }
+
+    reply.code(202);
+    return reply.send({ status: "accepted" });
+  });
+}

--- a/apgms/services/api-gateway/test/idempotency.spec.ts
+++ b/apgms/services/api-gateway/test/idempotency.spec.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import test from "node:test";
+import idempotencyPlugin from "../src/plugins/idempotency";
+import { redis } from "../src/redis";
+
+test("rejects POST requests without an idempotency key", { concurrency: false }, async () => {
+  await redis.flushall();
+  const app = Fastify();
+  await idempotencyPlugin(app);
+  app.post("/resource", async () => ({ ok: true }));
+
+  const response = await app.inject({ method: "POST", url: "/resource", payload: {} });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.json(), { error: "missing_idempotency_key" });
+
+  await app.close();
+});
+
+test("returns cached response on replay", { concurrency: false }, async () => {
+  await redis.flushall();
+  const app = Fastify();
+  await idempotencyPlugin(app);
+  app.post("/resource", async (request, reply) => {
+    const counter = Number(request.headers["x-counter"] ?? 0);
+    return reply.code(201).send({ ok: true, counter });
+  });
+
+  const headers = { "idempotency-key": "abc", "x-counter": "1" };
+  const first = await app.inject({ method: "POST", url: "/resource", payload: {}, headers });
+  assert.equal(first.statusCode, 201);
+  assert.deepEqual(first.json(), { ok: true, counter: 1 });
+
+  const second = await app.inject({ method: "POST", url: "/resource", payload: {}, headers });
+  assert.equal(second.statusCode, 200);
+  assert.equal(second.headers["x-idempotent-replay"], "1");
+  assert.deepEqual(second.json(), { ok: true, counter: 1 });
+
+  await app.close();
+});

--- a/apgms/services/api-gateway/test/webhook-replay.spec.ts
+++ b/apgms/services/api-gateway/test/webhook-replay.spec.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import Fastify from "fastify";
+import test from "node:test";
+import webhooksRoutes, { canonicalJson } from "../src/routes/webhooks";
+import { redis } from "../src/redis";
+
+const secret = "test-secret";
+
+function sign(body: unknown, nonce: string, timestamp: number) {
+  const canonicalBody = canonicalJson(body);
+  const signature = createHmac("sha256", secret).update(canonicalBody).digest("hex");
+  return {
+    payload: body,
+    headers: {
+      "x-signature": signature,
+      "x-nonce": nonce,
+      "x-timestamp": String(timestamp),
+    },
+  };
+}
+
+test("accepts a valid webhook", { concurrency: false }, async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  await redis.flushall();
+  const app = Fastify();
+  await webhooksRoutes(app, { prefix: "/webhooks" });
+  const now = Math.floor(Date.now() / 1000);
+  const { payload, headers } = sign({ amount: 100, currency: "AUD" }, "nonce-1", now);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers,
+  });
+
+  assert.equal(response.statusCode, 202);
+  assert.deepEqual(response.json(), { status: "accepted" });
+  await app.close();
+});
+
+test("rejects a replayed nonce", { concurrency: false }, async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  await redis.flushall();
+  const app = Fastify();
+  await webhooksRoutes(app, { prefix: "/webhooks" });
+  const now = Math.floor(Date.now() / 1000);
+  const nonce = "nonce-2";
+  const first = sign({ id: 1 }, nonce, now);
+
+  const firstResponse = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: first.payload,
+    headers: first.headers,
+  });
+  assert.equal(firstResponse.statusCode, 202);
+
+  const secondResponse = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload: first.payload,
+    headers: first.headers,
+  });
+
+  assert.equal(secondResponse.statusCode, 409);
+  assert.deepEqual(secondResponse.json(), { error: "replayed_nonce" });
+  await app.close();
+});
+
+test("rejects stale timestamps", { concurrency: false }, async () => {
+  process.env.WEBHOOK_SECRET = secret;
+  await redis.flushall();
+  const app = Fastify();
+  await webhooksRoutes(app, { prefix: "/webhooks" });
+  const stale = Math.floor(Date.now() / 1000) - 301;
+  const { payload, headers } = sign({ id: 2 }, "nonce-3", stale);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks/payto",
+    payload,
+    headers,
+  });
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(response.json(), { error: "stale_timestamp" });
+  await app.close();
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["node"],
+    "types": ["node", "node:test"],
     "baseUrl": "../../",
     "paths": {
       "@apgms/shared/*": ["shared/src/*"]


### PR DESCRIPTION
## Summary
- add an idempotency Fastify hook that persists POST responses and replays cached bodies on duplicate keys
- introduce a signed /webhooks/payto endpoint with nonce and timestamp validation to block stale or replayed calls
- cover the new behavior with node:test suites and provide replay-focused red-team scenarios

## Testing
- node --import tsx --test test/idempotency.spec.ts test/webhook-replay.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f4339b01388327a3a222511d156a78