### PR TITLE
feat(webapp): add dashboard and bank lines routes

### DIFF
--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,34 @@
+export type FetchJsonOptions = RequestInit & {
+  headers?: HeadersInit;
+};
+
+function createHeaders(init?: FetchJsonOptions): Headers {
+  const headers = new Headers(init?.headers);
+  headers.set('Accept', 'application/json');
+  return headers;
+}
+
+export async function fetchJson<T>(input: RequestInfo | URL, init?: FetchJsonOptions): Promise<T> {
+  const headers = createHeaders(init);
+  if (typeof window !== 'undefined' && !headers.has('Authorization')) {
+    const token = window.localStorage.getItem('devToken') ?? '';
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(input, { ...init, headers });
+
+  if (response.status === 401 && typeof window !== 'undefined') {
+    window.location.assign('/login');
+    throw new Error('Unauthorized');
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,93 @@
-﻿console.log('webapp');
+import { StrictMode, useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Link, Route, Routes, useLocation } from 'react-router-dom';
+import BankLines from './routes/bank-lines';
+import Dashboard from './routes/index';
+
+type Theme = 'light' | 'dark';
+
+type NavItem = {
+  path: string;
+  label: string;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { path: '/', label: 'Dashboard' },
+  { path: '/bank-lines', label: 'Bank lines' },
+];
+
+function usePreferredTheme(): Theme {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'light';
+  }
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+}
+
+function useCurrentPath(): string {
+  const location = useLocation();
+  return location.pathname;
+}
+
+function AppShell(): JSX.Element {
+  const [theme, setTheme] = useState<Theme>(() => usePreferredTheme());
+  const currentPath = useCurrentPath();
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  const navigation = useMemo(
+    () =>
+      NAV_ITEMS.map((item) => (
+        <Link
+          key={item.path}
+          to={item.path}
+          aria-current={currentPath === item.path ? 'page' : undefined}
+        >
+          {item.label}
+        </Link>
+      )),
+    [currentPath],
+  );
+
+  return (
+    <div className={`app-shell app-shell--${theme}`}>
+      <header className="app-shell__header">
+        <nav aria-label="Primary navigation">{navigation}</nav>
+        <button
+          type="button"
+          onClick={() => setTheme((value) => (value === 'light' ? 'dark' : 'light'))}
+        >
+          Switch to {theme === 'light' ? 'dark' : 'light'} theme
+        </button>
+      </header>
+      <main className="app-shell__content">
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/bank-lines" element={<BankLines />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}
+
+function App(): JSX.Element {
+  return (
+    <BrowserRouter>
+      <AppShell />
+    </BrowserRouter>
+  );
+}
+
+const container = document.getElementById('root');
+
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/apgms/webapp/src/routes/__tests__/bank-lines.a11y.test.tsx
+++ b/apgms/webapp/src/routes/__tests__/bank-lines.a11y.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BankLines from '../bank-lines';
+import { fetchJson } from '../../lib/api';
+
+vi.mock('../../lib/api', () => ({
+  fetchJson: vi.fn((path: string) => {
+    if (path === '/bank-lines') {
+      return Promise.resolve([
+        { id: '1', date: '2024-02-01T00:00:00.000Z', payee: 'Delta Corp', amount: 1200.5 },
+        { id: '2', date: '2024-02-02T00:00:00.000Z', payee: 'Alpha LLC', amount: 320.89 },
+      ]);
+    }
+
+    if (path.startsWith('/audit/rpt/by-line/')) {
+      return Promise.resolve({ verified: true, timestamp: '2024-02-10T12:34:56.000Z' });
+    }
+
+    return Promise.reject(new Error(`Unhandled path: ${path}`));
+  }),
+}));
+
+type FetchJsonMock = vi.Mock;
+const fetchJsonMock = fetchJson as unknown as FetchJsonMock;
+
+describe('BankLines accessibility behaviours', () => {
+  beforeEach(() => {
+    fetchJsonMock.mockClear();
+  });
+
+  it('traps focus inside the drawer and closes with Escape', async () => {
+    const user = userEvent.setup();
+    render(<BankLines />);
+
+    const openButtons = await screen.findAllByRole('button', { name: /view .* details/i });
+    await user.click(openButtons[0]);
+
+    const dialog = await screen.findByRole('dialog');
+    const buttons = within(dialog).getAllByRole('button');
+
+    expect(document.activeElement).toBe(buttons[0]);
+
+    await user.tab();
+    expect(document.activeElement).toBe(buttons[1]);
+
+    await user.tab();
+    expect(document.activeElement).toBe(buttons[0]);
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('is free of axe violations when the drawer is open', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<BankLines />);
+
+    const openButtons = await screen.findAllByRole('button', { name: /view .* details/i });
+    await user.click(openButtons[0]);
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
+
+    const results = await axe(container);
+    expect(results.violations).toHaveLength(0);
+  });
+});

--- a/apgms/webapp/src/routes/bank-lines.tsx
+++ b/apgms/webapp/src/routes/bank-lines.tsx
@@ -1,0 +1,274 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fetchJson } from '../lib/api';
+
+type BankLine = {
+  id: string;
+  date: string;
+  payee: string;
+  amount: number;
+};
+
+type VerificationResponse = {
+  verified: boolean;
+  timestamp: string;
+};
+
+type RequestStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
+type VerificationStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type DrawerState = {
+  line: BankLine;
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(value);
+}
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', year: 'numeric' }).format(
+    new Date(value),
+  );
+}
+
+const focusableSelectors = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export default function BankLines(): JSX.Element {
+  const [lines, setLines] = useState<BankLine[]>([]);
+  const [status, setStatus] = useState<RequestStatus>('loading');
+  const [error, setError] = useState('');
+  const [drawerState, setDrawerState] = useState<DrawerState | null>(null);
+  const [verificationStatus, setVerificationStatus] = useState<VerificationStatus>('idle');
+  const [verificationResult, setVerificationResult] = useState<VerificationResponse | null>(null);
+  const [verificationError, setVerificationError] = useState('');
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const lastTriggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    fetchJson<BankLine[]>('/bank-lines')
+      .then((response) => {
+        if (cancelled) return;
+        if (!response.length) {
+          setStatus('empty');
+          setLines([]);
+          return;
+        }
+        setLines(response);
+        setStatus('success');
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message);
+        setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!drawerState) return;
+
+    const container = drawerRef.current;
+    if (!container) return;
+
+    const focusable = Array.from(container.querySelectorAll<HTMLElement>(focusableSelectors));
+    focusable[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeDrawer();
+        return;
+      }
+
+      if (event.key === 'Tab' && focusable.length) {
+        const currentFocusable = Array.from(container.querySelectorAll<HTMLElement>(focusableSelectors));
+        const first = currentFocusable[0];
+        const last = currentFocusable[currentFocusable.length - 1];
+        if (!first || !last) return;
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    container.addEventListener('keydown', handleKeyDown);
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [drawerState]);
+
+  const openDrawer = (line: BankLine, trigger: HTMLElement) => {
+    lastTriggerRef.current = trigger;
+    setDrawerState({ line });
+    setVerificationStatus('idle');
+    setVerificationResult(null);
+    setVerificationError('');
+  };
+
+  const closeDrawer = () => {
+    setDrawerState(null);
+    Promise.resolve().then(() => {
+      lastTriggerRef.current?.focus();
+    });
+  };
+
+  const handleVerify = async () => {
+    if (!drawerState) return;
+    setVerificationStatus('loading');
+    setVerificationError('');
+    try {
+      const response = await fetchJson<VerificationResponse>(`/audit/rpt/by-line/${drawerState.line.id}`);
+      setVerificationResult(response);
+      setVerificationStatus('success');
+    } catch (err) {
+      setVerificationStatus('error');
+      setVerificationResult(null);
+      setVerificationError(err instanceof Error ? err.message : 'Verification failed');
+    }
+  };
+
+  const totalAmount = useMemo(
+    () =>
+      lines.reduce((accumulator, line) => {
+        return accumulator + line.amount;
+      }, 0),
+    [lines],
+  );
+
+  if (status === 'loading') {
+    return (
+      <section aria-busy="true" aria-live="polite" className="bank-lines bank-lines--loading">
+        <header className="bank-lines__header">
+          <h1>Bank lines</h1>
+          <p>Loading recent activity…</p>
+        </header>
+        <div className="bank-lines__skeleton" />
+      </section>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <section role="alert" className="bank-lines bank-lines--error">
+        <header className="bank-lines__header">
+          <h1>Bank lines</h1>
+          <p>We were unable to load transactions.</p>
+        </header>
+        <p>{error}</p>
+      </section>
+    );
+  }
+
+  if (status === 'empty') {
+    return (
+      <section className="bank-lines bank-lines--empty">
+        <header className="bank-lines__header">
+          <h1>Bank lines</h1>
+          <p>No bank lines to display.</p>
+        </header>
+        <p>Connect a financial account to see activity.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bank-lines" aria-live="polite">
+      <header className="bank-lines__header">
+        <h1>Bank lines</h1>
+        <p>Total across lines: {formatCurrency(totalAmount)}</p>
+      </header>
+
+      <div role="region" aria-label="Bank line transactions">
+        <table role="table" className="bank-lines__table">
+          <thead>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">Payee</th>
+              <th scope="col">Amount</th>
+              <th scope="col" aria-label="Actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {lines.map((line) => (
+              <tr key={line.id}>
+                <td>{formatDate(line.date)}</td>
+                <td>{line.payee}</td>
+                <td>{formatCurrency(line.amount)}</td>
+                <td>
+                  <button
+                    type="button"
+                    onClick={(event) => openDrawer(line, event.currentTarget)}
+                    aria-label={`View ${line.payee} details`}
+                  >
+                    View
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {drawerState && (
+        <div role="presentation" className="bank-lines__drawer-overlay">
+          <aside
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="bank-line-drawer-title"
+            className="bank-lines__drawer"
+            ref={drawerRef}
+          >
+            <header>
+              <h2 id="bank-line-drawer-title">{drawerState.line.payee}</h2>
+              <p>
+                {formatDate(drawerState.line.date)} · {formatCurrency(drawerState.line.amount)}
+              </p>
+            </header>
+            <div className="bank-lines__drawer-content" aria-live="polite">
+              <button type="button" onClick={handleVerify} disabled={verificationStatus === 'loading'}>
+                {verificationStatus === 'loading' ? 'Verifying…' : 'Verify RPT'}
+              </button>
+
+              {verificationStatus === 'success' && verificationResult && (
+                <dl className="bank-lines__verification">
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{verificationResult.verified ? 'Verified' : 'Not verified'}</dd>
+                  </div>
+                  <div>
+                    <dt>Timestamp</dt>
+                    <dd>{new Date(verificationResult.timestamp).toLocaleString()}</dd>
+                  </div>
+                </dl>
+              )}
+
+              {verificationStatus === 'error' && (
+                <p role="alert">{verificationError}</p>
+              )}
+            </div>
+            <footer>
+              <button type="button" onClick={closeDrawer}>
+                Close
+              </button>
+            </footer>
+          </aside>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apgms/webapp/src/routes/index.tsx
+++ b/apgms/webapp/src/routes/index.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useMemo, useState } from 'react';
+import { fetchJson } from '../lib/api';
+
+type Kpi = {
+  id: string;
+  label: string;
+  value: number;
+  delta?: number;
+};
+
+type DashboardSeriesPoint = {
+  date: string;
+  value: number;
+};
+
+type DashboardResponse = {
+  kpis: Kpi[];
+  series: DashboardSeriesPoint[];
+};
+
+type DashboardStatus = 'idle' | 'loading' | 'success' | 'empty' | 'error';
+
+type SeriesBucket = {
+  dateLabel: string;
+  value: number;
+};
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value);
+}
+
+function formatDateLabel(value: string): string {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(date);
+}
+
+export default function Dashboard(): JSX.Element {
+  const [data, setData] = useState<DashboardResponse | null>(null);
+  const [status, setStatus] = useState<DashboardStatus>('loading');
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    fetchJson<DashboardResponse>('/dashboard')
+      .then((response) => {
+        if (cancelled) return;
+        if (!response.kpis?.length && !response.series?.length) {
+          setStatus('empty');
+          setData(null);
+          return;
+        }
+        setData(response);
+        setStatus('success');
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setError(err.message);
+        setStatus('error');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const seriesBuckets = useMemo<SeriesBucket[]>(() => {
+    if (!data?.series?.length) return [];
+    return data.series.map((point) => ({
+      dateLabel: formatDateLabel(point.date),
+      value: point.value,
+    }));
+  }, [data]);
+
+  if (status === 'loading') {
+    return (
+      <section aria-busy="true" aria-live="polite" className="dashboard dashboard--loading">
+        <header className="dashboard__header">
+          <h1>Dashboard</h1>
+          <p>Loading financial performance…</p>
+        </header>
+        <div className="dashboard__kpis">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={`skeleton-${index}`} className="dashboard__kpi dashboard__kpi--skeleton" />
+          ))}
+        </div>
+        <div className="dashboard__series dashboard__series--skeleton" />
+      </section>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <section role="alert" className="dashboard dashboard--error">
+        <header className="dashboard__header">
+          <h1>Dashboard</h1>
+          <p>We were unable to load performance data.</p>
+        </header>
+        <p>{error}</p>
+      </section>
+    );
+  }
+
+  if (status === 'empty') {
+    return (
+      <section className="dashboard dashboard--empty">
+        <header className="dashboard__header">
+          <h1>Dashboard</h1>
+          <p>No metrics available for the past 30 days.</p>
+        </header>
+        <p>Connect your reporting sources to view insights.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="dashboard" aria-live="polite">
+      <header className="dashboard__header">
+        <h1>Dashboard</h1>
+        <p>Performance summary for the past 30 days.</p>
+      </header>
+
+      <div className="dashboard__kpis">
+        {data?.kpis.map((kpi) => (
+          <article key={kpi.id} className="dashboard__kpi" aria-label={kpi.label}>
+            <h2>{kpi.label}</h2>
+            <p className="dashboard__kpi-value">{formatNumber(kpi.value)}</p>
+            {typeof kpi.delta === 'number' && (
+              <p className="dashboard__kpi-delta" aria-label="30 day delta">
+                {kpi.delta >= 0 ? '+' : ''}
+                {formatNumber(kpi.delta)}%
+              </p>
+            )}
+          </article>
+        ))}
+      </div>
+
+      <section className="dashboard__series" aria-label="30 day trend">
+        <header>
+          <h2>Daily totals</h2>
+        </header>
+        {seriesBuckets.length > 0 ? (
+          <ol className="dashboard__series-list">
+            {seriesBuckets.map((bucket) => (
+              <li key={bucket.dateLabel}>
+                <span className="dashboard__series-date">{bucket.dateLabel}</span>
+                <span className="dashboard__series-value">{formatNumber(bucket.value)}</span>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <p>No trend data for the selected period.</p>
+        )}
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add authenticated fetch helper that attaches dev token headers and redirects unauthorized sessions
- build light/dark routed shell with dashboard metrics view and bank line drawer interactions
- cover bank line drawer accessibility with focus-trap, escape close, and axe checks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f47dc03a408327a5f6631192599852