### PR TITLE
feat: add admin privacy export/delete endpoints

### DIFF
--- a/apgms/docs/PRIVACY.md
+++ b/apgms/docs/PRIVACY.md
@@ -1,0 +1,13 @@
+# Privacy Operations
+
+## Administrative API Endpoints
+
+- `POST /admin/privacy/export` (api-gateway)
+  - Request body: `{ orgId: string, subjectEmail: string }`
+  - Requires `x-admin-token` header matching `ADMIN_PRIVACY_TOKEN`.
+  - Produces subject export artifact at `artifacts/privacy/<uuid>.json` with user + bank line payloads.
+
+- `POST /admin/privacy/delete` (api-gateway)
+  - Request body: `{ orgId: string, subjectEmail: string }`
+  - Requires `x-admin-token` header matching `ADMIN_PRIVACY_TOKEN`.
+  - Anonymizes the user, scrubs associated bank lines, and writes audit blob `artifacts/privacy/<uuid>-delete.json`.

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/privacy.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,6 +10,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { registerPrivacyRoutes } from "./routes/privacy";
 
 const app = Fastify({ logger: true });
 
@@ -64,6 +65,8 @@ app.post("/bank-lines", async (req, rep) => {
     return rep.code(400).send({ error: "bad_request" });
   }
 });
