### PR TITLE
Add pilot bundle packaging script and CI artifact upload

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,21 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  pilot-bundle:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: pnpm tsx scripts/make-pilot-bundle.ts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pilot-bundle
+          path: dist/pilot-bundle.zip

--- a/apgms/scripts/make-pilot-bundle.ts
+++ b/apgms/scripts/make-pilot-bundle.ts
@@ -1,0 +1,136 @@
+import { mkdir, readdir, rm, stat } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+interface CollectOptions {
+  filter?: (entryName: string) => boolean;
+  recursive?: boolean;
+}
+
+const repoRoot = resolve(__dirname, '..');
+
+async function ensureFile(path: string) {
+  try {
+    const fileStat = await stat(path);
+    if (!fileStat.isFile()) {
+      throw new Error(`Expected file at ${path}`);
+    }
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(`Missing required file: ${path}`);
+    }
+    throw error;
+  }
+}
+
+async function ensureDirectory(path: string) {
+  try {
+    const dirStat = await stat(path);
+    if (!dirStat.isDirectory()) {
+      throw new Error(`Expected directory at ${path}`);
+    }
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(`Missing required directory: ${path}`);
+    }
+    throw error;
+  }
+}
+
+async function collectFilesFromDirectory(dir: string, options: CollectOptions = {}): Promise<string[]> {
+  const results: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const absolutePath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (options.recursive) {
+        const nested = await collectFilesFromDirectory(absolutePath, options);
+        results.push(...nested);
+      }
+    } else if (entry.isFile()) {
+      if (!options.filter || options.filter(entry.name)) {
+        results.push(absolutePath);
+      }
+    }
+  }
+
+  return results;
+}
+
+async function zipBundle(files: string[], outputRelativePath: string) {
+  await mkdir(join(repoRoot, 'dist'), { recursive: true });
+  const absoluteOutputPath = join(repoRoot, outputRelativePath);
+  await rm(absoluteOutputPath, { force: true });
+
+  return new Promise<void>((resolvePromise, rejectPromise) => {
+    const zipArgs = ['-r', outputRelativePath, ...files];
+    const child = spawn('zip', zipArgs, { cwd: repoRoot, stdio: 'inherit' });
+
+    child.on('error', (error) => {
+      rejectPromise(error);
+    });
+
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolvePromise();
+      } else {
+        rejectPromise(new Error(`zip exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const filesToZip: string[] = [];
+
+  const atoDir = join(repoRoot, 'docs', 'ato');
+  await ensureDirectory(atoDir);
+  const atoMarkdown = await collectFilesFromDirectory(atoDir, {
+    filter: (name) => name.endsWith('.md'),
+    recursive: false,
+  });
+  filesToZip.push(...atoMarkdown.map((file) => relative(repoRoot, file)));
+
+  const policiesDir = join(repoRoot, 'policies');
+  await ensureDirectory(policiesDir);
+  const policyJson = await collectFilesFromDirectory(policiesDir, {
+    filter: (name) => name.endsWith('.json'),
+    recursive: false,
+  });
+  filesToZip.push(...policyJson.map((file) => relative(repoRoot, file)));
+
+  const evidenceManifest = join(repoRoot, 'docs', 'ato', 'evidence', 'manifest.json');
+  await ensureFile(evidenceManifest);
+  filesToZip.push(relative(repoRoot, evidenceManifest));
+
+  const artifactsDir = join(repoRoot, 'tmp', 'as4-artifacts');
+  await ensureDirectory(artifactsDir);
+  const as4Artifacts = await collectFilesFromDirectory(artifactsDir, {
+    recursive: true,
+  });
+  filesToZip.push(...as4Artifacts.map((file) => relative(repoRoot, file)));
+
+  const additionalFiles = [
+    join(repoRoot, 'artifacts', 'audit-sample.ndjson'),
+    join(repoRoot, 'eval', 'redteam-report.json'),
+    join(repoRoot, 'eval', 'golden-summary.json'),
+    join(repoRoot, 'sbom.json'),
+    join(repoRoot, 'sca.json'),
+  ];
+
+  for (const filePath of additionalFiles) {
+    await ensureFile(filePath);
+    filesToZip.push(relative(repoRoot, filePath));
+  }
+
+  filesToZip.sort();
+
+  const outputRelativePath = join('dist', 'pilot-bundle.zip');
+  await zipBundle(filesToZip, outputRelativePath);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a pilot bundle packaging script that assembles evidence files into dist/pilot-bundle.zip
- run the packaging script in CI after the build job completes and upload the resulting artifact

## Testing
- not run (pilot source material is not available in the repository snapshot)


------
https://chatgpt.com/codex/tasks/task_e_68f4392aaee883279ff649089c181cda