### PR TITLE
Harden API gateway security and secret handling

### DIFF
--- a/apgms/docker-compose.yml
+++ b/apgms/docker-compose.yml
@@ -1,11 +1,21 @@
-﻿services:
+services:
   postgres:
     image: postgres:15
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: apgms
-      POSTGRES_PASSWORD: apgms
-      POSTGRES_DB: apgms
-    ports: ['5432:5432']
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    ports:
+      - "127.0.0.1:5432:5432"
   redis:
     image: redis:7
-    ports: ['6379:6379']
+    env_file:
+      - .env
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    command: >-
+      sh -c 'if [ -n "$REDIS_PASSWORD" ]; then exec redis-server --requirepass "$REDIS_PASSWORD"; else exec redis-server; fi'
+    ports:
+      - "127.0.0.1:6379:6379"

--- a/apgms/docs/SECRETS.md
+++ b/apgms/docs/SECRETS.md
@@ -1,0 +1,18 @@
+# Secret Management
+
+The APGMS stack expects service credentials and connection strings to be provided via environment variables rather than hardcoded defaults.
+
+## Required Environment Variables
+
+- `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` — PostgreSQL application credentials consumed by Docker Compose and backend services.
+- `DATABASE_URL` — Full connection string for Prisma clients.
+- `REDIS_PASSWORD` — Optional Redis password used when Docker Compose starts the cache service.
+- `CORS_ALLOWLIST` — Comma-separated list of origins permitted to reach the API gateway in production.
+
+## Recommended Storage
+
+Secrets should be stored in your team's secret manager (for example, AWS Secrets Manager, GCP Secret Manager, or HashiCorp Vault). Generate an `.env` file for local development with placeholders that load values from the secret store during deployment pipelines.
+
+## Rotation Guidance
+
+Rotate credentials regularly and immediately after suspected exposure. Update the secret manager entry, redeploy services, and refresh any local `.env` files using the new values.

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,12 +8,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import securityPlugin from "./plugins/security";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await securityPlugin(app);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -77,4 +77,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,137 @@
+import cors from "@fastify/cors";
+import type { FastifyInstance } from "fastify";
+
+const RATE_LIMIT = 100;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const BODY_LIMIT_BYTES = 512 * 1024;
+
+const SECURITY_SKIP_PATHS = new Set(["/livez", "/readyz"]);
+
+const securityPlugin = async (app: FastifyInstance): Promise<void> => {
+  const allowlistEnv = process.env.CORS_ALLOWLIST ?? "";
+  const parsedAllowlist = allowlistEnv
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  const hasWildcard = parsedAllowlist.includes("*");
+  const isProduction = process.env.NODE_ENV === "production";
+
+  if (isProduction && hasWildcard) {
+    throw new Error("CORS wildcard is not permitted in production environments");
+  }
+
+  const allowAllOrigins = !isProduction && hasWildcard;
+  const allowlist = allowAllOrigins
+    ? parsedAllowlist
+    : parsedAllowlist.filter((value) => value !== "*");
+
+  const isOriginAllowed = (origin?: string | null): boolean => {
+    if (!origin) {
+      return true;
+    }
+
+    if (allowAllOrigins) {
+      return true;
+    }
+
+    return allowlist.includes(origin);
+  };
+
+  await app.register(cors, {
+    origin: (origin, callback) => {
+      if (isOriginAllowed(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      const error = new Error("Origin not allowed");
+      (error as any).code = "FST_CORS_ORIGIN_NOT_ALLOWED";
+      (error as any).statusCode = 403;
+      callback(error);
+    },
+    methods: ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"],
+    preflight: true,
+  });
+
+  const clientHits = new Map<string, { count: number; resetAt: number }>();
+
+  app.addHook("onRequest", async (request, reply) => {
+    const path = request.raw.url?.split("?")[0] ?? "/";
+    if (!SECURITY_SKIP_PATHS.has(path)) {
+      const now = Date.now();
+      const forwarded = request.headers["x-forwarded-for"];
+      const forwardedIp = Array.isArray(forwarded)
+        ? forwarded[0]
+        : typeof forwarded === "string"
+        ? forwarded.split(",")[0].trim()
+        : undefined;
+      const ip = forwardedIp || request.ip;
+      let record = clientHits.get(ip);
+
+      if (!record || record.resetAt <= now) {
+        record = { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS };
+        clientHits.set(ip, record);
+        const timer = setTimeout(() => {
+          const existing = clientHits.get(ip);
+          if (existing && existing.resetAt <= Date.now()) {
+            clientHits.delete(ip);
+          }
+        }, RATE_LIMIT_WINDOW_MS);
+        if (typeof timer.unref === "function") {
+          timer.unref();
+        }
+      } else {
+        record.count += 1;
+        if (record.count > RATE_LIMIT) {
+          const retryAfterSeconds = Math.ceil((record.resetAt - now) / 1000);
+          reply.header("Retry-After", retryAfterSeconds.toString());
+          await reply.code(429).send({ error: "rate_limit_exceeded" });
+          return reply;
+        }
+      }
+
+      const remaining = Math.max(RATE_LIMIT - record.count, 0);
+      reply.header("X-RateLimit-Limit", RATE_LIMIT.toString());
+      reply.header("X-RateLimit-Remaining", remaining.toString());
+      reply.header("X-RateLimit-Reset", record.resetAt.toString());
+    }
+
+    const method = request.raw.method?.toUpperCase();
+    if (!method || ["GET", "HEAD", "OPTIONS"].includes(method)) {
+      return;
+    }
+
+    const contentLengthHeader = request.headers["content-length"];
+    if (contentLengthHeader) {
+      const parsedLength = Number(contentLengthHeader);
+      if (!Number.isNaN(parsedLength) && parsedLength > BODY_LIMIT_BYTES) {
+        await reply.code(413).send({ error: "payload_too_large" });
+        return reply;
+      }
+    } else {
+      let total = 0;
+      const rawRequest = request.raw;
+
+      const handleData = (chunk: Buffer) => {
+        total += chunk.length;
+        if (total > BODY_LIMIT_BYTES && !reply.sent) {
+          rawRequest.off("data", handleData);
+          rawRequest.off("end", handleEnd);
+          reply.code(413).send({ error: "payload_too_large" });
+          rawRequest.destroy();
+        }
+      };
+
+      const handleEnd = () => {
+        rawRequest.off("data", handleData);
+        rawRequest.off("end", handleEnd);
+      };
+
+      rawRequest.on("data", handleData);
+      rawRequest.on("end", handleEnd);
+    }
+  });
+};
+
+export default securityPlugin;

--- a/apgms/services/api-gateway/tests/security.spec.ts
+++ b/apgms/services/api-gateway/tests/security.spec.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import Fastify from "fastify";
+
+import securityPlugin from "../src/plugins/security";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const resetEnv = () => {
+  process.env = { ...ORIGINAL_ENV };
+};
+
+describe("security plugin", () => {
+  beforeEach(() => {
+    resetEnv();
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  const buildApp = async (allowlist?: string) => {
+    if (allowlist !== undefined) {
+      process.env.CORS_ALLOWLIST = allowlist;
+    }
+
+    const app = Fastify({ logger: false });
+    await securityPlugin(app);
+    app.get("/resource", async () => ({ ok: true }));
+    app.post("/resource", async (request, reply) => {
+      reply.send({ received: true, size: (request.body as string)?.length ?? 0 });
+    });
+    await app.ready();
+    return app;
+  };
+
+  test("blocks preflight from non-allowlisted origin", async () => {
+    const app = await buildApp("https://allowed.example");
+
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/resource",
+      headers: {
+        origin: "https://blocked.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assert.equal(response.statusCode, 403);
+
+    await app.close();
+  });
+
+  test("allows preflight from allowlisted origin", async () => {
+    const app = await buildApp("https://allowed.example");
+
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/resource",
+      headers: {
+        origin: "https://allowed.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+
+    await app.close();
+  });
+
+  test("returns 429 when rate limit exceeded", async () => {
+    const app = await buildApp("https://allowed.example");
+
+    for (let i = 0; i < 100; i += 1) {
+      const okResponse = await app.inject({ method: "GET", url: "/resource" });
+      assert.equal(okResponse.statusCode, 200);
+    }
+
+    const limitedResponse = await app.inject({ method: "GET", url: "/resource" });
+    assert.equal(limitedResponse.statusCode, 429);
+
+    await app.close();
+  });
+
+  test("returns 413 when body exceeds 512KB", async () => {
+    const app = await buildApp("https://allowed.example");
+
+    const payload = "x".repeat(512 * 1024 + 1);
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/resource",
+      headers: {
+        "content-type": "text/plain",
+        "content-length": String(payload.length),
+      },
+      payload,
+    });
+
+    assert.equal(response.statusCode, 413);
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable security bootstrap that enforces the CORS allowlist, IP rate limiting, and payload size caps
- cover gateway security behavior with Node test cases and remove inline Fastify CORS setup
- externalize compose credentials to environment variables, tighten port bindings, and document required secrets

## Testing
- pnpm exec tsx --test services/api-gateway/tests/security.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68f47d41b400832798bfc7084ac5efb8