### PR TITLE
Add validation guards for bank lines and audit routes

### DIFF
--- a/apgms/webapp/src/contracts/schemas.ts
+++ b/apgms/webapp/src/contracts/schemas.ts
@@ -1,0 +1,123 @@
+export type SafeParseSuccess<T> = {
+  readonly success: true;
+  readonly data: T;
+};
+
+export type SafeParseFailure = {
+  readonly success: false;
+  readonly issues: readonly string[];
+};
+
+export type SafeParseResult<T> = SafeParseSuccess<T> | SafeParseFailure;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
+const isIsoDateString = (value: unknown): value is string =>
+  isNonEmptyString(value) && !Number.isNaN(Date.parse(value));
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const buildFailure = (...issues: string[]): SafeParseFailure => ({
+  success: false,
+  issues,
+});
+
+export type AllocationPreview = {
+  readonly id: string;
+  readonly label: string;
+  readonly limit: number;
+  readonly currency: string;
+  readonly updatedAt: string;
+};
+
+const isAllocationPreview = (value: unknown): value is AllocationPreview => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const { id, label, limit, currency, updatedAt } = value;
+
+  return (
+    isNonEmptyString(id) &&
+    isNonEmptyString(label) &&
+    isFiniteNumber(limit) &&
+    isNonEmptyString(currency) &&
+    isIsoDateString(updatedAt)
+  );
+};
+
+export const AllocationPreviewV = {
+  safeParse(value: unknown): SafeParseResult<AllocationPreview> {
+    if (!isAllocationPreview(value)) {
+      return buildFailure("Invalid allocation preview payload");
+    }
+
+    return { success: true, data: value };
+  },
+};
+
+export type Rpt = {
+  readonly id: string;
+  readonly status: string;
+  readonly generatedAt: string;
+  readonly summary: string;
+  readonly advanced?: Readonly<Record<string, string | number | boolean | null>>;
+};
+
+const isAdvancedFields = (
+  value: unknown,
+): value is Record<string, string | number | boolean | null> => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((entry) => {
+    const type = typeof entry;
+    return (
+      entry === null ||
+      type === "string" ||
+      type === "number" ||
+      type === "boolean"
+    );
+  });
+};
+
+const isRpt = (value: unknown): value is Rpt => {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  const { id, status, generatedAt, summary, advanced } = value;
+
+  if (
+    !(
+      isNonEmptyString(id) &&
+      isNonEmptyString(status) &&
+      isIsoDateString(generatedAt) &&
+      isNonEmptyString(summary)
+    )
+  ) {
+    return false;
+  }
+
+  if (typeof advanced === "undefined") {
+    return true;
+  }
+
+  return isAdvancedFields(advanced);
+};
+
+export const RptV = {
+  safeParse(value: unknown): SafeParseResult<Rpt> {
+    if (!isRpt(value)) {
+      return buildFailure("Invalid RPT payload");
+    }
+
+    return { success: true, data: value };
+  },
+};

