### PR TITLE
Implement RPT token minting, verification, and audit route

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test ../../tests/rpt.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,11 +9,13 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { prisma } from "@apgms/shared/db";
+import auditRoutes from "./routes/audit.js";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(auditRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,175 @@
+import { createHash, createPrivateKey, createPublicKey, KeyObject, sign, verify } from "node:crypto";
+
+type KeyLike = KeyObject | string | Buffer;
+
+export type CanonicalValue =
+  | null
+  | string
+  | number
+  | boolean
+  | CanonicalValue[]
+  | { [key: string]: CanonicalValue };
+
+export interface RptTokenLike {
+  rptId: string;
+  bankLineId: string;
+  orgId: string;
+  payload: unknown;
+  prevHash: string | null;
+  signature: string;
+  hash: string;
+  publicKey: string;
+}
+
+export interface MintRptInput {
+  rptId: string;
+  bankLineId: string;
+  orgId: string;
+  payload: unknown;
+  prevHash?: string | null;
+  privateKey: KeyLike;
+  publicKey?: KeyLike;
+}
+
+const normalize = (value: unknown): CanonicalValue => {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalize(item));
+  }
+
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => typeof v !== "undefined")
+      .sort(([a], [b]) => a.localeCompare(b));
+    const result: { [key: string]: CanonicalValue } = {};
+    for (const [key, val] of entries) {
+      result[key] = normalize(val);
+    }
+    return result;
+  }
+
+  return value?.toString?.() ?? String(value);
+};
+
+export const canonicalize = (value: unknown): string => {
+  const canonical = normalize(value);
+  return JSON.stringify(canonical);
+};
+
+const ensurePrivateKey = (key: KeyLike): KeyObject =>
+  key instanceof KeyObject && key.type === "private" ? key : createPrivateKey(key);
+
+const ensurePublicKey = (key: KeyLike): KeyObject =>
+  key instanceof KeyObject && key.type === "public" ? key : createPublicKey(key);
+
+const exportPublicKey = (key: KeyLike): string => {
+  const keyObj = ensurePublicKey(key);
+  return keyObj.export({ type: "spki", format: "pem" }).toString();
+};
+
+const canonicalPayload = (token: {
+  rptId: string;
+  bankLineId: string;
+  orgId: string;
+  payload: unknown;
+  prevHash: string | null;
+}): string =>
+  canonicalize({
+    rptId: token.rptId,
+    bankLineId: token.bankLineId,
+    orgId: token.orgId,
+    payload: token.payload,
+    prevHash: token.prevHash,
+  });
+
+const computeHash = (token: {
+  rptId: string;
+  bankLineId: string;
+  orgId: string;
+  payload: unknown;
+  prevHash: string | null;
+}): string => {
+  const canonical = canonicalPayload(token);
+  return createHash("sha256").update(canonical).digest("hex");
+};
+
+export const mintRpt = ({
+  rptId,
+  bankLineId,
+  orgId,
+  payload,
+  prevHash,
+  privateKey,
+  publicKey,
+}: MintRptInput): RptTokenLike => {
+  const normalizedPrevHash = prevHash ?? null;
+  const privateKeyObj = ensurePrivateKey(privateKey);
+  const publicKeyObj = publicKey ? ensurePublicKey(publicKey) : createPublicKey(privateKeyObj);
+  const canonical = canonicalPayload({ rptId, bankLineId, orgId, payload, prevHash: normalizedPrevHash });
+  const signature = sign(null, Buffer.from(canonical), privateKeyObj).toString("base64");
+  const hash = createHash("sha256").update(canonical).digest("hex");
+  const publicKeyPem = exportPublicKey(publicKeyObj);
+
+  return {
+    rptId,
+    bankLineId,
+    orgId,
+    payload,
+    prevHash: normalizedPrevHash,
+    signature,
+    hash,
+    publicKey: publicKeyPem,
+  };
+};
+
+export const verifyRpt = (token: RptTokenLike, suppliedPublicKey?: KeyLike): boolean => {
+  try {
+    const publicKeyObj = suppliedPublicKey
+      ? ensurePublicKey(suppliedPublicKey)
+      : ensurePublicKey(token.publicKey);
+    const canonical = canonicalPayload(token);
+    const expectedHash = computeHash(token);
+    if (token.hash !== expectedHash) {
+      return false;
+    }
+    const signatureBuffer = Buffer.from(token.signature, "base64");
+    return verify(null, Buffer.from(canonical), publicKeyObj, signatureBuffer);
+  } catch {
+    return false;
+  }
+};
+
+export const verifyChain = (tokens: RptTokenLike[]): boolean => {
+  let previousHash: string | null = null;
+  for (const token of tokens) {
+    const normalizedPrevHash = token.prevHash ?? null;
+    if (normalizedPrevHash !== previousHash) {
+      return false;
+    }
+    if (!verifyRpt(token)) {
+      return false;
+    }
+    const expectedHash = computeHash(token);
+    if (token.hash !== expectedHash) {
+      return false;
+    }
+    previousHash = token.hash;
+  }
+  return true;
+};

