### PR TITLE
feat: implement connector framework with OAuth and sync jobs

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.2"
   }
 }

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,88 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Fastify, { FastifyInstance, FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import { prisma } from "@apgms/shared/src/db";
+import { registerConnectorOAuthRoutes } from "./routes/connectors.oauth";
+import { registerConnectorWebhookRoutes } from "./routes/connectors.webhooks";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
+  const app = Fastify(options);
+
+  app.addContentTypeParser("application/json", { parseAs: "buffer" }, (request, body, done) => {
+    try {
+      const buffer = Buffer.isBuffer(body) ? body : Buffer.from(body as string);
+      (request as any).rawBody = buffer;
+      if (buffer.length === 0) {
+        done(null, {});
+        return;
+      }
+      const parsed = JSON.parse(buffer.toString("utf8"));
+      done(null, parsed);
+    } catch (err) {
+      done(err as Error, undefined);
+    }
+  });
+
+  app.register(cors, { origin: true });
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  registerConnectorOAuthRoutes(app);
+  registerConnectorWebhookRoutes(app);
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+export function resolveEnvPath() {
+  return path.resolve(__dirname, "../../../.env");
+}

--- a/apgms/services/api-gateway/src/connectors/base.ts
+++ b/apgms/services/api-gateway/src/connectors/base.ts
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+import { NormalizedEmployee, NormalizedEmployeeSchema, NormalizedInvoice, NormalizedInvoiceSchema, NormalizedPayment, NormalizedPaymentSchema, WebhookPayloadSchema } from "../schemas/connectors";
+import { Connector, ListEntitiesParams, OAuthTokenSet, WebhookVerificationResult } from "./types";
+import { verifyJwt } from "../utils/jwt";
+
+function randomToken(provider: string, prefix: string) {
+  return `${provider}_${prefix}_${crypto.randomBytes(12).toString("hex")}`;
+}
+
+function baseInvoices(provider: string, orgId: string): NormalizedInvoice[] {
+  return NormalizedInvoiceSchema.array().parse([
+    {
+      provider,
+      orgId,
+      externalId: `${provider}-${orgId}-inv-001`,
+      number: "INV-001",
+      status: "AUTHORISED",
+      total: 1280.5,
+      currency: "AUD",
+      issuedAt: new Date("2024-01-15T00:00:00Z"),
+      dueAt: new Date("2024-01-30T00:00:00Z"),
+      customerName: "Example Customer Pty Ltd",
+    },
+  ]);
+}
+
+function basePayments(provider: string, orgId: string): NormalizedPayment[] {
+  return NormalizedPaymentSchema.array().parse([
+    {
+      provider,
+      orgId,
+      externalId: `${provider}-${orgId}-pay-001`,
+      amount: 1280.5,
+      currency: "AUD",
+      occurredAt: new Date("2024-01-20T10:00:00Z"),
+      counterpartyName: "Example Customer Pty Ltd",
+      description: "Invoice payment",
+      type: "invoice_payment",
+    },
+  ]);
+}
+
+function baseEmployees(provider: string, orgId: string): NormalizedEmployee[] {
+  return NormalizedEmployeeSchema.array().parse([
+    {
+      provider,
+      orgId,
+      externalId: `${provider}-${orgId}-emp-001`,
+      fullName: "Sample Employee",
+      email: "employee@example.com",
+      status: "active",
+      hiredAt: new Date("2023-07-01T00:00:00Z"),
+    },
+  ]);
+}
+
+interface BuildConnectorOptions {
+  provider: string;
+  oauthBaseUrl: string;
+  webhookSecretEnv?: string;
+  webhookType?: "hmac" | "jwt";
+  hmacHeader?: string;
+}
+
+export function buildMockConnector(options: BuildConnectorOptions): Connector {
+  const {
+    provider,
+    oauthBaseUrl,
+    webhookSecretEnv,
+    webhookType = "hmac",
+    hmacHeader = "x-signature",
+  } = options;
+
+  async function ensureSecret(): Promise<string> {
+    if (!webhookSecretEnv) {
+      return "";
+    }
+    const value = process.env[webhookSecretEnv];
+    if (!value) {
+      throw new Error(`Missing ${webhookSecretEnv} secret`);
+    }
+    return value;
+  }
+
+  async function listWrapper<T>(params: ListEntitiesParams, factory: (provider: string, orgId: string) => T[]): Promise<T[]> {
+    void params;
+    switch (factory) {
+      case baseInvoices:
+        return baseInvoices(provider, params.orgId) as T[];
+      case basePayments:
+        return basePayments(provider, params.orgId) as T[];
+      case baseEmployees:
+        return baseEmployees(provider, params.orgId) as T[];
+      default:
+        return [];
+    }
+  }
+
+  return {
+    provider,
+    authorizeURL({ orgId, state, redirectUri }) {
+      const url = new URL(`${oauthBaseUrl}/${provider}/authorize`);
+      url.searchParams.set("state", state);
+      url.searchParams.set("orgId", orgId);
+      url.searchParams.set("redirect_uri", redirectUri);
+      url.searchParams.set("scope", "read accounting payroll");
+      return url.toString();
+    },
+    async exchangeCode({ orgId }) {
+      const now = Date.now();
+      const tokens: OAuthTokenSet = {
+        accessToken: randomToken(provider, "access"),
+        refreshToken: randomToken(provider, "refresh"),
+        expiresAt: new Date(now + 55 * 60 * 1000),
+        scope: ["accounting", "payroll"],
+      };
+      void orgId;
+      return tokens;
+    },
+    async refreshToken({ orgId }) {
+      const now = Date.now();
+      const tokens: OAuthTokenSet = {
+        accessToken: randomToken(provider, "access"),
+        refreshToken: randomToken(provider, "refresh"),
+        expiresAt: new Date(now + 60 * 60 * 1000),
+        scope: ["accounting", "payroll"],
+      };
+      void orgId;
+      return tokens;
+    },
+    listInvoices(params) {
+      return listWrapper(params, baseInvoices);
+    },
+    listPayments(params) {
+      return listWrapper(params, basePayments);
+    },
+    listEmployees(params) {
+      return listWrapper(params, baseEmployees);
+    },
+    async verifyWebhook(rawBody, headers): Promise<WebhookVerificationResult> {
+      const lowerHeaders: Record<string, string> = {};
+      for (const [key, value] of Object.entries(headers)) {
+        if (Array.isArray(value)) {
+          lowerHeaders[key.toLowerCase()] = value[0] ?? "";
+        } else if (typeof value === "string") {
+          lowerHeaders[key.toLowerCase()] = value;
+        }
+      }
+      const payload = WebhookPayloadSchema.safeParse(JSON.parse(rawBody.toString("utf8") || "{}"));
+      if (!payload.success) {
+        return { valid: false, reason: "invalid_payload" };
+      }
+      const timestamp = payload.data.timestamp;
+      const nonce = payload.data.nonce;
+      const connectionId = payload.data.connectionId;
+      if (!webhookSecretEnv) {
+        return { valid: true, orgId: payload.data.orgId, connectionId, events: payload.data.events, nonce, timestamp };
+      }
+      const secret = await ensureSecret();
+      if (webhookType === "jwt") {
+        const authHeader = lowerHeaders["authorization"] ?? lowerHeaders["Authorization"];
+        const token = authHeader?.replace(/^Bearer\s+/i, "");
+        const verified = verifyJwt(token, secret);
+        if (!verified) {
+          return { valid: false, reason: "invalid_jwt" };
+        }
+        if (verified.nonce && verified.nonce !== nonce) {
+          return { valid: false, reason: "nonce_mismatch" };
+        }
+        if (verified.orgId && verified.orgId !== payload.data.orgId) {
+          return { valid: false, reason: "org_mismatch" };
+        }
+        return { valid: true, orgId: payload.data.orgId, connectionId: (verified.connectionId as string | undefined) ?? connectionId, events: payload.data.events, nonce, timestamp };
+      }
+
+      const signature = lowerHeaders[hmacHeader];
+      if (!signature) {
+        return { valid: false, reason: "missing_signature" };
+      }
+      const digest = crypto.createHmac("sha256", secret).update(rawBody).digest("base64");
+      const normalizedSignature = signature.trim();
+      if (!crypto.timingSafeEqual(Buffer.from(digest), Buffer.from(normalizedSignature))) {
+        return { valid: false, reason: "signature_mismatch" };
+      }
+      return { valid: true, orgId: payload.data.orgId, connectionId, events: payload.data.events, nonce, timestamp };
+    },
+  };
+}

--- a/apgms/services/api-gateway/src/connectors/index.ts
+++ b/apgms/services/api-gateway/src/connectors/index.ts
@@ -1,0 +1,20 @@
+import XeroConnector from "./xero";
+import QuickBooksConnector from "./qbo";
+import MyobConnector from "./myob";
+import SquareConnector from "./square";
+import ShopifyConnector from "./shopify";
+import { ConnectorRegistry } from "./types";
+
+export const connectors: ConnectorRegistry = {
+  xero: XeroConnector,
+  qbo: QuickBooksConnector,
+  myob: MyobConnector,
+  square: SquareConnector,
+  shopify: ShopifyConnector,
+};
+
+export function getConnector(provider: string) {
+  return connectors[provider];
+}
+
+export type ProviderName = keyof typeof connectors;

--- a/apgms/services/api-gateway/src/connectors/myob.ts
+++ b/apgms/services/api-gateway/src/connectors/myob.ts
@@ -1,0 +1,11 @@
+import { buildMockConnector } from "./base";
+
+const MyobConnector = buildMockConnector({
+  provider: "myob",
+  oauthBaseUrl: "https://mock-oauth.example.com",
+  webhookSecretEnv: "MYOB_WEBHOOK_SECRET",
+  webhookType: "hmac",
+  hmacHeader: "x-myob-signature",
+});
+
+export default MyobConnector;

--- a/apgms/services/api-gateway/src/connectors/qbo.ts
+++ b/apgms/services/api-gateway/src/connectors/qbo.ts
@@ -1,0 +1,11 @@
+import { buildMockConnector } from "./base";
+
+const QuickBooksConnector = buildMockConnector({
+  provider: "qbo",
+  oauthBaseUrl: "https://mock-oauth.example.com",
+  webhookSecretEnv: "QBO_WEBHOOK_SECRET",
+  webhookType: "hmac",
+  hmacHeader: "x-intuit-signature",
+});
+
+export default QuickBooksConnector;

--- a/apgms/services/api-gateway/src/connectors/shopify.ts
+++ b/apgms/services/api-gateway/src/connectors/shopify.ts
@@ -1,0 +1,11 @@
+import { buildMockConnector } from "./base";
+
+const ShopifyConnector = buildMockConnector({
+  provider: "shopify",
+  oauthBaseUrl: "https://mock-oauth.example.com",
+  webhookSecretEnv: "SHOPIFY_WEBHOOK_SECRET",
+  webhookType: "hmac",
+  hmacHeader: "x-shopify-hmac-sha256",
+});
+
+export default ShopifyConnector;

--- a/apgms/services/api-gateway/src/connectors/square.ts
+++ b/apgms/services/api-gateway/src/connectors/square.ts
@@ -1,0 +1,11 @@
+import { buildMockConnector } from "./base";
+
+const SquareConnector = buildMockConnector({
+  provider: "square",
+  oauthBaseUrl: "https://mock-oauth.example.com",
+  webhookSecretEnv: "SQUARE_WEBHOOK_SECRET",
+  webhookType: "hmac",
+  hmacHeader: "x-square-signature",
+});
+
+export default SquareConnector;

--- a/apgms/services/api-gateway/src/connectors/types.ts
+++ b/apgms/services/api-gateway/src/connectors/types.ts
@@ -1,0 +1,54 @@
+import { NormalizedEmployee, NormalizedInvoice, NormalizedPayment, WebhookEvent } from "../schemas/connectors";
+
+export interface AuthorizeURLParams {
+  orgId: string;
+  state: string;
+  redirectUri: string;
+}
+
+export interface ExchangeCodeParams {
+  orgId: string;
+  code: string;
+  redirectUri: string;
+}
+
+export interface RefreshTokenParams {
+  orgId: string;
+  refreshToken: string;
+}
+
+export interface ListEntitiesParams {
+  orgId: string;
+  accessToken: string;
+  cursor?: string | null;
+}
+
+export interface OAuthTokenSet {
+  accessToken: string;
+  refreshToken?: string | null;
+  expiresAt?: Date | null;
+  scope?: string[];
+}
+
+export interface WebhookVerificationResult {
+  valid: boolean;
+  orgId?: string;
+  connectionId?: string;
+  events?: WebhookEvent[];
+  nonce?: string;
+  timestamp?: Date;
+  reason?: string;
+}
+
+export interface Connector {
+  readonly provider: string;
+  authorizeURL(params: AuthorizeURLParams): Promise<string> | string;
+  exchangeCode(params: ExchangeCodeParams): Promise<OAuthTokenSet>;
+  refreshToken(params: RefreshTokenParams): Promise<OAuthTokenSet>;
+  listInvoices(params: ListEntitiesParams): Promise<NormalizedInvoice[]>;
+  listPayments(params: ListEntitiesParams): Promise<NormalizedPayment[]>;
+  listEmployees(params: ListEntitiesParams): Promise<NormalizedEmployee[]>;
+  verifyWebhook(rawBody: Buffer, headers: Record<string, string | string[] | undefined>): Promise<WebhookVerificationResult>;
+}
+
+export type ConnectorRegistry = Record<string, Connector>;

--- a/apgms/services/api-gateway/src/connectors/xero.ts
+++ b/apgms/services/api-gateway/src/connectors/xero.ts
@@ -1,0 +1,10 @@
+import { buildMockConnector } from "./base";
+
+const XeroConnector = buildMockConnector({
+  provider: "xero",
+  oauthBaseUrl: "https://mock-oauth.example.com",
+  webhookSecretEnv: "XERO_WEBHOOK_SECRET",
+  webhookType: "jwt",
+});
+
+export default XeroConnector;

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,32 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { buildApp, resolveEnvPath } from "./app";
+import { scheduleSyncJobs } from "./jobs/sync";
 
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+dotenv.config({ path: resolveEnvPath() });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+const app = buildApp({ logger: true });
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const scheduler = scheduleSyncJobs();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
+  scheduler.stop();
   process.exit(1);
 });
 
