### PR TITLE
Add security program evidence documentation

### DIFF
--- a/apgms/docs/OSF_READINESS.md
+++ b/apgms/docs/OSF_READINESS.md
@@ -1,0 +1,15 @@
+# OSF Readiness Checklist
+
+| Control Area | Status | Evidence |
+|--------------|--------|----------|
+| CI Pipeline Integrity | ✅ | [Build workflow run](../status/ci/latest-build.md) |
+| Static Application Security Testing | ✅ | [SAST report artifact](../status/ci/sast-report.md) |
+| Dependency Vulnerability Scanning | ✅ | [Dependency scan results](../status/ci/dependency-scan.md) |
+| Infrastructure as Code Validation | ✅ | [Terraform plan output](../status/ci/terraform-plan.md) |
+| Secrets Detection | ✅ | [Secret scan log](../status/ci/secret-scan.md) |
+| Performance Benchmarking | ✅ | [k6 load test summary](../status/ci/k6-summary.md) |
+| DR Runbook Validation | ⬜ | Scheduled quarterly; track in Jira SEC-102 |
+
+## Additional Notes
+- Evidence artifacts are published from GitHub Actions and stored under `status/ci/` for auditability.
+- For pending controls, ensure Jira tickets reference the latest run output before submission.

--- a/apgms/docs/PRIVACY.md
+++ b/apgms/docs/PRIVACY.md
@@ -1,0 +1,26 @@
+# Privacy Program
+
+## APP 12: Access to Personal Information
+We provide individuals with access to their personal information upon verified request.
+- Submit requests via privacy@example.com or the self-service portal.
+- Identity verification uses multi-factor verification to prevent unauthorized disclosure.
+- Responses are provided within 30 calendar days, including confirmation of data held, purpose of processing, and third parties with access.
+
+## APP 13: Correction of Personal Information
+- Individuals may request correction or deletion of data through the same channels as APP 12 requests.
+- Corrections are acknowledged within 10 business days; if correction is declined, we provide written reasons and complaint escalation steps.
+- Deletion requests are actioned where lawful; for retention obligations (e.g., AML/KYC), data is segregated and access restricted.
+
+## Data Export
+- Machine-readable exports (JSON/CSV) are provided for account data, transaction history, and consent records.
+- Exports are delivered through secure download links that expire after 7 days.
+
+## Data Deletion Workflow
+1. Verify identity of requester.
+2. Confirm scope of data to delete and legal retention requirements.
+3. Remove data from primary stores, backups marked for deletion on next cycle.
+4. Issue confirmation to requester including residual data required for compliance.
+
+## Appeals and Complaints
+- Escalation contact: privacy-officer@example.com.
+- External complaint avenue: Office of the Australian Information Commissioner (OAIC).

--- a/apgms/docs/SECURITY.md
+++ b/apgms/docs/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Program Overview
+
+## Vulnerability Disclosure Intake
+- Email: security@example.com (alias monitored 24/7)
+- Web form: https://example.com/security-report
+- PGP Key: pending publication (`TODO: upload key fingerprint`)
+- Expected initial response within 1 business day
+
+## Service Level Agreements
+| Severity | Triage SLA | Remediation SLA |
+|----------|------------|-----------------|
+| Critical | 4 hours    | 7 days          |
+| High     | 1 business day | 14 days     |
+| Medium   | 3 business days | 30 days    |
+| Low      | 5 business days | 90 days    |
+
+## Security Contacts
+- Primary: Chief Information Security Officer (ciso@example.com)
+- Secondary: Security Operations Team (soc@example.com)
+
+## Coordinated Disclosure Policy
+We follow a 90-day disclosure window aligned with industry norms. Researchers are encouraged to coordinate publication timelines with our security team to ensure patches are delivered to customers before public disclosure.
+
+## Bug Bounty Coordination
+Bounties are handled through our private program on ExampleBugBounty Platform. Invitations are issued upon request to security researchers demonstrating relevant expertise.

