### PR TITLE
Add minimal OpenTelemetry tracing and CI artifact upload

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,10 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+      - name: Upload OTEL traces
+        if: ${{ hashFiles('**/otel-traces.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: otel-traces
+          path: '**/otel-traces.json'
+          if-no-files-found: ignore

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -11,7 +11,11 @@
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.53.1",
+    "@opentelemetry/sdk-node": "^0.53.1",
+    "@opentelemetry/sdk-trace-base": "^1.24.1"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,6 +7,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
+if (process.env.ENABLE_OTEL === "true") {
+  const { initOtel } = await import("./otel.js");
+  await initOtel();
+}
+
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";

--- a/apgms/services/api-gateway/src/otel.ts
+++ b/apgms/services/api-gateway/src/otel.ts
@@ -1,0 +1,94 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import {
+  ExportResultCode,
+  ReadableSpan,
+  SpanExporter,
+} from "@opentelemetry/sdk-trace-base";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+class JsonFileSpanExporter implements SpanExporter {
+  private readonly spans: unknown[] = [];
+  constructor(private readonly filePath: string) {}
+
+  export(spans: ReadableSpan[], resultCallback: (result: { code: ExportResultCode; error?: Error }) => void): void {
+    try {
+      const serialized = spans.map((span) => ({
+        spanContext: span.spanContext(),
+        parentSpanId: span.parentSpanId,
+        name: span.name,
+        kind: span.kind,
+        startTime: span.startTime,
+        endTime: span.endTime,
+        status: span.status,
+        attributes: span.attributes,
+        events: span.events,
+        links: span.links,
+        resource: span.resource.attributes,
+        instrumentationScope: span.instrumentationScope,
+      }));
+      this.spans.push(...serialized);
+      resultCallback({ code: ExportResultCode.SUCCESS });
+    } catch (error) {
+      resultCallback({ code: ExportResultCode.FAILED, error: error as Error });
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.flush();
+  }
+
+  async forceFlush(): Promise<void> {
+    await this.flush();
+  }
+
+  private async flush(): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(
+      this.filePath,
+      JSON.stringify(
+        {
+          resourceSpans: this.spans,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+  }
+}
+
+const outputPath = path.resolve(process.cwd(), "otel-traces.json");
+const exporter = new JsonFileSpanExporter(outputPath);
+
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+
+const sdk = new NodeSDK({
+  traceExporter: exporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+let started = false;
+
+export const initOtel = async (): Promise<void> => {
+  if (started) {
+    return;
+  }
+  started = true;
+  await sdk.start();
+
+  const shutdown = async () => {
+    try {
+      await sdk.shutdown();
+    } catch (error) {
+      diag.error("Failed to shutdown OpenTelemetry SDK", error as Error);
+    }
+  };
+
+  process.once("beforeExit", shutdown);
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+};


### PR DESCRIPTION
## Summary
- add a minimal OpenTelemetry bootstrap for the API gateway using the Node SDK and auto instrumentations
- write collected spans to otel-traces.json when tracing is enabled via ENABLE_OTEL
- conditionally initialize tracing in the service entrypoint and upload traces as a CI artifact when present

## Testing
- pnpm install --filter @apgms/api-gateway (fails: ERR_PNPM_FETCH_403)


------
https://chatgpt.com/codex/tasks/task_e_68f4849a00b48327aa650fb66c3c3bda