### PR TITLE
feat: add onboarding wizard flow

### DIFF
--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,22 @@
-﻿export default {};
+import { defineConfig } from "@playwright/test";
+import path from "node:path";
+
+const webappDir = path.resolve(__dirname, "webapp");
+
+export default defineConfig({
+  testDir: "tests/webapp",
+  timeout: 60_000,
+  expect: {
+    timeout: 5_000,
+  },
+  webServer: {
+    command: "pnpm --dir webapp dev --host 0.0.0.0 --port 5173",
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    cwd: webappDir,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+  },
+});

--- a/apgms/services/api-gateway/src/routes/onboarding.ts
+++ b/apgms/services/api-gateway/src/routes/onboarding.ts
@@ -1,0 +1,129 @@
+import type { FastifyInstance, FastifyRequest } from "fastify";
+import { randomUUID } from "node:crypto";
+import { zOrgProfile, zBank, zPolicySelect } from "../schemas/onboarding";
+
+export type OnboardingState = {
+  profile?: {
+    legalName: string;
+    abn?: string;
+    contactEmail: string;
+  };
+  bank?: {
+    bsbMasked: string;
+    accMasked: string;
+  };
+  policyId?: string;
+};
+
+export type AuditBlob = {
+  id: string;
+  orgId: string;
+  kind: "onboarding.bankMasked" | "onboarding.policySelected";
+  createdAt: string;
+  payload: Record<string, unknown>;
+};
+
+const onboardingStore = new Map<string, OnboardingState>();
+const auditBlobs: AuditBlob[] = [];
+
+const maskValue = (value: string, visible = 2) => {
+  const keep = Math.max(0, Math.min(value.length, visible));
+  const hidden = Math.max(0, value.length - keep);
+  return `${"*".repeat(hidden)}${value.slice(value.length - keep)}`;
+};
+
+const getOrgId = (req: FastifyRequest): string => {
+  const headerValue = req.headers["x-org-id"];
+  if (typeof headerValue === "string" && headerValue.trim().length > 0) {
+    return headerValue;
+  }
+  return "demo-org";
+};
+
+const getState = (orgId: string): OnboardingState => {
+  if (!onboardingStore.has(orgId)) {
+    onboardingStore.set(orgId, {});
+  }
+  return onboardingStore.get(orgId)!;
+};
+
+export const registerOnboardingRoutes = async (app: FastifyInstance) => {
+  app.patch("/onboarding/profile", async (req, rep) => {
+    const orgId = getOrgId(req);
+    const parsed = zOrgProfile.safeParse(req.body);
+
+    if (!parsed.success) {
+      return rep.code(400).send({ error: "invalid_profile", details: parsed.error.format() });
+    }
+
+    const state = getState(orgId);
+    state.profile = parsed.data;
+
+    return { profile: state.profile };
+  });
+
+  app.post("/onboarding/bank", async (req, rep) => {
+    const orgId = getOrgId(req);
+    const parsed = zBank.safeParse(req.body);
+
+    if (!parsed.success) {
+      return rep.code(400).send({ error: "invalid_bank", details: parsed.error.format() });
+    }
+
+    const { bsb, acc } = parsed.data;
+    const bsbMasked = maskValue(bsb, 2);
+    const accMasked = maskValue(acc, 3);
+
+    const state = getState(orgId);
+    state.bank = { bsbMasked, accMasked };
+
+    auditBlobs.push({
+      id: randomUUID(),
+      orgId,
+      kind: "onboarding.bankMasked",
+      createdAt: new Date().toISOString(),
+      payload: state.bank,
+    });
+
+    return { bank: state.bank };
+  });
+
+  app.post("/onboarding/policy", async (req, rep) => {
+    const orgId = getOrgId(req);
+    const parsed = zPolicySelect.safeParse(req.body);
+
+    if (!parsed.success) {
+      return rep.code(400).send({ error: "invalid_policy", details: parsed.error.format() });
+    }
+
+    const state = getState(orgId);
+    state.policyId = parsed.data.policyId;
+
+    auditBlobs.push({
+      id: randomUUID(),
+      orgId,
+      kind: "onboarding.policySelected",
+      createdAt: new Date().toISOString(),
+      payload: { policyId: parsed.data.policyId },
+    });
+
+    return { policyId: state.policyId };
+  });
+
+  app.get("/onboarding", async (req) => {
+    const orgId = getOrgId(req);
+    return { state: getState(orgId) };
+  });
+
+  app.get("/policies", async () => {
+    return {
+      policies: [
+        { id: "standard", name: "Standard Protection", description: "Baseline coverage for new partners." },
+        { id: "growth", name: "Growth Accelerator", description: "Enhanced coverage tailored for scaling orgs." },
+        { id: "enterprise", name: "Enterprise Shield", description: "Premium coverage for complex operations." },
+      ],
+    };
+  });
+
+  app.get("/audit-blobs", async () => ({ audit: auditBlobs }));
+};

