### PR TITLE
feat(webapp): add routed shell and data hooks

### DIFF
--- a/apgms/webapp/.env.example
+++ b/apgms/webapp/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,70 @@
+const baseURL = import.meta.env.VITE_API_URL ?? '';
+
+type ApiOptions = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  signal?: AbortSignal;
+  authToken?: string | null;
+  searchParams?: Record<string, string | number | boolean | undefined>;
+};
+
+const encodeSearchParams = (
+  params: Record<string, string | number | boolean | undefined> | undefined,
+) => {
+  if (!params) return '';
+  const usp = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    usp.set(key, String(value));
+  });
+  const query = usp.toString();
+  return query ? `?${query}` : '';
+};
+
+const normalizeError = async (response: Response) => {
+  try {
+    const data = await response.json();
+    const message = data?.message || data?.error || response.statusText;
+    return new Error(message || 'Request failed');
+  } catch (err) {
+    return new Error(response.statusText || 'Request failed');
+  }
+};
+
+export const apiFetch = async <T>(path: string, options: ApiOptions = {}): Promise<T> => {
+  const { method = 'GET', headers = {}, body, signal, authToken, searchParams } = options;
+  const query = encodeSearchParams(searchParams);
+  const url = `${baseURL}${path}${query}`;
+  const nextHeaders: Record<string, string> = {
+    Accept: 'application/json',
+    ...headers,
+  };
+  if (!(body instanceof FormData) && body !== undefined) {
+    nextHeaders['Content-Type'] = 'application/json';
+  }
+  if (authToken) {
+    nextHeaders['Authorization'] = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(url, {
+    method,
+    headers: nextHeaders,
+    body:
+      body !== undefined && !(body instanceof FormData)
+        ? JSON.stringify(body)
+        : (body as BodyInit | null),
+    signal,
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw await normalizeError(response);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return (await response.json()) as T;
+};

--- a/apgms/webapp/src/lib/hooks.ts
+++ b/apgms/webapp/src/lib/hooks.ts
@@ -1,0 +1,112 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './api';
+
+type DashboardMetric = {
+  label: string;
+  value: number;
+  change30d?: number;
+};
+
+type DailyPoint = {
+  date: string;
+  value: number;
+};
+
+type DashboardResponse = {
+  metrics: DashboardMetric[];
+  volumeLast30Days: DailyPoint[];
+};
+
+type BankLine = {
+  id: string;
+  name: string;
+  institution: string;
+  limit: number;
+  available: number;
+  currency: string;
+  status: 'ACTIVE' | 'PENDING' | 'SUSPENDED';
+  lastReviewedAt?: string;
+};
+
+type Policy = {
+  id: string;
+  reference: string;
+  insuredParty: string;
+  exposureLimit: number;
+  coveragePercent: number;
+  effectiveFrom: string;
+  effectiveTo?: string;
+  rulesSummary?: string;
+  rulesJson?: unknown;
+};
+
+type Gate = {
+  id: string;
+  name: string;
+  state: 'OPEN' | 'CLOSED' | 'SCHEDULED';
+  opensAt?: string;
+  closesAt?: string;
+  notes?: string;
+};
+
+type RptVerification = {
+  rptId: string;
+  bankLineId: string;
+  status: 'VERIFIED' | 'PENDING' | 'FAILED';
+  verifiedAt?: string;
+};
+
+export const useDashboard = () =>
+  useQuery({
+    queryKey: ['dashboard'],
+    queryFn: () => apiFetch<DashboardResponse>('/dashboard'),
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+export const useBankLines = (q?: string) =>
+  useQuery({
+    queryKey: ['bank-lines', q ?? ''],
+    queryFn: () =>
+      apiFetch<BankLine[]>('/bank-lines', {
+        searchParams: q ? { q } : undefined,
+      }),
+    staleTime: 15_000,
+    retry: 1,
+  });
+
+export const usePolicies = () =>
+  useQuery({
+    queryKey: ['policies'],
+    queryFn: () => apiFetch<Policy[]>('/policies'),
+    staleTime: 15_000,
+    retry: 1,
+  });
+
+export const useGates = () =>
+  useQuery({
+    queryKey: ['gates'],
+    queryFn: () => apiFetch<Gate[]>('/gates'),
+    staleTime: 15_000,
+    retry: 1,
+  });
+
+export const useRptById = (id?: string | null, options?: { enabled?: boolean }) =>
+  useQuery({
+    queryKey: ['rpt', id],
+    enabled: Boolean(id) && (options?.enabled ?? true),
+    queryFn: () => apiFetch<RptVerification>(`/rpts/${id}`),
+    staleTime: 5_000,
+    retry: 1,
+  });
+
+export const useRptByLine = (lineId?: string | null, options?: { enabled?: boolean }) =>
+  useQuery({
+    queryKey: ['rpt-by-line', lineId],
+    enabled: Boolean(lineId) && (options?.enabled ?? true),
+    queryFn: () => apiFetch<RptVerification>(`/bank-lines/${lineId}/rpt`),
+    staleTime: 5_000,
+    retry: 1,
+  });
+
+export type { DashboardResponse, BankLine, Policy, Gate, RptVerification };

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,31 @@
-﻿console.log('webapp');
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider } from '@tanstack/react-router';
+import { router } from './router';
+import { ThemeProvider } from './shell/AppShell';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </ThemeProvider>
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/router.tsx
+++ b/apgms/webapp/src/router.tsx
@@ -1,0 +1,91 @@
+import { createRouter, RootRoute, Route, Router } from '@tanstack/react-router';
+import { AppShell } from './shell/AppShell';
+import DashboardRoute from './routes';
+import BankLinesRoute from './routes/bank-lines';
+import PoliciesRoute from './routes/policies';
+import GatesRoute from './routes/gates';
+import AuditRoute from './routes/audit';
+import { ErrorState } from './ui/Error';
+
+const rootRoute = new RootRoute({
+  component: AppShell,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Something went wrong'}</ErrorState>
+    </div>
+  ),
+});
+
+const dashboardRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  component: DashboardRoute,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Unable to load dashboard.'}</ErrorState>
+    </div>
+  ),
+});
+
+const bankLinesRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/bank-lines',
+  component: BankLinesRoute,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Unable to load bank lines.'}</ErrorState>
+    </div>
+  ),
+});
+
+const policiesRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/policies',
+  component: PoliciesRoute,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Unable to load policies.'}</ErrorState>
+    </div>
+  ),
+});
+
+const gatesRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/gates',
+  component: GatesRoute,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Unable to load gates.'}</ErrorState>
+    </div>
+  ),
+});
+
+const auditRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/audit',
+  component: AuditRoute,
+  errorComponent: ({ error }) => (
+    <div className="p-6">
+      <ErrorState>{error instanceof Error ? error.message : 'Unable to load audit view.'}</ErrorState>
+    </div>
+  ),
+});
+
+const routeTree = rootRoute.addChildren([
+  dashboardRoute,
+  bankLinesRoute,
+  policiesRoute,
+  gatesRoute,
+  auditRoute,
+]);
+
+export const router: Router = createRouter({
+  routeTree,
+  defaultPreload: 'intent',
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/apgms/webapp/src/routes/audit.tsx
+++ b/apgms/webapp/src/routes/audit.tsx
@@ -1,0 +1,144 @@
+import { FormEvent, useState } from 'react';
+import { useRptById, useRptByLine } from '../lib/hooks';
+import { DateTime } from '../ui/DateTime';
+import { Skeleton } from '../ui/Skeleton';
+import { Empty } from '../ui/Empty';
+import { ErrorState } from '../ui/Error';
+
+export const AuditRoute = () => {
+  const [formState, setFormState] = useState({ rptId: '', bankLineId: '' });
+  const [search, setSearch] = useState<{ rptId?: string; bankLineId?: string }>({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const rptIdQuery = useRptById(search.rptId, { enabled: Boolean(search.rptId) });
+  const lineQuery = useRptByLine(search.bankLineId, { enabled: Boolean(search.bankLineId) });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState.rptId && !formState.bankLineId) {
+      setFormError('Provide an RPT ID or a bank line reference.');
+      return;
+    }
+    setFormError(null);
+    setSearch({
+      rptId: formState.rptId.trim() || undefined,
+      bankLineId: formState.bankLineId.trim() || undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm text-slate-600 dark:text-slate-300">
+            RPT reference
+            <input
+              type="text"
+              value={formState.rptId}
+              onChange={(event) => setFormState((prev) => ({ ...prev, rptId: event.target.value }))}
+              placeholder="Enter RPT identifier"
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
+            />
+          </label>
+          <label className="text-sm text-slate-600 dark:text-slate-300">
+            Bank line reference
+            <input
+              type="text"
+              value={formState.bankLineId}
+              onChange={(event) => setFormState((prev) => ({ ...prev, bankLineId: event.target.value }))}
+              placeholder="Enter line identifier"
+              className="mt-1 w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
+            />
+          </label>
+        </div>
+        {formError ? <p className="mt-3 text-sm text-rose-500">{formError}</p> : null}
+        <button
+          type="submit"
+          className="mt-4 inline-flex items-center rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500"
+        >
+          Search audit trail
+        </button>
+      </form>
+
+      <section className="space-y-4">
+        <AuditResultCard
+          title="RPT verification"
+          description="Verification status for the submitted RPT identifier."
+          isFetching={rptIdQuery.isFetching}
+          isError={rptIdQuery.isError}
+          onRetry={() => rptIdQuery.refetch()}
+          data={rptIdQuery.data}
+          visible={Boolean(search.rptId)}
+        />
+        <AuditResultCard
+          title="Line-based verification"
+          description="Most recent verification for the bank line."
+          isFetching={lineQuery.isFetching}
+          isError={lineQuery.isError}
+          onRetry={() => lineQuery.refetch()}
+          data={lineQuery.data}
+          visible={Boolean(search.bankLineId)}
+        />
+      </section>
+    </div>
+  );
+};
+
+type AuditResultCardProps = {
+  title: string;
+  description: string;
+  isFetching: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  data: { status: string; verifiedAt?: string } | undefined;
+  visible: boolean;
+};
+
+const AuditResultCard = ({ title, description, isFetching, isError, onRetry, data, visible }: AuditResultCardProps) => {
+  if (!visible) {
+    return null;
+  }
+
+  if (isFetching) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <Skeleton className="h-5 w-36" />
+        <Skeleton className="mt-2 h-4 w-48" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorState onRetry={onRetry}>
+        Unable to retrieve verification data. Try again.
+      </ErrorState>
+    );
+  }
+
+  if (!data) {
+    return <Empty>No verification entries yet.</Empty>;
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <h2 className="text-sm font-semibold text-slate-900 dark:text-slate-100">{title}</h2>
+      <p className="text-xs text-slate-500 dark:text-slate-400">{description}</p>
+      <div className="mt-3 space-y-1 text-sm text-slate-600 dark:text-slate-300">
+        <div>
+          Status: <span className="font-semibold text-slate-900 dark:text-slate-100">{data.status}</span>
+        </div>
+        {data.verifiedAt ? (
+          <div>
+            Verified <DateTime value={data.verifiedAt} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default AuditRoute;

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,218 @@
+import { useMemo, useState } from 'react';
+import { useBankLines, useRptByLine, type BankLine } from '../lib/hooks';
+import { Money } from '../ui/Money';
+import { DateTime } from '../ui/DateTime';
+import { Skeleton } from '../ui/Skeleton';
+import { Empty } from '../ui/Empty';
+import { ErrorState } from '../ui/Error';
+import { cn } from '../utils/cn';
+
+export const BankLinesRoute = () => {
+  const [query, setQuery] = useState('');
+  const [selectedLine, setSelectedLine] = useState<BankLine | null>(null);
+  const [shouldVerify, setShouldVerify] = useState(false);
+  const { data, isLoading, isError, refetch } = useBankLines(query);
+  const { data: rptData, isFetching: isVerifying, isError: rptError, refetch: refetchRpt } = useRptByLine(
+    selectedLine?.id,
+    { enabled: Boolean(selectedLine?.id) && shouldVerify },
+  );
+
+  const lines = data?.data ?? data ?? [];
+
+  const handleSelect = (line: BankLine) => {
+    setSelectedLine(line);
+    setShouldVerify(false);
+  };
+
+  const closeDrawer = () => {
+    setSelectedLine(null);
+    setShouldVerify(false);
+  };
+
+  const filteredLines = useMemo(() => {
+    if (!query) return lines;
+    const lower = query.toLowerCase();
+    return lines.filter((line) =>
+      [line.name, line.institution].some((field) => field?.toLowerCase().includes(lower)),
+    );
+  }, [lines, query]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-center">
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search lines by institution"
+          className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 md:w-72"
+        />
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {filteredLines.length} active {filteredLines.length === 1 ? 'line' : 'lines'}
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-12" />
+          <Skeleton className="h-12" />
+          <Skeleton className="h-12" />
+        </div>
+      ) : isError ? (
+        <ErrorState onRetry={() => refetch()}>Unable to load bank lines.</ErrorState>
+      ) : !filteredLines.length ? (
+        <Empty>No bank lines match the current filters.</Empty>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-900/80 dark:text-slate-400">
+              <tr>
+                <th className="px-4 py-3">Institution</th>
+                <th className="px-4 py-3">Program</th>
+                <th className="px-4 py-3">Limit</th>
+                <th className="px-4 py-3">Available</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Reviewed</th>
+                <th className="px-4 py-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
+              {filteredLines.map((line) => (
+                <tr key={line.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/60">
+                  <td className="px-4 py-3 font-medium text-slate-700 dark:text-slate-200">{line.institution}</td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-300">{line.name}</td>
+                  <td className="px-4 py-3"><Money amount={line.limit} currency={line.currency} /></td>
+                  <td className="px-4 py-3"><Money amount={line.available} currency={line.currency} /></td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        'inline-flex rounded-full px-2 py-1 text-xs font-medium',
+                        line.status === 'ACTIVE'
+                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200'
+                          : line.status === 'PENDING'
+                          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200'
+                          : 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-200',
+                      )}
+                    >
+                      {line.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500 dark:text-slate-300">
+                    <DateTime value={line.lastReviewedAt} variant="date" />
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(line)}
+                      className="rounded border border-slate-300 px-3 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                    >
+                      View details
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'fixed inset-y-0 right-0 z-40 w-full max-w-md transform bg-white shadow-xl transition-transform dark:bg-slate-950',
+          selectedLine ? 'translate-x-0' : 'translate-x-full',
+        )}
+        aria-hidden={!selectedLine}
+      >
+        {selectedLine ? (
+          <div className="flex h-full flex-col">
+            <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+              <div>
+                <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{selectedLine.institution}</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400">{selectedLine.name}</p>
+              </div>
+              <button
+                type="button"
+                onClick={closeDrawer}
+                className="rounded border border-slate-300 px-2 py-1 text-xs text-slate-500 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+              >
+                Close
+              </button>
+            </div>
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4 text-sm">
+              <div>
+                <h3 className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Limits</h3>
+                <dl className="mt-2 space-y-1">
+                  <div className="flex justify-between">
+                    <dt className="text-slate-500">Facility limit</dt>
+                    <dd className="font-medium text-slate-900 dark:text-slate-100">
+                      <Money amount={selectedLine.limit} currency={selectedLine.currency} />
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-slate-500">Available</dt>
+                    <dd className="font-medium text-emerald-600 dark:text-emerald-300">
+                      <Money amount={selectedLine.available} currency={selectedLine.currency} />
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div>
+                <h3 className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Last review</h3>
+                <p className="mt-2 text-slate-600 dark:text-slate-300">
+                  <DateTime value={selectedLine.lastReviewedAt} />
+                </p>
+              </div>
+
+              <div className="rounded border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/60">
+                <h3 className="text-sm font-medium text-slate-700 dark:text-slate-200">RPT verification</h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  We only surface verification status. Keys and internal identifiers remain hidden.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShouldVerify(true);
+                    refetchRpt();
+                  }}
+                  className="mt-3 inline-flex items-center rounded bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-indigo-500 disabled:opacity-60"
+                  disabled={isVerifying || !selectedLine?.id}
+                >
+                  {isVerifying ? 'Checking…' : 'Verify RPT'}
+                </button>
+                {shouldVerify ? (
+                  <div className="mt-3 space-y-2">
+                    {isVerifying ? <Skeleton className="h-4 w-32" /> : null}
+                    {rptError ? (
+                      <ErrorState className="text-xs" onRetry={() => refetchRpt()}>
+                        Verification failed. Try again.
+                      </ErrorState>
+                    ) : null}
+                    {rptData ? (
+                      <div className="rounded border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-800 dark:bg-slate-950">
+                        <div className="flex justify-between text-xs text-slate-500">
+                          <span>Status</span>
+                          <span className="font-semibold text-slate-900 dark:text-slate-100">{rptData.status}</span>
+                        </div>
+                        {rptData.verifiedAt ? (
+                          <div className="mt-1 text-xs text-slate-500">
+                            Verified <DateTime value={rptData.verifiedAt} />
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
+                    {!isVerifying && !rptError && !rptData ? (
+                      <p className="text-xs text-slate-500">No verification recorded yet.</p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default BankLinesRoute;

--- a/apgms/webapp/src/routes/gates.tsx
+++ b/apgms/webapp/src/routes/gates.tsx
@@ -1,0 +1,74 @@
+import { useGates } from '../lib/hooks';
+import { DateTime } from '../ui/DateTime';
+import { Skeleton } from '../ui/Skeleton';
+import { Empty } from '../ui/Empty';
+import { ErrorState } from '../ui/Error';
+import { cn } from '../utils/cn';
+
+export const GatesRoute = () => {
+  const { data, isLoading, isError, refetch } = useGates();
+  const gates = data?.data ?? data ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()}>Unable to load gates.</ErrorState>;
+  }
+
+  if (!gates.length) {
+    return <Empty>No gates configured at the moment.</Empty>;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {gates.map((gate) => (
+        <article
+          key={gate.id}
+          className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{gate.name}</h2>
+              <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{gate.state}</p>
+            </div>
+            <span
+              className={cn(
+                'rounded-full px-2 py-1 text-xs font-medium',
+                gate.state === 'OPEN'
+                  ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-200'
+                  : gate.state === 'SCHEDULED'
+                  ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200'
+                  : 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200',
+              )}
+            >
+              {gate.state}
+            </span>
+          </div>
+          <div className="mt-3 space-y-1 text-sm text-slate-600 dark:text-slate-300">
+            {gate.opensAt ? (
+              <div>
+                Opens <DateTime value={gate.opensAt} />
+              </div>
+            ) : null}
+            {gate.closesAt ? (
+              <div>
+                Closes <DateTime value={gate.closesAt} />
+              </div>
+            ) : null}
+            {gate.notes ? <p className="text-sm text-slate-500 dark:text-slate-400">{gate.notes}</p> : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+};
+
+export default GatesRoute;

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from 'react';
+import { useDashboard } from '../lib/hooks';
+import { Money } from '../ui/Money';
+import { Skeleton } from '../ui/Skeleton';
+import { Empty } from '../ui/Empty';
+import { ErrorState } from '../ui/Error';
+import { DateTime } from '../ui/DateTime';
+
+const MetricCard = ({
+  label,
+  value,
+  change30d,
+}: {
+  label: string;
+  value: number;
+  change30d?: number;
+}) => {
+  const formattedChange = change30d !== undefined ? `${change30d > 0 ? '+' : ''}${change30d.toFixed(1)}%` : null;
+  const isCurrency = /usd|exposure|volume|limit|credit|balance|outstanding/i.test(label);
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <p className="text-sm text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-slate-900 dark:text-slate-100">
+        {isCurrency ? <Money amount={value} /> : value.toLocaleString()}
+      </p>
+      {formattedChange ? (
+        <p className={`mt-1 text-xs ${change30d && change30d < 0 ? 'text-rose-500' : 'text-emerald-500'}`}>
+          {formattedChange} in the last 30 days
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+const VolumeChart = ({ points }: { points: Array<{ date: string; value: number }> }) => {
+  if (!points.length) {
+    return <Empty>We’ll show activity once transactions come in.</Empty>;
+  }
+  const max = Math.max(...points.map((p) => p.value), 0) || 1;
+  const maxHeight = 120;
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-800 dark:bg-slate-900">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-medium text-slate-600 dark:text-slate-300">Last 30 days volume</h2>
+        <DateTime value={points[points.length - 1]?.date} variant="date" className="text-xs text-slate-400" />
+      </div>
+      <div className="flex items-end gap-1">
+        {points.map((point) => {
+          const height = Math.max((point.value / max) * maxHeight, 8);
+          return (
+            <div key={point.date} className="flex flex-col items-center">
+              <div
+                className="w-2 rounded-t bg-indigo-500/70 dark:bg-indigo-400/80"
+                style={{ height }}
+                role="presentation"
+              />
+              <span className="mt-1 hidden text-[10px] text-slate-400 sm:block">{new Date(point.date).getDate()}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const DashboardRoute = () => {
+  const { data, isLoading, isError, refetch } = useDashboard();
+  const metrics = data?.data?.metrics ?? data?.metrics ?? [];
+  const points = useMemo(() => data?.data?.volumeLast30Days ?? data?.volumeLast30Days ?? [], [data]);
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+        <Skeleton className="h-28" />
+        <div className="lg:col-span-3">
+          <Skeleton className="h-64" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()}>Unable to load dashboard.</ErrorState>;
+  }
+
+  if (!metrics.length) {
+    return <Empty>Dashboard metrics will appear once the first cycle completes.</Empty>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.label} label={metric.label} value={metric.value} change30d={metric.change30d} />
+        ))}
+      </div>
+      <VolumeChart points={points} />
+    </div>
+  );
+};
+
+export default DashboardRoute;

--- a/apgms/webapp/src/routes/policies.tsx
+++ b/apgms/webapp/src/routes/policies.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { usePolicies } from '../lib/hooks';
+import { Money } from '../ui/Money';
+import { DateTime } from '../ui/DateTime';
+import { Skeleton } from '../ui/Skeleton';
+import { Empty } from '../ui/Empty';
+import { ErrorState } from '../ui/Error';
+
+export const PoliciesRoute = () => {
+  const { data, isLoading, isError, refetch } = usePolicies();
+  const policies = data?.data ?? data ?? [];
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+        <Skeleton className="h-20" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <ErrorState onRetry={() => refetch()}>Unable to load policies.</ErrorState>;
+  }
+
+  if (!policies.length) {
+    return <Empty>No policies are active yet.</Empty>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {policies.map((policy) => {
+        const isOpen = expanded === policy.id;
+        return (
+          <article
+            key={policy.id}
+            className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
+          >
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-base font-semibold text-slate-900 dark:text-slate-100">{policy.reference}</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400">{policy.insuredParty}</p>
+              </div>
+              <div className="flex items-center gap-6 text-sm text-slate-600 dark:text-slate-300">
+                <span>
+                  Limit: <Money amount={policy.exposureLimit} />
+                </span>
+                <span>Coverage: {policy.coveragePercent}%</span>
+                <span>
+                  Effective <DateTime value={policy.effectiveFrom} variant="date" />
+                </span>
+              </div>
+            </div>
+
+            {policy.rulesSummary ? (
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{policy.rulesSummary}</p>
+            ) : null}
+
+            <div className="mt-4 space-y-2 text-xs text-slate-500 dark:text-slate-400">
+              <div>
+                <span className="font-medium text-slate-600 dark:text-slate-300">Coverage window:</span>{' '}
+                <DateTime value={policy.effectiveFrom} variant="date" />
+                {policy.effectiveTo ? (
+                  <>
+                    {' '}– <DateTime value={policy.effectiveTo} variant="date" />
+                  </>
+                ) : (
+                  ' (open-ended)'
+                )}
+              </div>
+              <button
+                type="button"
+                onClick={() => setExpanded(isOpen ? null : policy.id)}
+                className="text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-300"
+              >
+                {isOpen ? 'Hide detailed rules' : 'Show detailed rules'}
+              </button>
+              {isOpen && policy.rulesJson ? (
+                <pre className="max-h-64 overflow-auto rounded bg-slate-900 p-3 text-[11px] text-slate-100">
+                  {JSON.stringify(policy.rulesJson, null, 2)}
+                </pre>
+              ) : null}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PoliciesRoute;

--- a/apgms/webapp/src/shell/AppShell.tsx
+++ b/apgms/webapp/src/shell/AppShell.tsx
@@ -1,0 +1,107 @@
+import { PropsWithChildren, createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { Link, Outlet, useRouterState } from '@tanstack/react-router';
+
+const ThemeContext = createContext<{ theme: 'light' | 'dark'; toggle: () => void }>({
+  theme: 'light',
+  toggle: () => undefined,
+});
+
+const getPreferredTheme = (): 'light' | 'dark' => {
+  if (typeof window === 'undefined') return 'light';
+  const stored = window.localStorage.getItem('apgms-theme');
+  if (stored === 'light' || stored === 'dark') return stored;
+  if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) return 'dark';
+  return 'light';
+};
+
+export const ThemeProvider = ({ children }: PropsWithChildren) => {
+  const [theme, setTheme] = useState<'light' | 'dark'>(getPreferredTheme);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') return;
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.dataset.theme = theme;
+    window.localStorage.setItem('apgms-theme', theme);
+  }, [theme]);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggle: () => setTheme((current) => (current === 'light' ? 'dark' : 'light')),
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => useContext(ThemeContext);
+
+const navItems = [
+  { to: '/', label: 'Dashboard' },
+  { to: '/bank-lines', label: 'Bank Lines' },
+  { to: '/policies', label: 'Policies' },
+  { to: '/gates', label: 'Gates' },
+  { to: '/audit', label: 'Audit' },
+];
+
+const AppHeader = () => {
+  const { theme, toggle } = useTheme();
+  const router = useRouterState();
+  const activeTitle = useMemo(() => {
+    const active = navItems.find((item) =>
+      item.to === '/'
+        ? router.location.pathname === '/'
+        : router.location.pathname.startsWith(item.to),
+    );
+    return active?.label ?? 'Overview';
+  }, [router.location.pathname]);
+
+  return (
+    <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-4 dark:border-slate-800 dark:bg-slate-900">
+      <div>
+        <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{activeTitle}</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Credit risk posture at a glance</p>
+      </div>
+      <button
+        type="button"
+        onClick={toggle}
+        className="inline-flex items-center rounded border border-slate-300 px-3 py-1 text-sm font-medium text-slate-700 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+        aria-label="Toggle theme"
+      >
+        {theme === 'light' ? '🌞 Light' : '🌙 Dark'}
+      </button>
+    </header>
+  );
+};
+
+export const AppShell = () => (
+  <div className="flex min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+    <aside className="hidden w-64 flex-col border-r border-slate-200 bg-white px-4 py-6 dark:border-slate-800 dark:bg-slate-900 md:flex">
+      <div className="mb-8 text-2xl font-bold text-indigo-600 dark:text-indigo-400">APGMS</div>
+      <nav className="space-y-1">
+        {navItems.map((item) => (
+          <Link
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              `block rounded px-3 py-2 text-sm font-medium transition ${
+                isActive
+                  ? 'bg-indigo-50 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-200'
+                  : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+              }`
+            }
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+    <div className="flex flex-1 flex-col">
+      <AppHeader />
+      <main className="flex-1 px-4 py-6 md:px-8">
+        <Outlet />
+      </main>
+    </div>
+  </div>
+);

--- a/apgms/webapp/src/ui/DateTime.tsx
+++ b/apgms/webapp/src/ui/DateTime.tsx
@@ -1,0 +1,24 @@
+import { memo } from 'react';
+
+type DateTimeProps = {
+  value?: string | number | Date;
+  className?: string;
+  variant?: 'date' | 'datetime';
+};
+
+const formatValue = (value?: string | number | Date, variant: 'date' | 'datetime' = 'datetime') => {
+  if (!value) return '—';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return variant === 'date'
+    ? date.toLocaleDateString()
+    : date.toLocaleString(undefined, { hour12: false });
+};
+
+export const DateTime = memo(({ value, className, variant = 'datetime' }: DateTimeProps) => (
+  <time className={className} dateTime={value ? new Date(value).toISOString() : undefined}>
+    {formatValue(value, variant)}
+  </time>
+));
+
+DateTime.displayName = 'DateTime';

--- a/apgms/webapp/src/ui/Empty.tsx
+++ b/apgms/webapp/src/ui/Empty.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+export const Empty = ({ children }: PropsWithChildren) => (
+  <div className="rounded border border-dashed border-slate-300 bg-white px-6 py-10 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+    {children ?? 'Nothing to show yet.'}
+  </div>
+);

--- a/apgms/webapp/src/ui/Error.tsx
+++ b/apgms/webapp/src/ui/Error.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren } from 'react';
+import { cn } from '../utils/cn';
+
+type ErrorProps = {
+  onRetry?: () => void;
+  className?: string;
+} & PropsWithChildren;
+
+export const ErrorState = ({ children, onRetry, className }: ErrorProps) => (
+  <div
+    role="alert"
+    className={cn(
+      'rounded border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200',
+      className,
+    )}
+  >
+    <div>{children ?? 'Something went wrong.'}</div>
+    {onRetry ? (
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-2 inline-flex items-center rounded border border-rose-300 px-3 py-1 text-xs font-medium text-rose-700 transition hover:bg-rose-100 dark:border-rose-700 dark:text-rose-200 dark:hover:bg-rose-900/60"
+      >
+        Try again
+      </button>
+    ) : null}
+  </div>
+);

--- a/apgms/webapp/src/ui/Money.tsx
+++ b/apgms/webapp/src/ui/Money.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+
+type MoneyProps = {
+  amount: number;
+  currency?: string;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  className?: string;
+};
+
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+const getFormatter = (currency = 'USD', minimumFractionDigits = 2, maximumFractionDigits = 2) => {
+  const key = `${currency}-${minimumFractionDigits}-${maximumFractionDigits}`;
+  if (!formatterCache.has(key)) {
+    formatterCache.set(
+      key,
+      new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+        minimumFractionDigits,
+        maximumFractionDigits,
+      }),
+    );
+  }
+  return formatterCache.get(key)!;
+};
+
+export const Money = memo(({ amount, currency = 'USD', minimumFractionDigits, maximumFractionDigits, className }: MoneyProps) => {
+  const formatter = getFormatter(currency, minimumFractionDigits ?? 2, maximumFractionDigits ?? 2);
+  return <span className={className}>{formatter.format(amount)}</span>;
+});
+
+Money.displayName = 'Money';

--- a/apgms/webapp/src/ui/Skeleton.tsx
+++ b/apgms/webapp/src/ui/Skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from '../utils/cn';
+
+type SkeletonProps = {
+  className?: string;
+};
+
+export const Skeleton = ({ className }: SkeletonProps) => (
+  <div className={cn('animate-pulse rounded bg-slate-200 dark:bg-slate-700', className)} />
+);

--- a/apgms/webapp/src/utils/cn.ts
+++ b/apgms/webapp/src/utils/cn.ts
@@ -1,0 +1,2 @@
+export const cn = (...classes: Array<string | false | null | undefined>) =>
+  classes.filter(Boolean).join(' ');


### PR DESCRIPTION
## Summary
- add app shell with themed navigation and tanstack router wiring
- create api client, react query hooks, and ui primitives for money/date formatting and states
- implement dashboard, bank lines, policies, gates, and audit routes with loading, empty, and error handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f43a20b5b8832794539f7406701c05