### PR TITLE
Add API gateway auth and security plugins

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/authz.spec.ts test/security.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
-    "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,73 +8,136 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import type { FastifyInstance, FastifyServerOptions } from "fastify";
+import { z } from "zod";
+import securityPlugin from "./plugins/security";
+import authPlugin from "./plugins/auth";
+import orgScopePlugin from "./plugins/org-scope";
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
+type PrismaClientLike = {
+  user: {
+    findMany: (args: {
+      select: { email: true; orgId: true; createdAt: true };
+      where: { orgId: string };
+      orderBy: { createdAt: "desc" };
+    }) => Promise<Array<{ email: string; orgId: string; createdAt: Date }>>;
+  };
+  bankLine: {
+    findMany: (args: {
+      where: { orgId: string };
+      orderBy: { date: "desc" };
+      take: number;
+    }) => Promise<
+      Array<{
+        id: string;
+        orgId: string;
+        date: Date;
+        amount: unknown;
+        payee: string;
+        desc: string;
+      }>
+    >;
+    create: (args: {
       data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
+        orgId: string;
+        date: Date;
+        amount: unknown;
+        payee: string;
+        desc: string;
+      };
+    }) => Promise<unknown>;
+  };
+};
+
+interface BuildAppOptions {
+  logger?: FastifyServerOptions["logger"];
+  prismaClient?: PrismaClientLike;
+}
+
+const bankLineBodySchema = z.object({
+  date: z.string(),
+  amount: z.union([z.number(), z.string()]),
+  payee: z.string(),
+  desc: z.string(),
+  orgId: z.string().optional(),
 });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+export const buildApp = async (
+  options: BuildAppOptions = {},
+): Promise<FastifyInstance> => {
+  const { logger = true } = options;
+  const prismaClient: PrismaClientLike =
+    options.prismaClient ??
+    ((await import("../../../shared/src/db")).prisma as PrismaClientLike);
+
+  const app = Fastify({ logger, bodyLimit: 512 * 1024 });
+
+  await securityPlugin(app);
+  await authPlugin(app);
+  await orgScopePlugin(app);
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async (request) => {
+    const users = await prismaClient.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      where: { orgId: request.orgId },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (request) => {
+    const query = request.query as Record<string, unknown>;
+    const requestedTake = Number(query.take ?? 20);
+    const parsedTake = Number.isFinite(requestedTake) ? requestedTake : 20;
+    const take = Math.min(Math.max(parsedTake, 1), 200);
+
+    const lines = await prismaClient.bankLine.findMany({
+      where: { orgId: request.orgId },
+      orderBy: { date: "desc" },
+      take,
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (request, reply) => {
+    try {
+      const body = bankLineBodySchema.parse(request.body ?? {});
+      const created = await prismaClient.bankLine.create({
+        data: {
+          orgId: request.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return reply.code(201).send(created);
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const app = await buildApp();
+  app
+    .listen({ port, host })
+    .catch((err) => {
+      app.log.error(err);
+      process.exit(1);
+    });
+}

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,105 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyPluginAsync } from "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user: {
+      id: string;
+      orgId: string;
+      roles: string[];
+    };
+  }
+}
+
+const verifyJwt = (token: string, secret: string): Record<string, unknown> => {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("invalid_token");
+  }
+
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const headerJson = Buffer.from(encodedHeader, "base64url").toString("utf8");
+  const header = JSON.parse(headerJson) as { alg?: string };
+  if (header.alg !== "HS256") {
+    throw new Error("unsupported_algorithm");
+  }
+
+  const expectedSignature = createHmac("sha256", secret)
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest("base64url");
+
+  const provided = Buffer.from(signature, "base64url");
+  const expected = Buffer.from(expectedSignature, "base64url");
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    throw new Error("invalid_signature");
+  }
+
+  const payloadJson = Buffer.from(encodedPayload, "base64url").toString("utf8");
+  const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+
+  const exp = payload.exp;
+  if (typeof exp === "number" && Date.now() >= exp * 1000) {
+    throw new Error("token_expired");
+  }
+
+  return payload;
+};
+
+const authPlugin: FastifyPluginAsync = async (fastify) => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SECRET is not configured");
+  }
+
+  fastify.decorateRequest(
+    "user",
+    null as unknown as {
+      id: string;
+      orgId: string;
+      roles: string[];
+    },
+  );
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (reply.sent) {
+      return;
+    }
+
+    if (request.method === "OPTIONS") {
+      return;
+    }
+
+    const url = request.raw.url ?? "";
+    if (url.startsWith("/health")) {
+      return;
+    }
+
+    const authorization = request.headers.authorization;
+    if (!authorization?.startsWith("Bearer ")) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    const token = authorization.slice("Bearer ".length).trim();
+
+    try {
+      const payload = verifyJwt(token, secret);
+      const sub = payload.sub;
+      const orgId = payload.orgId;
+      const roles = payload.roles;
+
+      if (typeof sub !== "string" || typeof orgId !== "string") {
+        return reply.code(401).send({ error: "unauthorized" });
+      }
+
+      request.user = {
+        id: sub,
+        orgId,
+        roles: Array.isArray(roles) ? (roles as string[]) : [],
+      };
+    } catch {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+  });
+};
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/plugins/org-scope.ts
+++ b/apgms/services/api-gateway/src/plugins/org-scope.ts
@@ -1,0 +1,60 @@
+import type { FastifyPluginAsync, FastifyRequest } from "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    orgId: string;
+  }
+}
+
+const orgScopePlugin: FastifyPluginAsync = async (fastify) => {
+  fastify.decorateRequest("orgId", "");
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (reply.sent) {
+      return;
+    }
+
+    if (request.method === "OPTIONS") {
+      return;
+    }
+
+    const url = request.raw.url ?? "";
+    if (url.startsWith("/health")) {
+      return;
+    }
+
+    const user = request.user;
+    if (!user?.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    request.orgId = user.orgId;
+
+    const candidateOrgId = getOrgIdFromRequest(request);
+    if (candidateOrgId && candidateOrgId !== user.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+  });
+};
+
+const getOrgIdFromRequest = (request: FastifyRequest): string | undefined => {
+  const sources: unknown[] = [
+    request.params,
+    request.body,
+    request.query,
+    request.headers,
+  ];
+
+  for (const source of sources) {
+    if (source && typeof source === "object" && "orgId" in source) {
+      const value = (source as Record<string, unknown>).orgId;
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+export default orgScopePlugin;

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,110 @@
+import type { FastifyPluginAsync } from "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    corsAllowedOrigin?: string | null;
+  }
+}
+
+const standardHeaders: Record<string, string> = {
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+  "x-xss-protection": "0",
+  "referrer-policy": "no-referrer",
+  "strict-transport-security": "max-age=31536000; includeSubDomains",
+  "content-security-policy": "default-src 'self'",
+  "cross-origin-opener-policy": "same-origin",
+  "cross-origin-resource-policy": "same-origin",
+  "permissions-policy": "geolocation=(), microphone=(), camera=()",
+};
+
+const securityPlugin: FastifyPluginAsync = async (fastify) => {
+  const allowList = new Set(
+    (process.env.CORS_ALLOW_ORIGINS ?? "")
+      .split(",")
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0),
+  );
+
+  const maxRequests = process.env.NODE_ENV === "production" ? 60 : 100;
+  const rateLimitWindowMs = 60_000;
+  const counters = new Map<string, { count: number; resetAt: number }>();
+
+  fastify.decorateRequest("corsAllowedOrigin", null as string | null | undefined);
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const originHeader = typeof request.headers.origin === "string" ? request.headers.origin : undefined;
+    if (originHeader) {
+      reply.header("vary", "Origin");
+    }
+    if (originHeader && allowList.has(originHeader)) {
+      request.corsAllowedOrigin = originHeader;
+    } else if (!originHeader) {
+      request.corsAllowedOrigin = null;
+    } else {
+      request.corsAllowedOrigin = undefined;
+    }
+
+    if (request.method === "OPTIONS") {
+      if (request.corsAllowedOrigin === undefined && originHeader) {
+        reply.header("vary", "Origin");
+        return reply.code(403).send();
+      }
+
+      if (request.corsAllowedOrigin) {
+        reply.header("access-control-allow-origin", request.corsAllowedOrigin);
+        reply.header("vary", "Origin");
+      }
+      reply.header("access-control-allow-methods", request.headers["access-control-request-method"] ?? "GET,POST,PUT,DELETE,OPTIONS");
+      const requestHeaders = request.headers["access-control-request-headers"];
+      if (typeof requestHeaders === "string") {
+        reply.header("access-control-allow-headers", requestHeaders);
+      }
+      reply.header("access-control-max-age", "600");
+      return reply.code(204).send();
+    }
+
+    if ((request.raw.url ?? "").startsWith("/health")) {
+      return;
+    }
+
+    if (request.corsAllowedOrigin === undefined && originHeader) {
+      reply.header("vary", "Origin");
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const key = request.ip;
+    const now = Date.now();
+    const bucket = counters.get(key);
+    if (!bucket || bucket.resetAt <= now) {
+      counters.set(key, { count: 1, resetAt: now + rateLimitWindowMs });
+      return;
+    }
+
+    if (bucket.count >= maxRequests) {
+      return reply.code(429).send({ error: "rate_limited" });
+    }
+
+    bucket.count += 1;
+  });
+
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    if (request.corsAllowedOrigin) {
+      reply.header("access-control-allow-origin", request.corsAllowedOrigin);
+      reply.header("vary", "Origin");
+      reply.header("access-control-allow-credentials", "true");
+    } else if (request.corsAllowedOrigin === null) {
+      reply.header("vary", "Origin");
+    }
+
+    for (const [header, value] of Object.entries(standardHeaders)) {
+      if (!reply.hasHeader(header)) {
+        reply.header(header, value);
+      }
+    }
+
+    return payload;
+  });
+};
+
+export default securityPlugin;

