### PR TITLE
feat: add bank consent and PayTo mandate lifecycle

### DIFF
--- a/apgms/docs/banking-payto.md
+++ b/apgms/docs/banking-payto.md
@@ -1,0 +1,64 @@
+# Banking integrations: Bank Linking & PayTo mandates
+
+## Overview
+This document outlines how to integrate with the banking consent and PayTo mandate APIs exposed by the API Gateway. It covers the consent lifecycle, mandate creation and fulfilment, webhook validation, and the sandbox flows available for partner testing.
+
+## HTTP headers
+All authenticated requests **must** include the following headers:
+
+- `Authorization: Bearer <token>` — partners receive a sandbox token out of band. The default for local environments is `sandbox-token`.
+- `X-Org-Id: <orgId>` — identifies the organisation that owns the consent or mandate. Requests scoped to a different organisation are rejected with `403`.
+- `Content-Type: application/json` — required for POST requests with JSON payloads.
+- `Idempotency-Key: <uuid>` (optional but recommended) — enables idempotent POST semantics. Replays return the cached response with `Idempotency-Replayed: true`.
+
+Webhook requests **from** APGMS include:
+
+- `X-Timestamp` — ISO-8601 timestamp when the event was emitted.
+- `X-Nonce` — unique per delivery; replays within 5 minutes are rejected.
+- `X-Signature` — lowercase hex HMAC-SHA256 of `<timestamp>.<nonce>.<body>` signed with your configured webhook secret.
+
+## Consent lifecycle (textual sequence diagram)
+```
+Client -> API Gateway: POST /bank/consents { orgId, bank, accountRef }
+API Gateway -> Prisma: create BankConnection(status=PENDING)
+API Gateway -> PayTo Sandbox: createConsent()
+API Gateway -> Client: 201 { id, status=PENDING, next.redirectUrl }
+Client -> Bank Mock: complete consent journey
+Bank Mock -> API Gateway: POST /webhooks/payto/consent (status=ACTIVE)
+API Gateway -> Prisma: update BankConnection.status
+API Gateway -> Prisma: create AuditBlob(bank_connection)
+API Gateway -> Bank Mock: 200 { ok: true }
+Client -> API Gateway: GET /bank/consents/:id -> status=ACTIVE
+```
+
+## Mandate lifecycle (textual sequence diagram)
+```
+Client -> API Gateway: POST /bank/mandates { orgId, bankConnectionId, reference, amountLimitCents }
+API Gateway -> Prisma: create PayToMandate(status=PENDING)
+API Gateway -> PayTo Sandbox: createMandate()
+API Gateway -> Client: 201 { id, status=PENDING, nextEvent }
+Sandbox Driver -> API Gateway: POST /webhooks/payto/mandate (status=ACTIVE)
+API Gateway -> Prisma: update PayToMandate.status
+API Gateway -> Prisma: create AuditBlob(mandate)
+API Gateway -> Sandbox Driver: 200 { ok: true }
+Client -> API Gateway: GET /bank/mandates/:id -> status=ACTIVE, latestEvent
+```
+
+## Webhook processing
+1. Validate signature: compute `HMAC-SHA256(secret, "<timestamp>.<nonce>.<body>")` and compare with `X-Signature` using a constant-time check.
+2. Enforce freshness: reject events older than five minutes from `X-Timestamp`.
+3. Enforce uniqueness: store each `X-Nonce` in Redis for five minutes and reject replays (HTTP 409).
+4. Upsert state: update the relevant `BankConnection` or `PayToMandate` status and write an `AuditBlob` row containing the raw payload.
+5. Return `{ ok: true }` on success.
+
+## Sandbox adapter flow
+- `createConsent()` issues a sandbox consent identifier (`consent_<uuid>`) and returns a mock redirect URL and expiry.
+- `createMandate()` issues `mandate_<uuid>` identifiers and exposes the next webhook payload via `nextEvent`.
+- `simulateEvents()` lets you generate consent, mandate, or payment webhook payloads for local testing.
+- `resetSandbox()` clears all in-memory state; tests call this between runs.
+
+## Security controls
+- HMAC signatures, nonce tracking, and 5-minute timestamp drift prevent tampering and replay attacks.
+- All API mutations require bearer authentication and organisation-scoped headers; cross-org access is rejected.
+- Idempotency caching leverages Redis to avoid duplicate consent or mandate creation when requests are retried.
+- Webhook payloads are persisted in `AuditBlob` rows for auditability and replay analysis.

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test tests/**/*.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/adapters/payto/sandbox.ts
+++ b/apgms/services/api-gateway/src/adapters/payto/sandbox.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+
+type Status = "PENDING" | "ACTIVE" | "REVOKED";
+
+type PaymentStatus = "PENDING" | "SETTLED" | "FAILED";
+
+interface ConsentRecord {
+  id: string;
+  orgId: string;
+  bank: string;
+  accountRef: string;
+  status: Status;
+}
+
+interface MandateRecord {
+  id: string;
+  orgId: string;
+  bankConnectionId: string;
+  reference: string;
+  amountLimitCents: number;
+  status: Status;
+}
+
+const consents = new Map<string, ConsentRecord>();
+const mandates = new Map<string, MandateRecord>();
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+export async function createConsent(input: {
+  orgId: string;
+  bank: string;
+  accountRef: string;
+}) {
+  const id = `consent_${randomUUID()}`;
+  const record: ConsentRecord = {
+    id,
+    orgId: input.orgId,
+    bank: input.bank,
+    accountRef: input.accountRef,
+    status: "PENDING",
+  };
+  consents.set(id, record);
+  return {
+    id,
+    status: record.status,
+    redirectUrl: `https://sandbox.bank.example/consents/${id}`,
+    expiresAt: new Date(Date.now() + 1000 * 60 * 10).toISOString(),
+  };
+}
+
+export async function createMandate(input: {
+  orgId: string;
+  bankConnectionId: string;
+  reference: string;
+  amountLimitCents: number;
+}) {
+  const consent = consents.get(input.bankConnectionId);
+  if (!consent) {
+    throw new Error("bank_connection_not_found");
+  }
+  const id = `mandate_${randomUUID()}`;
+  const record: MandateRecord = {
+    id,
+    orgId: input.orgId,
+    bankConnectionId: input.bankConnectionId,
+    reference: input.reference,
+    amountLimitCents: input.amountLimitCents,
+    status: "PENDING",
+  };
+  mandates.set(id, record);
+  return {
+    id,
+    status: record.status,
+    nextEvent: {
+      endpoint: "/webhooks/payto/mandate",
+      body: {
+        type: "mandate.updated",
+        orgId: input.orgId,
+        mandateId: id,
+        bankConnectionId: input.bankConnectionId,
+        reference: input.reference,
+        status: record.status,
+        amountLimitCents: input.amountLimitCents,
+        occurredAt: nowISO(),
+      },
+    },
+  };
+}
+
+export function simulateEvents() {
+  return {
+    consent(consentId: string, status: Status = "ACTIVE") {
+      const consent = consents.get(consentId);
+      if (!consent) {
+        throw new Error("consent_not_found");
+      }
+      consent.status = status;
+      const occurredAt = nowISO();
+      return {
+        endpoint: "/webhooks/payto/consent",
+        body: {
+          type: "consent.updated",
+          orgId: consent.orgId,
+          bankConnectionId: consent.id,
+          status,
+          occurredAt,
+        },
+      };
+    },
+    mandate(mandateId: string, status: Status = "ACTIVE") {
+      const mandate = mandates.get(mandateId);
+      if (!mandate) {
+        throw new Error("mandate_not_found");
+      }
+      mandate.status = status;
+      const occurredAt = nowISO();
+      return {
+        endpoint: "/webhooks/payto/mandate",
+        body: {
+          type: "mandate.updated",
+          orgId: mandate.orgId,
+          mandateId: mandate.id,
+          bankConnectionId: mandate.bankConnectionId,
+          reference: mandate.reference,
+          status,
+          amountLimitCents: mandate.amountLimitCents,
+          occurredAt,
+        },
+      };
+    },
+    payment(mandateId: string, amountCents: number, status: PaymentStatus = "SETTLED") {
+      const mandate = mandates.get(mandateId);
+      if (!mandate) {
+        throw new Error("mandate_not_found");
+      }
+      return {
+        endpoint: "/webhooks/payto/payment",
+        body: {
+          type: "payment.processed",
+          orgId: mandate.orgId,
+          mandateId: mandate.id,
+          paymentId: `payment_${randomUUID()}`,
+          amountCents,
+          status,
+          occurredAt: nowISO(),
+        },
+      };
+    },
+  };
+}
+
+export function resetSandbox() {
+  consents.clear();
+  mandates.clear();
+}

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+import Fastify, { FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import { prisma } from "../../../shared/src/db";
+import { bankRoutes } from "./routes/bank";
+import { payToWebhookRoutes } from "./routes/webhooks.payto";
+import { idempotencyPlugin } from "./plugins/idempotency";
+import { redisPlugin } from "./plugins/redis";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+export async function createApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+  await app.register(redisPlugin);
+  await app.register(idempotencyPlugin);
+
+  app.decorate("prisma", prisma);
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  await app.register(bankRoutes, { prefix: "/bank" });
+  await app.register(payToWebhookRoutes, { prefix: "/webhooks/payto" });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,11 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+import { createApp } from "./app";
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
+
+const app = await createApp();
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,105 @@
+import fp from "fastify-plugin";
+import type { FastifyReply } from "fastify";
+
+const IDEMPOTENCY_PREFIX = "idempotency";
+const LOCK_PREFIX = "idempotency-lock";
+const LOCK_TTL_SECONDS = 60;
+const CACHE_TTL_SECONDS = 60 * 60 * 24;
+
+interface StoredResponse {
+  statusCode: number;
+  body: string;
+  headers: Record<string, string>;
+  contentType?: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    idempotencyKey?: string;
+  }
+}
+
+async function replayResponse(reply: FastifyReply, stored: StoredResponse) {
+  reply.header("idempotency-replayed", "true");
+  if (stored.contentType) {
+    reply.header("content-type", stored.contentType);
+  }
+  for (const [key, value] of Object.entries(stored.headers)) {
+    if (key.toLowerCase() === "content-type") continue;
+    reply.header(key, value);
+  }
+  reply.code(stored.statusCode);
+  const contentType = stored.contentType ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const parsed = JSON.parse(stored.body);
+      return reply.send(parsed);
+    } catch {
+      return reply.send(stored.body);
+    }
+  }
+  return reply.send(stored.body);
+}
+
+export const idempotencyPlugin = fp(async (app) => {
+  app.addHook("onRequest", async (req, reply) => {
+    if (req.method !== "POST" && req.method !== "PUT" && req.method !== "PATCH") {
+      return;
+    }
+    const key = req.headers["idempotency-key"];
+    if (typeof key !== "string" || !key.trim()) {
+      return;
+    }
+    const cacheKey = `${IDEMPOTENCY_PREFIX}:${key}`;
+    const cached = await app.redis.get(cacheKey);
+    if (cached) {
+      const stored = JSON.parse(cached) as StoredResponse;
+      return replayResponse(reply, stored);
+    }
+    const lockKey = `${LOCK_PREFIX}:${key}`;
+    const acquired = await app.redis.setnx(lockKey, "1", LOCK_TTL_SECONDS);
+    if (!acquired) {
+      reply.code(409);
+      return reply.send({ error: "idempotency_conflict" });
+    }
+    req.idempotencyKey = key;
+  });
+
+  app.addHook("onSend", async (req, reply, payload) => {
+    const key = req.idempotencyKey;
+    if (!key) {
+      return payload;
+    }
+    try {
+      const cacheKey = `${IDEMPOTENCY_PREFIX}:${key}`;
+      const lockKey = `${LOCK_PREFIX}:${key}`;
+      const headers: Record<string, string> = {};
+      for (const name of Object.keys(reply.getHeaders())) {
+        const value = reply.getHeader(name);
+        if (typeof value === "string") {
+          headers[name] = value;
+        }
+      }
+      const contentType = reply.getHeader("content-type");
+      let bodyString: string;
+      if (payload instanceof Buffer) {
+        bodyString = payload.toString("utf8");
+      } else if (typeof payload === "string") {
+        bodyString = payload;
+      } else {
+        bodyString = JSON.stringify(payload);
+      }
+      const stored: StoredResponse = {
+        statusCode: reply.statusCode,
+        headers,
+        contentType: typeof contentType === "string" ? contentType : undefined,
+        body: bodyString,
+      };
+      await app.redis.set(cacheKey, JSON.stringify(stored), CACHE_TTL_SECONDS);
+      await app.redis.del(lockKey);
+    } catch (err) {
+      req.log.error({ err }, "failed to persist idempotency cache");
+    }
+    return payload;
+  });
+});

