### PR TITLE
feat: add zod validation for api gateway routes

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test ../../tests/contracts.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,177 @@
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { Decimal } from "@prisma/client/runtime/library";
+
+import { replyValidate } from "./lib/reply.js";
+import { zDateISO, zOrgId } from "./schemas/common.js";
+import {
+  createBankLineBodySchema,
+  createBankLineResponseSchema,
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+} from "./schemas/bank-lines.js";
+import { z } from "zod";
+
+type DecimalLike = { toNumber: () => number };
+
+type UserRecord = {
+  email: string;
+  orgId: string;
+  createdAt: Date;
+};
+
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: DecimalLike;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+type PrismaLike = {
+  user: {
+    findMany: (args: {
+      select: { email: true; orgId: true; createdAt: true };
+      orderBy: { createdAt: "desc" | "asc" };
+    }) => Promise<UserRecord[]>;
+  };
+  bankLine: {
+    findMany: (args: {
+      orderBy: { date: "desc" | "asc" };
+      take: number;
+      skip?: number;
+      cursor?: { id: string };
+    }) => Promise<BankLineRecord[]>;
+    create: (args: {
+      data: {
+        orgId: string;
+        date: Date;
+        amount: DecimalLike;
+        payee: string;
+        desc: string;
+      };
+    }) => Promise<BankLineRecord>;
+  };
+};
+
+export type BuildAppDependencies = {
+  prisma: PrismaLike;
+};
+
+const resolveDependencies = async (
+  deps?: BuildAppDependencies,
+): Promise<BuildAppDependencies> => {
+  if (deps) {
+    return deps;
+  }
+
+  const shared = await import("../../../shared/src/db.js");
+  return { prisma: shared.prisma as PrismaLike };
+};
+
+export const buildApp = async (deps?: BuildAppDependencies) => {
+  const resolvedDeps = await resolveDependencies(deps);
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+
+  const healthResponseSchema = z.object({
+    ok: z.literal(true),
+    service: z.string(),
+  });
+
+  app.get("/health", async () =>
+    replyValidate(healthResponseSchema)({ ok: true, service: "api-gateway" }),
+  );
+
+  const userSchema = z.object({
+    email: z.string().email(),
+    orgId: zOrgId,
+    createdAt: zDateISO,
+  });
+
+  const usersResponseSchema = z.object({
+    users: z.array(userSchema),
+  });
+
+  app.get("/users", async () => {
+    const users = await resolvedDeps.prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    const payload = {
+      users: users.map((user) => ({
+        email: user.email,
+        orgId: user.orgId,
+        createdAt: user.createdAt.toISOString(),
+      })),
+    };
+
+    return replyValidate(usersResponseSchema)(payload);
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const query = listBankLinesQuerySchema.parse(req.query ?? {});
+    const take = query.take ?? 20;
+
+    const records = await resolvedDeps.prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: take + 1,
+      skip: query.cursor ? 1 : undefined,
+      cursor: query.cursor ? { id: query.cursor } : undefined,
+    });
+
+    const nextCursor = records.length > take ? records[take].id : null;
+
+    const lines = records.slice(0, take).map((line) => ({
+      id: line.id,
+      orgId: line.orgId,
+      date: line.date.toISOString(),
+      amountCents: Math.round(line.amount.toNumber() * 100),
+      payee: line.payee,
+      desc: line.desc,
+      createdAt: line.createdAt.toISOString(),
+    }));
+
+    return replyValidate(listBankLinesResponseSchema)({
+      lines,
+      nextCursor,
+    });
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    const parsed = createBankLineBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      req.log.warn({ error: parsed.error }, "invalid request body");
+      return rep.code(400).send({ error: "bad_request" });
+    }
+
+    const { date, amountCents, ...rest } = parsed.data;
+    const amountDecimal = new Decimal(amountCents).dividedBy(100);
+
+    const created = await resolvedDeps.prisma.bankLine.create({
+      data: {
+        ...rest,
+        date,
+        amount: amountDecimal,
+      },
+    });
+
+    const response = replyValidate(createBankLineResponseSchema)({
+      id: created.id,
+      orgId: created.orgId,
+      date: created.date.toISOString(),
+      amountCents: Math.round(created.amount.toNumber() * 100),
+      payee: created.payee,
+      desc: created.desc,
+      createdAt: created.createdAt.toISOString(),
+    });
+
+    return rep.code(201).send(response);
+  });
+
+  return app;
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,65 +7,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { buildApp } from "./app.js";
 
