### PR TITLE
feat(sbr): implement AS4 envelope signing and receipt verification

### DIFF
--- a/apgms/services/sbr/package.json
+++ b/apgms/services/sbr/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@apgms/sbr",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "tsx --test test/sbr.spec.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.6.1"
+  }
+}

--- a/apgms/services/sbr/src/as4/envelope.ts
+++ b/apgms/services/sbr/src/as4/envelope.ts
@@ -1,0 +1,122 @@
+import crypto from "node:crypto";
+
+export interface EnvelopeOptions {
+  orgId: string;
+  docType: string;
+  payload: string;
+  receiverPartyId?: string;
+  receiverRole?: string;
+  service?: string;
+  action?: string;
+  messageId?: string;
+  timestamp?: string;
+}
+
+export interface EnvelopeResult {
+  messageId: string;
+  timestamp: string;
+  envelopeXml: string;
+  userMessageCanonical: string;
+  receiverPartyId: string;
+  receiverRole: string;
+  service: string;
+  action: string;
+}
+
+const XML_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+const DEFAULT_RECEIVER_PARTY_ID = "urn:gov:au:sbr:receiver";
+const DEFAULT_RECEIVER_ROLE = "http://docs.oasis-open.org/ebxml-msg/role/receiver";
+const DEFAULT_SERVICE = "SBR_PLACEHOLDER_SERVICE";
+const DEFAULT_ACTION = "SBR_PLACEHOLDER_ACTION";
+const PARTY_ID_TYPE = "urn:oasis:names:tc:ebcore:partyid-type:unregistered";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function buildUserMessage(options: Required<Pick<EnvelopeOptions, "orgId" | "docType" | "payload" | "receiverPartyId" | "receiverRole" | "service" | "action" | "messageId" | "timestamp">>): string {
+  const encodedPayload = Buffer.from(options.payload, "utf8").toString("base64");
+
+  return [
+    `<eb:UserMessage messageId="${options.messageId}" mpc="http://docs.oasis-open.org/ebxml-msg/mpc/default">`,
+    `<eb:PartyInfo>`,
+    `<eb:From><eb:PartyId type="${PARTY_ID_TYPE}">${escapeXml(options.orgId)}</eb:PartyId><eb:Role>http://docs.oasis-open.org/ebxml-msg/role/sender</eb:Role></eb:From>`,
+    `<eb:To><eb:PartyId type="${PARTY_ID_TYPE}">${escapeXml(options.receiverPartyId)}</eb:PartyId><eb:Role>${escapeXml(options.receiverRole)}</eb:Role></eb:To>`,
+    `</eb:PartyInfo>`,
+    `<eb:CollaborationInfo>`,
+    `<eb:Service type="${PARTY_ID_TYPE}">${escapeXml(options.service)}</eb:Service>`,
+    `<eb:Action>${escapeXml(options.action)}</eb:Action>`,
+    `<eb:ConversationId>${escapeXml(options.docType)}</eb:ConversationId>`,
+    `<eb:AgreementRef type="docType">${escapeXml(options.docType)}</eb:AgreementRef>`,
+    `</eb:CollaborationInfo>`,
+    `<eb:MessageProperties>`,
+    `<eb:Property name="OriginalSender">${escapeXml(options.orgId)}</eb:Property>`,
+    `<eb:Property name="OriginalDocumentType">${escapeXml(options.docType)}</eb:Property>`,
+    `<eb:Property name="CreationTimestamp">${options.timestamp}</eb:Property>`,
+    `</eb:MessageProperties>`,
+    `<eb:PayloadInfo>`,
+    `<eb:PartInfo href="cid:payload">`,
+    `<eb:PartProperties>`,
+    `<eb:Property name="MimeType">application/xml</eb:Property>`,
+    `<eb:Property name="Content-Transfer-Encoding">base64</eb:Property>`,
+    `</eb:PartProperties>`,
+    `<eb:DataHandler xml:lang="en">${encodedPayload}</eb:DataHandler>`,
+    `</eb:PartInfo>`,
+    `</eb:PayloadInfo>`,
+    `</eb:UserMessage>`,
+  ].join("");
+}
+
+export function buildEnvelope(options: EnvelopeOptions): EnvelopeResult {
+  const receiverPartyId = options.receiverPartyId ?? DEFAULT_RECEIVER_PARTY_ID;
+  const receiverRole = options.receiverRole ?? DEFAULT_RECEIVER_ROLE;
+  const service = options.service ?? DEFAULT_SERVICE;
+  const action = options.action ?? DEFAULT_ACTION;
+  const messageId = options.messageId ?? `urn:uuid:${crypto.randomUUID()}`;
+  const timestamp = options.timestamp ?? new Date().toISOString();
+
+  const canonicalUserMessage = buildUserMessage({
+    orgId: options.orgId,
+    docType: options.docType,
+    payload: options.payload,
+    receiverPartyId,
+    receiverRole,
+    service,
+    action,
+    messageId,
+    timestamp,
+  });
+
+  const envelopeXml = [
+    XML_HEADER,
+    `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:eb="http://docs.oasis-open.org/ebxml-msg/ebms/v3.0/ns/core/200704/" xmlns:sbr="urn:gov:au:sbr:payload">`,
+    `<soap:Header>`,
+    `<eb:Messaging soap:mustUnderstand="true">`,
+    canonicalUserMessage,
+    `</eb:Messaging>`,
+    `</soap:Header>`,
+    `<soap:Body>`,
+    `<sbr:Document>`,
+    `<sbr:PayloadEncoding>base64</sbr:PayloadEncoding>`,
+    `<sbr:PayloadReference>cid:payload</sbr:PayloadReference>`,
+    `</sbr:Document>`,
+    `</soap:Body>`,
+    `</soap:Envelope>`,
+  ].join("");
+
+  return {
+    messageId,
+    timestamp,
+    envelopeXml,
+    userMessageCanonical: canonicalUserMessage,
+    receiverPartyId,
+    receiverRole,
+    service,
+    action,
+  };
+}