--- a/apgms/services/api-gateway/src/plugins/redis.ts
+++ b/apgms/services/api-gateway/src/plugins/redis.ts
@@ -1,0 +1,60 @@
+import fp from "fastify-plugin";
+import type { FastifyInstance, FastifyPluginAsync } from "fastify";
+
+interface CacheValue {
+  value: string;
+  expiresAt: number | null;
+}
+
+const store = new Map<string, CacheValue>();
+
+function cleanupExpired(key: string, entry: CacheValue | undefined) {
+  if (!entry) return;
+  if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+    store.delete(key);
+  }
+}
+
+export const redis = {
+  async get(key: string): Promise<string | null> {
+    const entry = store.get(key);
+    cleanupExpired(key, entry);
+    return entry ? entry.value : null;
+  },
+  async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
+    store.set(key, {
+      value,
+      expiresAt: ttlSeconds ? Date.now() + ttlSeconds * 1000 : null,
+    });
+  },
+  async del(key: string): Promise<void> {
+    store.delete(key);
+  },
+  async setnx(key: string, value: string, ttlSeconds?: number): Promise<boolean> {
+    const existing = await this.get(key);
+    if (existing !== null) {
+      return false;
+    }
+    await this.set(key, value, ttlSeconds);
+    return true;
+  },
+  async reset(): Promise<void> {
+    store.clear();
+  },
+};
+
+export type RedisClient = typeof redis;
+
+declare module "fastify" {
+  interface FastifyInstance {
+    redis: RedisClient;
+  }
+}
+
+const plugin: FastifyPluginAsync = async (app: FastifyInstance) => {
+  app.decorate("redis", redis);
+};
+
+export const redisPlugin = fp(plugin, {
+  name: "redis-mock",
+});

