### PR TITLE
Add bank line request/response validation

### DIFF
--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,139 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import {
+  zBankLineCreateReq,
+  zBankLineListQuery,
+  zBankLineListRes,
+  zBankLineRes,
+} from "./schemas/bankLines";
+import { validateReply } from "./lib/validate";
+
+export type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: { toString(): string };
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+export type PrismaLike = {
+  user: {
+    findMany: (args: {
+      select: { email: true; orgId: true; createdAt: true };
+      orderBy: { createdAt: "desc" };
+    }) => Promise<Array<{ email: string; orgId: string; createdAt: Date }>>;
+  };
+  bankLine: {
+    findMany: (args: {
+      orderBy: { date: "desc" };
+      take: number;
+    }) => Promise<BankLineRecord[]>;
+    create: (args: {
+      data: {
+        orgId: string;
+        date: Date;
+        amount: string;
+        payee: string;
+        desc: string;
+      };
+    }) => Promise<BankLineRecord>;
+  };
+};
+
+export const formatBankLine = (line: BankLineRecord) => {
+  const amountCents = Number(line.amount.toString());
+
+  if (!Number.isInteger(amountCents) || amountCents < 0) {
+    throw new Error(`Invalid amount for bank line ${line.id}`);
+  }
+
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amountCents,
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+};
+
+export const createApp = async ({ prisma }: { prisma: PrismaLike }) => {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req, rep) => {
+    const queryResult = zBankLineListQuery.safeParse(req.query);
+
+    if (!queryResult.success) {
+      return rep.code(400).send({
+        error: "invalid_query",
+        details: queryResult.error.flatten(),
+      });
+    }
+
+    const take = queryResult.data.take ?? 20;
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    const payload = {
+      lines: lines.map((line) => formatBankLine(line)),
+    };
+
+    return validateReply(zBankLineListRes, payload);
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    const bodyResult = zBankLineCreateReq.safeParse(req.body);
+
+    if (!bodyResult.success) {
+      return rep.code(400).send({
+        error: "invalid_body",
+        details: bodyResult.error.flatten(),
+      });
+    }
+
+    try {
+      const data = bodyResult.data;
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: data.orgId,
+          date: new Date(data.date),
+          amount: data.amountCents.toString(),
+          payee: data.payee,
+          desc: data.desc,
+        },
+      });
+
+      const payload = validateReply(zBankLineRes, formatBankLine(created));
+      return rep.code(201).send(payload);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(500).send({ error: "internal_error" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,74 +7,21 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await createApp({ prisma });
 
-await app.register(cors, { origin: true });
+export { app };
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  app
+    .listen({ port, host })
+    .catch((err) => {
+      app.log.error(err);
+      process.exit(1);
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
-
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
-
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+}

--- a/apgms/services/api-gateway/src/lib/validate.ts
+++ b/apgms/services/api-gateway/src/lib/validate.ts
@@ -1,0 +1,13 @@
+import type { ZodTypeAny } from "zod";
+
+export function validateReply<T>(schema: ZodTypeAny, data: T): T {
+  try {
+    return schema.parse(data);
+  } catch (err) {
+    if (process.env.NODE_ENV === "production") {
+      console.error("Response validation failed", err, { data });
+      return data;
+    }
+    throw err;
+  }
+}

--- a/apgms/services/api-gateway/src/schemas/bankLines.ts
+++ b/apgms/services/api-gateway/src/schemas/bankLines.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+export const zBankLineCreateReq = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  date: z.string().datetime({ offset: true }),
+  amountCents: z
+    .number()
+    .int("amountCents must be an integer")
+    .min(0, "amountCents must be non-negative"),
+  payee: z.string().min(1, "payee is required").trim(),
+  desc: z.string().min(1, "desc is required").trim(),
+});
+
+export const zBankLineRes = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime({ offset: true }),
+  amountCents: z.number().int(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+export const zBankLineListQuery = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+export const zBankLineListRes = z.object({
+  lines: z.array(zBankLineRes),
+});
+
+export type BankLineCreateInput = z.infer<typeof zBankLineCreateReq>;
+export type BankLineResponse = z.infer<typeof zBankLineRes>;

--- a/apgms/services/api-gateway/tests/contract-banklines.spec.ts
+++ b/apgms/services/api-gateway/tests/contract-banklines.spec.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { createApp } from "../src/app.ts";
+
+const decimal = (value: number | string) => ({
+  toString: () => value.toString(),
+});
+
+process.env.NODE_ENV = "test";
+
+const prismaStub = {
+  user: {
+    findMany: async () => [],
+  },
+  bankLine: {
+    findMany: async () => [],
+    create: async () => {
+      throw new Error("create not mocked");
+    },
+  },
+};
+
+const app = await createApp({ prisma: prismaStub });
+
+await app.ready();
+
+const originalFindMany = prismaStub.bankLine.findMany;
+const originalCreate = prismaStub.bankLine.create;
+
+try {
+  prismaStub.bankLine.findMany = async () => [
+    {
+      id: "bank_line_invalid",
+      orgId: "org-invalid",
+      date: new Date("2024-01-01T00:00:00.000Z"),
+      amount: decimal("12.34"),
+      payee: "Bad Amount",
+      desc: "Invalid amount for contract",
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+    },
+  ];
+
+  const invalidResponse = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(
+    invalidResponse.statusCode,
+    500,
+    `Expected 500 when response validation fails, received ${invalidResponse.statusCode}`,
+  );
+
+  prismaStub.bankLine.findMany = async () => [
+    {
+      id: "bank_line_valid",
+      orgId: "org-valid",
+      date: new Date("2024-01-02T00:00:00.000Z"),
+      amount: decimal(1234),
+      payee: "ACME",
+      desc: "Invoice",
+      createdAt: new Date("2024-01-03T00:00:00.000Z"),
+    },
+  ];
+
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(response.statusCode, 200, response.payload);
+
+  const payload = response.json();
+  assert.ok(Array.isArray(payload.lines));
+  assert.equal(payload.lines[0].amountCents, 1234);
+  assert.equal(typeof payload.lines[0].amountCents, "number");
+
+  prismaStub.bankLine.create = async ({ data }) => ({
+    id: "bank_line_new",
+    orgId: data.orgId,
+    date: data.date,
+    amount: decimal(data.amount),
+    payee: data.payee,
+    desc: data.desc,
+    createdAt: new Date("2024-01-04T00:00:00.000Z"),
+  });
+
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-valid",
+      date: "2024-01-05T00:00:00.000Z",
+      amountCents: 9876,
+      payee: "Widgets Co",
+      desc: "Payment",
+    },
+  });
+
+  assert.equal(createResponse.statusCode, 201, createResponse.payload);
+  const created = createResponse.json();
+  assert.equal(created.amountCents, 9876);
+
+  const badCreate = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-valid",
+      date: "not-a-date",
+      amountCents: -10,
+      payee: "",
+      desc: "",
+    },
+  });
+
+  assert.equal(badCreate.statusCode, 400, badCreate.payload);
+} finally {
+  prismaStub.bankLine.findMany = originalFindMany;
+  prismaStub.bankLine.create = originalCreate;
+  await app.close();
+}


### PR DESCRIPTION
## Summary
- add a Fastify app builder that wires Zod validation into the bank line routes
- introduce shared bank line schemas plus a reusable reply validator to enforce response contracts
- cover the endpoints with a contract test that exercises failing and passing payloads

## Testing
- pnpm exec tsx tests/contract-banklines.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f47d4bd03483278c889f5aede5d24a