--- a/apgms/webapp/src/routes/audit.tsx
+++ b/apgms/webapp/src/routes/audit.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react";
+import { Rpt, RptV } from "../contracts/schemas";
+
+type AuditState =
+  | { status: "loading" }
+  | { status: "ready"; data: Rpt }
+  | { status: "error"; message: string };
+
+const getIsDev = (): boolean => {
+  if (typeof import.meta !== "undefined" && typeof (import.meta as any).env !== "undefined") {
+    const maybeEnv = (import.meta as any).env;
+    if (typeof maybeEnv.DEV === "boolean") {
+      return maybeEnv.DEV;
+    }
+  }
+
+  if (typeof process !== "undefined" && process.env && typeof process.env.NODE_ENV === "string") {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  return false;
+};
+
+const isDev = getIsDev();
+
+const sanitizeAdvanced = (
+  advanced: Readonly<Record<string, string | number | boolean | null>>,
+): ReadonlyArray<[string, string]> =>
+  Object.entries(advanced).map(([key, value]) => [key, String(value)] as const);
+
+const AuditRoute = (): JSX.Element => {
+  const [state, setState] = useState<AuditState>({ status: "loading" });
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const fetchRpt = async () => {
+      try {
+        const response = await fetch("/api/audit/rpt");
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const result = RptV.safeParse(payload);
+
+        if (!result.success) {
+          throw new Error("Invalid RPT payload");
+        }
+
+        if (!isCancelled) {
+          setState({ status: "ready", data: result.data });
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          if (isDev) {
+            console.error("[audit] Unable to render RPT", error);
+          }
+          setState({ status: "error", message: "Verification unavailable" });
+        }
+      }
+    };
+
+    void fetchRpt();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  const body = useMemo(() => {
+    if (state.status === "loading") {
+      return <p>Loading verification…</p>;
+    }
+
+    if (state.status === "error") {
+      return (
+        <p role="alert" aria-live="assertive">
+          {state.message}
+        </p>
+      );
+    }
+
+    const { data } = state;
+
+    return (
+      <article aria-labelledby="audit-rpt-heading">
+        <header>
+          <h1 id="audit-rpt-heading">Audit verification</h1>
+          <p className="audit-rpt__meta">
+            <span>Status: {data.status}</span>
+            <span>Generated: {new Date(data.generatedAt).toLocaleString()}</span>
+          </p>
+        </header>
+        <section aria-label="Summary">
+          <p>{data.summary}</p>
+        </section>
+        {data.advanced && (
+          <section aria-label="Advanced details" className="audit-rpt__advanced">
+            <button type="button" onClick={() => setShowAdvanced((current) => !current)}>
+              {showAdvanced ? "Hide advanced details" : "Show advanced details"}
+            </button>
+            {showAdvanced && (
+              <dl>
+                {sanitizeAdvanced(data.advanced).map(([key, value]) => (
+                  <div key={key}>
+                    <dt>{key}</dt>
+                    <dd>{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            )}
+          </section>
+        )}
+      </article>
+    );
+  }, [showAdvanced, state]);
+
+  return (
+    <section className="audit-rpt" aria-live="polite">
+      {body}
+    </section>
+  );
+};
+
+export default AuditRoute;

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from "react";
+import { AllocationPreview, AllocationPreviewV } from "../contracts/schemas";
+
+type BankLineState =
+  | { status: "loading" }
+  | { status: "ready"; data: readonly AllocationPreview[] }
+  | { status: "error"; message: string };
+
+const getIsDev = (): boolean => {
+  if (typeof import.meta !== "undefined" && typeof (import.meta as any).env !== "undefined") {
+    const maybeEnv = (import.meta as any).env;
+    if (typeof maybeEnv.DEV === "boolean") {
+      return maybeEnv.DEV;
+    }
+  }
+
+  if (typeof process !== "undefined" && process.env && typeof process.env.NODE_ENV === "string") {
+    return process.env.NODE_ENV !== "production";
+  }
+
+  return false;
+};
+
+const isDev = getIsDev();
+
+const parseAllocationResponse = (
+  payload: unknown,
+): readonly AllocationPreview[] | null => {
+  const items = Array.isArray(payload) ? payload : [payload];
+  const parsed: AllocationPreview[] = [];
+
+  for (const entry of items) {
+    const result = AllocationPreviewV.safeParse(entry);
+    if (!result.success) {
+      return null;
+    }
+
+    parsed.push(result.data);
+  }
+
+  return parsed;
+};
+
+const formatCurrency = (value: number, currency: string): string => {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    }).format(value);
+  } catch (error) {
+    if (isDev) {
+      console.warn("[bank-lines] Unable to format currency", error);
+    }
+    return `${currency} ${value.toFixed(2)}`;
+  }
+};
+
+const formatDate = (value: string): string => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString();
+};
+
+const BankLinesRoute = (): JSX.Element => {
+  const [state, setState] = useState<BankLineState>({ status: "loading" });
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    const fetchLines = async () => {
+      try {
+        const response = await fetch("/api/bank-lines");
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        const parsed = parseAllocationResponse(payload);
+
+        if (!parsed) {
+          throw new Error("Invalid allocation preview payload");
+        }
+
+        if (!isCancelled) {
+          setState({ status: "ready", data: parsed });
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          if (isDev) {
+            console.error("[bank-lines] Unable to render bank line preview", error);
+          }
+          setState({ status: "error", message: "Can't display this item" });
+        }
+      }
+    };
+
+    void fetchLines();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  const body = useMemo(() => {
+    if (state.status === "loading") {
+      return <p>Loading bank lines…</p>;
+    }
+
+    if (state.status === "error") {
+      return (
+        <p role="alert" aria-live="assertive">
+          {state.message}
+        </p>
+      );
+    }
+
+    if (state.data.length === 0) {
+      return <p>No bank lines available.</p>;
+    }
+
+    return (
+      <ul aria-label="Bank lines overview" className="bank-lines__list">
+        {state.data.map((line) => (
+          <li key={line.id} className="bank-lines__item">
+            <article>
+              <header>
+                <h2>{line.label}</h2>
+              </header>
+              <dl>
+                <div>
+                  <dt>Limit</dt>
+                  <dd>{formatCurrency(line.limit, line.currency)}</dd>
+                </div>
+                <div>
+                  <dt>Updated</dt>
+                  <dd>{formatDate(line.updatedAt)}</dd>
+                </div>
+              </dl>
+            </article>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [state]);
+
+  return (
+    <section aria-labelledby="bank-lines-heading" className="bank-lines">
+      <h1 id="bank-lines-heading">Bank lines</h1>
+      {body}
+    </section>
+  );
+};
+
+export default BankLinesRoute;


### PR DESCRIPTION
## Summary
- add shared allocation preview and RPT validators for the webapp
- validate bank line drawer data before rendering and show a friendly fallback when invalid
- validate audit RPT responses, hide advanced fields by default, and gate logging to dev builds

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f43ab547a48327b7384d9d4f16e376