### PR TITLE
feat: centralize RPT signer loading

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/rpt.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/lib/rpt.ts
+++ b/apgms/services/api-gateway/src/lib/rpt.ts
@@ -1,0 +1,35 @@
+import {
+  clearSignerCache,
+  getSigner,
+  type JWTPayload,
+  type JwtVerifyResult,
+  type SignJwtOptions,
+  type Signer,
+  type VerifyJwtOptions,
+} from "@apgms/shared";
+
+let signerPromise: Promise<Signer> | null = null;
+
+async function loadSigner(): Promise<Signer> {
+  if (!signerPromise) {
+    signerPromise = getSigner("rpt");
+  }
+  return signerPromise;
+}
+
+export interface MintRptOptions extends SignJwtOptions {}
+
+export async function mintRpt<T extends JWTPayload>(payload: T, options?: MintRptOptions): Promise<string> {
+  const signer = await loadSigner();
+  return signer.sign(payload, options);
+}
+
+export async function verifyRpt<T extends JWTPayload>(token: string, options?: VerifyJwtOptions): Promise<JwtVerifyResult<T>> {
+  const signer = await loadSigner();
+  return signer.verify<T>(token, options);
+}
+
+export function resetRptSignerCache() {
+  signerPromise = null;
+  clearSignerCache("rpt");
+}