--- a/apgms/services/api-gateway/src/routes/bank.ts
+++ b/apgms/services/api-gateway/src/routes/bank.ts
@@ -1,0 +1,189 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import {
+  createConsentRequestSchema,
+  createConsentResponseSchema,
+  createMandateRequestSchema,
+  createMandateResponseSchema,
+  getConsentResponseSchema,
+  getMandateResponseSchema,
+} from "../schemas/payto";
+import { createConsent, createMandate } from "../adapters/payto/sandbox";
+import { prisma } from "../../../shared/src/db";
+
+const AUTH_TOKEN = process.env.PAYTO_SANDBOX_TOKEN ?? "sandbox-token";
+
+type AuthResult = { orgId: string };
+
+async function authenticate(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  expectedOrgId?: string,
+): Promise<AuthResult | undefined> {
+  const authHeader = req.headers["authorization"];
+  if (!authHeader || typeof authHeader !== "string" || !authHeader.startsWith("Bearer ")) {
+    reply.code(401);
+    reply.send({ error: "unauthorized" });
+    return;
+  }
+  const token = authHeader.substring("Bearer ".length).trim();
+  if (token !== AUTH_TOKEN) {
+    reply.code(403);
+    reply.send({ error: "forbidden" });
+    return;
+  }
+  const orgHeader = req.headers["x-org-id"];
+  if (typeof orgHeader !== "string" || !orgHeader) {
+    reply.code(400);
+    reply.send({ error: "missing_org" });
+    return;
+  }
+  if (expectedOrgId && expectedOrgId !== orgHeader) {
+    reply.code(403);
+    reply.send({ error: "forbidden" });
+    return;
+  }
+  return { orgId: orgHeader };
+}
+
+export const bankRoutes: FastifyPluginAsync = async (app) => {
+  app.post("/consents", async (req, reply) => {
+    const parsed = createConsentRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return reply.send({ error: "invalid_request", details: parsed.error.flatten() });
+    }
+    const auth = await authenticate(req, reply, parsed.data.orgId);
+    if (!auth) return;
+
+    const org = await prisma.org.findUnique({ where: { id: parsed.data.orgId } });
+    if (!org) {
+      reply.code(404);
+      return reply.send({ error: "org_not_found" });
+    }
+
+    const created = await prisma.bankConnection.create({
+      data: {
+        orgId: parsed.data.orgId,
+        bank: parsed.data.bank,
+        accountRef: parsed.data.accountRef,
+        status: "PENDING",
+      },
+    });
+
+    const sandboxConsent = await createConsent(parsed.data);
+
+    const response = createConsentResponseSchema.parse({
+      id: created.id,
+      status: created.status,
+      next: {
+        type: "redirect",
+        url: sandboxConsent.redirectUrl,
+        expiresAt: sandboxConsent.expiresAt,
+      },
+    });
+
+    return reply.code(201).send(response);
+  });
+
+  app.get<{ Params: { id: string } }>("/consents/:id", async (req, reply) => {
+    const auth = await authenticate(req, reply);
+    if (!auth) return;
+
+    const consent = await prisma.bankConnection.findUnique({ where: { id: req.params.id } });
+    if (!consent) {
+      reply.code(404);
+      return reply.send({ error: "consent_not_found" });
+    }
+    if (consent.orgId !== auth.orgId) {
+      reply.code(403);
+      return reply.send({ error: "forbidden" });
+    }
+
+    const response = getConsentResponseSchema.parse({
+      id: consent.id,
+      status: consent.status,
+    });
+    return reply.send(response);
+  });
+
+  app.post("/mandates", async (req, reply) => {
+    const parsed = createMandateRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      reply.code(400);
+      return reply.send({ error: "invalid_request", details: parsed.error.flatten() });
+    }
+    const auth = await authenticate(req, reply, parsed.data.orgId);
+    if (!auth) return;
+
+    const connection = await prisma.bankConnection.findUnique({ where: { id: parsed.data.bankConnectionId } });
+    if (!connection) {
+      reply.code(404);
+      return reply.send({ error: "bank_connection_not_found" });
+    }
+    if (connection.orgId !== auth.orgId) {
+      reply.code(403);
+      return reply.send({ error: "forbidden" });
+    }
+
+    const created = await prisma.payToMandate.create({
+      data: {
+        orgId: parsed.data.orgId,
+        bankConnectionId: parsed.data.bankConnectionId,
+        reference: parsed.data.reference,
+        status: "PENDING",
+        amountLimitCents: parsed.data.amountLimitCents,
+        startAt: parsed.data.startAt ? new Date(parsed.data.startAt) : null,
+        endAt: parsed.data.endAt ? new Date(parsed.data.endAt) : null,
+      },
+    });
+
+    const sandboxMandate = await createMandate({
+      orgId: parsed.data.orgId,
+      bankConnectionId: parsed.data.bankConnectionId,
+      reference: parsed.data.reference,
+      amountLimitCents: parsed.data.amountLimitCents,
+    });
+
+    const response = createMandateResponseSchema.parse({
+      id: created.id,
+      status: created.status,
+      nextEvent: sandboxMandate.nextEvent,
+    });
+
+    return reply.code(201).send(response);
+  });
+
+  app.get<{ Params: { id: string } }>("/mandates/:id", async (req, reply) => {
+    const auth = await authenticate(req, reply);
+    if (!auth) return;
+
+    const mandate = await prisma.payToMandate.findUnique({ where: { id: req.params.id } });
+    if (!mandate) {
+      reply.code(404);
+      return reply.send({ error: "mandate_not_found" });
+    }
+    if (mandate.orgId !== auth.orgId) {
+      reply.code(403);
+      return reply.send({ error: "forbidden" });
+    }
+
+    const latestAudit = await prisma.auditBlob.findFirst({
+      where: { orgId: auth.orgId, subjectType: "mandate", subjectId: mandate.id },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const response = getMandateResponseSchema.parse({
+      id: mandate.id,
+      status: mandate.status,
+      latestEvent: latestAudit
+        ? {
+            kind: latestAudit.kind,
+            occurredAt: latestAudit.createdAt.toISOString(),
+            payload: latestAudit.payload as Record<string, unknown>,
+          }
+        : null,
+    });
+
+    return reply.send(response);
+  });
+};

--- a/apgms/services/api-gateway/src/routes/webhooks.payto.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.payto.ts
@@ -1,0 +1,180 @@
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+  consentWebhookSchema,
+  mandateWebhookSchema,
+  paymentWebhookSchema,
+} from "../schemas/payto";
+import { prisma } from "../../../shared/src/db";
+
+const SIGNATURE_HEADER = "x-signature";
+const NONCE_HEADER = "x-nonce";
+const TIMESTAMP_HEADER = "x-timestamp";
+const ALLOWED_DRIFT_MS = 5 * 60 * 1000;
+const WEBHOOK_SECRET = process.env.PAYTO_WEBHOOK_SECRET ?? "sandbox-secret";
+
+async function verifyEnvelope(req: FastifyRequest, reply: FastifyReply, bodyString: string) {
+  const signature = req.headers[SIGNATURE_HEADER];
+  const nonce = req.headers[NONCE_HEADER];
+  const timestamp = req.headers[TIMESTAMP_HEADER];
+
+  if (!signature || !nonce || !timestamp) {
+    reply.code(401);
+    reply.send({ error: "unauthorized" });
+    return;
+  }
+  if (Array.isArray(signature) || Array.isArray(nonce) || Array.isArray(timestamp)) {
+    reply.code(400);
+    reply.send({ error: "invalid_headers" });
+    return;
+  }
+
+  const receivedAt = new Date(timestamp);
+  if (Number.isNaN(receivedAt.getTime())) {
+    reply.code(400);
+    reply.send({ error: "invalid_timestamp" });
+    return;
+  }
+
+  const drift = Math.abs(Date.now() - receivedAt.getTime());
+  if (drift > ALLOWED_DRIFT_MS) {
+    reply.code(401);
+    reply.send({ error: "stale_event" });
+    return;
+  }
+
+  const nonceKey = `payto:nonce:${nonce}`;
+  const stored = await req.server.redis.setnx(nonceKey, "1", 5 * 60);
+  if (!stored) {
+    reply.code(409);
+    reply.send({ error: "replayed" });
+    return;
+  }
+
+  const computed = createHmac("sha256", WEBHOOK_SECRET)
+    .update(`${timestamp}.${nonce}.${bodyString}`)
+    .digest();
+  const received = Buffer.from(signature, "hex");
+  if (received.length !== computed.length || !timingSafeEqual(received, computed)) {
+    reply.code(401);
+    reply.send({ error: "signature_mismatch" });
+    return;
+  }
+
+  return { nonce, timestamp };
+}
+
+async function writeAudit(options: {
+  orgId: string;
+  subjectType: string;
+  subjectId: string;
+  kind: string;
+  payload: Record<string, unknown>;
+}) {
+  await prisma.auditBlob.create({
+    data: {
+      orgId: options.orgId,
+      subjectType: options.subjectType,
+      subjectId: options.subjectId,
+      kind: options.kind,
+      payload: options.payload,
+    },
+  });
+}
+
+export const payToWebhookRoutes: FastifyPluginAsync = async (app) => {
+  app.post("/consent", async (req, reply) => {
+    const body = consentWebhookSchema.safeParse(req.body);
+    if (!body.success) {
+      reply.code(400);
+      return reply.send({ error: "invalid_payload", details: body.error.flatten() });
+    }
+    const bodyString = JSON.stringify(body.data);
+    const verified = await verifyEnvelope(req, reply, bodyString);
+    if (!verified) return;
+
+    const connection = await prisma.bankConnection.findUnique({ where: { id: body.data.bankConnectionId } });
+    if (!connection) {
+      reply.code(404);
+      return reply.send({ error: "bank_connection_not_found" });
+    }
+
+    await prisma.bankConnection.update({
+      where: { id: connection.id },
+      data: { status: body.data.status },
+    });
+
+    await writeAudit({
+      orgId: connection.orgId,
+      subjectType: "bank_connection",
+      subjectId: connection.id,
+      kind: body.data.type,
+      payload: body.data,
+    });
+
+    return reply.send({ ok: true });
+  });
+
+  app.post("/mandate", async (req, reply) => {
+    const body = mandateWebhookSchema.safeParse(req.body);
+    if (!body.success) {
+      reply.code(400);
+      return reply.send({ error: "invalid_payload", details: body.error.flatten() });
+    }
+    const bodyString = JSON.stringify(body.data);
+    const verified = await verifyEnvelope(req, reply, bodyString);
+    if (!verified) return;
+
+    const mandate = await prisma.payToMandate.findUnique({ where: { id: body.data.mandateId } });
+    if (!mandate) {
+      reply.code(404);
+      return reply.send({ error: "mandate_not_found" });
+    }
+    if (mandate.orgId !== body.data.orgId) {
+      reply.code(403);
+      return reply.send({ error: "forbidden" });
+    }
+
+    await prisma.payToMandate.update({
+      where: { id: mandate.id },
+      data: { status: body.data.status },
+    });
+
+    await writeAudit({
+      orgId: mandate.orgId,
+      subjectType: "mandate",
+      subjectId: mandate.id,
+      kind: body.data.type,
+      payload: body.data,
+    });
+
+    return reply.send({ ok: true });
+  });
+
+  app.post("/payment", async (req, reply) => {
+    const body = paymentWebhookSchema.safeParse(req.body);
+    if (!body.success) {
+      reply.code(400);
+      return reply.send({ error: "invalid_payload", details: body.error.flatten() });
+    }
+    const bodyString = JSON.stringify(body.data);
+    const verified = await verifyEnvelope(req, reply, bodyString);
+    if (!verified) return;
+
+    const mandate = await prisma.payToMandate.findUnique({ where: { id: body.data.mandateId } });
+    if (!mandate) {
+      reply.code(404);
+      return reply.send({ error: "mandate_not_found" });
+    }
+
+    await writeAudit({
+      orgId: mandate.orgId,
+      subjectType: "mandate_payment",
+      subjectId: body.data.paymentId,
+      kind: body.data.type,
+      payload: body.data,
+    });
+
+    return reply.send({ ok: true });
+  });
+};