-const app = Fastify({ logger: true });
+const app = await buildApp();
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
@@ -73,8 +20,9 @@ app.ready(() => {
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/src/lib/reply.ts
+++ b/apgms/services/api-gateway/src/lib/reply.ts
@@ -1,0 +1,3 @@
+import { ZodTypeAny } from "zod";
+
+export const replyValidate = <T extends ZodTypeAny>(schema: T) => (value: unknown) => schema.parse(value);

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { zDateISO, zId, zMoneyCents, zOrgId } from "./common.js";
+
+export const bankLineSchema = z.object({
+  id: zId,
+  orgId: zOrgId,
+  date: zDateISO,
+  amountCents: zMoneyCents,
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: zDateISO,
+});
+
+export const listBankLinesQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+  cursor: zId.optional(),
+});
+
+export const listBankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+  nextCursor: zId.nullable(),
+});
+
+export const createBankLineBodySchema = z.object({
+  orgId: zOrgId,
+  date: z.coerce.date(),
+  amountCents: zMoneyCents,
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const createBankLineResponseSchema = bankLineSchema;
+
+export type ListBankLinesQuery = z.infer<typeof listBankLinesQuerySchema>;
+export type ListBankLinesResponse = z.infer<typeof listBankLinesResponseSchema>;
+export type CreateBankLineBody = z.infer<typeof createBankLineBodySchema>;
+export type CreateBankLineResponse = z.infer<typeof createBankLineResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const zId = z.string().cuid();
+export const zOrgId = zId;
+export const zDateISO = z.string().datetime({ offset: true });
+export const zMoneyCents = z.coerce.number().int();
+
+export type Id = z.infer<typeof zId>;
+export type OrgId = z.infer<typeof zOrgId>;
+export type DateISO = z.infer<typeof zDateISO>;
+export type MoneyCents = z.infer<typeof zMoneyCents>;

--- a/apgms/tests/contracts.spec.ts
+++ b/apgms/tests/contracts.spec.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { after, before, describe, it } from "node:test";
+import type { FastifyInstance } from "fastify";
+import { Decimal } from "@prisma/client/runtime/library";
+import { z } from "zod";
+
+import { buildApp, type BuildAppDependencies } from "../services/api-gateway/src/app.js";
+import { replyValidate } from "../services/api-gateway/src/lib/reply.js";
+
+const userRecords = [
+  {
+    email: "alpha@example.com",
+    orgId: "clorg123456000000000000000",
+    createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  },
+];
+
+const bankLineRecords = [
+  {
+    id: "clline123456000000000000000",
+    orgId: "clorg123456000000000000000",
+    date: new Date("2024-02-01T00:00:00.000Z"),
+    amount: new Decimal("123.45"),
+    payee: "Acme Corp",
+    desc: "Invoice 1",
+    createdAt: new Date("2024-02-02T00:00:00.000Z"),
+  },
+  {
+    id: "clline123456000000000000001",
+    orgId: "clorg123456000000000000000",
+    date: new Date("2024-01-15T00:00:00.000Z"),
+    amount: new Decimal("5.00"),
+    payee: "Beta LLC",
+    desc: "Subscription",
+    createdAt: new Date("2024-01-16T00:00:00.000Z"),
+  },
+];
+
+const userFindManyCalls: unknown[] = [];
+const bankLineFindManyCalls: unknown[] = [];
+const bankLineCreateCalls: unknown[] = [];
+
+const stubPrisma: BuildAppDependencies["prisma"] = {
+  user: {
+    findMany: async (args: unknown) => {
+      userFindManyCalls.push(args);
+      return userRecords;
+    },
+  },
+  bankLine: {
+    findMany: async (args: { take?: number }) => {
+      bankLineFindManyCalls.push(args);
+      const take = args.take ?? bankLineRecords.length;
+      return bankLineRecords.slice(0, take);
+    },
+    create: async (args: any) => {
+      bankLineCreateCalls.push(args);
+      return {
+        id: "clline123456000000000000999",
+        orgId: args.data.orgId,
+        date: args.data.date,
+        amount: args.data.amount,
+        payee: args.data.payee,
+        desc: args.data.desc,
+        createdAt: new Date("2024-03-01T00:00:00.000Z"),
+      };
+    },
+  },
+};
+
+describe("replyValidate", () => {
+  it("throws when payload violates schema", () => {
+    const schema = z.object({ foo: z.string() });
+    assert.throws(() => replyValidate(schema)({ foo: 1 } as any));
+  });
+});
+
+describe("api gateway contracts", () => {
+  let app: FastifyInstance;
+
+  before(async () => {
+    app = await buildApp({ prisma: stubPrisma });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it("returns users with iso dates", async () => {
+    const response = await app.inject({ method: "GET", url: "/users" });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), {
+      users: userRecords.map((user) => ({
+        email: user.email,
+        orgId: user.orgId,
+        createdAt: user.createdAt.toISOString(),
+      })),
+    });
+    assert.equal(userFindManyCalls.length, 1);
+  });
+
+  it("paginates bank lines and exposes amount cents", async () => {
+    const response = await app.inject({ method: "GET", url: "/bank-lines?take=1" });
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.json(), {
+      lines: [
+        {
+          id: bankLineRecords[0].id,
+          orgId: bankLineRecords[0].orgId,
+          date: bankLineRecords[0].date.toISOString(),
+          amountCents: Math.round(bankLineRecords[0].amount.toNumber() * 100),
+          payee: bankLineRecords[0].payee,
+          desc: bankLineRecords[0].desc,
+          createdAt: bankLineRecords[0].createdAt.toISOString(),
+        },
+      ],
+      nextCursor: bankLineRecords[1].id,
+    });
+
+    assert.equal(bankLineFindManyCalls.length, 1);
+    assert.equal((bankLineFindManyCalls[0] as any).take, 2);
+  });
+
+  it("creates bank lines with validated payload", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "clorg123456000000000000000",
+        date: "2024-03-02",
+        amountCents: 2222,
+        payee: "Gamma Co",
+        desc: "Office supplies",
+      },
+    });
+
+    assert.equal(response.statusCode, 201);
+    const body = response.json();
+    assert.equal(body.amountCents, 2222);
+    assert.equal(body.date, new Date("2024-03-02T00:00:00.000Z").toISOString());
+    assert.equal(body.orgId, "clorg123456000000000000000");
+    assert.equal(body.payee, "Gamma Co");
+    assert.equal(body.desc, "Office supplies");
+    assert.equal(bankLineCreateCalls.length, 1);
+
+    const amountDecimal = new Decimal(2222).dividedBy(100);
+    assert.equal(
+      (bankLineCreateCalls[0] as any).data.amount.toString(),
+      amountDecimal.toString(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Zod schemas for ids, dates, and bank line contracts
- wrap Fastify handlers with replyValidate and new app builder using dependency injection
- cover response validation and pagination with contract tests using a stub prisma client

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f48396c8588327940236a52cace8b8