### PR TITLE
Implement ABN/TFN validation and secure PII handling

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/pii.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,5 @@
-﻿import path from "node:path";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,18 +8,117 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import piiSchema from "./schemas/pii.schema.json" assert { type: "json" };
+import {
+  configurePIIProviders,
+  encryptPII,
+  registerPIIRoutes,
+  tokenizeTFN,
+  type KeyManagementService,
+  type TokenSaltProvider,
+  type AuditLogger,
+} from "./lib/pii";
+import { isValidABN, normalizeAbn } from "@apgms/shared-au/abn";
+import { isValidTFN } from "@apgms/shared-au/tfn";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+app.addSchema(piiSchema);
+
+const keyId = process.env.PII_KEY_ID ?? "local-default";
+const keyMaterialEnv = process.env.PII_KEY_MATERIAL;
+const keyMaterial = (() => {
+  if (keyMaterialEnv) {
+    const buffer = Buffer.from(keyMaterialEnv, "base64");
+    if (buffer.length === 32) {
+      return buffer;
+    }
+  }
+  return randomBytes(32);
+})();
+
+const kms: KeyManagementService = {
+  getActiveKey: () => ({ kid: keyId, material: keyMaterial }),
+  getKeyById: (kid: string) => (kid === keyId ? { kid, material: keyMaterial } : undefined),
+};
+
+const saltId = process.env.TFN_SALT_ID ?? "local-1";
+const saltSecretEnv = process.env.TFN_SALT_SECRET;
+const saltSecret = (() => {
+  if (saltSecretEnv) {
+    const buffer = Buffer.from(saltSecretEnv, "base64");
+    if (buffer.length > 0) {
+      return buffer;
+    }
+  }
+  return randomBytes(32);
+})();
+
+const saltProvider: TokenSaltProvider = {
+  getActiveSalt: () => ({ sid: saltId, secret: saltSecret }),
+  getSaltById: (id: string) => (id === saltId ? { sid: saltId, secret: saltSecret } : undefined),
+};
+
+const auditLogger: AuditLogger = {
+  record: async (event) => {
+    app.log.info({ audit: { actorId: event.actorId, action: event.action, metadata: event.metadata } }, "audit_event");
+  },
+};
+
+configurePIIProviders({ kms, saltProvider, auditLogger });
+
+const adminGuard = (request: FastifyRequest): { allowed: boolean; actorId: string } => {
+  const isAdmin = request.headers["x-admin"] === "true";
+  const actorId = String(request.headers["x-actor-id"] ?? "unknown");
+  return { allowed: Boolean(isAdmin), actorId };
+};
+
+registerPIIRoutes(app, adminGuard);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+app.post(
+  "/pii",
+  {
+    schema: {
+      body: {
+        type: "object",
+        required: ["abn", "tfn"],
+        additionalProperties: false,
+        properties: {
+          abn: { type: "string" },
+          tfn: { type: "string" },
+          payload: { type: "string" },
+        },
+      },
+      response: {
+        201: { $ref: "https://apgms.example.com/schemas/pii.schema.json" },
+      },
+    },
+  },
+  async (request, reply) => {
+    const body = request.body as { abn: string; tfn: string; payload?: string };
+    if (!isValidABN(body.abn)) {
+      return reply.code(400).send({ error: "invalid_abn" });
+    }
+    if (!isValidTFN(body.tfn)) {
+      return reply.code(400).send({ error: "invalid_tfn" });
+    }
+
+    const abn = normalizeAbn(body.abn);
+    const tfnToken = tokenizeTFN(body.tfn);
+    const secret = encryptPII(body.payload ?? "");
+
+    return reply.code(201).send({ abn, tfnToken, secret });
+  },
+);
 
 // List users (email + org)
 app.get("/users", async () => {
@@ -77,4 +177,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/lib/pii.ts
+++ b/apgms/services/api-gateway/src/lib/pii.ts
@@ -1,0 +1,147 @@
+import { createCipheriv, createDecipheriv, createHmac, randomBytes } from "node:crypto";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+const AES_ALGORITHM = "aes-256-gcm";
+const AES_IV_LENGTH = 12;
+const AES_AUTH_TAG_LENGTH = 16;
+
+export interface EncryptionKey {
+  kid: string;
+  material: Buffer;
+}
+
+export interface KeyManagementService {
+  getActiveKey(): EncryptionKey;
+  getKeyById(kid: string): EncryptionKey | undefined;
+}
+
+export interface SaltMaterial {
+  sid: string;
+  secret: Buffer;
+}
+
+export interface TokenSaltProvider {
+  getActiveSalt(): SaltMaterial;
+  getSaltById(id: string): SaltMaterial | undefined;
+}
+
+export interface AuditEvent {
+  actorId: string;
+  action: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditLogger {
+  record(event: AuditEvent): void | Promise<void>;
+}
+
+interface PIIContext {
+  kms: KeyManagementService;
+  saltProvider: TokenSaltProvider;
+  auditLogger: AuditLogger;
+}
+
+let context: PIIContext | undefined;
+
+export function configurePIIProviders(newContext: PIIContext): void {
+  context = newContext;
+}
+
+export function tokenizeTFN(plain: string): string {
+  if (!context) {
+    throw new Error("PII providers not configured");
+  }
+
+  const normalized = plain.replace(/\s+/g, "");
+  if (!/^\d{8,9}$/.test(normalized)) {
+    throw new Error("Invalid TFN format");
+  }
+
+  const { sid, secret } = context.saltProvider.getActiveSalt();
+  const digest = createHmac("sha256", secret).update(normalized).digest("base64url");
+  return `${sid}.${digest}`;
+}
+
+export function encryptPII(plain: string): { ciphertext: string; kid: string } {
+  if (!context) {
+    throw new Error("PII providers not configured");
+  }
+
+  const key = context.kms.getActiveKey();
+  if (key.material.length !== 32) {
+    throw new Error("Invalid encryption key length");
+  }
+
+  const iv = randomBytes(AES_IV_LENGTH);
+  const cipher = createCipheriv(AES_ALGORITHM, key.material, iv, { authTagLength: AES_AUTH_TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  const payload = Buffer.concat([iv, authTag, encrypted]);
+  return { kid: key.kid, ciphertext: payload.toString("base64") };
+}
+
+export function decryptPII(payload: { ciphertext: string; kid: string }): string {
+  if (!context) {
+    throw new Error("PII providers not configured");
+  }
+
+  const key = context.kms.getKeyById(payload.kid);
+  if (!key) {
+    throw new Error("Unknown key identifier");
+  }
+
+  const data = Buffer.from(payload.ciphertext, "base64");
+  if (data.length < AES_IV_LENGTH + AES_AUTH_TAG_LENGTH) {
+    throw new Error("Malformed ciphertext");
+  }
+
+  const iv = data.subarray(0, AES_IV_LENGTH);
+  const authTag = data.subarray(AES_IV_LENGTH, AES_IV_LENGTH + AES_AUTH_TAG_LENGTH);
+  const encrypted = data.subarray(AES_IV_LENGTH + AES_AUTH_TAG_LENGTH);
+  const decipher = createDecipheriv(AES_ALGORITHM, key.material, iv, { authTagLength: AES_AUTH_TAG_LENGTH });
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString("utf8");
+}
+
+export interface AdminGuardResult {
+  allowed: boolean;
+  actorId: string;
+}
+
+export type AdminGuard = (request: FastifyRequest) => Promise<AdminGuardResult> | AdminGuardResult;
+
+export function registerPIIRoutes(app: FastifyInstance, guard: AdminGuard): void {
+  app.post(
+    "/admin/pii/decrypt",
+    async (request: FastifyRequest, reply: FastifyReply): Promise<FastifyReply> => {
+      if (!context) {
+        return reply.code(500).send({ error: "pii_unconfigured" });
+      }
+
+      const decision = await guard(request);
+      if (!decision.allowed) {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+
+      const body = request.body as { ciphertext?: string; kid?: string };
+      if (!body?.ciphertext || !body?.kid) {
+        return reply.code(400).send({ error: "invalid_request" });
+      }
+
+      try {
+        const value = decryptPII({ ciphertext: body.ciphertext, kid: body.kid });
+        await context.auditLogger.record({
+          actorId: decision.actorId,
+          action: "pii.decrypt",
+          timestamp: new Date().toISOString(),
+          metadata: { kid: body.kid },
+        });
+        return reply.code(200).send({ value });
+      } catch (error) {
+        return reply.code(400).send({ error: "invalid_payload" });
+      }
+    },
+  );
+}

--- a/apgms/services/api-gateway/src/schemas/pii.schema.json
+++ b/apgms/services/api-gateway/src/schemas/pii.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://apgms.example.com/schemas/pii.schema.json",
+  "title": "PIIRecord",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["abn", "tfnToken", "secret"],
+  "properties": {
+    "abn": {
+      "type": "string",
+      "pattern": "^\\d{11}$"
+    },
+    "tfnToken": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]{43,}$"
+    },
+    "secret": {
+      "type": "object",
+      "required": ["ciphertext", "kid"],
+      "additionalProperties": false,
+      "properties": {
+        "ciphertext": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kid": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/apgms/services/api-gateway/test/pii.spec.ts
+++ b/apgms/services/api-gateway/test/pii.spec.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import Fastify from "fastify";
+
+import {
+  configurePIIProviders,
+  decryptPII,
+  encryptPII,
+  registerPIIRoutes,
+  tokenizeTFN,
+  type AuditEvent,
+  type AuditLogger,
+  type KeyManagementService,
+  type TokenSaltProvider,
+} from "../src/lib/pii";
+import { isValidABN } from "@apgms/shared-au/abn";
+import { isValidTFN } from "@apgms/shared-au/tfn";
+
+const TEST_KEY = Buffer.alloc(32, 7);
+const TEST_SALT = Buffer.from("test-salt-secret", "utf8");
+
+const kms: KeyManagementService = {
+  getActiveKey: () => ({ kid: "test-kid", material: TEST_KEY }),
+  getKeyById: (kid) => (kid === "test-kid" ? { kid, material: TEST_KEY } : undefined),
+};
+
+const saltProvider: TokenSaltProvider = {
+  getActiveSalt: () => ({ sid: "salt-v1", secret: TEST_SALT }),
+  getSaltById: (sid) => (sid === "salt-v1" ? { sid, secret: TEST_SALT } : undefined),
+};
+
+const events: AuditEvent[] = [];
+
+function setupProviders() {
+  events.length = 0;
+  const auditLogger: AuditLogger = {
+    record: (event) => {
+      events.push(event);
+    },
+  };
+  configurePIIProviders({ kms, saltProvider, auditLogger });
+}
+
+beforeEach(() => {
+  setupProviders();
+});
+
+afterEach(() => {
+  events.length = 0;
+});
+
+describe("ABN validation", () => {
+  it("accepts known valid ABNs", () => {
+    const valid = ["51824753556", "51 824 753 556", "10 000 000 032"];
+    for (const abn of valid) {
+      assert.equal(isValidABN(abn), true);
+    }
+  });
+
+  it("rejects invalid ABNs", () => {
+    const invalid = ["51824753555", "1234567890", "ABCDEFGHIJK", "00 000 000 000", "83 004 085 616"];
+    for (const abn of invalid) {
+      assert.equal(isValidABN(abn), false);
+    }
+  });
+});
+
+describe("TFN handling", () => {
+  it("never exposes the original TFN", () => {
+    const tfn = "123 456 788";
+    assert.equal(isValidTFN(tfn), true);
+
+    const token = tokenizeTFN(tfn);
+    assert.equal(token.includes("123456788"), false);
+    assert.equal(token.startsWith("salt-v1."), true);
+
+    assert.throws(() => decryptPII({ ciphertext: token, kid: "test-kid" }));
+  });
+});
+
+describe("admin decryption", () => {
+  it("emits an audit event when decryption succeeds", async () => {
+    const app = Fastify();
+    registerPIIRoutes(app, () => ({ allowed: true, actorId: "admin-user" }));
+    await app.ready();
+
+    const secret = encryptPII("sensitive payload");
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/pii/decrypt",
+      payload: secret,
+    });
+
+    assert.equal(response.statusCode, 200);
+    const body = response.json() as { value: string };
+    assert.equal(body.value, "sensitive payload");
+
+    assert.equal(events.length, 1);
+    assert.deepEqual(events[0], {
+      actorId: "admin-user",
+      action: "pii.decrypt",
+      timestamp: events[0].timestamp,
+      metadata: { kid: secret.kid },
+    });
+    assert.equal(JSON.stringify(events[0]).includes("sensitive payload"), false);
+
+    await app.close();
+  });
+
+  it("denies non-admin access", async () => {
+    const app = Fastify();
+    registerPIIRoutes(app, () => ({ allowed: false, actorId: "guest" }));
+    await app.ready();
+
+    const secret = encryptPII("payload");
+    const response = await app.inject({
+      method: "POST",
+      url: "/admin/pii/decrypt",
+      payload: secret,
+    });
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(events.length, 0);
+
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -6,11 +6,13 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "resolveJsonModule": true,
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared/*": ["shared/src/*"],
+      "@apgms/shared-au/*": ["shared/au/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test", "src/schemas"]
 }

--- a/apgms/shared/au/abn.ts
+++ b/apgms/shared/au/abn.ts
@@ -1,0 +1,29 @@
+const ABN_WEIGHTS = [10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19] as const;
+
+const DIGIT_ONLY = /\d+/g;
+
+export function normalizeAbn(input: string): string {
+  const digits = input.match(DIGIT_ONLY)?.join("") ?? "";
+  return digits;
+}
+
+export function isValidABN(input: string): boolean {
+  const normalized = normalizeAbn(input);
+  if (normalized.length !== 11) {
+    return false;
+  }
+
+  if (!/^\d{11}$/.test(normalized)) {
+    return false;
+  }
+
+  const digits = normalized
+    .split("")
+    .map((char, index) => {
+      const value = Number(char);
+      return index === 0 ? value - 1 : value;
+    });
+
+  const weightedSum = digits.reduce((sum, digit, index) => sum + digit * ABN_WEIGHTS[index], 0);
+  return weightedSum % 89 === 0;
+}

--- a/apgms/shared/au/tfn.ts
+++ b/apgms/shared/au/tfn.ts
@@ -1,0 +1,23 @@
+const TFN_8_WEIGHTS = [10, 7, 8, 4, 6, 3, 5, 2] as const;
+const TFN_9_WEIGHTS = [1, 4, 7, 10, 3, 5, 8, 11, 2] as const;
+
+const DIGIT_ONLY = /\d+/g;
+
+export function normalizeTfn(input: string): string {
+  const digits = input.match(DIGIT_ONLY)?.join("") ?? "";
+  return digits;
+}
+
+export function isValidTFN(input: string): boolean {
+  const normalized = normalizeTfn(input);
+  if (!/^\d{8,9}$/.test(normalized)) {
+    return false;
+  }
+
+  const weights = normalized.length === 8 ? TFN_8_WEIGHTS : TFN_9_WEIGHTS;
+  const weightedSum = normalized
+    .split("")
+    .reduce((sum, digit, index) => sum + Number(digit) * weights[index], 0);
+
+  return weightedSum % 11 === 0;
+}


### PR DESCRIPTION
## Summary
- add ABN and TFN validation helpers for Australian identifiers
- secure TFN handling via HMAC tokenization and AES-GCM PII encryption with admin-guarded decryption
- document response schema and cover flows with node:test assertions

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f438d92b1c83279c91ae19bf0c882b