### PR TITLE
feat: add RPT signing and audit verification routes

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import auditRoutes from "./routes/audit";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(auditRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,183 @@
+import { randomUUID, createHash, sign, verify, createPrivateKey, createPublicKey } from "node:crypto";
+
+const PRIVATE_KEY_PEM = `-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIPleqpz3Uaxew5FyiFSlljUXI7FeB+FxFidR6+Aj8m2v\n-----END PRIVATE KEY-----`;
+const PUBLIC_KEY_PEM = `-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAiXdSvgAIE1hixflwsxrlOF9mVBuJ3k2d1LtYG7gHJFo=\n-----END PUBLIC KEY-----`;
+
+const signerKey = createPrivateKey(PRIVATE_KEY_PEM);
+const verifierKey = createPublicKey(PUBLIC_KEY_PEM);
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export interface Allocation {
+  accountId: string;
+  amount: number;
+  currency?: string;
+}
+
+export interface MintRptArgs {
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: Allocation[];
+  prevHash?: string | null;
+  now: Date;
+}
+
+export interface RptPayloadBase {
+  orgId: string;
+  bankLineId: string;
+  policyHash: string;
+  allocations: Allocation[];
+  prevHash: string | null;
+  timestamp: string;
+}
+
+export interface RptPayload extends RptPayloadBase {
+  hash: string;
+}
+
+export interface RptRecord {
+  rptId: string;
+  payload: RptPayload;
+  sig: string;
+}
+
+const rptById = new Map<string, RptRecord>();
+const rptIdByHash = new Map<string, string>();
+const latestRptByLine = new Map<string, RptRecord>();
+
+function canonicalize(input: JsonValue): string {
+  if (input === null) {
+    return "null";
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) {
+      throw new Error("Non-finite numbers are not supported");
+    }
+    return input.toString();
+  }
+  if (typeof input === "boolean") {
+    return input ? "true" : "false";
+  }
+  if (typeof input === "string") {
+    return JSON.stringify(input);
+  }
+  if (Array.isArray(input)) {
+    return `[${input.map((item) => canonicalize(item as JsonValue)).join(",")}]`;
+  }
+  const keys = Object.keys(input).sort();
+  const entries = keys.map((key) => `${JSON.stringify(key)}:${canonicalize((input as Record<string, JsonValue>)[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+function canonicalHash(payload: RptPayloadBase): string {
+  const canonicalJson = canonicalize(payload as unknown as JsonValue);
+  return createHash("sha256").update(canonicalJson).digest("base64");
+}
+
+function storeRpt(record: RptRecord) {
+  rptById.set(record.rptId, record);
+  rptIdByHash.set(record.payload.hash, record.rptId);
+  const currentLatest = latestRptByLine.get(record.payload.bankLineId);
+  if (!currentLatest || currentLatest.payload.timestamp < record.payload.timestamp) {
+    latestRptByLine.set(record.payload.bankLineId, record);
+  }
+}
+
+export function resetRptStore() {
+  rptById.clear();
+  rptIdByHash.clear();
+  latestRptByLine.clear();
+}
+
+export function getRptById(rptId: string) {
+  return rptById.get(rptId);
+}
+
+export function getLatestRptByBankLineId(bankLineId: string) {
+  return latestRptByLine.get(bankLineId);
+}
+
+export function mintRpt({ orgId, bankLineId, policyHash, allocations, prevHash = null, now }: MintRptArgs): RptRecord {
+  const timestamp = now.toISOString();
+  const rptId = randomUUID();
+  const sanitizedAllocations = allocations.map((alloc) => {
+    const cloned: Allocation = {
+      accountId: alloc.accountId,
+      amount: alloc.amount,
+    };
+    if (alloc.currency !== undefined) {
+      cloned.currency = alloc.currency;
+    }
+    return cloned;
+  });
+  const payloadBase: RptPayloadBase = {
+    orgId,
+    bankLineId,
+    policyHash,
+    allocations: sanitizedAllocations,
+    prevHash,
+    timestamp,
+  };
+  const hash = canonicalHash(payloadBase);
+  const signature = sign(null, Buffer.from(hash, "base64"), signerKey).toString("base64");
+
+  const record: RptRecord = {
+    rptId,
+    payload: { ...payloadBase, hash },
+    sig: signature,
+  };
+
+  storeRpt(record);
+  return record;
+}
+
+export function verifyRpt(record: RptRecord): boolean {
+  try {
+    const { payload, sig } = record;
+    const { hash, ...rest } = payload;
+    const recalculatedHash = canonicalHash(rest);
+    if (recalculatedHash !== hash) {
+      return false;
+    }
+    const signature = Buffer.from(sig, "base64");
+    const hashedPayload = Buffer.from(hash, "base64");
+    return verify(null, hashedPayload, verifierKey, signature);
+  } catch (err) {
+    return false;
+  }
+}
+
+export function verifyChain(headRptId: string): { valid: boolean; brokenAt?: string } {
+  const visited = new Set<string>();
+  let currentId: string | undefined = headRptId;
+
+  while (currentId) {
+    if (visited.has(currentId)) {
+      return { valid: false, brokenAt: currentId };
+    }
+    visited.add(currentId);
+
+    const current = rptById.get(currentId);
+    if (!current) {
+      return { valid: false, brokenAt: currentId };
+    }
+    if (!verifyRpt(current)) {
+      return { valid: false, brokenAt: currentId };
+    }
+
+    const prevHash = current.payload.prevHash;
+    if (!prevHash) {
+      return { valid: true };
+    }
+
+    const prevId = rptIdByHash.get(prevHash);
+    if (!prevId) {
+      return { valid: false, brokenAt: currentId };
+    }
+
+    currentId = prevId;
+  }
+
+  return { valid: true };
+}

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,55 @@
+import { FastifyPluginAsync } from "fastify";
+import {
+  getLatestRptByBankLineId,
+  getRptById,
+  verifyRpt,
+  verifyChain,
+} from "../lib/rpt";
+
+export const auditRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/audit/rpt/:id", async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const rpt = getRptById(id);
+
+    if (!rpt) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const verified = verifyRpt(rpt);
+    const chain = verifyChain(rpt.rptId);
+
+    return {
+      rpt: {
+        id: rpt.rptId,
+        payload: rpt.payload,
+        sig: rpt.sig,
+      },
+      verified,
+      chain,
+    };
+  });
+
+  app.get("/audit/rpt/by-line/:bankLineId", async (request, reply) => {
+    const { bankLineId } = request.params as { bankLineId: string };
+    const rpt = getLatestRptByBankLineId(bankLineId);
+
+    if (!rpt) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const verified = verifyRpt(rpt);
+    const chain = verifyChain(rpt.rptId);
+
+    return {
+      rpt: {
+        id: rpt.rptId,
+        payload: rpt.payload,
+        sig: rpt.sig,
+      },
+      verified,
+      chain,
+    };
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/tests/rpt.spec.ts
+++ b/apgms/services/api-gateway/tests/rpt.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mintRpt,
+  verifyRpt,
+  verifyChain,
+  resetRptStore,
+  getRptById,
+} from "../src/lib/rpt";
+
+describe("RPT signing", () => {
+  beforeEach(() => {
+    resetRptStore();
+  });
+
+  it("should verify a freshly minted RPT", () => {
+    const rpt = mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: [
+        { accountId: "acct-1", amount: 1000, currency: "AUD" },
+        { accountId: "acct-2", amount: 500 },
+      ],
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    assert.equal(verifyRpt(rpt), true, "minted RPT should verify");
+    const chain = verifyChain(rpt.rptId);
+    assert.equal(chain.valid, true, "single RPT chain should be valid");
+  });
+
+  it("should fail verification when payload is tampered", () => {
+    const rpt = mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: [{ accountId: "acct-1", amount: 1000 }],
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    rpt.payload.allocations[0].amount = 999;
+
+    assert.equal(verifyRpt(rpt), false, "tampered RPT should not verify");
+  });
+
+  it("should detect a broken prevHash chain", () => {
+    const first = mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: [{ accountId: "acct-1", amount: 1000 }],
+      now: new Date("2024-01-01T00:00:00Z"),
+    });
+
+    const second = mintRpt({
+      orgId: "org-1",
+      bankLineId: "line-1",
+      policyHash: "policy-abc",
+      allocations: [{ accountId: "acct-1", amount: 2000 }],
+      prevHash: first.payload.hash,
+      now: new Date("2024-01-02T00:00:00Z"),
+    });
+
+    const storedSecond = getRptById(second.rptId);
+    assert.ok(storedSecond);
+    if (storedSecond) {
+      storedSecond.payload.prevHash = "broken";
+    }
+
+    const chain = verifyChain(second.rptId);
+    assert.equal(chain.valid, false, "chain should be invalid when prevHash is broken");
+    assert.equal(chain.brokenAt, second.rptId, "chain should flag the tampered record");
+  });
+});


### PR DESCRIPTION
## Summary
- add Ed25519-backed RPT minting, verification, and chain integrity helpers
- expose audit routes for fetching RPTs directly and by bank line
- cover signature, tampering, and prevHash break detection with node:test specs

## Testing
- `pnpm exec tsc --noEmit` *(fails: @prisma/client types are unavailable in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68f47db0323c83279c792682008121ac