### PR TITLE
Add api-gateway Docker hardening and security reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  security-artifacts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apgms
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: Prepare artifact directory
+        run: mkdir -p services/api-gateway/artifacts
+
+      - name: Generate CycloneDX SBOM
+        run: npm run sbom --prefix services/api-gateway
+
+      - name: Run npm audit SCA
+        run: npm run sca --prefix services/api-gateway
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-gateway-sbom
+          path: services/api-gateway/artifacts/sbom.json
+
+      - name: Upload SCA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-gateway-sca
+          path: services/api-gateway/artifacts/sca.json

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20 AS builder
+WORKDIR /workspace
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY services/api-gateway/package.json services/api-gateway/package.json
+COPY shared/package.json shared/package.json
+
+RUN corepack enable \
+  && pnpm install --filter @apgms/api-gateway... --frozen-lockfile
+
+COPY services/api-gateway services/api-gateway
+COPY shared shared
+
+FROM gcr.io/distroless/nodejs20:nonroot
+WORKDIR /app
+
+COPY --from=builder /workspace/node_modules ./node_modules
+COPY --from=builder /workspace/services/api-gateway ./services/api-gateway
+COPY --from=builder /workspace/shared ./shared
+
+USER nonroot
+WORKDIR /app/services/api-gateway
+
+HEALTHCHECK CMD ["node","healthcheck.js"]
+
+CMD ["--loader","tsx","./src/index.ts"]

--- a/apgms/services/api-gateway/healthcheck.js
+++ b/apgms/services/api-gateway/healthcheck.js
@@ -1,0 +1,34 @@
+const port = process.env.PORT || 3000;
+const url = `http://127.0.0.1:${port}/health`;
+
+const controller = new AbortController();
+const timeout = setTimeout(() => {
+  controller.abort();
+}, 5000);
+
+async function main() {
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      console.error(`Healthcheck request failed with status ${response.status}`);
+      process.exit(1);
+    }
+    const data = await response.json().catch(() => null);
+    if (!data || data.ok !== true) {
+      console.error("Healthcheck response missing ok: true");
+      process.exit(1);
+    }
+    process.exit(0);
+  } catch (error) {
+    if (error.name === "AbortError") {
+      console.error("Healthcheck timed out");
+    } else {
+      console.error("Healthcheck error", error);
+    }
+    process.exit(1);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+main();

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "sbom": "npx @cyclonedx/cyclonedx-npm --output-format json --output-file artifacts/sbom.json",
+    "sca": "npm audit --json > artifacts/sca.json || true"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",


### PR DESCRIPTION
## Summary
- add a distroless multi-stage Dockerfile for the api-gateway service with a node healthcheck
- expose npm scripts that generate CycloneDX SBOM and npm audit SCA reports
- run SBOM/SCA steps in CI and upload the resulting artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f47d822b988327a00d43df359018f0