--- a/apgms/services/api-gateway/src/schemas/payto.json
+++ b/apgms/services/api-gateway/src/schemas/payto.json
@@ -1,0 +1,144 @@
+{
+  "$id": "https://apgms.example.com/schemas/payto.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "definitions": {
+    "status": {
+      "type": "string",
+      "enum": ["PENDING", "ACTIVE", "REVOKED"]
+    },
+    "createConsentRequest": {
+      "type": "object",
+      "required": ["orgId", "bank", "accountRef"],
+      "additionalProperties": false,
+      "properties": {
+        "orgId": { "type": "string", "minLength": 1 },
+        "bank": { "type": "string", "minLength": 1 },
+        "accountRef": { "type": "string", "minLength": 1 }
+      }
+    },
+    "createConsentResponse": {
+      "type": "object",
+      "required": ["id", "status", "next"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "$ref": "#/definitions/status" },
+        "next": {
+          "type": "object",
+          "required": ["type", "url", "expiresAt"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "const": "redirect" },
+            "url": { "type": "string", "format": "uri" },
+            "expiresAt": { "type": "string" }
+          }
+        }
+      }
+    },
+    "getConsentResponse": {
+      "type": "object",
+      "required": ["id", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "$ref": "#/definitions/status" }
+      }
+    },
+    "createMandateRequest": {
+      "type": "object",
+      "required": ["orgId", "bankConnectionId", "reference", "amountLimitCents"],
+      "additionalProperties": false,
+      "properties": {
+        "orgId": { "type": "string", "minLength": 1 },
+        "bankConnectionId": { "type": "string", "minLength": 1 },
+        "reference": { "type": "string", "minLength": 1 },
+        "amountLimitCents": { "type": "integer", "minimum": 1 },
+        "startAt": { "type": "string" },
+        "endAt": { "type": "string" }
+      }
+    },
+    "createMandateResponse": {
+      "type": "object",
+      "required": ["id", "status", "nextEvent"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "$ref": "#/definitions/status" },
+        "nextEvent": {
+          "type": "object",
+          "required": ["endpoint", "body"],
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": { "type": "string" },
+            "body": { "type": "object" }
+          }
+        }
+      }
+    },
+    "getMandateResponse": {
+      "type": "object",
+      "required": ["id", "status", "latestEvent"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "status": { "$ref": "#/definitions/status" },
+        "latestEvent": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["kind", "occurredAt", "payload"],
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "type": "string" },
+                "occurredAt": { "type": "string" },
+                "payload": { "type": "object" }
+              }
+            },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "consentWebhook": {
+      "type": "object",
+      "required": ["type", "orgId", "bankConnectionId", "status", "occurredAt"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "consent.updated" },
+        "orgId": { "type": "string", "minLength": 1 },
+        "bankConnectionId": { "type": "string", "minLength": 1 },
+        "status": { "$ref": "#/definitions/status" },
+        "occurredAt": { "type": "string" }
+      }
+    },
+    "mandateWebhook": {
+      "type": "object",
+      "required": ["type", "orgId", "mandateId", "bankConnectionId", "reference", "status", "amountLimitCents", "occurredAt"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "mandate.updated" },
+        "orgId": { "type": "string", "minLength": 1 },
+        "mandateId": { "type": "string", "minLength": 1 },
+        "bankConnectionId": { "type": "string", "minLength": 1 },
+        "reference": { "type": "string", "minLength": 1 },
+        "status": { "$ref": "#/definitions/status" },
+        "amountLimitCents": { "type": "integer", "minimum": 1 },
+        "occurredAt": { "type": "string" }
+      }
+    },
+    "paymentWebhook": {
+      "type": "object",
+      "required": ["type", "orgId", "mandateId", "paymentId", "amountCents", "status", "occurredAt"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "payment.processed" },
+        "orgId": { "type": "string", "minLength": 1 },
+        "mandateId": { "type": "string", "minLength": 1 },
+        "paymentId": { "type": "string", "minLength": 1 },
+        "amountCents": { "type": "integer", "minimum": 0 },
+        "status": { "type": "string", "enum": ["PENDING", "SETTLED", "FAILED"] },
+        "occurredAt": { "type": "string" }
+      }
+    }
+  }
+}

