### PR TITLE
feat: implement dashboard and bank lines shell

### DIFF
--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en" class="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>APGMS</title>
+  </head>
+  <body class="min-h-screen">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,39 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext .ts,.tsx",
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.1",
+    "@tanstack/react-router": "^1.45.9",
+    "@tanstack/react-router-devtools": "^1.45.9",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.428.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "recharts": "^2.12.7"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "axe-core": "^4.10.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.7",
+    "typescript": "^5.5.4",
+    "vite": "^5.3.3"
+  }
+}

--- a/apgms/webapp/playwright.config.ts
+++ b/apgms/webapp/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'pnpm --filter @apgms/webapp dev -- --host 0.0.0.0 --port 5173',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+});

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apgms/webapp/src/api/client.ts
+++ b/apgms/webapp/src/api/client.ts
@@ -1,0 +1,43 @@
+export type FetchJSONOptions = RequestInit & {
+  ignoreStatuses?: number[];
+};
+
+export async function fetchJSON<T>(input: RequestInfo, options: FetchJSONOptions = {}): Promise<T | null> {
+  const { ignoreStatuses = [], headers, ...init } = options;
+  const response = await fetch(input, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(headers || {})
+    },
+    ...init
+  });
+
+  if (ignoreStatuses.includes(response.status)) {
+    return null;
+  }
+
+  if (!response.ok) {
+    const message = await safeReadText(response);
+    throw new Error(message || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return (await response.json()) as T;
+  }
+
+  return null;
+}
+
+async function safeReadText(response: Response) {
+  try {
+    return await response.text();
+  } catch (error) {
+    console.error('Failed to read response text', error);
+    return '';
+  }
+}

