### PR TITLE
Add read-only policies and gates views

### DIFF
--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,18 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "echo build webapp",
+    "test": "echo test webapp"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0"
+  }
+}

--- a/apgms/webapp/src/app.tsx
+++ b/apgms/webapp/src/app.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import GatesRoute from './routes/gates';
+import PoliciesRoute from './routes/policies';
+
+const App: React.FC = () => {
+  return (
+    <main className="app-shell">
+      <PoliciesRoute />
+      <GatesRoute />
+    </main>
+  );
+};
+
+export default App;

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,17 @@
-﻿console.log('webapp');
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './app';
+import './styles.css';
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Root element not found');
+}
+
+const root = createRoot(container);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apgms/webapp/src/routes/gates.tsx
+++ b/apgms/webapp/src/routes/gates.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+type GateState = 'OPEN' | 'PAUSED' | 'CLOSED';
+
+interface Gate {
+  id: string;
+  name: string;
+  state: GateState;
+  schedule: string;
+  reason?: string;
+}
+
+const gates: Gate[] = [
+  {
+    id: 'gate-sla-01',
+    name: 'SLA monitoring gate',
+    state: 'OPEN',
+    schedule: 'Every 15 minutes',
+  },
+  {
+    id: 'gate-maintenance-02',
+    name: 'Maintenance blackout',
+    state: 'CLOSED',
+    schedule: 'Until 7 Oct 2024 02:00 UTC',
+    reason: 'Ops requested downtime for ledger upgrades.',
+  },
+  {
+    id: 'gate-backlog-03',
+    name: 'Backlog throttling',
+    state: 'PAUSED',
+    schedule: 'Daily 01:00–03:00 UTC',
+    reason: 'Auto-paused when queue > 10k events.',
+  },
+];
+
+const gateTone: Record<GateState, string> = {
+  OPEN: 'badge badge--active',
+  PAUSED: 'badge badge--draft',
+  CLOSED: 'badge badge--warning',
+};
+
+const GatesRoute: React.FC = () => {
+  return (
+    <section>
+      <header className="section-header">
+        <h2>Gates</h2>
+        <p className="muted">Operational gates and their execution windows.</p>
+      </header>
+      <div className="stack">
+        {gates.map((gate) => (
+          <article
+            key={gate.id}
+            className={`card ${gate.state === 'CLOSED' ? 'card--warning' : ''}`}
+            aria-labelledby={`${gate.id}-heading`}
+          >
+            <div className="card__header">
+              <div className="card__title-group">
+                <h3 id={`${gate.id}-heading`}>{gate.name}</h3>
+                <span className="muted">{gate.schedule}</span>
+              </div>
+              <span className={gateTone[gate.state]}>{gate.state}</span>
+            </div>
+            {gate.reason && (
+              <div className="card__body">
+                <p className="muted">{gate.reason}</p>
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default GatesRoute;

--- a/apgms/webapp/src/routes/policies.tsx
+++ b/apgms/webapp/src/routes/policies.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+type PolicyState = 'ACTIVE' | 'DRAFT' | 'DEPRECATED';
+
+interface Policy {
+  id: string;
+  name: string;
+  version: string;
+  state: PolicyState;
+  rulesJson: Record<string, unknown>;
+}
+
+const policies: Policy[] = [
+  {
+    id: 'policy-aml-01',
+    name: 'AML transaction screening',
+    version: 'v2.1',
+    state: 'ACTIVE',
+    rulesJson: {
+      riskThreshold: 0.72,
+      escalation: ['freeze_account', 'notify_compliance'],
+      jurisdictions: ['AU', 'NZ'],
+    },
+  },
+  {
+    id: 'policy-liq-02',
+    name: 'Liquidity reserve',
+    version: 'v1.4',
+    state: 'DRAFT',
+    rulesJson: {
+      minimumReserve: 1250000,
+      alertChannels: ['ops@apgms'],
+      dependencies: ['reporting.gates.sla-monitor'],
+    },
+  },
+  {
+    id: 'policy-retention-03',
+    name: 'Retention & archival',
+    version: 'v1.0',
+    state: 'DEPRECATED',
+    rulesJson: {
+      retentionDays: 730,
+      archivalBucket: 's3://apgms-archive',
+      encrypt: true,
+    },
+  },
+];
+
+const stateBadgeStyles: Record<PolicyState, string> = {
+  ACTIVE: 'badge badge--active',
+  DRAFT: 'badge badge--draft',
+  DEPRECATED: 'badge badge--deprecated',
+};
+
+const prettyPrintJson = (value: Record<string, unknown>) =>
+  JSON.stringify(value, null, 2);
+
+const PolicyRow: React.FC<{ policy: Policy }> = ({ policy }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <article className="card" aria-labelledby={`${policy.id}-heading`}>
+      <div className="card__header">
+        <div className="card__title-group">
+          <h3 id={`${policy.id}-heading`}>{policy.name}</h3>
+          <span className="muted">{policy.version}</span>
+        </div>
+        <span className={stateBadgeStyles[policy.state]}>{policy.state}</span>
+      </div>
+      <div className="card__body">
+        <button
+          type="button"
+          className="link-button"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+          aria-controls={`${policy.id}-rules`}
+        >
+          {expanded ? 'Hide rules' : 'View rules'}
+        </button>
+        <div
+          id={`${policy.id}-rules`}
+          className={`rules ${expanded ? 'rules--expanded' : 'rules--collapsed'}`}
+          role="region"
+          aria-live="polite"
+        >
+          <pre>{prettyPrintJson(policy.rulesJson)}</pre>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const PoliciesRoute: React.FC = () => {
+  return (
+    <section>
+      <header className="section-header">
+        <h2>Policies</h2>
+        <p className="muted">Read-only registry of current automation policies.</p>
+      </header>
+      <div className="stack">
+        {policies.map((policy) => (
+          <PolicyRow key={policy.id} policy={policy} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default PoliciesRoute;

--- a/apgms/webapp/src/styles.css
+++ b/apgms/webapp/src/styles.css
@@ -1,0 +1,194 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #0f172a;
+  color: #f8fafc;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+#root {
+  display: flex;
+  justify-content: center;
+  padding: 48px 16px;
+}
+
+.app-shell {
+  width: min(960px, 100%);
+  display: grid;
+  gap: 32px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+.card {
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.card--warning {
+  border-color: rgba(248, 113, 113, 0.5);
+  background: linear-gradient(
+    135deg,
+    rgba(248, 113, 113, 0.15),
+    rgba(30, 41, 59, 0.85)
+  );
+}
+
+.card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.card__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card__title-group h3 {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.card__body {
+  display: grid;
+  gap: 12px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.badge--active {
+  background: rgba(52, 211, 153, 0.18);
+  color: #34d399;
+  border: 1px solid rgba(52, 211, 153, 0.4);
+}
+
+.badge--draft {
+  background: rgba(129, 140, 248, 0.18);
+  color: #818cf8;
+  border: 1px solid rgba(129, 140, 248, 0.4);
+}
+
+.badge--deprecated {
+  background: rgba(248, 113, 113, 0.16);
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+}
+
+.badge--warning {
+  background: rgba(251, 191, 36, 0.18);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.4);
+}
+
+.link-button {
+  appearance: none;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: #38bdf8;
+  cursor: pointer;
+  text-align: left;
+}
+
+.link-button:hover,
+.link-button:focus-visible {
+  text-decoration: underline;
+}
+
+.rules {
+  position: relative;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 16px;
+  overflow: hidden;
+}
+
+.rules pre {
+  margin: 0;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.rules--collapsed {
+  max-height: 140px;
+}
+
+.rules--collapsed::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 40px;
+  background: linear-gradient(to top, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0));
+}
+
+.rules--expanded {
+  max-height: none;
+}
+
+@media (max-width: 640px) {
+  #root {
+    padding: 32px 12px;
+  }
+
+  .card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .badge {
+    margin-top: 4px;
+  }
+}


### PR DESCRIPTION
## Summary
- implement read-only policies list with state badges and expandable rules JSON viewer
- add gates list with warning styling for closed gates and schedule details
- wire the app shell and shared styling for the new read-only views

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68f43a5d28148327888ff1e41fd76e69