### PR TITLE
Add Playwright accessibility and happy path tests for webapp

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,30 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "web:dev": "pnpm --filter webapp dev",
+    "web:test:e2e": "playwright test -c webapp/playwright.config.ts",
+    "web:test:a11y": "playwright test webapp/tests/a11y.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/webapp/playwright.config.ts
+++ b/apgms/webapp/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:4173';
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? DEFAULT_BASE_URL;
+const shouldStartWebServer = !process.env.PLAYWRIGHT_SKIP_WEB_SERVER;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: shouldStartWebServer
+    ? {
+        command: 'pnpm --filter webapp dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }
+    : undefined,
+});

--- a/apgms/webapp/tests/a11y.spec.ts
+++ b/apgms/webapp/tests/a11y.spec.ts
@@ -1,0 +1,18 @@
+import AxeBuilder from '@axe-core/playwright';
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173';
+const routes = ['/', '/bank-lines'] as const;
+
+test.describe('Accessibility scans', () => {
+  for (const route of routes) {
+    test(`has no detectable accessibility violations at ${route}`, async ({ page }) => {
+      await page.goto(new URL(route, BASE_URL).toString());
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa'])
+        .analyze();
+
+      expect(results.violations, `Accessibility issues found on ${route}`).toEqual([]);
+    });
+  }
+});

--- a/apgms/webapp/tests/happy.spec.ts
+++ b/apgms/webapp/tests/happy.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:4173';
+
+const withBaseUrl = (path: string) => new URL(path, BASE_URL).toString();
+
+test.describe('Bank line happy path', () => {
+  test('user can open, verify, and close a bank line drawer', async ({ page }) => {
+    await test.step('Visit the dashboard and confirm KPIs are visible', async () => {
+      await page.goto(withBaseUrl('/'));
+      const kpiSection = page.getByTestId('kpi-section');
+      await expect(kpiSection, 'KPI section should be present on the landing page').toBeVisible();
+      await expect(
+        kpiSection.getByRole('heading', { level: 2, name: /key performance indicators/i })
+      ).toBeVisible();
+    });
+
+    await test.step('Open the first bank line drawer', async () => {
+      await page.goto(withBaseUrl('/bank-lines'));
+      const lineItem = page.getByTestId('bank-line-item').first();
+      await expect(lineItem, 'Expected at least one bank line item to display').toBeVisible();
+      await lineItem.click();
+    });
+
+    const drawer = page.getByRole('dialog', { name: /bank line details/i });
+    await expect(drawer, 'Drawer with bank line details should be visible').toBeVisible();
+
+    await test.step('Verify the bank line from the drawer', async () => {
+      await drawer.getByRole('button', { name: /verify/i }).click();
+      await expect(drawer.getByTestId('verification-status')).toContainText(/verified/i);
+    });
+
+    await test.step('Close the drawer after verification', async () => {
+      await drawer.getByRole('button', { name: /close/i }).click();
+      await expect(drawer).not.toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration for the webapp with optional embedded dev server startup
- add accessibility coverage for `/` and `/bank-lines` routes using axe-core
- script a happy-path drawer interaction test for bank lines and expose root helpers for running the suite

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f43a851ee8832789561ab7a5bb81c0