--- a/apgms/services/api-gateway/test/rpt.test.ts
+++ b/apgms/services/api-gateway/test/rpt.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+
+import { mintRpt, resetRptSignerCache, verifyRpt } from "../src/lib/rpt";
+
+type KeyEntry = {
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+};
+
+function createKey(kid: string): KeyEntry {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return {
+    kid,
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicKey: publicKey.export({ type: "spki", format: "pem" }).toString(),
+  };
+}
+
+async function assertMintUsesActiveKey() {
+  const primary = createKey("kid-primary");
+  const secondary = createKey("kid-secondary");
+
+  process.env.RPT_PRIVATE_KEYS = JSON.stringify([primary, secondary]);
+  resetRptSignerCache();
+
+  const token = await mintRpt(
+    { sub: "user-123", scope: ["bank:read"] },
+    { issuer: "api-gateway", audience: "birchal" },
+  );
+
+  const { payload, protectedHeader } = await verifyRpt(token, {
+    issuer: "api-gateway",
+    audience: "birchal",
+  });
+
+  assert.equal(protectedHeader.kid, primary.kid);
+  assert.equal(payload.sub, "user-123");
+  assert.deepEqual(payload.scope, ["bank:read"]);
+}
+
+async function assertRotationSupportsLegacyTokens() {
+  const keyA = createKey("kid-a");
+  const keyB = createKey("kid-b");
+
+  process.env.RPT_PRIVATE_KEYS = JSON.stringify([keyA, keyB]);
+  resetRptSignerCache();
+
+  const legacyToken = await mintRpt({ sub: "user-456", scope: ["bank:write"] }, { issuer: "api-gateway" });
+
+  const keyC = createKey("kid-c");
+  process.env.RPT_PRIVATE_KEYS = JSON.stringify([keyC, keyA, keyB]);
+  resetRptSignerCache();
+
+  const { payload: legacyPayload, protectedHeader: legacyHeader } = await verifyRpt(legacyToken, {
+    issuer: "api-gateway",
+  });
+
+  assert.equal(legacyHeader.kid, keyA.kid);
+  assert.equal(legacyPayload.sub, "user-456");
+
+  const rotatedToken = await mintRpt({ sub: "user-456", scope: ["bank:approve"] }, { issuer: "api-gateway" });
+  const { protectedHeader: rotatedHeader } = await verifyRpt(rotatedToken, { issuer: "api-gateway" });
+
+  assert.equal(rotatedHeader.kid, keyC.kid);
+}
+
+async function run() {
+  await assertMintUsesActiveKey();
+  await assertRotationSupportsLegacyTokens();
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,8 +9,9 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
+      "@apgms/shared": ["shared/src/index.ts"],
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,1 @@
-﻿// shared
+export * from "./signers";

--- a/apgms/shared/src/signers.ts
+++ b/apgms/shared/src/signers.ts
@@ -1,0 +1,256 @@
+import { createPrivateKey, createPublicKey, createSign, createVerify, KeyObject } from "node:crypto";
+
+export type SupportedAlgorithms = "RS256" | "RS384" | "RS512";
+
+export interface RawSignerConfig {
+  kid: string;
+  privateKey: string;
+  publicKey: string;
+  alg?: SupportedAlgorithms;
+}
+
+export interface JWTPayload {
+  [key: string]: unknown;
+  iss?: string;
+  sub?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+}
+
+export interface SignJwtOptions {
+  audience?: string | string[];
+  expiresIn?: string | number;
+  issuer?: string;
+  subject?: string;
+  notBefore?: string | number;
+}
+
+export interface VerifyJwtOptions {
+  audience?: string | string[];
+  issuer?: string;
+  subject?: string;
+  clockTolerance?: number;
+}
+
+export interface JwtHeader {
+  alg: SupportedAlgorithms;
+  kid: string;
+  typ: "JWT";
+}
+
+export interface JwtVerifyResult<T extends JWTPayload> {
+  payload: T;
+  protectedHeader: JwtHeader;
+}
+
+export interface Signer {
+  kid: string;
+  algorithm: SupportedAlgorithms;
+  sign<T extends JWTPayload>(payload: T, options?: SignJwtOptions): Promise<string>;
+  verify<T extends JWTPayload>(token: string, options?: VerifyJwtOptions): Promise<JwtVerifyResult<T>>;
+}
+
+const signerCache = new Map<string, Promise<Signer>>();
+
+export function clearSignerCache(name?: string) {
+  if (name) {
+    signerCache.delete(name);
+    return;
+  }
+  signerCache.clear();
+}
+
+const SIGN_ALGORITHMS: Record<SupportedAlgorithms, string> = {
+  RS256: "RSA-SHA256",
+  RS384: "RSA-SHA384",
+  RS512: "RSA-SHA512",
+};
+
+function parseDuration(input: string | number): number {
+  if (typeof input === "number") {
+    return input;
+  }
+  const match = /^(\d+)([smhd])$/.exec(input.trim());
+  if (!match) {
+    throw new Error(`Unsupported duration format: ${input}`);
+  }
+  const value = Number(match[1]);
+  const unit = match[2];
+  const multiplier: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+  return value * multiplier[unit];
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function base64UrlDecode(segment: string): Buffer {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = normalized.length % 4;
+  const padded = pad === 0 ? normalized : normalized + "=".repeat(4 - pad);
+  return Buffer.from(padded, "base64");
+}
+
+function isAudienceMatch(expected: string | string[], actual?: string | string[]): boolean {
+  if (expected === undefined) {
+    return true;
+  }
+  const expectedSet = Array.isArray(expected) ? expected : [expected];
+  const actualSet = actual === undefined ? [] : Array.isArray(actual) ? actual : [actual];
+  return expectedSet.every((entry) => actualSet.includes(entry));
+}
+
+function assertClaim(condition: boolean, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function buildSigner(name: string): Promise<Signer> {
+  const envKey = `${name.toUpperCase()}_PRIVATE_KEYS`;
+  const envValue = process.env[envKey];
+
+  if (!envValue) {
+    throw new Error(`Missing environment variable ${envKey} for signer "${name}"`);
+  }
+
+  let rawConfigs: RawSignerConfig[];
+  try {
+    rawConfigs = JSON.parse(envValue) as RawSignerConfig[];
+  } catch (error) {
+    throw new Error(`Failed to parse ${envKey} as JSON array: ${(error as Error).message}`);
+  }
+
+  if (!Array.isArray(rawConfigs) || rawConfigs.length === 0) {
+    throw new Error(`${envKey} must be a non-empty JSON array`);
+  }
+
+  const configs = rawConfigs.map((config) => {
+    if (!config || typeof config !== "object") {
+      throw new Error(`${envKey} entries must be objects`);
+    }
+    if (!config.kid || !config.privateKey || !config.publicKey) {
+      throw new Error(`${envKey} entries must include kid, privateKey and publicKey`);
+    }
+    const algorithm = config.alg ?? "RS256";
+    if (!(algorithm in SIGN_ALGORITHMS)) {
+      throw new Error(`Unsupported algorithm ${algorithm} for signer "${name}"`);
+    }
+    return {
+      kid: config.kid,
+      privateKey: createPrivateKey(config.privateKey),
+      publicKey: createPublicKey(config.publicKey),
+      alg: algorithm as SupportedAlgorithms,
+    };
+  });
+
+  const [active, ...rest] = configs;
+  const verificationEntries = [active, ...rest];
+  const verificationMap = new Map<string, KeyObject>();
+
+  for (const entry of verificationEntries) {
+    if (!verificationMap.has(entry.kid)) {
+      verificationMap.set(entry.kid, entry.publicKey);
+    }
+  }
+
+  const resolveVerificationKey = (kid?: string): KeyObject => {
+    const effectiveKid = kid ?? active.kid;
+    const key = verificationMap.get(effectiveKid);
+    if (!key) {
+      throw new Error(`Unknown key id "${effectiveKid}" for signer "${name}"`);
+    }
+    return key;
+  };
+
+  return {
+    kid: active.kid,
+    algorithm: active.alg,
+    async sign<T extends JWTPayload>(payload: T, options: SignJwtOptions = {}) {
+      const claims: JWTPayload = { ...payload };
+      const now = Math.floor(Date.now() / 1000);
+
+      if (claims.iat === undefined) {
+        claims.iat = now;
+      }
+      if (options.expiresIn !== undefined) {
+        claims.exp = now + parseDuration(options.expiresIn);
+      }
+      if (options.audience !== undefined) {
+        claims.aud = options.audience;
+      }
+      if (options.issuer !== undefined) {
+        claims.iss = options.issuer;
+      }
+      if (options.subject !== undefined) {
+        claims.sub = options.subject;
+      }
+      if (options.notBefore !== undefined) {
+        claims.nbf = now + parseDuration(options.notBefore);
+      }
+
+      const header: JwtHeader = { alg: active.alg, kid: active.kid, typ: "JWT" };
+      const encodedHeader = base64UrlEncode(Buffer.from(JSON.stringify(header)));
+      const encodedPayload = base64UrlEncode(Buffer.from(JSON.stringify(claims)));
+      const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+      const signer = createSign(SIGN_ALGORITHMS[active.alg]);
+      signer.update(signingInput);
+      signer.end();
+      const signature = signer.sign(active.privateKey);
+      const encodedSignature = base64UrlEncode(signature);
+
+      return `${encodedHeader}.${encodedPayload}.${encodedSignature}`;
+    },
+    async verify<T extends JWTPayload>(token: string, options: VerifyJwtOptions = {}) {
+      const segments = token.split(".");
+      assertClaim(segments.length === 3, "Token must have three segments");
+
+      const [encodedHeader, encodedPayload, encodedSignature] = segments;
+      const header = JSON.parse(base64UrlDecode(encodedHeader).toString("utf8")) as JwtHeader;
+      assertClaim(header.alg in SIGN_ALGORITHMS, "Unsupported algorithm in token");
+
+      const signingInput = `${encodedHeader}.${encodedPayload}`;
+      const verifier = createVerify(SIGN_ALGORITHMS[header.alg]);
+      verifier.update(signingInput);
+      verifier.end();
+      const signatureValid = verifier.verify(resolveVerificationKey(header.kid), base64UrlDecode(encodedSignature));
+      assertClaim(signatureValid, "Invalid token signature");
+
+      const payload = JSON.parse(base64UrlDecode(encodedPayload).toString("utf8")) as T;
+      const now = Math.floor(Date.now() / 1000);
+      const tolerance = options.clockTolerance ?? 0;
+
+      if (payload.exp !== undefined) {
+        assertClaim(now <= payload.exp + tolerance, "Token has expired");
+      }
+      if (payload.nbf !== undefined) {
+        assertClaim(now >= payload.nbf - tolerance, "Token not yet valid");
+      }
+      if (options.issuer !== undefined) {
+        assertClaim(payload.iss === options.issuer, "Issuer mismatch");
+      }
+      if (options.subject !== undefined) {
+        assertClaim(payload.sub === options.subject, "Subject mismatch");
+      }
+      if (options.audience !== undefined) {
+        assertClaim(isAudienceMatch(options.audience, payload.aud), "Audience mismatch");
+      }
+
+      return { payload, protectedHeader: header } satisfies JwtVerifyResult<T>;
+    },
+  } satisfies Signer;
+}
+
+export async function getSigner(name: string): Promise<Signer> {
+  if (!signerCache.has(name)) {
+    signerCache.set(name, buildSigner(name));
+  }
+  return signerCache.get(name)!;
+}


### PR DESCRIPTION
## Summary
- add a shared signer utility that loads signing keys from the environment and caches them for reuse
- update the RPT helper to rely on the async signer API and expose a cache reset hook
- add coverage to ensure tokens survive key rotation using the shared signer

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f48ea21fe08327b27521b4bfb91db4