--- a/apgms/services/api-gateway/src/schemas/payto.ts
+++ b/apgms/services/api-gateway/src/schemas/payto.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+export const payToStatusSchema = z.enum(["PENDING", "ACTIVE", "REVOKED"]);
+
+export const createConsentRequestSchema = z.object({
+  orgId: z.string().min(1),
+  bank: z.string().min(1),
+  accountRef: z.string().min(1),
+});
+
+export const createConsentResponseSchema = z.object({
+  id: z.string(),
+  status: payToStatusSchema,
+  next: z.object({
+    type: z.literal("redirect"),
+    url: z.string().url(),
+    expiresAt: z.string(),
+  }),
+});
+
+export const getConsentResponseSchema = z.object({
+  id: z.string(),
+  status: payToStatusSchema,
+});
+
+export const createMandateRequestSchema = z.object({
+  orgId: z.string().min(1),
+  bankConnectionId: z.string().min(1),
+  reference: z.string().min(1),
+  amountLimitCents: z.number().int().positive(),
+  startAt: z.string().optional(),
+  endAt: z.string().optional(),
+});
+
+export const createMandateResponseSchema = z.object({
+  id: z.string(),
+  status: payToStatusSchema,
+  nextEvent: z.object({
+    endpoint: z.string(),
+    body: z.record(z.any()),
+  }),
+});
+
+export const getMandateResponseSchema = z.object({
+  id: z.string(),
+  status: payToStatusSchema,
+  latestEvent: z
+    .object({
+      kind: z.string(),
+      occurredAt: z.string(),
+      payload: z.record(z.any()),
+    })
+    .nullable(),
+});
+
+const webhookHeadersSchema = z.object({
+  "x-signature": z.string().min(1),
+  "x-nonce": z.string().min(1),
+  "x-timestamp": z.string().min(1),
+});
+
+export const consentWebhookSchema = z.object({
+  type: z.literal("consent.updated"),
+  orgId: z.string().min(1),
+  bankConnectionId: z.string().min(1),
+  status: payToStatusSchema,
+  occurredAt: z.string(),
+});
+
+export const mandateWebhookSchema = z.object({
+  type: z.literal("mandate.updated"),
+  orgId: z.string().min(1),
+  mandateId: z.string().min(1),
+  bankConnectionId: z.string().min(1),
+  reference: z.string().min(1),
+  status: payToStatusSchema,
+  amountLimitCents: z.number().int().positive(),
+  occurredAt: z.string(),
+});
+
+export const paymentWebhookSchema = z.object({
+  type: z.literal("payment.processed"),
+  orgId: z.string().min(1),
+  mandateId: z.string().min(1),
+  paymentId: z.string().min(1),
+  amountCents: z.number().int().nonnegative(),
+  status: z.enum(["PENDING", "SETTLED", "FAILED"]),
+  occurredAt: z.string(),
+});
+
+export const webhookEnvelopeSchema = z.object({
+  headers: webhookHeadersSchema,
+});
+
+export type CreateConsentRequest = z.infer<typeof createConsentRequestSchema>;
+export type CreateConsentResponse = z.infer<typeof createConsentResponseSchema>;
+export type GetConsentResponse = z.infer<typeof getConsentResponseSchema>;
+export type CreateMandateRequest = z.infer<typeof createMandateRequestSchema>;
+export type CreateMandateResponse = z.infer<typeof createMandateResponseSchema>;
+export type GetMandateResponse = z.infer<typeof getMandateResponseSchema>;
+export type ConsentWebhookPayload = z.infer<typeof consentWebhookSchema>;
+export type MandateWebhookPayload = z.infer<typeof mandateWebhookSchema>;
+export type PaymentWebhookPayload = z.infer<typeof paymentWebhookSchema>;