+process.on("SIGINT", async () => {
+  scheduler.stop();
+  await app.close();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  scheduler.stop();
+  await app.close();
+  process.exit(0);
+});

--- a/apgms/services/api-gateway/src/jobs/sync.ts
+++ b/apgms/services/api-gateway/src/jobs/sync.ts
@@ -1,0 +1,271 @@
+import { Prisma, ProviderConnection } from "@prisma/client";
+import { prisma } from "@apgms/shared/src/db";
+import { connectors, getConnector } from "../connectors";
+import { Connector } from "../connectors/types";
+import {
+  NormalizedEmployeeSchema,
+  NormalizedInvoiceSchema,
+  NormalizedPaymentSchema,
+  WebhookEvent,
+} from "../schemas/connectors";
+
+const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
+export interface SyncResult {
+  connectionId: string;
+  provider: string;
+  orgId: string;
+  counts: {
+    invoices: number;
+    payments: number;
+    employees: number;
+  };
+  reason: string;
+}
+
+export interface SyncContext {
+  reason: string;
+  events?: WebhookEvent[];
+}
+
+export async function ensureFreshAccessToken(connection: ProviderConnection, connector: Connector) {
+  if (!connection.accessToken) {
+    throw new Error("missing_access_token");
+  }
+  const expiresAt = connection.expiresAt ? new Date(connection.expiresAt).getTime() : null;
+  const shouldRefresh =
+    !!connection.refreshToken && (!expiresAt || expiresAt - Date.now() < REFRESH_THRESHOLD_MS);
+  if (!shouldRefresh) {
+    return { accessToken: connection.accessToken, connection };
+  }
+  const refreshed = await connector.refreshToken({
+    orgId: connection.orgId,
+    refreshToken: connection.refreshToken!,
+  });
+  const meta = (connection.meta as Record<string, unknown> | null | undefined) ?? {};
+  const updated = await prisma.providerConnection.update({
+    where: { id: connection.id },
+    data: {
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken ?? connection.refreshToken,
+      expiresAt: refreshed.expiresAt ?? new Date(Date.now() + 60 * 60 * 1000),
+      meta: { ...meta, refreshedAt: new Date().toISOString() },
+    },
+  });
+  return { accessToken: updated.accessToken!, connection: updated };
+}
+
+async function persistInvoices(connection: ProviderConnection, invoices: unknown[]) {
+  const parsed = NormalizedInvoiceSchema.array().parse(invoices);
+  for (const invoice of parsed) {
+    await prisma.auditBlob.upsert({
+      where: {
+        provider_externalId_type: {
+          provider: connection.provider,
+          externalId: invoice.externalId,
+          type: "invoice",
+        },
+      },
+      create: {
+        orgId: connection.orgId,
+        provider: connection.provider,
+        type: "invoice",
+        externalId: invoice.externalId,
+        payload: invoice,
+      },
+      update: {
+        payload: invoice,
+      },
+    });
+  }
+  return parsed.length;
+}
+
+async function persistEmployees(connection: ProviderConnection, employees: unknown[]) {
+  const parsed = NormalizedEmployeeSchema.array().parse(employees);
+  for (const employee of parsed) {
+    await prisma.auditBlob.upsert({
+      where: {
+        provider_externalId_type: {
+          provider: connection.provider,
+          externalId: employee.externalId,
+          type: "employee",
+        },
+      },
+      create: {
+        orgId: connection.orgId,
+        provider: connection.provider,
+        type: "employee",
+        externalId: employee.externalId,
+        payload: employee,
+      },
+      update: {
+        payload: employee,
+      },
+    });
+  }
+  return parsed.length;
+}
+
+async function persistPayments(connection: ProviderConnection, payments: unknown[]) {
+  const parsed = NormalizedPaymentSchema.array().parse(payments);
+  for (const payment of parsed) {
+    await prisma.bankLine.upsert({
+      where: {
+        orgId_externalId: {
+          orgId: connection.orgId,
+          externalId: payment.externalId,
+        },
+      },
+      create: {
+        orgId: connection.orgId,
+        date: payment.occurredAt,
+        amount: new Prisma.Decimal(payment.amount),
+        payee: payment.counterpartyName,
+        desc: payment.description ?? payment.type,
+        externalId: payment.externalId,
+        provider: connection.provider,
+      },
+      update: {
+        date: payment.occurredAt,
+        amount: new Prisma.Decimal(payment.amount),
+        payee: payment.counterpartyName,
+        desc: payment.description ?? payment.type,
+        provider: connection.provider,
+      },
+    });
+  }
+  return parsed.length;
+}
+
+export async function syncConnection(
+  connection: ProviderConnection,
+  connector: Connector,
+  context: SyncContext
+): Promise<SyncResult> {
+  const { accessToken, connection: ensured } = await ensureFreshAccessToken(connection, connector);
+  const [invoices, payments, employees] = await Promise.all([
+    connector.listInvoices({ orgId: ensured.orgId, accessToken }),
+    connector.listPayments({ orgId: ensured.orgId, accessToken }),
+    connector.listEmployees({ orgId: ensured.orgId, accessToken }),
+  ]);
+
+  const invoiceCount = await persistInvoices(ensured, invoices);
+  const paymentCount = await persistPayments(ensured, payments);
+  const employeeCount = await persistEmployees(ensured, employees);
+
+  const meta = (ensured.meta as Record<string, unknown> | null | undefined) ?? {};
+  await prisma.providerConnection.update({
+    where: { id: ensured.id },
+    data: {
+      meta: {
+        ...meta,
+        lastSyncAt: new Date().toISOString(),
+        lastSyncReason: context.reason,
+        lastSyncCounts: {
+          invoices: invoiceCount,
+          payments: paymentCount,
+          employees: employeeCount,
+        },
+      },
+    },
+  });
+
+  return {
+    connectionId: ensured.id,
+    provider: ensured.provider,
+    orgId: ensured.orgId,
+    counts: {
+      invoices: invoiceCount,
+      payments: paymentCount,
+      employees: employeeCount,
+    },
+    reason: context.reason,
+  };
+}
+
+export async function runSyncForConnection(connectionId: string, context: Partial<SyncContext> = {}) {
+  const connection = await prisma.providerConnection.findFirst({ where: { id: connectionId } });
+  if (!connection) {
+    throw new Error("connection_not_found");
+  }
+  const connector = getConnector(connection.provider);
+  if (!connector) {
+    throw new Error("connector_not_found");
+  }
+  return syncConnection(connection, connector, {
+    reason: context.reason ?? "manual",
+    events: context.events,
+  });
+}
+
+export async function runScheduledSync(): Promise<SyncResult[]> {
+  const connections = await prisma.providerConnection.findMany({
+    where: { status: "CONNECTED" },
+  });
+  const results: SyncResult[] = [];
+  for (const connection of connections) {
+    const connector = getConnector(connection.provider);
+    if (!connector) {
+      continue;
+    }
+    const result = await syncConnection(connection, connector, { reason: "schedule" });
+    results.push(result);
+  }
+  return results;
+}
+
+export function scheduleSyncJobs(intervalMs = 15 * 60 * 1000) {
+  let timer: NodeJS.Timeout | null = setInterval(() => {
+    runScheduledSync().catch((err) => {
+      console.error("sync job failed", err);
+    });
+  }, intervalMs);
+  return {
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
+const pendingKeys = new Set<string>();
+
+export interface EnqueueSyncOptions {
+  provider: string;
+  orgId: string;
+  connectionId?: string;
+  reason: string;
+  events?: WebhookEvent[];
+}
+
+export async function enqueueSyncJob(options: EnqueueSyncOptions) {
+  const key = options.connectionId ?? `${options.provider}:${options.orgId}`;
+  if (pendingKeys.has(key)) {
+    return;
+  }
+  pendingKeys.add(key);
+  queueMicrotask(async () => {
+    try {
+      const connection = options.connectionId
+        ? await prisma.providerConnection.findFirst({ where: { id: options.connectionId } })
+        : await prisma.providerConnection.findFirst({ where: { provider: options.provider, orgId: options.orgId } });
+      if (!connection) {
+        return;
+      }
+      const connector = getConnector(connection.provider);
+      if (!connector) {
+        return;
+      }
+      await syncConnection(connection, connector, { reason: options.reason, events: options.events });
+    } finally {
+      pendingKeys.delete(key);
+    }
+  });
+}
+
+export function getRegisteredProviders() {
+  return Object.keys(connectors);
+}

--- a/apgms/services/api-gateway/src/routes/connectors.oauth.ts
+++ b/apgms/services/api-gateway/src/routes/connectors.oauth.ts
@@ -1,0 +1,104 @@
+import crypto from "node:crypto";
+import { FastifyInstance } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+import { getConnector } from "../connectors";
+import { OAuthCallbackSchema, OAuthStartSchema } from "../schemas/connectors";
+
+function randomState() {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+export function registerConnectorOAuthRoutes(app: FastifyInstance) {
+  app.get("/connect/:provider/start", async (request, reply) => {
+    const { provider } = request.params as { provider: string };
+    const connector = getConnector(provider);
+    if (!connector) {
+      return reply.code(404).send({ error: "unknown_provider" });
+    }
+    const query = OAuthStartSchema.safeParse(request.query ?? {});
+    if (!query.success) {
+      return reply.code(400).send({ error: "invalid_request", details: query.error.flatten() });
+    }
+    const state = randomState();
+    const redirectUri = query.data.redirectUri ?? `${process.env.CONNECT_REDIRECT_BASE ?? "https://app.local"}/connect/${provider}/callback`;
+    const existing = await prisma.providerConnection.findFirst({
+      where: { provider, orgId: query.data.orgId },
+    });
+    const nextMeta = {
+      ...(existing?.meta as Record<string, unknown> | null | undefined ?? {}),
+      oauthState: state,
+      oauthStateCreatedAt: new Date().toISOString(),
+    };
+    const connection = existing
+      ? await prisma.providerConnection.update({
+          where: { id: existing.id },
+          data: { status: "PENDING", meta: nextMeta },
+        })
+      : await prisma.providerConnection.create({
+          data: {
+            orgId: query.data.orgId,
+            provider,
+            status: "PENDING",
+            meta: nextMeta,
+          },
+        });
+    const authorizeUrl = await connector.authorizeURL({
+      orgId: query.data.orgId,
+      state,
+      redirectUri,
+    });
+    return reply.send({ redirectUrl: authorizeUrl, state, connectionId: connection.id });
+  });
+
+  app.get("/connect/:provider/callback", async (request, reply) => {
+    const { provider } = request.params as { provider: string };
+    const connector = getConnector(provider);
+    if (!connector) {
+      return reply.code(404).send({ error: "unknown_provider" });
+    }
+    const parsed = OAuthCallbackSchema.safeParse(request.query ?? {});
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_request", details: parsed.error.flatten() });
+    }
+    if (parsed.data.error) {
+      return reply.code(400).send({ error: parsed.data.error });
+    }
+    const connection = await prisma.providerConnection.findFirst({
+      where: { provider, orgId: parsed.data.orgId },
+    });
+    if (!connection) {
+      return reply.code(404).send({ error: "connection_not_found" });
+    }
+    const meta = (connection.meta as Record<string, unknown> | null | undefined) ?? {};
+    if (meta.oauthState !== parsed.data.state) {
+      return reply.code(400).send({ error: "state_mismatch" });
+    }
+    try {
+      const tokenSet = await connector.exchangeCode({
+        orgId: parsed.data.orgId,
+        code: parsed.data.code,
+        redirectUri: parsed.data.redirectUri ?? "",
+      });
+      const updatedMeta = {
+        ...meta,
+        oauthState: null,
+        connectedAt: new Date().toISOString(),
+        scope: tokenSet.scope ?? [],
+      };
+      const updated = await prisma.providerConnection.update({
+        where: { id: connection.id },
+        data: {
+          status: "CONNECTED",
+          accessToken: tokenSet.accessToken,
+          refreshToken: tokenSet.refreshToken ?? null,
+          expiresAt: tokenSet.expiresAt ?? null,
+          meta: updatedMeta,
+        },
+      });
+      return reply.send({ ok: true, provider, connectionId: updated.id });
+    } catch (err) {
+      request.log.error({ err }, "oauth_exchange_failed");
+      return reply.code(502).send({ error: "oauth_exchange_failed" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/routes/connectors.webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/connectors.webhooks.ts
@@ -1,0 +1,78 @@
+import { FastifyInstance } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+import { getConnector } from "../connectors";
+import { enqueueSyncJob } from "../jobs/sync";
+
+class WebhookNonceStore {
+  private cache = new Map<string, number>();
+  constructor(private ttlMs: number) {}
+
+  purge(now: number) {
+    for (const [nonce, ts] of this.cache.entries()) {
+      if (now - ts > this.ttlMs) {
+        this.cache.delete(nonce);
+      }
+    }
+  }
+
+  check(nonce: string, timestamp: Date) {
+    const now = Date.now();
+    if (!nonce) {
+      return { ok: false, reason: "missing_nonce" } as const;
+    }
+    if (now - timestamp.getTime() > this.ttlMs) {
+      return { ok: false, reason: "stale" } as const;
+    }
+    const existing = this.cache.get(nonce);
+    if (existing && now - existing < this.ttlMs) {
+      return { ok: false, reason: "replay" } as const;
+    }
+    this.cache.set(nonce, now);
+    this.purge(now);
+    return { ok: true } as const;
+  }
+}
+
+const nonceStore = new WebhookNonceStore(5 * 60 * 1000);
+
+export function registerConnectorWebhookRoutes(app: FastifyInstance) {
+  app.post("/webhooks/:provider", async (request, reply) => {
+    const { provider } = request.params as { provider: string };
+    const connector = getConnector(provider);
+    if (!connector) {
+      return reply.code(404).send({ error: "unknown_provider" });
+    }
+    const rawBody = (request as any).rawBody as Buffer | undefined;
+    const bodyBuffer = rawBody ?? Buffer.from(JSON.stringify(request.body ?? {}));
+    let verification;
+    try {
+      verification = await connector.verifyWebhook(bodyBuffer, request.headers);
+    } catch (err) {
+      request.log.error({ err }, "webhook_verification_failed");
+      return reply.code(400).send({ error: "verification_failed" });
+    }
+    if (!verification.valid || !verification.orgId) {
+      return reply.code(401).send({ error: verification.reason ?? "unauthorized" });
+    }
+    const nonce = verification.nonce ?? "";
+    const timestamp = verification.timestamp ?? new Date();
+    const nonceResult = nonceStore.check(nonce, timestamp);
+    if (!nonceResult.ok) {
+      return reply.code(409).send({ error: nonceResult.reason });
+    }
+    const connection = verification.connectionId
+      ? await prisma.providerConnection.findFirst({ where: { id: verification.connectionId } })
+      : await prisma.providerConnection.findFirst({ where: { provider, orgId: verification.orgId } });
+    if (!connection) {
+      return reply.code(202).send({ ok: true, ignored: true });
+    }
+    await enqueueSyncJob({
+      provider,
+      orgId: connection.orgId,
+      connectionId: connection.id,
+      reason: "webhook",
+      events: verification.events,
+    });
+    return reply.code(202).send({ ok: true });
+  });
+}

--- a/apgms/services/api-gateway/src/schemas/connectors.ts
+++ b/apgms/services/api-gateway/src/schemas/connectors.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+export const OAuthStartSchema = z.object({
+  orgId: z.string().min(1, "orgId required"),
+  redirectUri: z.string().url().optional(),
+});
+
+export const OAuthCallbackSchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(8),
+  orgId: z.string().min(1),
+  redirectUri: z.string().url().optional(),
+  scope: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export const NormalizedInvoiceSchema = z.object({
+  provider: z.string(),
+  orgId: z.string(),
+  externalId: z.string(),
+  number: z.string(),
+  status: z.string(),
+  total: z.number(),
+  currency: z.string().length(3),
+  issuedAt: z.date(),
+  dueAt: z.date().optional(),
+  customerName: z.string(),
+});
+
+export const NormalizedPaymentSchema = z.object({
+  provider: z.string(),
+  orgId: z.string(),
+  externalId: z.string(),
+  amount: z.number(),
+  currency: z.string().length(3),
+  occurredAt: z.date(),
+  counterpartyName: z.string(),
+  description: z.string().optional(),
+  type: z.string(),
+});
+
+export const NormalizedEmployeeSchema = z.object({
+  provider: z.string(),
+  orgId: z.string(),
+  externalId: z.string(),
+  fullName: z.string(),
+  email: z.string().email().optional(),
+  status: z.string(),
+  hiredAt: z.date().optional(),
+});
+
+export const WebhookEventSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  occurredAt: z.coerce.date(),
+  payload: z.unknown().optional(),
+});
+
+export const WebhookPayloadSchema = z.object({
+  orgId: z.string(),
+  connectionId: z.string().optional(),
+  nonce: z.string(),
+  timestamp: z.coerce.date(),
+  events: z.array(WebhookEventSchema).default([]),
+});
+
+export type NormalizedInvoice = z.infer<typeof NormalizedInvoiceSchema>;
+export type NormalizedPayment = z.infer<typeof NormalizedPaymentSchema>;
+export type NormalizedEmployee = z.infer<typeof NormalizedEmployeeSchema>;
+export type WebhookEvent = z.infer<typeof WebhookEventSchema>;
+export type WebhookPayload = z.infer<typeof WebhookPayloadSchema>;

--- a/apgms/services/api-gateway/src/utils/jwt.ts
+++ b/apgms/services/api-gateway/src/utils/jwt.ts
@@ -1,0 +1,65 @@
+import crypto from "node:crypto";
+
+type JwtHeader = {
+  alg: string;
+  typ: string;
+};
+
+type JwtPayload = Record<string, any>;
+
+function base64UrlDecode(segment: string): Buffer {
+  segment = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = segment.length % 4;
+  if (pad) {
+    segment += "=".repeat(4 - pad);
+  }
+  return Buffer.from(segment, "base64");
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+export function verifyJwt(token: string | undefined, secret: string): JwtPayload | null {
+  if (!token) {
+    return null;
+  }
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    return null;
+  }
+  const [headerSeg, payloadSeg, signatureSeg] = segments;
+  try {
+    const header = JSON.parse(base64UrlDecode(headerSeg).toString("utf8")) as JwtHeader;
+    if (header.alg !== "HS256") {
+      return null;
+    }
+    const payload = JSON.parse(base64UrlDecode(payloadSeg).toString("utf8")) as JwtPayload;
+    const expected = base64UrlEncode(
+      crypto.createHmac("sha256", secret).update(`${headerSeg}.${payloadSeg}`).digest()
+    );
+    if (!crypto.timingSafeEqual(Buffer.from(signatureSeg), Buffer.from(expected))) {
+      return null;
+    }
+    const exp = payload.exp as number | undefined;
+    if (exp && exp * 1000 < Date.now()) {
+      return null;
+    }
+    return payload;
+  } catch (err) {
+    return null;
+  }
+}
+
+export function signJwt(payload: JwtPayload, secret: string, options?: { header?: Partial<JwtHeader> }) {
+  const header: JwtHeader = { alg: "HS256", typ: "JWT", ...(options?.header ?? {}) };
+  const headerSeg = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+  const payloadSeg = base64UrlEncode(Buffer.from(JSON.stringify(payload)));
+  const signature = crypto.createHmac("sha256", secret).update(`${headerSeg}.${payloadSeg}`).digest();
+  const signatureSeg = base64UrlEncode(signature);
+  return `${headerSeg}.${payloadSeg}.${signatureSeg}`;
+}

--- a/apgms/services/api-gateway/test/connectors.oauth.spec.ts
+++ b/apgms/services/api-gateway/test/connectors.oauth.spec.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createMockPrisma, MockPrismaClient } from "./utils/mockPrisma";
+
+const prismaHolder: { prisma: MockPrismaClient } = { prisma: createMockPrisma() };
+
+vi.mock("@apgms/shared/src/db", () => ({
+  get prisma() {
+    return prismaHolder.prisma;
+  },
+}));
+
+import { buildApp } from "../src/app";
+import { connectors } from "../src/connectors";
+import { ensureFreshAccessToken } from "../src/jobs/sync";
+
+describe("connector oauth routes", () => {
+  beforeEach(() => {
+    prismaHolder.prisma = createMockPrisma();
+  });
+
+  afterEach(async () => {
+    await prismaHolder.prisma?.providerConnection?.findMany({});
+  });
+
+  it("starts oauth flow and stores pending connection", async () => {
+    const app = buildApp();
+    const response = await app.inject({
+      method: "GET",
+      url: "/connect/xero/start",
+      query: { orgId: "org-1", redirectUri: "https://example.com/callback" },
+    });
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as { state: string; redirectUrl: string; connectionId: string };
+    expect(body.state).toHaveLength(32);
+    expect(body.redirectUrl).toContain("state=");
+    const connection = prismaHolder.prisma.__stores.connections.get(body.connectionId);
+    expect(connection?.status).toBe("PENDING");
+    expect(connection?.meta).toMatchObject({ oauthState: body.state });
+    await app.close();
+  });
+
+  it("completes oauth callback and persists tokens", async () => {
+    const app = buildApp();
+    const start = await app.inject({
+      method: "GET",
+      url: "/connect/xero/start",
+      query: { orgId: "org-2", redirectUri: "https://example.com/callback" },
+    });
+    const { state, connectionId } = start.json() as { state: string; connectionId: string };
+    const callback = await app.inject({
+      method: "GET",
+      url: "/connect/xero/callback",
+      query: { orgId: "org-2", code: "auth-code", state },
+    });
+    expect(callback.statusCode).toBe(200);
+    const updated = prismaHolder.prisma.__stores.connections.get(connectionId);
+    expect(updated?.status).toBe("CONNECTED");
+    expect(updated?.accessToken).toBeTruthy();
+    expect(updated?.refreshToken).toBeTruthy();
+    await app.close();
+  });
+
+  it("rejects oauth callback when state mismatches", async () => {
+    const app = buildApp();
+    await app.inject({
+      method: "GET",
+      url: "/connect/xero/start",
+      query: { orgId: "org-3", redirectUri: "https://example.com/callback" },
+    });
+    const callback = await app.inject({
+      method: "GET",
+      url: "/connect/xero/callback",
+      query: { orgId: "org-3", code: "auth-code", state: "bad-state" },
+    });
+    expect(callback.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("refreshes access tokens when expiring", async () => {
+    prismaHolder.prisma = createMockPrisma();
+    const connection = await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-4",
+        provider: "xero",
+        status: "CONNECTED",
+        accessToken: "old-token",
+        refreshToken: "refresh-token",
+        expiresAt: new Date(Date.now() + 1000),
+        meta: {},
+      },
+    });
+    expect(prismaHolder.prisma.providerConnection.update).not.toHaveBeenCalled();
+    const result = await ensureFreshAccessToken(connection as any, connectors.xero);
+    expect(result.accessToken).not.toBe("old-token");
+    expect(prismaHolder.prisma.providerConnection.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apgms/services/api-gateway/test/connectors.webhooks.spec.ts
+++ b/apgms/services/api-gateway/test/connectors.webhooks.spec.ts
@@ -1,0 +1,176 @@
+import crypto from "node:crypto";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createMockPrisma, MockPrismaClient } from "./utils/mockPrisma";
+import { signJwt } from "../src/utils/jwt";
+
+const prismaHolder: { prisma: MockPrismaClient } = { prisma: createMockPrisma() };
+
+vi.mock("@apgms/shared/src/db", () => ({
+  get prisma() {
+    return prismaHolder.prisma;
+  },
+}));
+
+import { buildApp } from "../src/app";
+
+describe("connector webhooks", () => {
+  beforeEach(() => {
+    prismaHolder.prisma = createMockPrisma();
+    process.env.SHOPIFY_WEBHOOK_SECRET = "shopify-secret";
+    process.env.SQUARE_WEBHOOK_SECRET = "square-secret";
+    process.env.XERO_WEBHOOK_SECRET = "xero-secret";
+  });
+
+  it("validates shopify hmac and enqueues sync", async () => {
+    const app = buildApp();
+    const connection = await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-5",
+        provider: "shopify",
+        status: "CONNECTED",
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        meta: {},
+      },
+    });
+    const payload = {
+      orgId: "org-5",
+      connectionId: connection.id,
+      nonce: "nonce-1",
+      timestamp: new Date().toISOString(),
+      events: [
+        { id: "evt-1", type: "payment.updated", occurredAt: new Date().toISOString() },
+      ],
+    };
+    const raw = JSON.stringify(payload);
+    const signature = crypto.createHmac("sha256", process.env.SHOPIFY_WEBHOOK_SECRET!).update(raw).digest("base64");
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/shopify",
+      headers: {
+        "content-type": "application/json",
+        "x-shopify-hmac-sha256": signature,
+      },
+      payload: raw,
+    });
+    expect(response.statusCode).toBe(202);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(prismaHolder.prisma.bankLine.upsert).toHaveBeenCalled();
+    await app.close();
+  });
+
+  it("rejects replayed nonce", async () => {
+    const app = buildApp();
+    const connection = await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-6",
+        provider: "shopify",
+        status: "CONNECTED",
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        meta: {},
+      },
+    });
+    const payload = {
+      orgId: "org-6",
+      connectionId: connection.id,
+      nonce: "nonce-2",
+      timestamp: new Date().toISOString(),
+      events: [],
+    };
+    const raw = JSON.stringify(payload);
+    const signature = crypto.createHmac("sha256", process.env.SHOPIFY_WEBHOOK_SECRET!).update(raw).digest("base64");
+    const first = await app.inject({
+      method: "POST",
+      url: "/webhooks/shopify",
+      headers: {
+        "content-type": "application/json",
+        "x-shopify-hmac-sha256": signature,
+      },
+      payload: raw,
+    });
+    expect(first.statusCode).toBe(202);
+    const second = await app.inject({
+      method: "POST",
+      url: "/webhooks/shopify",
+      headers: {
+        "content-type": "application/json",
+        "x-shopify-hmac-sha256": signature,
+      },
+      payload: raw,
+    });
+    expect(second.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it("rejects stale webhook payload", async () => {
+    const app = buildApp();
+    await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-7",
+        provider: "shopify",
+        status: "CONNECTED",
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        meta: {},
+      },
+    });
+    const payload = {
+      orgId: "org-7",
+      nonce: "nonce-stale",
+      timestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+      events: [],
+    };
+    const raw = JSON.stringify(payload);
+    const signature = crypto.createHmac("sha256", process.env.SHOPIFY_WEBHOOK_SECRET!).update(raw).digest("base64");
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/shopify",
+      headers: {
+        "content-type": "application/json",
+        "x-shopify-hmac-sha256": signature,
+      },
+      payload: raw,
+    });
+    expect(response.statusCode).toBe(409);
+    await app.close();
+  });
+
+  it("validates xero jwt signature", async () => {
+    const app = buildApp();
+    const connection = await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-8",
+        provider: "xero",
+        status: "CONNECTED",
+        accessToken: "token",
+        refreshToken: "refresh",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        meta: {},
+      },
+    });
+    const payload = {
+      orgId: "org-8",
+      connectionId: connection.id,
+      nonce: "jwt-nonce",
+      timestamp: new Date().toISOString(),
+      events: [],
+    };
+    const raw = JSON.stringify(payload);
+    const jwt = signJwt({ orgId: "org-8", connectionId: connection.id, nonce: "jwt-nonce", exp: Math.floor(Date.now() / 1000) + 60 }, process.env.XERO_WEBHOOK_SECRET!);
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/xero",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${jwt}`,
+      },
+      payload: raw,
+    });
+    expect(response.statusCode).toBe(202);
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/test/sync.jobs.spec.ts
+++ b/apgms/services/api-gateway/test/sync.jobs.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createMockPrisma, MockPrismaClient } from "./utils/mockPrisma";
+
+const prismaHolder: { prisma: MockPrismaClient } = { prisma: createMockPrisma() };
+
+vi.mock("@apgms/shared/src/db", () => ({
+  get prisma() {
+    return prismaHolder.prisma;
+  },
+}));
+
+import { runScheduledSync } from "../src/jobs/sync";
+
+describe("sync jobs", () => {
+  beforeEach(() => {
+    prismaHolder.prisma = createMockPrisma();
+    process.env.XERO_WEBHOOK_SECRET = "xero-secret";
+  });
+
+  it("runs scheduled sync and upserts normalized records", async () => {
+    await prismaHolder.prisma.providerConnection.create({
+      data: {
+        orgId: "org-10",
+        provider: "xero",
+        status: "CONNECTED",
+        accessToken: "token",
+        refreshToken: "refresh-token",
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        meta: {},
+      },
+    });
+
+    const results = await runScheduledSync();
+    expect(results).toHaveLength(1);
+    expect(results[0].counts.invoices).toBeGreaterThan(0);
+    expect(prismaHolder.prisma.bankLine.upsert).toHaveBeenCalled();
+    expect(prismaHolder.prisma.auditBlob.upsert).toHaveBeenCalled();
+
+    const connection = Array.from(prismaHolder.prisma.__stores.connections.values())[0];
+    expect(connection.meta).toMatchObject({ lastSyncReason: "schedule" });
+  });
+});