--- a/apgms/services/api-gateway/src/schemas/onboarding.ts
+++ b/apgms/services/api-gateway/src/schemas/onboarding.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const zOrgProfile = z.object({
+  legalName: z.string().min(1, "Legal name is required"),
+  abn: z
+    .string()
+    .trim()
+    .optional()
+    .transform((value) => (value === "" ? undefined : value)),
+  contactEmail: z.string().email("A valid contact email is required"),
+});
+
+export type OrgProfileInput = z.infer<typeof zOrgProfile>;
+
+export const zBank = z.object({
+  bsb: z
+    .string()
+    .regex(/^[0-9]{6}$/u, "BSB must be 6 digits"),
+  acc: z
+    .string()
+    .regex(/^[0-9]{6,9}$/u, "Account number must be 6-9 digits"),
+});
+
+export type BankInput = z.infer<typeof zBank>;
+
+export const zPolicySelect = z.object({
+  policyId: z.string().min(1, "Policy is required"),
+});
+
+export type PolicySelectInput = z.infer<typeof zPolicySelect>;

--- a/apgms/tests/webapp/onboarding.spec.ts
+++ b/apgms/tests/webapp/onboarding.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+import axe from "axe-core";
+
+const authScript = () => {
+  window.sessionStorage.setItem("apgms.auth", "1");
+  window.sessionStorage.setItem("apgms.orgId", "test-org");
+};
+
+declare global {
+  interface Window {
+    axe: typeof axe;
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(authScript);
+});
+
+test("guides the user through onboarding with accessible flow", async ({ page }) => {
+  await page.goto("/onboarding");
+
+  await page.addScriptTag({ content: axe.source });
+
+  const nextButton = page.getByRole("button", { name: "Next" });
+  await expect(nextButton).toBeDisabled();
+
+  await page.getByLabel("Legal name").fill("Acme Trading Pty Ltd");
+  await page.getByLabel("ABN", { exact: false }).fill("12345678901");
+  await page.getByLabel("Contact email").fill("finance@acme.test");
+  await expect(nextButton).toBeEnabled();
+
+  await nextButton.click();
+
+  await page.waitForURL("**/onboarding");
+  await expect(page.getByRole("heading", { name: "Bank Connect" })).toBeVisible();
+
+  const bankNext = page.getByRole("button", { name: "Next" });
+  await expect(bankNext).toBeDisabled();
+
+  await page.getByLabel("BSB").fill("062001");
+  await page.getByLabel("Account number").fill("123456789");
+  await expect(bankNext).toBeEnabled();
+  await bankNext.click();
+
+  await expect(page.getByRole("heading", { name: "Policy Select" })).toBeVisible();
+  await page.getByLabel("Growth Accelerator").check();
+  await expect(page.getByRole("button", { name: "Next" })).toBeEnabled();
+  await page.getByRole("button", { name: "Next" }).click();
+
+  await expect(page.getByRole("heading", { name: "Confirm" })).toBeVisible();
+  await expect(page.getByText("BSB: ****01")).toBeVisible();
+  await expect(page.getByText("Account: ******789")).toBeVisible();
+  await expect(page.getByText("Growth Accelerator")).toBeVisible();
+
+  const accessibilityReport = await page.evaluate(async () => {
+    return window.axe.run();
+  });
+
+  expect(accessibilityReport.violations).toEqual([]);
+});

--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,12 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>APGMS Onboarding</title>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,32 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.62.7",
+    "@tanstack/react-router": "^1.77.1",
+    "@tanstack/router-devtools": "^1.77.1",
+    "axios": "^1.7.7",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.2",
+    "@types/react": "^18.3.7",
+    "@types/react-dom": "^18.3.2",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.20",
+    "axe-core": "^4.10.0",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.10"
+  }
+}

