### PR TITLE
Add KMS artifacts directory and ignore local key material

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -5,3 +5,6 @@ coverage/
 .DS_Store
 .vscode/
 **/__pycache__/
+
+# Local KMS artifacts (private keys generated outside CI)
+artifacts/kms/**/*.json

--- a/apgms/README.md
+++ b/apgms/README.md
@@ -6,3 +6,9 @@ pnpm -r build
 docker compose up -d
 pnpm -r test
 pnpm -w exec playwright test
+
+## Local development notes
+
+- Store any developer-provisioned KMS credentials in `artifacts/kms/`. The directory is
+  tracked in git via a `.gitkeep`, while the JSON key material is ignored so local keys
+  never end up in version control.


### PR DESCRIPTION
## Summary
- ignore JSON KMS artifacts under artifacts/kms so private keys stay out of git
- add a tracked artifacts/kms directory via .gitkeep for local development
- document where to store local KMS credentials in the developer README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f48ea3ca308327acc26885fb100f53