--- a/apgms/services/api-gateway/tests/payto.consents.spec.ts
+++ b/apgms/services/api-gateway/tests/payto.consents.spec.ts
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../src/app";
+import { prisma } from "../../../shared/src/db";
+import { redis } from "../src/plugins/redis";
+import { resetSandbox } from "../src/adapters/payto/sandbox";
+
+async function reset() {
+  await prisma.auditBlob.deleteMany();
+  await prisma.payToMandate.deleteMany();
+  await prisma.bankConnection.deleteMany();
+  await prisma.bankLine.deleteMany();
+  await prisma.user.deleteMany();
+  await prisma.org.deleteMany();
+  await redis.reset();
+  resetSandbox();
+}
+
+test("create consent and read status", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Acme" } });
+  const app = await createApp();
+  await app.ready();
+
+  const createRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": org.id,
+      "content-type": "application/json",
+    },
+    payload: {
+      orgId: org.id,
+      bank: "AussieBank",
+      accountRef: "123456",
+    },
+  });
+
+  assert.equal(createRes.statusCode, 201);
+  const created = createRes.json();
+  assert.equal(created.status, "PENDING");
+  assert.ok(created.next.url.includes(created.id));
+
+  const getRes = await app.inject({
+    method: "GET",
+    url: `/bank/consents/${created.id}`,
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": org.id,
+    },
+  });
+
+  assert.equal(getRes.statusCode, 200);
+  const fetched = getRes.json();
+  assert.equal(fetched.id, created.id);
+  assert.equal(fetched.status, "PENDING");
+
+  await app.close();
+});
+
+test("rejects missing auth", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "NoAuth" } });
+  const app = await createApp();
+  await app.ready();
+
+  const res = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    payload: { orgId: org.id, bank: "Bank", accountRef: "789" },
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+
+test("rejects mismatched org", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Org" } });
+  const other = await prisma.org.create({ data: { name: "Other" } });
+  const app = await createApp();
+  await app.ready();
+
+  const res = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": other.id,
+      "content-type": "application/json",
+    },
+    payload: { orgId: org.id, bank: "Bank", accountRef: "789" },
+  });
+
+  assert.equal(res.statusCode, 403);
+
+  await app.close();
+});
+
+test("org-scoped consent lookup", async () => {
+  await reset();
+  const owner = await prisma.org.create({ data: { name: "Owner" } });
+  const intruder = await prisma.org.create({ data: { name: "Intruder" } });
+  const app = await createApp();
+  await app.ready();
+
+  const createRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": owner.id,
+      "content-type": "application/json",
+    },
+    payload: {
+      orgId: owner.id,
+      bank: "Bank",
+      accountRef: "321",
+    },
+  });
+
+  const created = createRes.json();
+
+  const getRes = await app.inject({
+    method: "GET",
+    url: `/bank/consents/${created.id}`,
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": intruder.id,
+    },
+  });
+
+  assert.equal(getRes.statusCode, 403);
+
+  await app.close();
+});