--- a/apgms/docs/THREAT_MODEL.md
+++ b/apgms/docs/THREAT_MODEL.md
@@ -1,0 +1,47 @@
+# Threat Model
+
+## System Overview
+The APGMS platform consists of the following core components:
+- Web Application (Next.js frontend) served via CDN.
+- API Gateway that fronts microservices for portfolio management, investor onboarding, and analytics.
+- Authentication service integrating with third-party identity provider.
+- Data stores: PostgreSQL (transactions, users), Redis (sessions), S3-compatible object storage (documents).
+- External integrations: Payment processor, KYC provider, notification service.
+
+## Data Flow Diagram (DFD)
+1. **Investor Browser** → HTTPS → **CDN / Web App** → API calls to **API Gateway**.
+2. **API Gateway** → mTLS → **Microservices** (Portfolio, Onboarding, Analytics).
+3. **Microservices** ↔ **PostgreSQL** (encrypted at rest) for persistent data.
+4. **Onboarding Service** → HTTPS → **KYC Provider** (PII transfer, response tokens stored).
+5. **Portfolio Service** → HTTPS → **Payment Processor** (tokenized payment info).
+6. **Notification Service** pulls events from **Event Bus** and sends via email/SMS provider.
+7. **Admin Portal** → SSO → **API Gateway** with elevated scopes for operations staff.
+
+## Assets
+- Investor personal and financial data.
+- Authentication secrets and session tokens.
+- Payment tokens and transaction records.
+- Administrative audit logs and operational dashboards.
+
+## Threat Actors
+- External attackers attempting account takeover or data exfiltration.
+- Malicious insiders with privileged access.
+- Third-party service compromise (KYC, payments).
+- Automated bot traffic seeking to abuse onboarding workflows.
+
+## Security Controls
+- TLS 1.2+ enforced on all external endpoints; HSTS enabled at CDN.
+- OAuth 2.0 / OIDC for user authentication; refresh tokens stored in HTTP-only cookies.
+- Role-based access control enforced at API gateway and service layer.
+- Data encryption at rest using cloud-managed KMS for PostgreSQL, object storage, and backups.
+- Web Application Firewall (WAF) rules for OWASP Top 10 patterns; rate limiting via CDN.
+- Secrets managed via HashiCorp Vault; rotation policies every 90 days.
+- Audit logging centralized in SIEM with immutable storage for 365 days.
+
+## Residual Risks & Mitigations
+- **Supply Chain Risk:** mitigated via dependency scanning and signed releases.
+- **Denial of Service:** mitigated through auto-scaling and CDN edge protections.
+- **Insider Abuse:** mitigated with least-privilege IAM, activity monitoring, and quarterly access reviews.
+
+## Review Cadence
+Threat model reviewed quarterly and after major architecture changes; tracked in Jira security backlog.

--- a/apgms/docs/observability.md
+++ b/apgms/docs/observability.md
@@ -1,0 +1,23 @@
+# Observability Strategy
+
+## Logging
+- Centralized structured logging via OpenTelemetry collector.
+- Application logs enriched with request IDs, tenant IDs, and user claims.
+- Retention: 30 days hot storage in Elasticsearch, 365 days archived to object storage.
+- PII minimization enforced through log scrubbing middleware.
+
+## Metrics
+- Prometheus scrapes service endpoints at 30-second intervals.
+- Key service-level indicators (SLIs): request latency (p95), error rate, throughput, queue depth.
+- Alerts defined in Grafana for SLO breaches with paging via PagerDuty.
+- Business metrics (investor signups, funds committed) exported to analytics warehouse nightly.
+
+## Traces
+- Distributed tracing with OpenTelemetry instrumentation across web, API, and worker services.
+- Traces sampled at 10% baseline, auto-increased during incidents using adaptive sampling.
+- Trace data retained for 14 days for root cause analysis and 90 days for critical incidents.
+
+## Dashboards & Runbooks
+- Grafana dashboards version-controlled under `infra/grafana/` and deployed via CI.
+- Runbooks stored in `ops/runbooks/` with direct links from alert notifications.
+- Incident retrospectives documented in Confluence with tickets cross-referenced in Jira.


### PR DESCRIPTION
## Summary
- add security, privacy, and threat model documentation for DSP OSF evidence pack
- document OSF readiness checklist with links to CI artifacts and observability strategy

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f484809c3083278969f85e2886aae6