### PR TITLE
Add AS4 redteam scenarios

### DIFF
--- a/eval/redteam/as4_cert_expiring.json
+++ b/eval/redteam/as4_cert_expiring.json
@@ -1,0 +1,37 @@
+{
+  "id": "as4_cert_expiring",
+  "summary": "Warn on near-expiry signing certificate and reject production delivery.",
+  "profile": "AS4",
+  "category": "certificate",
+  "input": {
+    "mode": "production",
+    "messageId": "urn:uuid:6b5ef9f7-5a9f-46ea-95d3-e86d0b48d4a1",
+    "headers": {
+      "AS4-To": "urn:ato:apgms:prod",
+      "AS4-From": "urn:ato:redteam",
+      "AS4-MessageType": "UserMessage"
+    },
+    "security": {
+      "signature": {
+        "kid": "urn:ato:signing:prod-expiring",
+        "notBefore": "2024-08-28T23:50:00Z",
+        "notAfter": "2024-08-29T23:55:00Z",
+        "checkedAt": "2024-08-29T23:50:30Z"
+      }
+    }
+  },
+  "expectations": {
+    "logs": [
+      {
+        "level": "WARN",
+        "code": "security.certificate.expiring",
+        "message": "Signing certificate urn:ato:signing:prod-expiring expires on 2024-08-29T23:55:00Z"
+      }
+    ],
+    "delivery": {
+      "mode": "production",
+      "outcome": "reject",
+      "reason": "Reject messages signed with certificates expiring within 10 minutes in production mode."
+    }
+  }
+}

--- a/eval/redteam/as4_clock_skew.json
+++ b/eval/redteam/as4_clock_skew.json
@@ -1,0 +1,25 @@
+{
+  "id": "as4_clock_skew",
+  "summary": "Receipt timestamp outside ±10 minutes triggers retry window then failure.",
+  "profile": "AS4",
+  "category": "receipt",
+  "input": {
+    "messageId": "urn:uuid:24eb7c5d-e4b0-4e3c-9f3f-a9186e8de92d",
+    "receiptTimestamp": "2024-08-29T11:49:30Z",
+    "processing": {
+      "receivedAt": "2024-08-29T12:02:30Z",
+      "skewToleranceMinutes": 10
+    }
+  },
+  "expectations": {
+    "initial": {
+      "outcome": "soft-fail",
+      "reason": "Receipt timestamp is outside ±10 minutes window.",
+      "retryWindowMinutes": 10
+    },
+    "postWindow": {
+      "outcome": "fail",
+      "reason": "Retry window elapsed without valid receipt timestamp."
+    }
+  }
+}

--- a/eval/redteam/as4_dup_msgid.json
+++ b/eval/redteam/as4_dup_msgid.json
@@ -1,0 +1,18 @@
+{
+  "id": "as4_dup_msgid",
+  "summary": "Duplicate AS4 messageId should return HTTP 409 conflict.",
+  "profile": "AS4",
+  "category": "replay",
+  "input": {
+    "messageId": "urn:uuid:103fd8bb-1464-40c7-9a4d-4fa9b11683c2",
+    "conversationId": "urn:ato:conversation:2024-08-29",
+    "attempt": 2
+  },
+  "expectations": {
+    "httpResponse": {
+      "status": 409,
+      "reason": "Duplicate messageId replay detected",
+      "retryable": false
+    }
+  }
+}

--- a/eval/run-redteam.ts
+++ b/eval/run-redteam.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from 'node:url';
+import { basename } from 'node:path';
+
+import as4CertExpiring from './redteam/as4_cert_expiring.json';
+import as4ClockSkew from './redteam/as4_clock_skew.json';
+import as4DupMsgId from './redteam/as4_dup_msgid.json';
+
+type RedTeamScenario = {
+  id: string;
+  summary: string;
+  profile: string;
+  category: string;
+  input: Record<string, unknown>;
+  expectations: Record<string, unknown>;
+};
+
+export const redteamScenarios: readonly RedTeamScenario[] = [
+  as4CertExpiring,
+  as4ClockSkew,
+  as4DupMsgId
+];
+
+if (process.argv[1] && basename(fileURLToPath(import.meta.url)) === basename(process.argv[1])) {
+  console.log(JSON.stringify(redteamScenarios, null, 2));
+}


### PR DESCRIPTION
## Summary
- add certificate expiry, clock skew, and duplicate messageId AS4 evaluation cases
- expose the new scenarios through the redteam runner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4391e33d08327a24bc00f98e5d603