--- a/apgms/webapp/src/components/app-shell.tsx
+++ b/apgms/webapp/src/components/app-shell.tsx
@@ -1,0 +1,90 @@
+import { Link, useRouterState } from '@tanstack/react-router';
+import { Menu, Moon, Sun } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import { useTheme } from '../theme/theme-provider';
+import { clsx } from 'clsx';
+
+const navigation = [
+  { label: 'Dashboard', to: '/' },
+  { label: 'Bank Lines', to: '/bank-lines' }
+];
+
+export function AppShell({ children }: { children: ReactNode }) {
+  const { theme, toggleTheme } = useTheme();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const closeSidebar = () => setSidebarOpen(false);
+
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      {sidebarOpen ? (
+        <button
+          type="button"
+          aria-label="Close navigation"
+          className="fixed inset-0 z-20 bg-slate-950/40 lg:hidden"
+          onClick={closeSidebar}
+        />
+      ) : null}
+      <aside
+        className={clsx(
+          'fixed inset-y-0 left-0 z-30 w-64 transform bg-white shadow-lg transition-transform dark:bg-slate-900 lg:static lg:translate-x-0',
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+        )}
+      >
+        <div className="flex h-16 items-center justify-center border-b border-slate-200 px-4 dark:border-slate-700">
+          <span className="text-lg font-semibold text-slate-900 dark:text-slate-100">APGMS</span>
+        </div>
+        <nav className="flex flex-col gap-1 p-4" aria-label="Main navigation">
+          {navigation.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              onClick={closeSidebar}
+              activeProps={{ 'aria-current': 'page' }}
+              className={({ isActive }) =>
+                clsx(
+                  'rounded-md px-3 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                  isActive
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+                )
+              }
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </aside>
+      <div className="flex flex-1 flex-col lg:pl-64">
+        <header className="sticky top-0 z-20 flex h-16 items-center justify-between border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md p-2 text-slate-600 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:text-slate-300 dark:hover:bg-slate-800 lg:hidden"
+              onClick={() => setSidebarOpen((prev) => !prev)}
+              aria-label="Toggle navigation"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
+            <span className="text-sm text-slate-500 dark:text-slate-400">
+              {navigation.find((item) => item.to === pathname)?.label ?? 'APGMS'}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+            aria-label="Toggle theme"
+          >
+            {theme === 'light' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            <span className="hidden sm:inline">{theme === 'light' ? 'Light' : 'Dark'}</span>
+          </button>
+        </header>
+        <main className="flex-1 bg-slate-50 p-6 dark:bg-slate-950">
+          <div className="mx-auto max-w-6xl space-y-6">{children}</div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/drawer.tsx
+++ b/apgms/webapp/src/components/drawer.tsx
@@ -1,0 +1,122 @@
+import { createPortal } from 'react-dom';
+import { type ReactNode, useEffect, useRef } from 'react';
+import { clsx } from 'clsx';
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+type DrawerProps = {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  footer?: ReactNode;
+};
+
+export function Drawer({ open, onClose, title, children, footer }: DrawerProps) {
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    previousFocus.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    const focusable = panel ? Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)) : [];
+    focusable[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      if (!panel) {
+        return;
+      }
+
+      const focusableElements = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute('disabled')
+      );
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+      const isShift = event.shiftKey;
+
+      if (!isShift && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+
+      if (isShift && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.classList.add('overflow-hidden');
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.classList.remove('overflow-hidden');
+      previousFocus.current?.focus();
+    };
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-stretch justify-end">
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="absolute inset-0 bg-slate-950/40"
+        onClick={onClose}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+        className={clsx(
+          'relative flex h-full w-full max-w-md flex-col bg-white shadow-xl focus:outline-none dark:bg-slate-900'
+        )}
+      >
+        <header className="flex items-center justify-between border-b border-slate-200 px-4 py-4 dark:border-slate-700">
+          <h2 id="drawer-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-slate-600 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            Close
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto px-4 py-4 text-sm text-slate-600 dark:text-slate-300">{children}</div>
+        {footer ? (
+          <footer className="border-t border-slate-200 bg-slate-50 px-4 py-4 dark:border-slate-700 dark:bg-slate-950">
+            {footer}
+          </footer>
+        ) : null}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-background text-foreground transition-colors duration-300;
+}
+
+.dark body {
+  @apply bg-slate-950 text-slate-100;
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,21 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import { AppProviders, AppRouter } from './router';
+import { ThemeProvider } from './theme/theme-provider';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <AppProviders>
+        <AppRouter />
+      </AppProviders>
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/router.tsx
+++ b/apgms/webapp/src/router.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Outlet, RouterProvider, createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { type ReactNode, Suspense } from 'react';
+import { AppShell } from './components/app-shell';
+import { TanStackRouterDevtools } from '@tanstack/react-router-devtools';
+import { Dashboard } from './routes/dashboard';
+import { BankLines } from './routes/bank-lines';
+
+const queryClient = new QueryClient();
+
+const rootRoute = createRootRoute({
+  component: () => (
+    <AppShell>
+      <Suspense fallback={<div className="p-6">Loading...</div>}>
+        <Outlet />
+      </Suspense>
+      {import.meta.env.DEV ? <TanStackRouterDevtools position="bottom-right" /> : null}
+    </AppShell>
+  )
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: Dashboard
+});
+
+const bankLinesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: 'bank-lines',
+  component: BankLines
+});
+
+const routeTree = rootRoute.addChildren([dashboardRoute, bankLinesRoute]);
+
+const router = createRouter({ routeTree, defaultPreload: 'intent' });
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+export function AppRouter() {
+  return <RouterProvider router={router} />;
+}
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,297 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { fetchJSON } from '../api/client';
+import { Drawer } from '../components/drawer';
+import { clsx } from 'clsx';
+
+const PAGE_SIZE = 10;
+
+type BankLine = {
+  id: string;
+  date: string;
+  payee: string;
+  amount: number;
+  currency?: string;
+  rptId?: string | null;
+};
+
+type BankLinesResponse = {
+  data?: BankLine[];
+  meta?: {
+    page?: number;
+    pageSize?: number;
+    totalPages?: number;
+    totalItems?: number;
+  };
+};
+
+type RptResponse = {
+  id: string;
+  status: string;
+  lastVerifiedAt?: string;
+  details?: string;
+};
+
+export function BankLines() {
+  const [page, setPage] = useState(1);
+  const [selectedLine, setSelectedLine] = useState<BankLine | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isError, error, isFetching } = useQuery<BankLinesResponse | null>({
+    queryKey: ['bank-lines', page],
+    queryFn: () => fetchJSON<BankLinesResponse>(`/bank-lines?page=${page}&pageSize=${PAGE_SIZE}`)
+  });
+
+  const lines = data?.data ?? [];
+  const meta = data?.meta ?? {};
+  const totalPages = meta.totalPages ?? (lines.length < PAGE_SIZE ? page : page + 1);
+
+  const rptQueryKey = ['rpt', selectedLine?.id];
+  const {
+    data: rptData,
+    isFetching: rptLoading,
+    isError: rptError
+  } = useQuery<RptResponse | null>({
+    queryKey: rptQueryKey,
+    queryFn: () => fetchJSON<RptResponse>(`/audit/rpt/by-line/${selectedLine?.id}`, { ignoreStatuses: [404] }),
+    enabled: Boolean(selectedLine?.id),
+    retry: false
+  });
+
+  const verifyMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedLine) {
+        return null;
+      }
+
+      const response = await fetchJSON<RptResponse>(`/audit/rpt/by-line/${selectedLine.id}`, {
+        method: 'POST',
+        ignoreStatuses: [404]
+      });
+
+      return response;
+    },
+    onSuccess: (result) => {
+      if (!selectedLine) {
+        return;
+      }
+
+      queryClient.invalidateQueries({ queryKey: rptQueryKey });
+      setFeedback(result ? 'Verification completed.' : 'No RPT available for this bank line.');
+    },
+    onError: (mutationError) => {
+      setFeedback(mutationError instanceof Error ? mutationError.message : 'Verification failed.');
+    }
+  });
+
+  const openDrawer = (line: BankLine) => {
+    setSelectedLine(line);
+    setDrawerOpen(true);
+    setFeedback(null);
+  };
+
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    setSelectedLine(null);
+    setFeedback(null);
+  };
+
+  const formattedLines = useMemo(
+    () =>
+      lines.map((line) => ({
+        ...line,
+        formattedDate: new Date(line.date).toLocaleDateString(),
+        formattedAmount: formatAmount(line.amount, line.currency)
+      })),
+    [lines]
+  );
+
+  return (
+    <section aria-labelledby="bank-lines-heading" className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 id="bank-lines-heading" className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            Bank Lines
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Review recent bank line activity and verify related RPT records.
+          </p>
+        </div>
+      </div>
+
+      {isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          {error instanceof Error ? error.message : 'Unable to load bank lines.'}
+        </div>
+      ) : null}
+
+      <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50 dark:bg-slate-800">
+              <tr>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
+                  Date
+                </th>
+                <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
+                  Payee
+                </th>
+                <th scope="col" className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-300">
+                  Amount
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              {isLoading || isFetching ? (
+                Array.from({ length: PAGE_SIZE }).map((_, index) => (
+                  <tr key={index} className="animate-pulse bg-slate-50/60 dark:bg-slate-800/60">
+                    <td className="px-4 py-3">
+                      <div className="h-3 w-24 rounded bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="h-3 w-32 rounded bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <div className="ml-auto h-3 w-20 rounded bg-slate-200 dark:bg-slate-700" aria-hidden="true" />
+                    </td>
+                  </tr>
+                ))
+              ) : formattedLines.length > 0 ? (
+                formattedLines.map((line) => (
+                  <tr
+                    key={line.id}
+                    role="button"
+                    aria-label={`View bank line for ${line.payee} dated ${line.formattedDate}`}
+                    className="cursor-pointer transition-colors hover:bg-slate-50 focus-visible:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:hover:bg-slate-800 dark:focus-visible:bg-slate-800/70"
+                    onClick={() => openDrawer(line)}
+                    tabIndex={0}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        openDrawer(line);
+                      }
+                    }}
+                  >
+                    <td className="px-4 py-3 text-sm text-slate-700 dark:text-slate-200">{line.formattedDate}</td>
+                    <td className="px-4 py-3 text-sm text-slate-700 dark:text-slate-200">{line.payee}</td>
+                    <td className="px-4 py-3 text-right text-sm font-medium text-slate-900 dark:text-slate-100">
+                      {line.formattedAmount}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td
+                    colSpan={3}
+                    className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400"
+                  >
+                    No bank lines available.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3 text-sm dark:border-slate-800 dark:bg-slate-900">
+          <p className="text-slate-500 dark:text-slate-400">
+            Page {page}
+            {typeof meta.totalPages === 'number' ? ` of ${Math.max(meta.totalPages, 1)}` : ''}
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPage((prev) => Math.max(prev - 1, 1))}
+              className={clsx(
+                'rounded-md border border-slate-200 px-3 py-2 font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary dark:border-slate-700',
+                page <= 1
+                  ? 'cursor-not-allowed bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-600'
+                  : 'bg-white text-slate-700 hover:bg-slate-100 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800'
+              )}
+              disabled={page <= 1}
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              onClick={() => setPage((prev) => prev + 1)}
+              className="rounded-md border border-slate-200 bg-white px-3 py-2 font-medium text-slate-700 transition-colors hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800 dark:disabled:bg-slate-800 dark:disabled:text-slate-600"
+              disabled={page >= totalPages}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <Drawer
+        open={drawerOpen}
+        onClose={closeDrawer}
+        title={selectedLine ? `Bank line ${selectedLine.id}` : 'Bank line details'}
+        footer={
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="text-sm text-slate-500 dark:text-slate-300">
+              {feedback
+                ? feedback
+                : rptError
+                ? 'Unable to load RPT details.'
+                : rptLoading
+                ? 'Loading RPT status...'
+                : rptData
+                ? `Status: ${rptData.status}${
+                    rptData.lastVerifiedAt ? ` · Last verified ${new Date(rptData.lastVerifiedAt).toLocaleString()}` : ''
+                  }`
+                : 'No RPT record is linked to this bank line.'}
+            </div>
+            <button
+              type="button"
+              onClick={() => verifyMutation.mutate()}
+              disabled={!selectedLine || verifyMutation.isLoading || (!rptData && !rptError)}
+              className="inline-flex items-center justify-center rounded-md border border-primary bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition-colors hover:bg-blue-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {verifyMutation.isLoading ? 'Verifying...' : 'Verify'}
+            </button>
+          </div>
+        }
+      >
+        {selectedLine ? (
+          <dl className="space-y-4">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Date</dt>
+              <dd className="text-sm text-slate-900 dark:text-slate-100">
+                {new Date(selectedLine.date).toLocaleString()}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Payee</dt>
+              <dd className="text-sm text-slate-900 dark:text-slate-100">{selectedLine.payee}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Amount</dt>
+              <dd className="text-sm text-slate-900 dark:text-slate-100">
+                {formatAmount(selectedLine.amount, selectedLine.currency)}
+              </dd>
+            </div>
+            {selectedLine.rptId ? (
+              <div>
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">RPT ID</dt>
+                <dd className="text-sm text-slate-900 dark:text-slate-100">{selectedLine.rptId}</dd>
+              </div>
+            ) : null}
+          </dl>
+        ) : (
+          <p className="text-sm text-slate-500 dark:text-slate-400">Select a bank line to view details.</p>
+        )}
+      </Drawer>
+    </section>
+  );
+}
+
+function formatAmount(amount: number, currency = 'USD') {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    currencyDisplay: 'symbol'
+  }).format(amount);
+}