--- a/apgms/services/api-gateway/src/routes/audit.ts
+++ b/apgms/services/api-gateway/src/routes/audit.ts
@@ -1,0 +1,43 @@
+import { FastifyPluginAsync } from "fastify";
+import { prisma } from "@apgms/shared/db";
+import { verifyChain } from "../lib/rpt.js";
+import { RptResponseSchema } from "../schemas/rpt.js";
+
+const auditRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/audit/rpt/:rptId", async (req) => {
+    const { rptId } = req.params as { rptId: string };
+    const tokens = await prisma.rptToken.findMany({
+      where: { rptId },
+      orderBy: { createdAt: "asc" },
+    });
+
+    const serialized = tokens.map((token) => ({
+      ...token,
+      prevHash: token.prevHash ?? null,
+      createdAt: token.createdAt.toISOString(),
+    }));
+
+    const chainValid = verifyChain(
+      serialized.map((token) => ({
+        rptId: token.rptId,
+        bankLineId: token.bankLineId,
+        orgId: token.orgId,
+        payload: token.payload,
+        prevHash: token.prevHash,
+        signature: token.signature,
+        hash: token.hash,
+        publicKey: token.publicKey,
+      }))
+    );
+
+    const response = {
+      rptId,
+      tokens: serialized,
+      chainValid,
+    };
+
+    return RptResponseSchema.parse(response);
+  });
+};
+
+export default auditRoutes;

--- a/apgms/services/api-gateway/src/schemas/rpt.ts
+++ b/apgms/services/api-gateway/src/schemas/rpt.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const RptTokenSchema = z.object({
+  id: z.string().optional(),
+  rptId: z.string(),
+  bankLineId: z.string(),
+  orgId: z.string(),
+  payload: z.unknown(),
+  signature: z.string(),
+  prevHash: z.string().nullable(),
+  hash: z.string(),
+  publicKey: z.string(),
+  createdAt: z.string().optional(),
+});
+
+export const RptResponseSchema = z.object({
+  rptId: z.string(),
+  tokens: z.array(RptTokenSchema),
+  chainValid: z.boolean(),
+});
+
+export type RptTokenResponse = z.infer<typeof RptTokenSchema>;
+export type RptResponse = z.infer<typeof RptResponseSchema>;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -34,3 +34,20 @@ model BankLine {
   desc      String
   createdAt DateTime @default(now())
 }
+
+model RptToken {
+  id         String   @id @default(cuid())
+  rptId      String
+  bankLineId String
+  orgId      String
+  payload    Json
+  signature  String
+  prevHash   String?
+  hash       String
+  publicKey  String
+  createdAt  DateTime @default(now())
+
+  @@index([rptId])
+  @@index([bankLineId])
+  @@index([orgId])
+}

--- a/apgms/tests/rpt.spec.ts
+++ b/apgms/tests/rpt.spec.ts
@@ -1,0 +1,80 @@
+import { strict as assert } from "node:assert";
+import { generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+import { canonicalize, mintRpt, verifyChain, verifyRpt } from "../services/api-gateway/src/lib/rpt.js";
+
+test("canonicalize produces stable ordering", () => {
+  const value = { b: 2, a: 1, nested: { y: 2, x: 1 } };
+  const result = canonicalize(value);
+  assert.equal(result, "{\"a\":1,\"b\":2,\"nested\":{\"x\":1,\"y\":2}}");
+});
+
+test("tampered payload fails verification", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const rpt = mintRpt({
+    rptId: "rpt-1",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { amount: 100 },
+    privateKey,
+  });
+
+  assert.equal(verifyRpt(rpt, publicKey), true);
+
+  const tampered = {
+    ...rpt,
+    payload: { amount: 999 },
+  };
+
+  assert.equal(verifyRpt(tampered, publicKey), false);
+});
+
+test("broken prevHash fails chain verification", () => {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const rpt1 = mintRpt({
+    rptId: "rpt-2",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { step: 1 },
+    privateKey,
+  });
+  const rpt2 = mintRpt({
+    rptId: "rpt-2",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { step: 2 },
+    prevHash: "invalid",
+    privateKey,
+  });
+
+  assert.equal(verifyChain([rpt1, rpt2]), false);
+});
+
+test("valid chain verifies", () => {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const rpt1 = mintRpt({
+    rptId: "rpt-3",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { step: 1 },
+    privateKey,
+  });
+  const rpt2 = mintRpt({
+    rptId: "rpt-3",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { step: 2 },
+    prevHash: rpt1.hash,
+    privateKey,
+  });
+  const rpt3 = mintRpt({
+    rptId: "rpt-3",
+    bankLineId: "line-1",
+    orgId: "org-1",
+    payload: { step: 3 },
+    prevHash: rpt2.hash,
+    privateKey,
+  });
+
+  assert.equal(verifyChain([rpt1, rpt2, rpt3]), true);
+});


### PR DESCRIPTION
## Summary
- add Ed25519 canonicalization, signing, and verification utilities for RPT tokens
- define Prisma RptToken model and expose audit chain retrieval route with schemas
- cover tampering, chain breaks, and successful verification via node:test suite

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f483badf00832780852b9a14273ae5