--- a/apgms/services/sbr/src/as4/receipt.ts
+++ b/apgms/services/sbr/src/as4/receipt.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export interface ReceiptVerification {
+  digestValue: string;
+  matches: boolean;
+}
+
+const DIGEST_REGEX = /<DigestValue>([^<]+)<\/DigestValue>/i;
+
+export function extractReceiptDigest(receiptXml: string): string {
+  const match = receiptXml.match(DIGEST_REGEX);
+  if (!match) {
+    throw new Error("Receipt missing DigestValue");
+  }
+  return match[1].trim();
+}
+
+export function verifyNonRepudiation(receiptXml: string, expectedDigestHex: string): ReceiptVerification {
+  const digestValue = extractReceiptDigest(receiptXml);
+  return {
+    digestValue,
+    matches: digestValue === expectedDigestHex,
+  };
+}
+
+export async function writeReceiptArtifacts(baseDir: string, receiptXml: string, verification: ReceiptVerification): Promise<void> {
+  const receiptPath = path.join(baseDir, "receipt.xml");
+  await fs.writeFile(receiptPath, receiptXml, "utf8");
+
+  const verificationPath = path.join(baseDir, "receipt-verification.json");
+  await fs.writeFile(
+    verificationPath,
+    JSON.stringify(
+      {
+        digestValue: verification.digestValue,
+        matches: verification.matches,
+        verifiedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+}

--- a/apgms/services/sbr/src/as4/sign.ts
+++ b/apgms/services/sbr/src/as4/sign.ts
@@ -1,0 +1,43 @@
+import crypto from "node:crypto";
+
+const DEV_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIDvwJ0fBbHktHEOugMrn2gFG/no6r3dYxRq5Szjp9U0D
+-----END PRIVATE KEY-----\n`;
+
+const DEV_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAjXMO786lCq6uVtA0tUELMMt/Ju9ix6EvbxuNaz+tDZY=
+-----END PUBLIC KEY-----\n`;
+
+export interface SignatureArtifacts {
+  digestHex: string;
+  digestBase64: string;
+  signature: Buffer;
+  signatureBase64: string;
+  publicKeyPem: string;
+}
+
+export function digestCanonicalUserMessage(canonicalUserMessage: string): Buffer {
+  const hash = crypto.createHash("sha256");
+  hash.update(canonicalUserMessage, "utf8");
+  return hash.digest();
+}
+
+export function signCanonicalUserMessage(canonicalUserMessage: string): SignatureArtifacts {
+  const digest = digestCanonicalUserMessage(canonicalUserMessage);
+  const privateKey = crypto.createPrivateKey({ key: DEV_PRIVATE_KEY, format: "pem" });
+  const signature = crypto.sign(null, digest, privateKey);
+
+  return {
+    digestHex: digest.toString("hex"),
+    digestBase64: digest.toString("base64"),
+    signature,
+    signatureBase64: signature.toString("base64"),
+    publicKeyPem: DEV_PUBLIC_KEY,
+  };
+}
+
+export function verifySignatureFromDigest(digestHex: string, signature: Buffer): boolean {
+  const publicKey = crypto.createPublicKey({ key: DEV_PUBLIC_KEY, format: "pem" });
+  const digestBuffer = Buffer.from(digestHex, "hex");
+  return crypto.verify(null, digestBuffer, publicKey, signature);
+}

--- a/apgms/services/sbr/src/index.ts
+++ b/apgms/services/sbr/src/index.ts
@@ -1,1 +1,171 @@
-﻿console.log('sbr service');
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import Fastify from "fastify";
+
+import { buildEnvelope } from "./as4/envelope";
+import { signCanonicalUserMessage } from "./as4/sign";
+import { verifyNonRepudiation, writeReceiptArtifacts } from "./as4/receipt";
+
+const ARTIFACT_BASE = path.join(process.cwd(), "tmp", "as4-artifacts");
+const ADMIN_TOKEN = process.env.SBR_ADMIN_TOKEN ?? "dev-admin-token";
+const ALLOWED_ARTIFACTS = new Set([
+  "envelope.xml",
+  "signature.bin",
+  "receipt.xml",
+  "receipt-verification.json",
+  "digest.txt",
+  "meta.json",
+]);
+
+const CONTENT_TYPES: Record<string, string> = {
+  "envelope.xml": "application/xml",
+  "receipt.xml": "application/xml",
+  "signature.bin": "application/octet-stream",
+  "digest.txt": "text/plain",
+  "meta.json": "application/json",
+  "receipt-verification.json": "application/json",
+};
+
+async function ensureArtifactsDir(messageId: string): Promise<string> {
+  const safeMessageId = messageId.replace(/[^A-Za-z0-9:_-]/g, "_");
+  const dir = path.join(ARTIFACT_BASE, safeMessageId);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+async function writeArtifacts(
+  dir: string,
+  envelopeXml: string,
+  digestHex: string,
+  signature: Buffer,
+  meta: Record<string, unknown>,
+): Promise<void> {
+  await Promise.all([
+    fs.writeFile(path.join(dir, "envelope.xml"), envelopeXml, "utf8"),
+    fs.writeFile(path.join(dir, "digest.txt"), `${digestHex}\n`, "utf8"),
+    fs.writeFile(path.join(dir, "signature.bin"), signature),
+    fs.writeFile(path.join(dir, "meta.json"), JSON.stringify(meta, null, 2), "utf8"),
+  ]);
+}
+
+const app = Fastify({ logger: true });
+
+app.post("/sbr/send", async (req, rep) => {
+  const body = req.body as {
+    orgId?: string;
+    docType?: string;
+    payload?: string;
+    service?: string;
+    action?: string;
+    receiverPartyId?: string;
+    receiverRole?: string;
+    messageId?: string;
+    timestamp?: string;
+  };
+
+  if (!body?.orgId || !body?.docType || typeof body.payload !== "string") {
+    return rep.code(400).send({ error: "invalid_request" });
+  }
+
+  const envelope = buildEnvelope({
+    orgId: body.orgId,
+    docType: body.docType,
+    payload: body.payload,
+    service: body.service,
+    action: body.action,
+    receiverPartyId: body.receiverPartyId,
+    receiverRole: body.receiverRole,
+    messageId: body.messageId,
+    timestamp: body.timestamp,
+  });
+
+  const signature = signCanonicalUserMessage(envelope.userMessageCanonical);
+
+  const dir = await ensureArtifactsDir(envelope.messageId);
+  const meta = {
+    messageId: envelope.messageId,
+    timestamp: envelope.timestamp,
+    orgId: body.orgId,
+    docType: body.docType,
+    receiverPartyId: envelope.receiverPartyId,
+    receiverRole: envelope.receiverRole,
+    service: envelope.service,
+    action: envelope.action,
+    digestHex: signature.digestHex,
+    digestBase64: signature.digestBase64,
+    signatureBase64: signature.signatureBase64,
+    publicKeyPem: signature.publicKeyPem,
+  };
+  await writeArtifacts(dir, envelope.envelopeXml, signature.digestHex, signature.signature, meta);
+
+  return rep.code(202).send({ messageId: envelope.messageId, timestamp: envelope.timestamp });
+});
+
+app.post("/sbr/receive-receipt", async (req, rep) => {
+  const body = req.body as { messageId?: string; receiptXml?: string };
+  if (!body?.messageId || typeof body.receiptXml !== "string") {
+    return rep.code(400).send({ error: "invalid_request" });
+  }
+
+  const dir = await ensureArtifactsDir(body.messageId);
+  const digestPath = path.join(dir, "digest.txt");
+  let expectedDigest = "";
+  try {
+    expectedDigest = (await fs.readFile(digestPath, "utf8")).trim();
+  } catch (err) {
+    req.log.error(err);
+    return rep.code(404).send({ error: "unknown_message" });
+  }
+
+  const verification = verifyNonRepudiation(body.receiptXml, expectedDigest);
+  await writeReceiptArtifacts(dir, body.receiptXml, verification);
+
+  const metaPath = path.join(dir, "meta.json");
+  let meta: Record<string, unknown> = {};
+  try {
+    const metaRaw = await fs.readFile(metaPath, "utf8");
+    meta = JSON.parse(metaRaw) as Record<string, unknown>;
+  } catch (err) {
+    req.log.warn({ err }, "meta missing for message");
+  }
+
+  meta.receiptDigestHex = verification.digestValue;
+  meta.receiptVerified = verification.matches;
+  meta.receiptVerifiedAt = new Date().toISOString();
+  await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), "utf8");
+
+  return rep.send({ messageId: body.messageId, verified: verification.matches, digest: verification.digestValue });
+});
+
+app.get("/sbr/artifact/:messageId/:name", async (req, rep) => {
+  const token = req.headers["x-admin-token"];
+  if (token !== ADMIN_TOKEN) {
+    return rep.code(403).send({ error: "forbidden" });
+  }
+
+  const params = req.params as { messageId: string; name: string };
+  if (!ALLOWED_ARTIFACTS.has(params.name)) {
+    return rep.code(404).send({ error: "not_found" });
+  }
+
+  const dir = path.join(ARTIFACT_BASE, params.messageId.replace(/[^A-Za-z0-9:_-]/g, "_"));
+  const filePath = path.join(dir, params.name);
+
+  try {
+    const data = await fs.readFile(filePath);
+    const contentType = CONTENT_TYPES[params.name] ?? "application/octet-stream";
+    return rep.type(contentType).send(data);
+  } catch (err) {
+    req.log.error({ err }, "failed to read artifact");
+    return rep.code(404).send({ error: "not_found" });
+  }
+});
+
+const port = Number(process.env.PORT ?? 3000);
+const host = "0.0.0.0";
+
+app.listen({ port, host }).catch((err) => {
+  app.log.error(err);
+  process.exit(1);
+});

--- a/apgms/services/sbr/test/sbr.spec.ts
+++ b/apgms/services/sbr/test/sbr.spec.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildEnvelope } from "../src/as4/envelope";
+import { signCanonicalUserMessage } from "../src/as4/sign";
+import { verifyNonRepudiation } from "../src/as4/receipt";
+
+describe("SBR AS4", () => {
+  it("produces stable canonical digest", () => {
+    const input = {
+      orgId: "ORG123",
+      docType: "DOC-TYPE",
+      payload: "<Document>payload</Document>",
+      messageId: "urn:uuid:fixed-message-id",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    };
+
+    const first = buildEnvelope(input);
+    const second = buildEnvelope(input);
+
+    assert.equal(first.userMessageCanonical, second.userMessageCanonical);
+
+    const sigOne = signCanonicalUserMessage(first.userMessageCanonical);
+    const sigTwo = signCanonicalUserMessage(second.userMessageCanonical);
+
+    assert.equal(sigOne.digestHex, sigTwo.digestHex);
+    assert.equal(sigOne.signatureBase64, sigTwo.signatureBase64);
+  });
+
+  it("accepts valid receipt for NRR", () => {
+    const envelope = buildEnvelope({
+      orgId: "ORG123",
+      docType: "DOC-TYPE",
+      payload: "<Document>payload</Document>",
+      messageId: "urn:uuid:valid-receipt",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    const signature = signCanonicalUserMessage(envelope.userMessageCanonical);
+    const receiptXml = `<Receipt><DigestValue>${signature.digestHex}</DigestValue></Receipt>`;
+
+    const verification = verifyNonRepudiation(receiptXml, signature.digestHex);
+    assert.equal(verification.matches, true);
+    assert.equal(verification.digestValue, signature.digestHex);
+  });
+
+  it("rejects tampered receipt for NRR", () => {
+    const envelope = buildEnvelope({
+      orgId: "ORG123",
+      docType: "DOC-TYPE",
+      payload: "<Document>payload</Document>",
+      messageId: "urn:uuid:tampered-receipt",
+      timestamp: "2024-01-01T00:00:00.000Z",
+    });
+
+    const signature = signCanonicalUserMessage(envelope.userMessageCanonical);
+    const tamperedDigest = signature.digestHex.replace(/.$/, (char) => (char === "a" ? "b" : "a"));
+    const receiptXml = `<Receipt><DigestValue>${tamperedDigest}</DigestValue></Receipt>`;
+
+    const verification = verifyNonRepudiation(receiptXml, signature.digestHex);
+    assert.equal(verification.matches, false);
+    assert.equal(verification.digestValue, tamperedDigest);
+  });
+});

--- a/apgms/services/sbr/tsconfig.json
+++ b/apgms/services/sbr/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- add deterministic ebMS3/AS4 envelope builder with placeholder defaults and artifact persistence
- implement Ed25519 signing support, receipt verification utilities, and Fastify routes for SBR artifacts
- cover canonical digest stability and receipt verification with automated tests

## Testing
- pnpm --filter @apgms/sbr test

------
https://chatgpt.com/codex/tasks/task_e_68f438e8079483278db8e4e952b77939