+
+await registerPrivacyRoutes(app, { prisma });
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {

--- a/apgms/services/api-gateway/src/routes/privacy.ts
+++ b/apgms/services/api-gateway/src/routes/privacy.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+import { PrivacyAdminRequestSchema, type PrivacyAdminRequest } from "../schemas/privacy";
+
+const ADMIN_HEADER = "x-admin-token";
+
+type UserDelegate = PrismaClient["user"];
+type BankLineDelegate = PrismaClient["bankLine"];
+
+export type PrivacyRouteDeps = {
+  prisma: {
+    user: Pick<UserDelegate, "findFirst" | "update">;
+    bankLine: Pick<BankLineDelegate, "findMany" | "updateMany">;
+  };
+  artifactRoot?: string;
+  adminToken?: string;
+};
+
+const defaultArtifactRoot = path.resolve(process.cwd(), "artifacts/privacy");
+
+async function ensureArtifactRoot(dir: string) {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function requireAdminToken(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  expectedToken: string
+) {
+  const rawToken =
+    request.headers[ADMIN_HEADER] ??
+    request.headers[ADMIN_HEADER.toLowerCase() as keyof typeof request.headers];
+  const token = Array.isArray(rawToken) ? rawToken[0] : rawToken;
+  if (!token || token !== expectedToken) {
+    reply.code(401).send({ error: "unauthorized" });
+    return false;
+  }
+  return true;
+}
+
+async function handleExport(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: PrivacyRouteDeps,
+  artifactRoot: string
+) {
+  const parsed = PrivacyAdminRequestSchema.safeParse(request.body);
+  if (!parsed.success) {
+    reply.code(400).send({ error: "invalid_request", details: parsed.error.flatten() });
+    return;
+  }
+
+  const body: PrivacyAdminRequest = parsed.data;
+  const [user, bankLines] = await Promise.all([
+    deps.prisma.user.findFirst({ where: { orgId: body.orgId, email: body.subjectEmail } }),
+    deps.prisma.bankLine.findMany({ where: { orgId: body.orgId }, orderBy: { date: "desc" } }),
+  ]);
+
+  const artifactId = randomUUID();
+  const artifactPath = path.join(artifactRoot, `${artifactId}.json`);
+  const artifact = {
+    artifactId,
+    generatedAt: new Date().toISOString(),
+    orgId: body.orgId,
+    subjectEmail: body.subjectEmail,
+    user,
+    bankLines,
+  };
+  await fs.writeFile(artifactPath, JSON.stringify(artifact, null, 2), "utf8");
+
+  reply.code(200).send({
+    artifactId,
+    artifactPath,
+    bankLineCount: bankLines.length,
+    hasUser: Boolean(user),
+  });
+}
+
+async function handleDelete(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  deps: PrivacyRouteDeps,
+  artifactRoot: string
+) {
+  const parsed = PrivacyAdminRequestSchema.safeParse(request.body);
+  if (!parsed.success) {
+    reply.code(400).send({ error: "invalid_request", details: parsed.error.flatten() });
+    return;
+  }
+
+  const body: PrivacyAdminRequest = parsed.data;
+  const user = await deps.prisma.user.findFirst({
+    where: { orgId: body.orgId, email: body.subjectEmail },
+  });
+
+  let anonymizedEmail: string | null = null;
+  if (user) {
+    anonymizedEmail = `deleted+${user.id}@example.com`;
+    await deps.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        email: anonymizedEmail,
+        password: "__deleted__",
+      },
+    });
+  }
+
+  const bankLineResult = await deps.prisma.bankLine.updateMany({
+    where: { orgId: body.orgId },
+    data: { payee: "[deleted]", desc: "[deleted]" },
+  });
+
+  const auditId = randomUUID();
+  const auditPath = path.join(artifactRoot, `${auditId}-delete.json`);
+  const audit = {
+    auditId,
+    action: "privacy_delete",
+    occurredAt: new Date().toISOString(),
+    orgId: body.orgId,
+    subjectEmail: body.subjectEmail,
+    userId: user?.id ?? null,
+    anonymizedEmail,
+    bankLinesUpdated: bankLineResult.count,
+  };
+
+  await fs.writeFile(auditPath, JSON.stringify(audit, null, 2), "utf8");
+
+  reply.code(200).send({
+    auditId,
+    auditPath,
+    anonymized: Boolean(user),
+    bankLinesUpdated: bankLineResult.count,
+  });
+}
+
+export async function registerPrivacyRoutes(app: FastifyInstance, deps: PrivacyRouteDeps) {
+  const artifactRoot = deps.artifactRoot ?? defaultArtifactRoot;
+  const adminToken = deps.adminToken ?? process.env.ADMIN_PRIVACY_TOKEN ?? "changeme";
+  await ensureArtifactRoot(artifactRoot);
+
+  app.post("/admin/privacy/export", async (request, reply) => {
+    if (!requireAdminToken(request, reply, adminToken)) {
+      return;
+    }
+    await handleExport(request, reply, deps, artifactRoot);
+  });
+
+  app.post("/admin/privacy/delete", async (request, reply) => {
+    if (!requireAdminToken(request, reply, adminToken)) {
+      return;
+    }
+    await handleDelete(request, reply, deps, artifactRoot);
+  });
+}

--- a/apgms/services/api-gateway/src/schemas/privacy.ts
+++ b/apgms/services/api-gateway/src/schemas/privacy.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const PrivacyAdminRequestSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  subjectEmail: z.string().email("subjectEmail must be a valid email"),
+});
+
+export type PrivacyAdminRequest = z.infer<typeof PrivacyAdminRequestSchema>;

