### PR TITLE
Add webapp error boundary and API retry helper

### DIFF
--- a/apgms/README.md
+++ b/apgms/README.md
@@ -1,8 +1,30 @@
-﻿# APGMS
+# APGMS
 
-Quickstart:
-pnpm i
+## Quickstart
+
+### Prerequisites
+- [pnpm](https://pnpm.io/installation)
+- Node.js 18+
+
+### Install dependencies
+```bash
+pnpm install
+```
+
+### Configure environment
+Copy the sample environment file for the web application and update values as needed:
+```bash
+cp webapp/.env.example webapp/.env
+```
+
+### Run the web application
+```bash
+pnpm --filter @apgms/webapp dev
+```
+
+### Additional scripts
+```bash
 pnpm -r build
-docker compose up -d
 pnpm -r test
 pnpm -w exec playwright test
+```

--- a/apgms/webapp/.env.example
+++ b/apgms/webapp/.env.example
@@ -1,0 +1,2 @@
+# Base URL for backend API requests. Include protocol and host.
+VITE_API_URL=https://api.example.com/

--- a/apgms/webapp/README.md
+++ b/apgms/webapp/README.md
@@ -1,0 +1,16 @@
+# APGMS Web Application
+
+## Quickstart
+
+1. Install dependencies from the repository root:
+   ```bash
+   pnpm install
+   ```
+2. Copy the example environment file and update `VITE_API_URL`:
+   ```bash
+   cp webapp/.env.example webapp/.env
+   ```
+3. Start the development server:
+   ```bash
+   pnpm --filter @apgms/webapp dev
+   ```

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,10 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "echo dev webapp",
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  }
+}

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,48 @@
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 200;
+
+const apiBaseUrl = (import.meta.env.VITE_API_URL as string | undefined)?.replace(/\/+$/, '/') ?? '';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const resolveUrl = (path: string): string => {
+  try {
+    return new URL(path, apiBaseUrl || window.location.origin).toString();
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to resolve request URL', error);
+    }
+    throw error;
+  }
+};
+
+const shouldRetry = (status: number) => status >= 500 && status < 600;
+
+export type ApiFetch = (path: string, init?: RequestInit) => Promise<Response>;
+
+export const apiFetch: ApiFetch = async (path, init) => {
+  const url = resolveUrl(path);
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, init);
+
+      if (!shouldRetry(response.status) || attempt === MAX_ATTEMPTS) {
+        return response;
+      }
+
+      const backoffMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+      await sleep(backoffMs);
+    } catch (error) {
+      if (attempt === MAX_ATTEMPTS) {
+        throw error;
+      }
+
+      const backoffMs = BASE_DELAY_MS * 2 ** (attempt - 1);
+      await sleep(backoffMs);
+    }
+  }
+
+  throw new Error('Failed to execute request');
+};

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,24 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import { ErrorBoundary } from './shell/ErrorBoundary';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Failed to find the root element');
+}
+
+const AppRoutes = () => (
+  <main>
+    <h1>APGMS Web Application</h1>
+  </main>
+);
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <AppRoutes />
+    </ErrorBoundary>
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/shell/ErrorBoundary.tsx
+++ b/apgms/webapp/src/shell/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  /** Optional callback fired whenever the boundary resets after an error. */
+  onReset?: () => void;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+  error?: Error;
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+    error: undefined,
+  };
+
+  public static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('Uncaught error in application boundary', error, errorInfo);
+    }
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: undefined });
+    this.props.onReset?.();
+  };
+
+  public render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="app-error-boundary">
+          <h1>Something went wrong.</h1>
+          <p>Please try again or contact support if the problem persists.</p>
+          {this.state.error?.message ? (
+            <pre className="app-error-boundary__message">{this.state.error.message}</pre>
+          ) : null}
+          <button type="button" onClick={this.handleReset}>
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
- add an application-level error boundary with a reset action and wrap the root render tree
- implement a fetch helper with 5xx-only exponential backoff retries and VITE_API_URL support
- provide environment sample and updated quickstart instructions for the web application

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f43a75e62c8327b73f51e7af22acd2