--- a/apgms/webapp/postcss.config.cjs
+++ b/apgms/webapp/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apgms/webapp/src/index.css
+++ b/apgms/webapp/src/index.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}

--- a/apgms/webapp/src/lib/api.ts
+++ b/apgms/webapp/src/lib/api.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+export const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000",
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+api.interceptors.request.use((config) => {
+  if (!config.headers) {
+    config.headers = {};
+  }
+  if (typeof window !== "undefined") {
+    const orgId = window.sessionStorage.getItem("apgms.orgId") ?? "demo-org";
+    config.headers["x-org-id"] = orgId;
+  }
+  return config;
+});

--- a/apgms/webapp/src/lib/auth.tsx
+++ b/apgms/webapp/src/lib/auth.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useMemo, useState } from "react";
+
+const STORAGE_KEY = "apgms.auth";
+
+type AuthContextValue = {
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const getInitialAuthState = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.sessionStorage.getItem(STORAGE_KEY) === "1";
+};
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(getInitialAuthState);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    isAuthenticated,
+    login: () => {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.setItem(STORAGE_KEY, "1");
+      }
+      setIsAuthenticated(true);
+    },
+    logout: () => {
+      if (typeof window !== "undefined") {
+        window.sessionStorage.removeItem(STORAGE_KEY);
+      }
+      setIsAuthenticated(false);
+    },
+  }), [isAuthenticated]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider");
+  }
+  return ctx;
+};

--- a/apgms/webapp/src/main.tsx
+++ b/apgms/webapp/src/main.tsx
@@ -1,1 +1,31 @@
-﻿console.log('webapp');
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import { createRouter, RouterProvider } from "@tanstack/react-router";
+import { rootRoute } from "./routes/__root";
+import { onboardingRoute } from "./routes/onboarding";
+import { loginRoute } from "./routes/login";
+
+const routeTree = rootRoute.addChildren([onboardingRoute, loginRoute]);
+
+const router = createRouter({
+  routeTree,
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Root element not found");
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>,
+);

--- a/apgms/webapp/src/routes/__root.tsx
+++ b/apgms/webapp/src/routes/__root.tsx
@@ -1,0 +1,31 @@
+import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { Suspense, useMemo } from "react";
+import { AuthProvider } from "../lib/auth";
+import { RouterDevtools } from "@tanstack/router-devtools";
+
+const queryClient = new QueryClient();
+
+export const rootRoute = createRootRoute({
+  component: () => {
+    const devtools = useMemo(() => {
+      if (import.meta.env.DEV) {
+        return <RouterDevtools />;
+      }
+      return null;
+    }, []);
+
+    return (
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <div className="min-h-screen bg-slate-50 text-slate-900">
+            <Suspense fallback={<div className="p-6">Loading…</div>}>
+              <Outlet />
+            </Suspense>
+          </div>
+          {devtools}
+        </QueryClientProvider>
+      </AuthProvider>
+    );
+  },
+});

--- a/apgms/webapp/src/routes/login.tsx
+++ b/apgms/webapp/src/routes/login.tsx
@@ -1,0 +1,35 @@
+import { createRoute, Link } from "@tanstack/react-router";
+import { rootRoute } from "./__root";
+import { useAuth } from "../lib/auth";
+
+export const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  component: LoginPage,
+});
+
+function LoginPage() {
+  const { login } = useAuth();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-lg flex-col items-center justify-center gap-6 p-8 text-center">
+      <h1 className="text-3xl font-semibold">Welcome back</h1>
+      <p className="text-slate-600">
+        This demo login instantly authenticates you to continue onboarding.
+      </p>
+      <button
+        type="button"
+        onClick={login}
+        className="rounded-lg bg-sky-600 px-6 py-3 text-white shadow transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600"
+      >
+        Continue to Onboarding
+      </button>
+      <Link
+        to="/onboarding"
+        className="text-sm text-sky-700 underline decoration-dotted underline-offset-4"
+      >
+        Skip to onboarding
+      </Link>
+    </main>
+  );
+}