--- a/apgms/services/api-gateway/test/utils/mockPrisma.ts
+++ b/apgms/services/api-gateway/test/utils/mockPrisma.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import { vi } from "vitest";
+
+export interface MockProviderConnectionRecord {
+  id: string;
+  orgId: string;
+  provider: string;
+  status: string;
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: Date | null;
+  meta: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface MockBankLineRecord {
+  id: string;
+  orgId: string;
+  externalId: string;
+  date: Date;
+  amount: any;
+  payee: string;
+  desc: string;
+  provider?: string | null;
+  createdAt: Date;
+}
+
+export interface MockAuditBlobRecord {
+  id: string;
+  provider: string;
+  externalId: string;
+  type: string;
+  orgId: string;
+  payload: unknown;
+  createdAt: Date;
+}
+
+function matchesWhere<T extends Record<string, any>>(where: Record<string, any> | undefined, record: T) {
+  if (!where) return true;
+  return Object.entries(where).every(([key, value]) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return matchesWhere(value as Record<string, any>, record[key] ?? record);
+    }
+    return record[key] === value;
+  });
+}
+
+export function createMockPrisma() {
+  const connections = new Map<string, MockProviderConnectionRecord>();
+  const bankLines = new Map<string, MockBankLineRecord>();
+  const auditBlobs = new Map<string, MockAuditBlobRecord>();
+
+  const prisma = {
+    __stores: { connections, bankLines, auditBlobs },
+    providerConnection: {
+      create: vi.fn(async ({ data }: { data: Partial<MockProviderConnectionRecord> }) => {
+        const record: MockProviderConnectionRecord = {
+          id: data.id ?? randomUUID(),
+          orgId: data.orgId!,
+          provider: data.provider!,
+          status: data.status ?? "PENDING",
+          accessToken: (data.accessToken as string | null) ?? null,
+          refreshToken: (data.refreshToken as string | null) ?? null,
+          expiresAt: (data.expiresAt as Date | null) ?? null,
+          meta: (data.meta as Record<string, unknown> | null) ?? null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        };
+        connections.set(record.id, record);
+        return structuredClone(record);
+      }),
+      update: vi.fn(async ({ where, data }: { where: { id: string }; data: Partial<MockProviderConnectionRecord> }) => {
+        const existing = connections.get(where.id);
+        if (!existing) throw new Error("connection_not_found");
+        const updated: MockProviderConnectionRecord = {
+          ...existing,
+          ...data,
+          meta: (data.meta as Record<string, unknown> | null) ?? (existing.meta ?? null),
+          updatedAt: new Date(),
+        };
+        connections.set(updated.id, updated);
+        return structuredClone(updated);
+      }),
+      findFirst: vi.fn(async ({ where }: { where?: Record<string, any> }) => {
+        for (const record of connections.values()) {
+          if (matchesWhere(where, record)) {
+            return structuredClone(record);
+          }
+        }
+        return null;
+      }),
+      findMany: vi.fn(async ({ where }: { where?: Record<string, any> }) => {
+        const results: MockProviderConnectionRecord[] = [];
+        for (const record of connections.values()) {
+          if (matchesWhere(where, record)) {
+            results.push(structuredClone(record));
+          }
+        }
+        return results;
+      }),
+    },
+    bankLine: {
+      upsert: vi.fn(async ({
+        where,
+        create,
+        update,
+      }: {
+        where: { orgId_externalId: { orgId: string; externalId: string } };
+        create: Partial<MockBankLineRecord>;
+        update: Partial<MockBankLineRecord>;
+      }) => {
+        const key = `${where.orgId_externalId.orgId}:${where.orgId_externalId.externalId}`;
+        const existing = bankLines.get(key);
+        if (existing) {
+          const next: MockBankLineRecord = {
+            ...existing,
+            ...update,
+            createdAt: existing.createdAt,
+          };
+          bankLines.set(key, next);
+          return structuredClone(next);
+        }
+        const record: MockBankLineRecord = {
+          id: randomUUID(),
+          orgId: create.orgId!,
+          externalId: create.externalId!,
+          date: create.date as Date,
+          amount: create.amount,
+          payee: create.payee!,
+          desc: create.desc!,
+          provider: create.provider ?? null,
+          createdAt: new Date(),
+        };
+        bankLines.set(key, record);
+        return structuredClone(record);
+      }),
+      findMany: vi.fn(async () => Array.from(bankLines.values()).map((item) => structuredClone(item))),
+      create: vi.fn(async ({ data }: { data: Partial<MockBankLineRecord> }) => {
+        const record: MockBankLineRecord = {
+          id: randomUUID(),
+          orgId: data.orgId!,
+          externalId: data.externalId ?? randomUUID(),
+          date: data.date as Date,
+          amount: data.amount,
+          payee: data.payee!,
+          desc: data.desc!,
+          provider: data.provider ?? null,
+          createdAt: new Date(),
+        };
+        bankLines.set(`${record.orgId}:${record.externalId}`, record);
+        return structuredClone(record);
+      }),
+    },
+    auditBlob: {
+      upsert: vi.fn(async ({
+        where,
+        create,
+        update,
+      }: {
+        where: { provider_externalId_type: { provider: string; externalId: string; type: string } };
+        create: Partial<MockAuditBlobRecord>;
+        update: Partial<MockAuditBlobRecord>;
+      }) => {
+        const key = `${where.provider_externalId_type.provider}:${where.provider_externalId_type.externalId}:${where.provider_externalId_type.type}`;
+        const existing = auditBlobs.get(key);
+        if (existing) {
+          const next: MockAuditBlobRecord = {
+            ...existing,
+            ...update,
+            createdAt: existing.createdAt,
+          };
+          auditBlobs.set(key, next);
+          return structuredClone(next);
+        }
+        const record: MockAuditBlobRecord = {
+          id: randomUUID(),
+          provider: create.provider!,
+          externalId: create.externalId!,
+          type: create.type!,
+          orgId: create.orgId!,
+          payload: create.payload,
+          createdAt: new Date(),
+        };
+        auditBlobs.set(key, record);
+        return structuredClone(record);
+      }),
+    },
+    user: {
+      findMany: vi.fn(async () => []),
+    },
+  };
+
+  return prisma;
+}
+
+export type MockPrismaClient = ReturnType<typeof createMockPrisma>;

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/services/api-gateway/vitest.config.ts
+++ b/apgms/services/api-gateway/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.spec.ts"],
+    globals: true,
+  },
+});

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -13,6 +13,8 @@ model Org {
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
+  providerConnections ProviderConnection[]
+  auditBlobs AuditBlob[]
 }
 
 model User {
@@ -32,5 +34,38 @@ model BankLine {
   amount    Decimal
   payee     String
   desc      String
+  externalId String?
+  provider   String?
   createdAt DateTime @default(now())
+
+  @@unique([orgId, externalId])
+}
+
+model ProviderConnection {
+  id           String   @id @default(cuid())
+  org          Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
+  provider     String
+  status       String   @db.VarChar(16)
+  accessToken  String?
+  refreshToken String?
+  expiresAt    DateTime?
+  meta         Json
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@unique([orgId, provider])
+}
+
+model AuditBlob {
+  id         String   @id @default(cuid())
+  org        Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId      String
+  provider   String
+  type       String
+  externalId String
+  payload    Json
+  createdAt  DateTime @default(now())
+
+  @@unique([provider, externalId, type])
 }

--- a/apgms/webapp/src/lib/oauth.ts
+++ b/apgms/webapp/src/lib/oauth.ts
@@ -1,0 +1,56 @@
+export interface OAuthWindowOptions {
+  provider: string;
+  url: string;
+  timeoutMs?: number;
+}
+
+export interface OAuthResult<T = unknown> {
+  provider: string;
+  ok: boolean;
+  payload?: T;
+  error?: string;
+}
+
+export function openOAuthWindow<T = unknown>(options: OAuthWindowOptions): Promise<OAuthResult<T>> {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("window_unavailable"));
+  }
+  const timeout = options.timeoutMs ?? 60_000;
+  const popup = window.open(options.url, `${options.provider}-oauth`, "width=600,height=800");
+  return new Promise<OAuthResult<T>>((resolve, reject) => {
+    const timer = window.setTimeout(() => {
+      cleanup();
+      reject(new Error("oauth_timeout"));
+    }, timeout);
+
+    function cleanup() {
+      window.removeEventListener("message", onMessage);
+      window.clearTimeout(timer);
+      if (popup && !popup.closed) {
+        popup.close();
+      }
+    }
+
+    function onMessage(event: MessageEvent) {
+      const data = event.data as { type?: string; provider?: string; payload?: T; error?: string };
+      if (!data || data.type !== "oauth:callback" || data.provider !== options.provider) {
+        return;
+      }
+      cleanup();
+      if (data.error) {
+        resolve({ provider: options.provider, ok: false, error: data.error });
+        return;
+      }
+      resolve({ provider: options.provider, ok: true, payload: data.payload });
+    }
+
+    window.addEventListener("message", onMessage);
+  });
+}
+
+export function simulateOAuthCallback<T = unknown>(provider: string, payload: T) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.postMessage({ type: "oauth:callback", provider, payload }, window.origin);
+}

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,29 @@
-﻿console.log('webapp');
+import { attachIntegrationHandlers, defaultTiles } from "./routes/integrations";
+import { openOAuthWindow } from "./lib/oauth";
+
+declare const document: Document | undefined;
+
+timeoutFallback();
+
+function timeoutFallback() {
+  // placeholder to ensure module executes in non-browser tests
+}
+
+if (typeof document !== "undefined") {
+  const root = document.getElementById("app");
+  if (root) {
+    attachIntegrationHandlers(root, {
+      tiles: defaultTiles(),
+      onConnect: async (provider) => {
+        try {
+          await openOAuthWindow({ provider, url: `/connect/${provider}/start` });
+        } catch (err) {
+          console.error("oauth_start_failed", err);
+        }
+      },
+      onDisconnect: (provider) => {
+        console.log("disconnect", provider);
+      },
+    });
+  }
+}