--- a/apgms/webapp/src/routes/dashboard.tsx
+++ b/apgms/webapp/src/routes/dashboard.tsx
@@ -1,0 +1,131 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { fetchJSON } from '../api/client';
+import { useTheme } from '../theme/theme-provider';
+
+export type DashboardKpi = {
+  label: string;
+  value: number | string;
+  change?: number;
+};
+
+export type DashboardChartPoint = {
+  date: string;
+  value: number;
+};
+
+type DashboardResponse = {
+  kpis?: DashboardKpi[];
+  chart?: DashboardChartPoint[];
+};
+
+export function Dashboard() {
+  const { theme } = useTheme();
+  const { data, isLoading, isError, error } = useQuery<DashboardResponse | null>({
+    queryKey: ['dashboard'],
+    queryFn: () => fetchJSON<DashboardResponse>('/dashboard')
+  });
+
+  const kpis = data?.kpis ?? [];
+  const chart = data?.chart ?? [];
+  const axisColor = theme === 'dark' ? '#cbd5f5' : '#64748b';
+  const tooltipStyle = {
+    backgroundColor: theme === 'dark' ? 'rgb(15 23 42)' : 'white',
+    border: 'none',
+    borderRadius: '0.5rem',
+    color: theme === 'dark' ? 'white' : 'rgb(15 23 42)'
+  };
+
+  return (
+    <section aria-labelledby="dashboard-heading" className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 id="dashboard-heading" className="text-2xl font-semibold text-slate-900 dark:text-slate-100">
+            Dashboard
+          </h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Key performance indicators and recent trends.</p>
+        </div>
+      </div>
+
+      {isError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+          {error instanceof Error ? error.message : 'Unable to load dashboard data.'}
+        </div>
+      ) : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {(isLoading ? Array.from({ length: 4 }) : kpis).map((item, index) => (
+          <div
+            key={item ? item.label : index}
+            className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+          >
+            {item ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{item.label}</p>
+                <p className="text-2xl font-semibold text-slate-900 dark:text-slate-50">{formatValue(item.value)}</p>
+                {typeof item.change === 'number' ? (
+                  <p className={item.change >= 0 ? 'text-sm text-emerald-600' : 'text-sm text-rose-500'}>
+                    {item.change >= 0 ? '+' : ''}
+                    {item.change.toFixed(1)}%
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="h-20 animate-pulse rounded bg-slate-100 dark:bg-slate-800" aria-hidden="true" />
+            )}
+          </div>
+        ))}
+        {kpis.length === 0 && !isLoading ? (
+          <p className="col-span-full text-sm text-slate-500 dark:text-slate-400">No KPIs available.</p>
+        ) : null}
+      </div>
+
+      <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">30-day trend</h2>
+        </div>
+        <div className="h-72">
+          {isLoading ? (
+            <div className="h-full animate-pulse rounded bg-slate-100 dark:bg-slate-800" aria-hidden="true" />
+          ) : chart.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chart} margin={{ top: 16, right: 24, left: 0, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#2563eb" stopOpacity={0.4} />
+                    <stop offset="95%" stopColor="#2563eb" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                <XAxis dataKey="date" stroke={axisColor} />
+                <YAxis stroke={axisColor} />
+                <Tooltip contentStyle={tooltipStyle} />
+                <Area type="monotone" dataKey="value" stroke="#2563eb" fill="url(#colorValue)" strokeWidth={2} />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-full items-center justify-center text-sm text-slate-500 dark:text-slate-400">
+              No chart data available.
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function formatValue(value: number | string) {
+  if (typeof value === 'number') {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+
+  return value;
+}

--- a/apgms/webapp/src/theme/theme-provider.tsx
+++ b/apgms/webapp/src/theme/theme-provider.tsx
@@ -1,0 +1,72 @@
+import { createContext, type ReactNode, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+type ThemeContextValue = {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem('apgms-theme') as Theme | null;
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme: Theme) {
+  const root = window.document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(theme);
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  }
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getPreferredTheme);
+
+  useEffect(() => {
+    applyTheme(theme);
+    window.localStorage.setItem('apgms-theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const handleMediaChange = (event: MediaQueryListEvent) => {
+      setThemeState(event.matches ? 'dark' : 'light');
+    };
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    media.addEventListener('change', handleMediaChange);
+
+    return () => media.removeEventListener('change', handleMediaChange);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setThemeState((prev) => (prev === 'light' ? 'dark' : 'light')),
+      setTheme: setThemeState
+    }),
+    [theme]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/apgms/webapp/tailwind.config.ts
+++ b/apgms/webapp/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#2563eb',
+          foreground: '#ffffff'
+        },
+        background: '#f8fafc',
+        foreground: '#0f172a',
+        muted: '#e2e8f0',
+        'muted-foreground': '#475569',
+        border: '#cbd5f5'
+      }
+    }
+  },
+  plugins: []
+} satisfies Config;

--- a/apgms/webapp/tests/smoke.spec.ts
+++ b/apgms/webapp/tests/smoke.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const axePath = require.resolve('axe-core/axe.min.js');
+
+const dashboardResponse = {
+  kpis: [
+    { label: 'Total Volume', value: 125000, change: 3.2 },
+    { label: 'New Clients', value: 28, change: 1.5 },
+    { label: 'Approvals', value: 92, change: -0.6 },
+    { label: 'Pending Reviews', value: 14 }
+  ],
+  chart: Array.from({ length: 10 }).map((_, index) => ({
+    date: `2024-07-${String(index + 1).padStart(2, '0')}`,
+    value: 100000 + index * 2500
+  }))
+};
+
+const bankLinesResponse = {
+  data: [
+    {
+      id: 'line-1',
+      date: '2024-07-15T12:00:00Z',
+      payee: 'Acme Corp',
+      amount: 4500.78,
+      currency: 'USD',
+      rptId: 'rpt-1'
+    }
+  ],
+  meta: {
+    page: 1,
+    totalPages: 1,
+    pageSize: 10,
+    totalItems: 1
+  }
+};
+
+const rptResponse = {
+  id: 'rpt-1',
+  status: 'Verified',
+  lastVerifiedAt: '2024-07-15T18:30:00Z'
+};
+
+test('dashboard to bank lines flow', async ({ page }) => {
+  await page.route('**/dashboard', (route) => route.fulfill({ json: dashboardResponse }));
+  await page.route('**/bank-lines?**', (route) => route.fulfill({ json: bankLinesResponse }));
+  await page.route('**/audit/rpt/by-line/line-1', (route) => {
+    if (route.request().method() === 'POST') {
+      return route.fulfill({ json: rptResponse });
+    }
+
+    return route.fulfill({ json: rptResponse });
+  });
+
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Dashboard' })).toBeVisible();
+  await expect(page.getByText('Total Volume')).toBeVisible();
+  await expect(page.getByText(/125[\s,]?000/)).toBeVisible();
+
+  await expectPageAccessible(page);
+
+  await page.getByRole('link', { name: 'Bank Lines' }).click();
+  await expect(page.getByRole('heading', { level: 1, name: 'Bank Lines' })).toBeVisible();
+  await expect(page.getByRole('row', { name: /Acme Corp/ })).toBeVisible();
+
+  await page.getByRole('row', { name: /Acme Corp/ }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(/Status: Verified/)).toBeVisible();
+
+  await expect(dialog.getByRole('button', { name: 'Verify' })).toBeEnabled();
+  await dialog.getByRole('button', { name: 'Verify' }).click();
+  await expect(dialog.getByText('Verification completed.')).toBeVisible();
+
+  await expectPageAccessible(page);
+});
+
+async function expectPageAccessible(page: Page) {
+  await page.addScriptTag({ path: axePath });
+  const results = await page.evaluate(async () => {
+    return await (window as any).axe.run();
+  });
+  expect(results.violations).toEqual([]);
+}

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold the webapp with Vite, Tailwind, TanStack Router, React Query, and shared theme support
- build dashboard KPIs and chart with graceful empty states and responsive application shell
- add bank lines table with drawer verification flow plus Playwright smoke test covering accessibility

## Testing
- Not run (pnpm install --filter @apgms/webapp... fails with 403 from registry in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f433fa21a883278222d979c956636c