--- a/apgms/services/api-gateway/tests/payto.mandates.spec.ts
+++ b/apgms/services/api-gateway/tests/payto.mandates.spec.ts
@@ -1,0 +1,254 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import { createApp } from "../src/app";
+import { prisma } from "../../../shared/src/db";
+import { redis } from "../src/plugins/redis";
+import { simulateEvents, resetSandbox } from "../src/adapters/payto/sandbox";
+
+const AUTH_HEADERS = (orgId: string) => ({
+  authorization: "Bearer sandbox-token",
+  "x-org-id": orgId,
+  "content-type": "application/json",
+});
+
+const WEBHOOK_SECRET = process.env.PAYTO_WEBHOOK_SECRET ?? "sandbox-secret";
+
+async function reset() {
+  await prisma.auditBlob.deleteMany();
+  await prisma.payToMandate.deleteMany();
+  await prisma.bankConnection.deleteMany();
+  await prisma.org.deleteMany();
+  await redis.reset();
+  resetSandbox();
+}
+
+function sign(body: Record<string, unknown>, timestamp: string, nonce: string) {
+  return createHmac("sha256", WEBHOOK_SECRET)
+    .update(`${timestamp}.${nonce}.${JSON.stringify(body)}`)
+    .digest("hex");
+}
+
+test("mandate activation via webhook", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Mandates" } });
+  const app = await createApp();
+  await app.ready();
+
+  const consentRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: AUTH_HEADERS(org.id),
+    payload: { orgId: org.id, bank: "Bank", accountRef: "444" },
+  });
+  assert.equal(consentRes.statusCode, 201);
+  const consent = consentRes.json();
+
+  const mandateRes = await app.inject({
+    method: "POST",
+    url: "/bank/mandates",
+    headers: AUTH_HEADERS(org.id),
+    payload: {
+      orgId: org.id,
+      bankConnectionId: consent.id,
+      reference: "rent",
+      amountLimitCents: 50000,
+    },
+  });
+  assert.equal(mandateRes.statusCode, 201);
+  const mandate = mandateRes.json();
+
+  const event = simulateEvents().mandate(mandate.id, "ACTIVE");
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-1";
+  const signature = sign(event.body, timestamp, nonce);
+
+  const webhookRes = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+  assert.equal(webhookRes.statusCode, 200);
+
+  const getRes = await app.inject({
+    method: "GET",
+    url: `/bank/mandates/${mandate.id}`,
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": org.id,
+    },
+  });
+
+  assert.equal(getRes.statusCode, 200);
+  const fetched = getRes.json();
+  assert.equal(fetched.status, "ACTIVE");
+  assert.ok(fetched.latestEvent);
+  assert.equal(fetched.latestEvent.kind, "mandate.updated");
+
+  await app.close();
+});
+
+test("rejects stale timestamp", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Stale" } });
+  const app = await createApp();
+  await app.ready();
+
+  const consentRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: AUTH_HEADERS(org.id),
+    payload: { orgId: org.id, bank: "Bank", accountRef: "555" },
+  });
+  const consent = consentRes.json();
+
+  const mandateRes = await app.inject({
+    method: "POST",
+    url: "/bank/mandates",
+    headers: AUTH_HEADERS(org.id),
+    payload: {
+      orgId: org.id,
+      bankConnectionId: consent.id,
+      reference: "rent",
+      amountLimitCents: 50000,
+    },
+  });
+  const mandate = mandateRes.json();
+
+  const event = simulateEvents().mandate(mandate.id, "ACTIVE");
+  const timestamp = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+  const nonce = "nonce-stale";
+  const signature = sign(event.body, timestamp, nonce);
+
+  const res = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+
+test("rejects signature mismatch", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Sig" } });
+  const app = await createApp();
+  await app.ready();
+
+  const consentRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: AUTH_HEADERS(org.id),
+    payload: { orgId: org.id, bank: "Bank", accountRef: "666" },
+  });
+  const consent = consentRes.json();
+
+  const mandateRes = await app.inject({
+    method: "POST",
+    url: "/bank/mandates",
+    headers: AUTH_HEADERS(org.id),
+    payload: {
+      orgId: org.id,
+      bankConnectionId: consent.id,
+      reference: "rent",
+      amountLimitCents: 50000,
+    },
+  });
+  const mandate = mandateRes.json();
+
+  const event = simulateEvents().mandate(mandate.id, "ACTIVE");
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-bad";
+  const signature = createHmac("sha256", "bad-secret")
+    .update(`${timestamp}.${nonce}.${JSON.stringify(event.body)}`)
+    .digest("hex");
+
+  const res = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+
+  assert.equal(res.statusCode, 401);
+  await app.close();
+});
+
+test("rejects nonce replay", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Nonce" } });
+  const app = await createApp();
+  await app.ready();
+
+  const consentRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: AUTH_HEADERS(org.id),
+    payload: { orgId: org.id, bank: "Bank", accountRef: "777" },
+  });
+  const consent = consentRes.json();
+
+  const mandateRes = await app.inject({
+    method: "POST",
+    url: "/bank/mandates",
+    headers: AUTH_HEADERS(org.id),
+    payload: {
+      orgId: org.id,
+      bankConnectionId: consent.id,
+      reference: "rent",
+      amountLimitCents: 50000,
+    },
+  });
+  const mandate = mandateRes.json();
+
+  const event = simulateEvents().mandate(mandate.id, "ACTIVE");
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-repeat";
+  const signature = sign(event.body, timestamp, nonce);
+
+  const first = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+  assert.equal(first.statusCode, 200);
+
+  const second = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+
+  assert.equal(second.statusCode, 409);
+  await app.close();
+});