--- a/apgms/webapp/src/routes/integrations.tsx
+++ b/apgms/webapp/src/routes/integrations.tsx
@@ -1,0 +1,73 @@
+export type IntegrationStatus = "connected" | "disconnected" | "pending" | "error";
+
+export interface IntegrationTileModel {
+  provider: string;
+  title: string;
+  status: IntegrationStatus;
+  lastSyncedAt?: string | null;
+  error?: string | null;
+}
+
+export interface IntegrationsPageOptions {
+  tiles: IntegrationTileModel[];
+  onConnect?: (provider: string) => void;
+  onDisconnect?: (provider: string) => void;
+}
+
+function formatStatus(tile: IntegrationTileModel) {
+  switch (tile.status) {
+    case "connected":
+      return tile.lastSyncedAt ? `Connected · Last sync ${tile.lastSyncedAt}` : "Connected";
+    case "pending":
+      return "Connecting…";
+    case "error":
+      return tile.error ? `Error · ${tile.error}` : "Error";
+    default:
+      return "Not connected";
+  }
+}
+
+export function renderIntegrationsPage(options: IntegrationsPageOptions): string {
+  const { tiles } = options;
+  const items = tiles
+    .map((tile) => {
+      const status = formatStatus(tile);
+      const actionLabel = tile.status === "connected" ? "Disconnect" : "Connect";
+      const action = tile.status === "connected" ? "disconnect" : "connect";
+      return `
+        <article class="integration-tile" data-provider="${tile.provider}">
+          <header>
+            <h3>${tile.title}</h3>
+          </header>
+          <p class="status">${status}</p>
+          <button data-action="${action}" data-provider="${tile.provider}">${actionLabel}</button>
+        </article>
+      `;
+    })
+    .join("\n");
+  return `<section class="integrations-grid">${items}</section>`;
+}
+
+export function attachIntegrationHandlers(root: HTMLElement, options: IntegrationsPageOptions) {
+  root.innerHTML = renderIntegrationsPage(options);
+  root.querySelectorAll<HTMLButtonElement>("button[data-provider]").forEach((button) => {
+    const provider = button.dataset.provider!;
+    button.addEventListener("click", () => {
+      if (button.dataset.action === "connect") {
+        options.onConnect?.(provider);
+      } else {
+        options.onDisconnect?.(provider);
+      }
+    });
+  });
+}
+
+export function defaultTiles(): IntegrationTileModel[] {
+  return [
+    { provider: "xero", title: "Xero", status: "disconnected" },
+    { provider: "qbo", title: "QuickBooks Online", status: "disconnected" },
+    { provider: "myob", title: "MYOB", status: "disconnected" },
+    { provider: "square", title: "Square", status: "disconnected" },
+    { provider: "shopify", title: "Shopify", status: "disconnected" },
+  ];
+}


### PR DESCRIPTION
## Summary
- add prisma models for provider connections and audit blobs
- implement connector stubs, OAuth/webhook routes, and scheduled sync jobs
- build integrations UI helpers and OAuth window utility for the web app
- add vitest-based test suites covering OAuth flows, webhook validation, and sync jobs

## Testing
- `pnpm -r test` *(fails: vitest binary unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f47eb81ab483278c199463d2023535