--- a/apgms/services/api-gateway/test/authz.spec.ts
+++ b/apgms/services/api-gateway/test/authz.spec.ts
@@ -1,0 +1,111 @@
+import { createHmac } from "node:crypto";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "test";
+
+const buildPrismaStub = () => ({
+  user: {
+    findMany: async () => [],
+  },
+  bankLine: {
+    findMany: async () => [],
+    create: async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "line-1",
+      ...data,
+    }),
+  },
+});
+
+const signToken = (payload: Record<string, unknown>, secret: string) => {
+  const encode = (segment: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(segment)).toString("base64url");
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const body = encode(payload);
+  const signature = createHmac("sha256", secret)
+    .update(`${header}.${body}`)
+    .digest("base64url");
+  return `${header}.${body}.${signature}`;
+};
+
+const setupApp = async () => {
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? "test-secret";
+  process.env.CORS_ALLOW_ORIGINS = process.env.CORS_ALLOW_ORIGINS ?? "https://example.com";
+
+  const { buildApp } = await import("../src/index.ts");
+  const app = await buildApp({ logger: false, prismaClient: buildPrismaStub() });
+  await app.ready();
+  return app;
+};
+
+test("non-health routes require bearer token", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(response.statusCode, 401);
+});
+
+test("rejects invalid token", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const token = signToken({ sub: "user-1", orgId: "org-1" }, process.env.JWT_SECRET as string);
+  const response = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+    headers: { Authorization: `Bearer ${token}invalid` },
+  });
+
+  assert.equal(response.statusCode, 401);
+});
+
+test("prevents cross-org access on create", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const token = signToken({ sub: "user-1", orgId: "org-1" }, process.env.JWT_SECRET as string);
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { Authorization: `Bearer ${token}` },
+    payload: {
+      orgId: "org-2",
+      date: new Date().toISOString(),
+      amount: 100,
+      payee: "Vendor",
+      desc: "Mismatch org",
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+});
+
+test("allows authorized create within org", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const token = signToken({ sub: "user-1", orgId: "org-1" }, process.env.JWT_SECRET as string);
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { Authorization: `Bearer ${token}` },
+    payload: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 100,
+      payee: "Vendor",
+      desc: "ok",
+    },
+  });
+
+  assert.equal(response.statusCode, 201);
+});

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,110 @@
+import { createHmac } from "node:crypto";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "test";
+
+const buildPrismaStub = () => ({
+  user: {
+    findMany: async () => [],
+  },
+  bankLine: {
+    findMany: async () => [],
+    create: async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "line-1",
+      ...data,
+    }),
+  },
+});
+
+const signToken = (payload: Record<string, unknown>, secret: string) => {
+  const encode = (segment: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(segment)).toString("base64url");
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const body = encode(payload);
+  const signature = createHmac("sha256", secret)
+    .update(`${header}.${body}`)
+    .digest("base64url");
+  return `${header}.${body}.${signature}`;
+};
+
+const setupApp = async () => {
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? "test-secret";
+  process.env.CORS_ALLOW_ORIGINS = "https://allowed.example.com";
+
+  const { buildApp } = await import("../src/index.ts");
+  const app = await buildApp({ logger: false, prismaClient: buildPrismaStub() });
+  await app.ready();
+  return app;
+};
+
+test("allows CORS preflight for allowed origin", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/bank-lines",
+    headers: {
+      Origin: "https://allowed.example.com",
+      "Access-Control-Request-Method": "POST",
+    },
+  });
+
+  assert.equal(response.statusCode, 204);
+  assert.equal(response.headers["access-control-allow-origin"], "https://allowed.example.com");
+});
+
+test("enforces rate limiting", async (t) => {
+  process.env.NODE_ENV = "production";
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+    process.env.NODE_ENV = "test";
+  });
+
+  const token = signToken({ sub: "user-1", orgId: "org-1" }, process.env.JWT_SECRET as string);
+
+  for (let i = 0; i < 60; i += 1) {
+    const res = await app.inject({
+      method: "GET",
+      url: "/users",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(res.statusCode, 200);
+  }
+
+  const limited = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  assert.equal(limited.statusCode, 429);
+});
+
+test("rejects payloads over body limit", async (t) => {
+  const app = await setupApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const token = signToken({ sub: "user-1", orgId: "org-1" }, process.env.JWT_SECRET as string);
+  const bigDescription = "x".repeat(600_000);
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { Authorization: `Bearer ${token}` },
+    payload: {
+      orgId: "org-1",
+      date: new Date().toISOString(),
+      amount: 10,
+      payee: "Vendor",
+      desc: bigDescription,
+    },
+  });
+
+  assert.equal(response.statusCode, 413);
+});


### PR DESCRIPTION
## Summary
- add dedicated auth, org scope, and security plugins for the API gateway
- tighten route handlers to scope Prisma queries to the authenticated org and validate payloads
- add node:test coverage for auth rejection cases, CORS preflight, rate limiting, and body limits

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4332fd4908327baf26ee6bd6d763b