--- a/apgms/services/api-gateway/tests/payto.replay.spec.ts
+++ b/apgms/services/api-gateway/tests/payto.replay.spec.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createApp } from "../src/app";
+import { prisma } from "../../../shared/src/db";
+import { redis } from "../src/plugins/redis";
+import { simulateEvents, resetSandbox } from "../src/adapters/payto/sandbox";
+import { createHmac } from "node:crypto";
+
+const WEBHOOK_SECRET = process.env.PAYTO_WEBHOOK_SECRET ?? "sandbox-secret";
+
+async function reset() {
+  await prisma.auditBlob.deleteMany();
+  await prisma.payToMandate.deleteMany();
+  await prisma.bankConnection.deleteMany();
+  await prisma.org.deleteMany();
+  await redis.reset();
+  resetSandbox();
+}
+
+function sign(body: Record<string, unknown>, timestamp: string, nonce: string) {
+  return createHmac("sha256", WEBHOOK_SECRET)
+    .update(`${timestamp}.${nonce}.${JSON.stringify(body)}`)
+    .digest("hex");
+}
+
+test("rejects replayed payment webhook", async () => {
+  await reset();
+  const org = await prisma.org.create({ data: { name: "Replay" } });
+  const app = await createApp();
+  await app.ready();
+
+  const consentRes = await app.inject({
+    method: "POST",
+    url: "/bank/consents",
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": org.id,
+      "content-type": "application/json",
+    },
+    payload: { orgId: org.id, bank: "Bank", accountRef: "888" },
+  });
+  const consent = consentRes.json();
+
+  const mandateRes = await app.inject({
+    method: "POST",
+    url: "/bank/mandates",
+    headers: {
+      authorization: "Bearer sandbox-token",
+      "x-org-id": org.id,
+      "content-type": "application/json",
+    },
+    payload: {
+      orgId: org.id,
+      bankConnectionId: consent.id,
+      reference: "utilities",
+      amountLimitCents: 10000,
+    },
+  });
+  const mandate = mandateRes.json();
+
+  const event = simulateEvents().payment(mandate.id, 4200);
+  const timestamp = new Date().toISOString();
+  const nonce = "nonce-payment";
+  const signature = sign(event.body, timestamp, nonce);
+
+  const first = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+  assert.equal(first.statusCode, 200);
+
+  const second = await app.inject({
+    method: "POST",
+    url: event.endpoint,
+    headers: {
+      "content-type": "application/json",
+      "x-timestamp": timestamp,
+      "x-nonce": nonce,
+      "x-signature": signature,
+    },
+    payload: event.body,
+  });
+  assert.equal(second.statusCode, 409);
+
+  await app.close();
+});

--- a/apgms/shared/prisma/migrations/20250316120000_bank_payto/migration.sql
+++ b/apgms/shared/prisma/migrations/20250316120000_bank_payto/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "BankConnection" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "bank" TEXT NOT NULL,
+    "accountRef" TEXT NOT NULL,
+    "status" VARCHAR(16) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "PayToMandate" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "bankConnectionId" TEXT NOT NULL,
+    "reference" TEXT NOT NULL,
+    "status" VARCHAR(16) NOT NULL,
+    "amountLimitCents" INTEGER NOT NULL,
+    "startAt" TIMESTAMP(3),
+    "endAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateTable
+CREATE TABLE "AuditBlob" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "subjectType" TEXT NOT NULL,
+    "subjectId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- AddForeignKey
+ALTER TABLE "BankConnection" ADD CONSTRAINT "BankConnection_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PayToMandate" ADD CONSTRAINT "PayToMandate_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PayToMandate" ADD CONSTRAINT "PayToMandate_bankConnectionId_fkey" FOREIGN KEY ("bankConnectionId") REFERENCES "BankConnection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditBlob" ADD CONSTRAINT "AuditBlob_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -13,6 +13,9 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  bankConnections BankConnection[]
+  mandates        PayToMandate[]
+  audits          AuditBlob[]
 }
 
 model User {
@@ -33,4 +36,42 @@ model BankLine {
   payee     String
   desc      String
   createdAt DateTime @default(now())
+}
+
+model BankConnection {
+  id          String         @id @default(cuid())
+  org         Org            @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  bank        String
+  accountRef  String
+  status      String         @db.VarChar(16)
+  mandates    PayToMandate[]
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+}
+
+model PayToMandate {
+  id               String         @id @default(cuid())
+  org              Org            @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId            String
+  bankConnection   BankConnection @relation(fields: [bankConnectionId], references: [id], onDelete: Cascade)
+  bankConnectionId String
+  reference        String
+  status           String         @db.VarChar(16)
+  amountLimitCents Int
+  startAt          DateTime?
+  endAt            DateTime?
+  createdAt        DateTime       @default(now())
+  updatedAt        DateTime       @updatedAt
+}
+
+model AuditBlob {
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  subjectType String
+  subjectId   String
+  kind        String
+  payload     Json
+  createdAt   DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- add Prisma models and migration for bank connections, PayTo mandates, and audit blobs
- implement API gateway routes, sandbox adapter, schemas, and webhook handling for consents and mandates
- add redis-backed idempotency, end-to-end tests, and partner documentation for PayTo integration

## Testing
- not run (database not configured in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f47e88f5f083279e3e5e63d0e2fb0c