### PR TITLE
Add health endpoints, logging, and observability safeguards

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test tests/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,140 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import cors from "@fastify/cors";
 import dotenv from "dotenv";
+import Fastify, { type FastifyInstance } from "fastify";
+
+import { prisma } from "../../../shared/src/db";
+import { registerHealthRoutes } from "./routes/health";
+import { finishHttpSpan, startHttpSpan } from "./otel.js";
+import { setupGracefulShutdown } from "./shutdown.js";
 
 // Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+type PrismaClientLike = typeof prisma;
 
-const app = Fastify({ logger: true });
+type CreateAppOptions = {
+  prisma: PrismaClientLike;
+};
 
-await app.register(cors, { origin: true });
+export async function createApp({ prisma: prismaClient }: CreateAppOptions): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  app.addHook("onRequest", (request, _reply, done) => {
+    (request as any)._otelSpan = startHttpSpan(`${request.method} ${request.url}`, {
+      "http.method": request.method,
+      "http.target": request.url,
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+    done();
+  });
+
+  app.addHook("onResponse", (request, reply, done) => {
+    const durationMs = reply.getResponseTime();
+    request.log.info(
+      {
+        method: request.method,
+        url: request.url,
+        status: reply.statusCode,
+        duration_ms: Number(durationMs),
+        req_id: request.id,
+      },
+      "request completed",
+    );
+    const spanHandle = (request as any)._otelSpan;
+    if (spanHandle) {
+      finishHttpSpan(spanHandle, reply.statusCode, {
+        "http.method": request.method,
+        "http.target": request.url,
+        duration_ms: Number(durationMs),
+      });
+    }
+    done();
+  });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  registerHealthRoutes(app, prismaClient);
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prismaClient.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prismaClient.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prismaClient.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+async function startServer() {
+  const app = await createApp({ prisma });
+  const removeSignalHandlers = setupGracefulShutdown(app, prisma);
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    removeSignalHandlers();
+    await prisma.$disconnect();
+    process.exit(1);
   }
-});
+}
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const isMainModule = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+  : false;
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
-
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+if (isMainModule) {
+  startServer().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apgms/services/api-gateway/src/otel.ts
+++ b/apgms/services/api-gateway/src/otel.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomBytes } from "node:crypto";
+
+type AttributeValue = string | number | boolean;
+
+type SpanRecord = {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  kind: number;
+  startTimeUnixNano: string;
+  endTimeUnixNano: string;
+  attributes: Record<string, AttributeValue>;
+  status: {
+    code: number;
+    message?: string;
+  };
+};
+
+type SpanHandle = {
+  record: SpanRecord;
+  startHrTime: bigint;
+};
+
+const activeSpans = new Set<SpanHandle>();
+const completedSpans: SpanRecord[] = [];
+
+const SERVICE_NAME = "api-gateway";
+const SPAN_KIND_SERVER = 2;
+const STATUS_CODE_OK = 1;
+const STATUS_CODE_ERROR = 2;
+
+const toUnixNano = (date: Date) => (BigInt(date.getTime()) * 1_000_000n).toString();
+
+const randomHex = (bytes: number) => randomBytes(bytes).toString("hex");
+
+export function startHttpSpan(name: string, attributes: Record<string, AttributeValue> = {}): SpanHandle {
+  const start = new Date();
+  const handle: SpanHandle = {
+    record: {
+      traceId: randomHex(16),
+      spanId: randomHex(8),
+      parentSpanId: null,
+      name,
+      kind: SPAN_KIND_SERVER,
+      startTimeUnixNano: toUnixNano(start),
+      endTimeUnixNano: toUnixNano(start),
+      attributes: { ...attributes },
+      status: { code: STATUS_CODE_OK },
+    },
+    startHrTime: process.hrtime.bigint(),
+  };
+
+  activeSpans.add(handle);
+  return handle;
+}
+
+export function finishHttpSpan(
+  handle: SpanHandle,
+  statusCode: number,
+  extraAttributes: Record<string, AttributeValue> = {},
+  statusMessage?: string,
+): void {
+  if (!activeSpans.has(handle)) {
+    return;
+  }
+
+  activeSpans.delete(handle);
+
+  const durationNs = process.hrtime.bigint() - handle.startHrTime;
+  const startTime = BigInt(handle.record.startTimeUnixNano);
+  handle.record.endTimeUnixNano = (startTime + durationNs).toString();
+  handle.record.attributes = {
+    ...handle.record.attributes,
+    ...extraAttributes,
+    "http.status_code": statusCode,
+  };
+
+  handle.record.status = {
+    code: statusCode >= 500 ? STATUS_CODE_ERROR : STATUS_CODE_OK,
+    message: statusMessage,
+  };
+
+  if (!statusMessage) {
+    delete handle.record.status.message;
+  }
+
+  completedSpans.push(handle.record);
+}
+
+const attributeValue = (value: AttributeValue) => {
+  if (typeof value === "number") {
+    return { doubleValue: value };
+  }
+  if (typeof value === "boolean") {
+    return { boolValue: value };
+  }
+  return { stringValue: String(value) };
+};
+
+const toOtelPayload = () => ({
+  resourceSpans: [
+    {
+      resource: {
+        attributes: [
+          {
+            key: "service.name",
+            value: { stringValue: SERVICE_NAME },
+          },
+        ],
+      },
+      scopeSpans: [
+        {
+          scope: { name: "manual-http" },
+          spans: completedSpans.map((span) => ({
+            traceId: span.traceId,
+            spanId: span.spanId,
+            parentSpanId: span.parentSpanId ?? undefined,
+            name: span.name,
+            kind: span.kind,
+            startTimeUnixNano: span.startTimeUnixNano,
+            endTimeUnixNano: span.endTimeUnixNano,
+            attributes: Object.entries(span.attributes).map(([key, value]) => ({
+              key,
+              value: attributeValue(value),
+            })),
+            status: span.status,
+          })),
+        },
+      ],
+    },
+  ],
+});
+
+const writeSpansIfRequested = async () => {
+  if (!process.env.OTEL_DUMP || completedSpans.length === 0) {
+    return;
+  }
+
+  const artifactsDir = path.resolve(process.cwd(), "artifacts");
+  await fs.promises.mkdir(artifactsDir, { recursive: true });
+  const filePath = path.join(artifactsDir, "otel-http.json");
+  const payload = toOtelPayload();
+  await fs.promises.writeFile(filePath, JSON.stringify(payload, null, 2));
+};
+
+process.on("beforeExit", () => {
+  void writeSpansIfRequested();
+});

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,21 @@
+import type { FastifyInstance } from "fastify";
+
+type Queryable = {
+  $queryRaw<T = unknown>(query: TemplateStringsArray | string): Promise<T>;
+};
+
+export function registerHealthRoutes(app: FastifyInstance, prisma: Queryable): void {
+  app.get("/livez", async (_, reply) => {
+    reply.code(200).send({ ok: true });
+  });
+
+  app.get("/readyz", async (_, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      reply.code(200).send({ ready: true });
+    } catch (err) {
+      app.log.error({ err }, "database readiness check failed");
+      reply.code(503).send({ ready: false, reason: "db" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/shutdown.ts
+++ b/apgms/services/api-gateway/src/shutdown.ts
@@ -1,0 +1,63 @@
+import type { FastifyInstance } from "fastify";
+
+type Disconnectable = {
+  $disconnect(): Promise<void>;
+};
+
+type ShutdownOptions = {
+  exit?: boolean;
+  signals?: NodeJS.Signals[];
+};
+
+export function setupGracefulShutdown(
+  app: FastifyInstance,
+  prismaClient: Disconnectable,
+  options: ShutdownOptions = {},
+): () => void {
+  const { exit = process.env.NODE_ENV !== "test", signals = ["SIGTERM", "SIGINT"] } = options;
+  const listeners = new Map<NodeJS.Signals, () => void>();
+  let shuttingDown = false;
+
+  const cleanup = () => {
+    for (const [signal, listener] of listeners.entries()) {
+      process.off(signal, listener);
+    }
+    listeners.clear();
+  };
+
+  const initiateShutdown = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    cleanup();
+    app.log.info({ signal }, "received shutdown signal");
+
+    const shutdown = async () => {
+      const results = await Promise.allSettled([app.close(), prismaClient.$disconnect()]);
+
+      const rejected = results.find((result) => result.status === "rejected");
+      if (rejected && rejected.status === "rejected") {
+        app.log.error({ err: rejected.reason }, "error during shutdown");
+        if (exit) {
+          process.exit(1);
+        }
+        return;
+      }
+
+      if (exit) {
+        process.exit(0);
+      }
+    };
+
+    void shutdown();
+  };
+
+  for (const signal of signals) {
+    const listener = () => initiateShutdown(signal);
+    listeners.set(signal, listener);
+    process.on(signal, listener);
+  }
+
+  return cleanup;
+}

--- a/apgms/services/api-gateway/tests/health.spec.ts
+++ b/apgms/services/api-gateway/tests/health.spec.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { test } from "node:test";
+
+import Fastify from "fastify";
+
+import { registerHealthRoutes } from "../src/routes/health";
+import { setupGracefulShutdown } from "../src/shutdown";
+
+test("/readyz returns 200 when the database responds", async () => {
+  const app = Fastify();
+  registerHealthRoutes(app, {
+    $queryRaw: async () => 1,
+  });
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ready: true });
+});
+
+test("/readyz returns 503 when the database is unavailable", async () => {
+  const app = Fastify({ logger: false });
+  registerHealthRoutes(app, {
+    $queryRaw: async () => {
+      throw new Error("db down");
+    },
+  });
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), { ready: false, reason: "db" });
+});
+
+test("setupGracefulShutdown closes the server and disconnects Prisma on SIGTERM", async () => {
+  let closed = false;
+  let disconnected = false;
+
+  const fakeApp = {
+    close: async () => {
+      closed = true;
+    },
+    log: {
+      info: () => {},
+      error: () => {},
+    },
+  } as unknown as ReturnType<typeof Fastify>;
+
+  const fakePrisma = {
+    $disconnect: async () => {
+      disconnected = true;
+    },
+  } as any;
+
+  const cleanup = setupGracefulShutdown(fakeApp, fakePrisma, { exit: false });
+  process.emit("SIGTERM");
+
+  await setImmediate();
+
+  assert.equal(closed, true);
+  assert.equal(disconnected, true);
+
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- add /livez and /readyz endpoints backed by a database probe
- wrap Fastify with structured logging, OTEL-style span capture, and graceful shutdown helpers
- cover health readiness logic and signal handling with automated tests

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f47d5badbc8327b09433be3ddddaf5