### PR TITLE
Add readiness probes and graceful shutdown to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test ../../tests/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,18 @@
+import type { FastifyPluginAsync } from "fastify";
+import { prisma } from "../../../../shared/src/db";
+
+const healthRoutes: FastifyPluginAsync = async (app) => {
+  app.get("/healthz", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/readyz", async (request, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return { ready: true };
+    } catch (error) {
+      request.log.error({ err: error }, "readiness check failed");
+      return reply.status(503).send({ ready: false, reason: "db_unreachable" });
+    }
+  });
+};
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/src/shutdown.ts
+++ b/apgms/services/api-gateway/src/shutdown.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance } from "fastify";
+
+type PrismaClientLike = {
+  $disconnect: () => Promise<void>;
+};
+
+type ExitFunction = (code: number) => void;
+
+type Options = {
+  signals?: NodeJS.Signals[];
+  exit?: ExitFunction;
+};
+
+export const registerGracefulShutdown = (
+  app: FastifyInstance,
+  prisma: PrismaClientLike,
+  options: Options = {}
+) => {
+  const signals = options.signals ?? ["SIGINT", "SIGTERM"];
+  const exitFn = options.exit ?? ((code) => process.exit(code));
+
+  let isShuttingDown = false;
+
+  const shutdown = async (signal?: NodeJS.Signals, code = 0) => {
+    if (isShuttingDown) {
+      return;
+    }
+    isShuttingDown = true;
+
+    app.log.info({ signal }, "shutting down");
+
+    try {
+      await app.close();
+    } catch (closeError) {
+      app.log.error({ err: closeError }, "failed to close fastify");
+    }
+
+    try {
+      await prisma.$disconnect();
+    } catch (disconnectError) {
+      app.log.error({ err: disconnectError }, "failed to disconnect prisma");
+    }
+
+    exitFn(code);
+  };
+
+  const listeners = new Map<NodeJS.Signals, () => void>();
+
+  for (const signal of signals) {
+    const listener = () => {
+      shutdown(signal).catch((err) => {
+        app.log.error({ err }, "error during shutdown");
+        exitFn(1);
+      });
+    };
+    listeners.set(signal, listener);
+    process.once(signal, listener);
+  }
+
+  const dispose = () => {
+    for (const [signal, listener] of listeners) {
+      process.removeListener(signal, listener);
+    }
+  };
+
+  return { shutdown, dispose };
+};

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,28 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import { createRequire } from "node:module";
+
+type PrismaLike = {
+  $queryRaw: (...args: any[]) => Promise<unknown>;
+  $disconnect: () => Promise<void>;
+};
+
+class MockPrismaClient implements PrismaLike {
+  async $queryRaw() {
+    return [];
+  }
+
+  async $disconnect() {
+    // no-op for mock client
+  }
+}
+
+let prismaClient: PrismaLike;
+
+if (process.env.MOCK_PRISMA === "1") {
+  prismaClient = new MockPrismaClient();
+} else {
+  const require = createRequire(import.meta.url);
+  const { PrismaClient } = require("@prisma/client");
+  prismaClient = new PrismaClient();
+}
+
+export const prisma = prismaClient;

--- a/apgms/tests/health.spec.ts
+++ b/apgms/tests/health.spec.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import Fastify from "fastify";
+import { mock, test } from "node:test";
+
+process.env.MOCK_PRISMA = "1";
+process.env.DATABASE_URL ??= "postgresql://user:pass@localhost:5432/apgms";
+process.env.SHADOW_DATABASE_URL ??= process.env.DATABASE_URL;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+let prismaPromise: Promise<any> | undefined;
+const getPrisma = () => {
+  prismaPromise ??= import(path.resolve(projectRoot, "shared/src/db.ts")).then((mod) => mod.prisma);
+  return prismaPromise;
+};
+
+let healthRoutesPromise: Promise<any> | undefined;
+const getHealthRoutes = () => {
+  healthRoutesPromise ??= import(path.resolve(projectRoot, "services/api-gateway/src/routes/health.ts")).then((mod) => mod.default);
+  return healthRoutesPromise;
+};
+
+let shutdownModulePromise: Promise<any> | undefined;
+const getShutdownModule = () => {
+  shutdownModulePromise ??= import(path.resolve(projectRoot, "services/api-gateway/src/shutdown.ts"));
+  return shutdownModulePromise;
+};
+
+const createApp = async () => {
+  const app = Fastify();
+  await app.register(await getHealthRoutes());
+  return app;
+};
+
+test("/readyz responds 200 when database is reachable", async (t) => {
+  const [app, prisma] = await Promise.all([createApp(), getPrisma()]);
+  t.after(async () => {
+    await app.close();
+  });
+
+  const readyMock = mock.method(prisma, "$queryRaw", async () => [{ ok: 1 }]);
+  t.after(() => readyMock.mock.restore());
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ready: true });
+});
+
+test("/readyz responds 503 when database is unreachable", async (t) => {
+  const [app, prisma] = await Promise.all([createApp(), getPrisma()]);
+  t.after(async () => {
+    await app.close();
+  });
+
+  const errorMock = mock.method(prisma, "$queryRaw", async () => {
+    throw new Error("connection failed");
+  });
+  t.after(() => errorMock.mock.restore());
+
+  const response = await app.inject({ method: "GET", url: "/readyz" });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), { ready: false, reason: "db_unreachable" });
+});
+
+test("process exits cleanly on SIGTERM", async (t) => {
+  const { registerGracefulShutdown } = await getShutdownModule();
+  const closeMock = mock.fn(async () => {
+    await delay(10);
+  });
+  const disconnectMock = mock.fn(async () => {
+    await delay(5);
+  });
+
+  const app = {
+    close: closeMock,
+    log: {
+      info: mock.fn(() => {}),
+      error: mock.fn(() => {}),
+    },
+  };
+
+  const prisma = {
+    $disconnect: disconnectMock,
+  };
+
+  let exitCode: number | undefined;
+  let resolveExit: (() => void) | undefined;
+  const exitPromise = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const { dispose } = registerGracefulShutdown(app as any, prisma as any, {
+    signals: ["SIGTERM"],
+    exit: (code) => {
+      exitCode = code;
+      resolveExit?.();
+    },
+  });
+
+  t.after(() => {
+    dispose();
+  });
+
+  process.emit("SIGTERM");
+
+  await exitPromise;
+
+  assert.equal(closeMock.mock.callCount(), 1);
+  assert.equal(disconnectMock.mock.callCount(), 1);
+  assert.equal(exitCode, 0);
+});


### PR DESCRIPTION
## Summary
- add `/healthz` and `/readyz` routes with Prisma-based readiness checks
- implement reusable Fastify shutdown helper wiring Prisma disconnect
- cover readiness and shutdown behaviour with node:test specs

## Testing
- pnpm -C services/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f483c7fe208327bed1374ef83fb64a