--- a/apgms/services/api-gateway/test/privacy.spec.ts
+++ b/apgms/services/api-gateway/test/privacy.spec.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import Fastify from "fastify";
+import { registerPrivacyRoutes, type PrivacyRouteDeps } from "../src/routes/privacy";
+
+async function createTempDir() {
+  return mkdtemp(path.join(tmpdir(), "privacy-artifacts-"));
+}
+
+test("POST /admin/privacy/export writes artifact", async (t) => {
+  const app = Fastify();
+  const artifactRoot = await createTempDir();
+
+  const userRecord = {
+    id: "user_1",
+    email: "person@example.com",
+    password: "secret",
+    createdAt: new Date(),
+    orgId: "org_123",
+  } as const;
+
+  const bankLineRecord = {
+    id: "line_1",
+    orgId: "org_123",
+    date: new Date(),
+    amount: 10,
+    payee: "Example Payee",
+    desc: "Invoice #1",
+    createdAt: new Date(),
+  } as const;
+
+  const prismaStub: PrivacyRouteDeps["prisma"] = {
+    user: {
+      findFirst: async (args) => {
+        if (args?.where?.email === userRecord.email && args?.where?.orgId === userRecord.orgId) {
+          return { ...userRecord } as any;
+        }
+        return null;
+      },
+      update: async () => ({ ...userRecord, email: "updated" } as any),
+    },
+    bankLine: {
+      findMany: async () => [{ ...bankLineRecord } as any],
+      updateMany: async () => ({ count: 0 }),
+    },
+  };
+
+  await registerPrivacyRoutes(app, {
+    prisma: prismaStub,
+    artifactRoot,
+    adminToken: "admin-secret",
+  });
+
+  await app.ready();
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/admin/privacy/export",
+    headers: { "x-admin-token": "admin-secret" },
+    payload: { orgId: "org_123", subjectEmail: "person@example.com" },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as any;
+  assert.ok(body.artifactId);
+  assert.equal(body.bankLineCount, 1);
+  assert.equal(body.hasUser, true);
+
+  const artifactPath = path.join(artifactRoot, `${body.artifactId}.json`);
+  const rawArtifact = await readFile(artifactPath, "utf8");
+  const artifact = JSON.parse(rawArtifact);
+  assert.equal(artifact.subjectEmail, "person@example.com");
+  assert.equal(Array.isArray(artifact.bankLines), true);
+  assert.equal(artifact.bankLines.length, 1);
+});
+
+test("POST /admin/privacy/delete anonymizes and audits", async (t) => {
+  const app = Fastify();
+  const artifactRoot = await createTempDir();
+
+  let updatedUserData: any = null;
+
+  const prismaStub: PrivacyRouteDeps["prisma"] = {
+    user: {
+      findFirst: async (args) => {
+        if (args?.where?.email === "person@example.com" && args?.where?.orgId === "org_123") {
+          return {
+            id: "user_1",
+            email: "person@example.com",
+            password: "secret",
+            createdAt: new Date(),
+            orgId: "org_123",
+          } as any;
+        }
+        return null;
+      },
+      update: async (args) => {
+        updatedUserData = args;
+        return {
+          id: "user_1",
+          email: args.data.email,
+          password: args.data.password,
+          orgId: "org_123",
+          createdAt: new Date(),
+        } as any;
+      },
+    },
+    bankLine: {
+      findMany: async () => [],
+      updateMany: async () => ({ count: 2 }),
+    },
+  };
+
+  await registerPrivacyRoutes(app, {
+    prisma: prismaStub,
+    artifactRoot,
+    adminToken: "admin-secret",
+  });
+
+  await app.ready();
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/admin/privacy/delete",
+    headers: { "x-admin-token": "admin-secret" },
+    payload: { orgId: "org_123", subjectEmail: "person@example.com" },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as any;
+  assert.ok(body.auditId);
+  assert.equal(body.anonymized, true);
+  assert.equal(body.bankLinesUpdated, 2);
+  assert.ok(updatedUserData);
+  assert.match(updatedUserData.data.email, /^deleted\+/);
+  assert.equal(updatedUserData.where.id, "user_1");
+
+  const auditPath = path.join(artifactRoot, `${body.auditId}-delete.json`);
+  const rawAudit = await readFile(auditPath, "utf8");
+  const audit = JSON.parse(rawAudit);
+  assert.equal(audit.action, "privacy_delete");
+  assert.equal(audit.bankLinesUpdated, 2);
+  assert.equal(audit.anonymizedEmail, updatedUserData.data.email);
+});


### PR DESCRIPTION
## Summary
- add admin privacy export and delete routes in the api gateway
- add zod validation plus test coverage for the new privacy flows
- document the new admin endpoints in PRIVACY.md

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4848d57a48327a4356c54ffdce6ab