--- a/apgms/webapp/src/routes/onboarding/index.tsx
+++ b/apgms/webapp/src/routes/onboarding/index.tsx
@@ -1,0 +1,523 @@
+import { createRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { rootRoute } from "../__root";
+import { useAuth } from "../../lib/auth";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../lib/api";
+import { z } from "zod";
+
+const profileSchema = z.object({
+  legalName: z.string().min(1, "Legal name is required"),
+  abn: z.string().optional(),
+  contactEmail: z.string().email("Enter a valid email"),
+});
+
+const bankSchema = z.object({
+  bsb: z.string().regex(/^[0-9]{6}$/u, "BSB must be 6 digits"),
+  acc: z.string().regex(/^[0-9]{6,9}$/u, "Account number must be 6-9 digits"),
+});
+
+const policySchema = z.object({
+  policyId: z.string().min(1, "Select a policy"),
+});
+
+type OnboardingState = {
+  profile?: z.infer<typeof profileSchema>;
+  bank?: {
+    bsbMasked: string;
+    accMasked: string;
+  };
+  policyId?: string;
+};
+
+type Step = {
+  id: "profile" | "bank" | "policy" | "confirm";
+  label: string;
+  description: string;
+};
+
+const steps: Step[] = [
+  { id: "profile", label: "Org Profile", description: "Tell us about your organisation." },
+  { id: "bank", label: "Bank Connect", description: "Securely connect your payout details." },
+  { id: "policy", label: "Policy Select", description: "Choose the right policy for you." },
+  { id: "confirm", label: "Confirm", description: "Review and confirm your information." },
+];
+
+const initialProfileState = { legalName: "", abn: "", contactEmail: "" };
+const initialBankState = { bsb: "", acc: "" };
+
+export const onboardingRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/onboarding",
+  component: OnboardingPage,
+});
+
+function OnboardingPage() {
+  const { isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate({ to: "/login" });
+    }
+  }, [isAuthenticated, navigate]);
+
+  const { data: onboardingState } = useQuery({
+    queryKey: ["onboarding", "state"],
+    queryFn: async () => {
+      const response = await api.get<{ state: OnboardingState }>("/onboarding");
+      return response.data.state;
+    },
+  });
+
+  const { data: policiesData } = useQuery({
+    queryKey: ["policies"],
+    queryFn: async () => {
+      const response = await api.get<{ policies: { id: string; name: string; description: string }[] }>("/policies");
+      return response.data.policies;
+    },
+  });
+
+  const [currentStep, setCurrentStep] = useState<number>(0);
+  const [furthestStep, setFurthestStep] = useState<number>(0);
+
+  const [profileForm, setProfileForm] = useState(() => ({
+    ...initialProfileState,
+    ...(onboardingState?.profile ?? {}),
+  }));
+
+  const [bankForm, setBankForm] = useState(() => ({ ...initialBankState }));
+  const [policySelection, setPolicySelection] = useState(() => onboardingState?.policyId ?? "");
+
+  useEffect(() => {
+    if (onboardingState?.profile) {
+      setProfileForm((prev) => ({
+        ...prev,
+        ...onboardingState.profile!,
+        abn: onboardingState.profile?.abn ?? "",
+      }));
+      setFurthestStep((prev) => Math.max(prev, 1));
+    }
+    if (onboardingState?.bank) {
+      setFurthestStep((prev) => Math.max(prev, 2));
+    }
+    if (onboardingState?.policyId) {
+      setPolicySelection(onboardingState.policyId);
+      setFurthestStep((prev) => Math.max(prev, 3));
+    }
+  }, [onboardingState]);
+
+  const [profileErrors, setProfileErrors] = useState<Record<string, string>>({});
+  const [bankErrors, setBankErrors] = useState<Record<string, string>>({});
+  const [policyErrors, setPolicyErrors] = useState<Record<string, string>>({});
+
+  const profileMutation = useMutation({
+    mutationFn: async (payload: typeof profileForm) => {
+      const parsed = profileSchema.parse(payload);
+      const response = await api.patch<{ profile: OnboardingState["profile"] }>("/onboarding/profile", parsed);
+      return response.data.profile;
+    },
+    onSuccess: (profile) => {
+      queryClient.setQueryData(["onboarding", "state"], (prev: OnboardingState | undefined) => ({
+        ...(prev ?? {}),
+        profile: profile ?? undefined,
+      }));
+    },
+  });
+
+  const bankMutation = useMutation({
+    mutationFn: async (payload: typeof bankForm) => {
+      const parsed = bankSchema.parse(payload);
+      const response = await api.post<{ bank: OnboardingState["bank"] }>("/onboarding/bank", parsed);
+      return response.data.bank;
+    },
+    onSuccess: (bank) => {
+      queryClient.setQueryData(["onboarding", "state"], (prev: OnboardingState | undefined) => ({
+        ...(prev ?? {}),
+        bank: bank ?? undefined,
+      }));
+    },
+  });
+
+  const policyMutation = useMutation({
+    mutationFn: async (payload: { policyId: string }) => {
+      const parsed = policySchema.parse(payload);
+      const response = await api.post<{ policyId: string }>("/onboarding/policy", parsed);
+      return response.data.policyId;
+    },
+    onSuccess: (policyId) => {
+      queryClient.setQueryData(["onboarding", "state"], (prev: OnboardingState | undefined) => ({
+        ...(prev ?? {}),
+        policyId,
+      }));
+    },
+  });
+
+  const handleProfileNext = async () => {
+    try {
+      setProfileErrors({});
+      await profileMutation.mutateAsync(profileForm);
+      setCurrentStep(1);
+      setFurthestStep((prev) => Math.max(prev, 1));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const formatted: Record<string, string> = {};
+        error.issues.forEach((issue) => {
+          const key = issue.path[0];
+          if (typeof key === "string") {
+            formatted[key] = issue.message;
+          }
+        });
+        setProfileErrors(formatted);
+      }
+    }
+  };
+
+  const handleBankNext = async () => {
+    try {
+      setBankErrors({});
+      await bankMutation.mutateAsync(bankForm);
+      setCurrentStep(2);
+      setFurthestStep((prev) => Math.max(prev, 2));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const formatted: Record<string, string> = {};
+        error.issues.forEach((issue) => {
+          const key = issue.path[0];
+          if (typeof key === "string") {
+            formatted[key] = issue.message;
+          }
+        });
+        setBankErrors(formatted);
+      }
+    }
+  };
+
+  const handlePolicyNext = async () => {
+    try {
+      setPolicyErrors({});
+      await policyMutation.mutateAsync({ policyId: policySelection });
+      setCurrentStep(3);
+      setFurthestStep((prev) => Math.max(prev, 3));
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        const formatted: Record<string, string> = {};
+        error.issues.forEach((issue) => {
+          const key = issue.path[0];
+          if (typeof key === "string") {
+            formatted[key] = issue.message;
+          }
+        });
+        setPolicyErrors(formatted);
+      }
+    }
+  };
+
+  const handleStepKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+      event.preventDefault();
+      const next = Math.min(furthestStep, index + 1);
+      setCurrentStep(next);
+    }
+    if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const prev = Math.max(0, index - 1);
+      setCurrentStep(prev);
+    }
+  };
+
+  const stepContent = useMemo(() => {
+    switch (steps[currentStep]?.id) {
+      case "profile":
+        return (
+          <form className="grid gap-4" aria-labelledby="onboarding-profile">
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="legalName">
+                Legal name
+              </label>
+              <input
+                id="legalName"
+                name="legalName"
+                type="text"
+                value={profileForm.legalName}
+                onChange={(event) => setProfileForm((prev) => ({ ...prev, legalName: event.target.value }))}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                aria-invalid={Boolean(profileErrors.legalName)}
+              />
+              {profileErrors.legalName ? (
+                <p className="mt-1 text-sm text-rose-600" role="alert">
+                  {profileErrors.legalName}
+                </p>
+              ) : null}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="abn">
+                ABN <span className="text-slate-400">(optional)</span>
+              </label>
+              <input
+                id="abn"
+                name="abn"
+                type="text"
+                value={profileForm.abn}
+                onChange={(event) => setProfileForm((prev) => ({ ...prev, abn: event.target.value }))}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                aria-invalid={Boolean(profileErrors.abn)}
+              />
+              {profileErrors.abn ? (
+                <p className="mt-1 text-sm text-rose-600" role="alert">
+                  {profileErrors.abn}
+                </p>
+              ) : null}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="contactEmail">
+                Contact email
+              </label>
+              <input
+                id="contactEmail"
+                name="contactEmail"
+                type="email"
+                value={profileForm.contactEmail}
+                onChange={(event) => setProfileForm((prev) => ({ ...prev, contactEmail: event.target.value }))}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                aria-invalid={Boolean(profileErrors.contactEmail)}
+              />
+              {profileErrors.contactEmail ? (
+                <p className="mt-1 text-sm text-rose-600" role="alert">
+                  {profileErrors.contactEmail}
+                </p>
+              ) : null}
+            </div>
+          </form>
+        );
+      case "bank":
+        return (
+          <form className="grid gap-4" aria-labelledby="onboarding-bank">
+            <p className="text-sm text-slate-600">
+              Enter your bank details. We only retain masked values for your security.
+            </p>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="bsb">
+                BSB
+              </label>
+              <input
+                id="bsb"
+                name="bsb"
+                inputMode="numeric"
+                value={bankForm.bsb}
+                onChange={(event) => setBankForm((prev) => ({ ...prev, bsb: event.target.value }))}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                aria-invalid={Boolean(bankErrors.bsb)}
+              />
+              {bankErrors.bsb ? (
+                <p className="mt-1 text-sm text-rose-600" role="alert">
+                  {bankErrors.bsb}
+                </p>
+              ) : null}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="acc">
+                Account number
+              </label>
+              <input
+                id="acc"
+                name="acc"
+                inputMode="numeric"
+                value={bankForm.acc}
+                onChange={(event) => setBankForm((prev) => ({ ...prev, acc: event.target.value }))}
+                className="mt-1 w-full rounded border border-slate-300 px-3 py-2 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-200"
+                aria-invalid={Boolean(bankErrors.acc)}
+              />
+              {bankErrors.acc ? (
+                <p className="mt-1 text-sm text-rose-600" role="alert">
+                  {bankErrors.acc}
+                </p>
+              ) : null}
+            </div>
+            {onboardingState?.bank ? (
+              <div className="rounded-lg bg-slate-100 p-4 text-sm text-slate-700">
+                <p className="font-medium">Stored securely</p>
+                <p>BSB: {onboardingState.bank.bsbMasked}</p>
+                <p>Account: {onboardingState.bank.accMasked}</p>
+              </div>
+            ) : null}
+          </form>
+        );
+      case "policy":
+        return (
+          <fieldset className="grid gap-4" aria-labelledby="onboarding-policy">
+            <legend className="sr-only">Select a policy</legend>
+            {policiesData?.map((policy) => (
+              <label
+                key={policy.id}
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-slate-300 bg-white p-4 shadow-sm focus-within:border-sky-500 focus-within:ring-2 focus-within:ring-sky-200"
+              >
+                <input
+                  type="radio"
+                  name="policy"
+                  value={policy.id}
+                  checked={policySelection === policy.id}
+                  onChange={() => setPolicySelection(policy.id)}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block text-base font-semibold text-slate-800">{policy.name}</span>
+                  <span className="text-sm text-slate-600">{policy.description}</span>
+                </span>
+              </label>
+            ))}
+            {policyErrors.policyId ? (
+              <p className="text-sm text-rose-600" role="alert">
+                {policyErrors.policyId}
+              </p>
+            ) : null}
+          </fieldset>
+        );
+      case "confirm": {
+        const summary = queryClient.getQueryData<OnboardingState>(["onboarding", "state"]);
+        return (
+          <section className="space-y-6" aria-labelledby="onboarding-confirm">
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900">Organisation</h3>
+              <p className="text-sm text-slate-600">{summary?.profile?.legalName}</p>
+              <p className="text-sm text-slate-600">{summary?.profile?.contactEmail}</p>
+              {summary?.profile?.abn ? (
+                <p className="text-sm text-slate-600">ABN: {summary.profile.abn}</p>
+              ) : null}
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900">Bank</h3>
+              <p className="text-sm text-slate-600">BSB: {summary?.bank?.bsbMasked}</p>
+              <p className="text-sm text-slate-600">Account: {summary?.bank?.accMasked}</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-slate-900">Policy</h3>
+              <p className="text-sm text-slate-600">
+                {policiesData?.find((policy) => policy.id === summary?.policyId)?.name ?? "Not selected"}
+              </p>
+            </div>
+            <div className="rounded-lg bg-emerald-50 p-4 text-emerald-700">
+              You are all set! Review the details and finish onboarding when ready.
+            </div>
+          </section>
+        );
+      }
+      default:
+        return null;
+    }
+  }, [currentStep, profileForm, profileErrors, bankForm, bankErrors, onboardingState, policiesData, policySelection, policyErrors, queryClient]);
+
+  const isNextDisabled = useMemo(() => {
+    const current = steps[currentStep]?.id;
+    if (current === "profile") {
+      const parsed = profileSchema.safeParse(profileForm);
+      return !parsed.success || profileMutation.isPending;
+    }
+    if (current === "bank") {
+      const parsed = bankSchema.safeParse(bankForm);
+      return !parsed.success || bankMutation.isPending;
+    }
+    if (current === "policy") {
+      const parsed = policySchema.safeParse({ policyId: policySelection });
+      return !parsed.success || policyMutation.isPending;
+    }
+    return false;
+  }, [bankForm, bankMutation.isPending, currentStep, policySelection, policyMutation.isPending, profileForm, profileMutation.isPending]);
+
+  const nextButtonLabel = useMemo(() => {
+    if (steps[currentStep]?.id === "confirm") {
+      return "Finish";
+    }
+    return "Next";
+  }, [currentStep]);
+
+  const handleNext = async () => {
+    const current = steps[currentStep]?.id;
+    if (current === "profile") {
+      await handleProfileNext();
+    } else if (current === "bank") {
+      await handleBankNext();
+    } else if (current === "policy") {
+      await handlePolicyNext();
+    } else if (current === "confirm") {
+      navigate({ to: "/onboarding" });
+    }
+  };
+
+  const handleBack = () => {
+    setCurrentStep((prev) => Math.max(0, prev - 1));
+  };
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-8 p-6 md:p-10" aria-label="Onboarding wizard">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold text-slate-900">Onboarding Wizard</h1>
+        <p className="text-slate-600">
+          Complete the guided steps to finish setting up your organisation. You can navigate using your keyboard or the controls below.
+        </p>
+      </header>
+
+      <nav aria-label="Onboarding steps">
+        <ol className="flex flex-wrap gap-4" role="list">
+          {steps.map((step, index) => {
+            const isActive = index === currentStep;
+            const isCompleted = index < furthestStep;
+            const isLocked = index > furthestStep;
+            return (
+              <li key={step.id}>
+                <button
+                  type="button"
+                  aria-current={isActive ? "step" : undefined}
+                  className={`flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+                    isActive
+                      ? "bg-sky-600 text-white focus-visible:outline-sky-600"
+                      : isLocked
+                      ? "bg-slate-200 text-slate-500 focus-visible:outline-slate-300"
+                      : "bg-white text-slate-700 shadow focus-visible:outline-sky-600"
+                  }`}
+                  disabled={isLocked}
+                  onClick={() => setCurrentStep(index)}
+                  onKeyDown={(event) => handleStepKeyDown(event, index)}
+                >
+                  <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-current text-xs">
+                    {isCompleted ? "✓" : index + 1}
+                  </span>
+                  <span>{step.label}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <section className="grid gap-8 rounded-2xl bg-white p-6 shadow-lg" aria-live="polite">
+        <div className="space-y-1">
+          <h2 id={`onboarding-${steps[currentStep]?.id}`} className="text-2xl font-semibold text-slate-900">
+            {steps[currentStep]?.label}
+          </h2>
+          <p className="text-slate-600">{steps[currentStep]?.description}</p>
+        </div>
+        {stepContent}
+        <div className="mt-4 flex flex-wrap justify-between gap-3">
+          <button
+            type="button"
+            onClick={handleBack}
+            disabled={currentStep === 0}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={isNextDisabled}
+            className="rounded-lg bg-sky-600 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-600 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {nextButtonLabel}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apgms/webapp/tailwind.config.ts
+++ b/apgms/webapp/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;

--- a/apgms/webapp/tsconfig.json
+++ b/apgms/webapp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"],
+  "references": []
+}

--- a/apgms/webapp/vite.config.ts
+++ b/apgms/webapp/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add onboarding schemas and routes for org profile, bank masking, and policy selection
- implement a multi-step onboarding wizard with auth guard, accessibility, and React Query data hooks
- cover the onboarding journey with a Playwright test including axe accessibility verification

## Testing
- `pnpm --dir webapp test` *(fails: playwright not found in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4890046cc8327955adc254e103fe0