### PR TITLE
Add API gateway KMS module and tests

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,6 +1,7 @@
-﻿node_modules/
+node_modules/
 dist/
 coverage/
+artifacts/
 .env*
 .DS_Store
 .vscode/

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "NODE_TEST_EXTENSIONS=.test.ts node --import tsx --test test/kms.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,162 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { getSigner, loadKeyMaterial, rotateKey } from "./kms";
 
-const app = Fastify({ logger: true });
+const ADMIN_ROLES_HEADER = "x-actor-roles";
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+function requestHasAdminRole(request: FastifyRequest): boolean {
+  const header = request.headers[ADMIN_ROLES_HEADER];
+  if (!header) {
+    return false;
   }
-});
+  const raw = Array.isArray(header) ? header.join(",") : header;
+  return raw
+    .split(",")
+    .map((role) => role.trim().toLowerCase())
+    .filter(Boolean)
+    .includes("admin");
+}
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+async function ensureAdmin(request: FastifyRequest, reply: FastifyReply): Promise<boolean> {
+  if (requestHasAdminRole(request)) {
+    return true;
+  }
+  await reply.code(403).send({ error: "forbidden" });
+  return false;
+}
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+export interface PrismaLike {
+  user: { findMany(args: unknown): Promise<any[]> };
+  bankLine: {
+    findMany(args: unknown): Promise<any[]>;
+    create(args: unknown): Promise<any>;
+  };
+}
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+export interface BuildAppOptions {
+  logger?: boolean;
+  prisma?: PrismaLike;
+}
 
+export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: options.logger ?? true });
+
+  await app.register(cors, { origin: true });
+
+  const prisma: PrismaLike =
+    options.prisma ?? ((await import("../../../shared/src/db")).prisma as PrismaLike);
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.post("/admin/keys/rotate", async (req, rep) => {
+    if (!(await ensureAdmin(req, rep))) {
+      return;
+    }
+    const body = req.body as { alias?: string } | undefined;
+    if (!body?.alias) {
+      return rep.code(400).send({ error: "invalid_alias" });
+    }
+    const material = await rotateKey(body.alias);
+    return rep.send({ alias: material.alias, version: material.version, publicKey: material.publicKey });
+  });
+
+  app.get("/admin/keys/:alias/pub", async (req, rep) => {
+    if (!(await ensureAdmin(req, rep))) {
+      return;
+    }
+    const params = req.params as { alias: string };
+    const query = req.query as { version?: string };
+    const version = query.version === undefined ? undefined : Number(query.version);
+    if (query.version !== undefined && Number.isNaN(version)) {
+      return rep.code(400).send({ error: "invalid_version" });
+    }
+    const material = await loadKeyMaterial(params.alias, version);
+    if (!material) {
+      return rep.code(404).send({ error: "not_found" });
+    }
+    return rep.send({ alias: material.alias, version: material.version, publicKey: material.publicKey });
+  });
+
+  app.addHook("onReady", async () => {
+    app.log.info(app.printRoutes());
+    await getSigner("rpt");
+  });
+
+  return app;
+}
+
+async function start() {
+  const app = await buildApp();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}
+
+const isMain = (() => {
+  const entry = process.argv[1];
+  if (!entry) {
+    return false;
+  }
+  return import.meta.url === pathToFileURL(entry).href;
+})();
+
+if (isMain) {
+  start();
+}

--- a/apgms/services/api-gateway/src/kms.ts
+++ b/apgms/services/api-gateway/src/kms.ts
@@ -1,0 +1,195 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  sign as signRaw,
+  verify as verifyRaw,
+} from "node:crypto";
+
+export interface KeyMaterial {
+  alias: string;
+  version: number;
+  createdAt: string;
+  publicKey: string;
+  privateKey: string;
+}
+
+export interface SignResult {
+  signature: string;
+  version: number;
+}
+
+export interface Signer {
+  sign(payload: Buffer | string): Promise<SignResult>;
+  verify(payload: Buffer | string, signature: string, version?: number): Promise<boolean>;
+  getPublicKey(version?: number): Promise<{ version: number; publicKey: string }>;
+}
+
+const VERSION_FILE_PREFIX = "v";
+const VERSION_PAD = 6;
+
+function normalizeAlias(alias: string): string {
+  const trimmed = alias.trim();
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    throw new Error(`Invalid key alias: ${alias}`);
+  }
+  return trimmed;
+}
+
+function resolveArtifactsBase(): string {
+  const configured = process.env.KMS_ARTIFACTS_DIR;
+  if (configured && configured.length > 0) {
+    return path.resolve(configured);
+  }
+  return path.resolve(process.cwd(), "artifacts", "kms");
+}
+
+function aliasDir(alias: string): string {
+  return path.join(resolveArtifactsBase(), normalizeAlias(alias));
+}
+
+async function ensureAliasDir(alias: string): Promise<string> {
+  const dir = aliasDir(alias);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function formatVersion(version: number): string {
+  return `${VERSION_FILE_PREFIX}${String(version).padStart(VERSION_PAD, "0")}`;
+}
+
+function parseVersion(filename: string): number | null {
+  const match = filename.match(/^v(\d+)\.json$/);
+  if (!match) {
+    return null;
+  }
+  return Number.parseInt(match[1]!, 10);
+}
+
+async function readMaterialFile(filepath: string): Promise<KeyMaterial | null> {
+  try {
+    const raw = await fs.readFile(filepath, "utf8");
+    const parsed = JSON.parse(raw) as KeyMaterial;
+    return parsed;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+export async function listKeyVersions(alias: string): Promise<number[]> {
+  const dir = aliasDir(alias);
+  try {
+    const files = await fs.readdir(dir);
+    return files
+      .map((file) => parseVersion(file))
+      .filter((version): version is number => typeof version === "number" && !Number.isNaN(version))
+      .sort((a, b) => a - b);
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+}
+
+export async function loadKeyMaterial(alias: string, version?: number): Promise<KeyMaterial | null> {
+  const normalized = normalizeAlias(alias);
+  const dir = aliasDir(normalized);
+  if (version !== undefined) {
+    const filepath = path.join(dir, `${formatVersion(version)}.json`);
+    return readMaterialFile(filepath);
+  }
+  const versions = await listKeyVersions(normalized);
+  if (versions.length === 0) {
+    return null;
+  }
+  const latestVersion = versions[versions.length - 1]!;
+  const filepath = path.join(dir, `${formatVersion(latestVersion)}.json`);
+  return readMaterialFile(filepath);
+}
+
+function bufferize(payload: Buffer | string): Buffer {
+  return typeof payload === "string" ? Buffer.from(payload) : payload;
+}
+
+function signWithKey(payload: Buffer, keyPem: string): Buffer {
+  const privateKey = createPrivateKey(keyPem);
+  return signRaw(null, payload, privateKey);
+}
+
+function verifyWithKey(payload: Buffer, signature: Buffer, keyPem: string): boolean {
+  const publicKey = createPublicKey(keyPem);
+  return verifyRaw(null, payload, publicKey, signature);
+}
+
+export async function rotateKey(alias: string): Promise<KeyMaterial> {
+  const normalized = normalizeAlias(alias);
+  const dir = await ensureAliasDir(normalized);
+  const existing = await loadKeyMaterial(normalized);
+  const nextVersion = (existing?.version ?? 0) + 1;
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const material: KeyMaterial = {
+    alias: normalized,
+    version: nextVersion,
+    createdAt: new Date().toISOString(),
+    publicKey: publicKey.export({ type: "spki", format: "pem" }).toString(),
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+  const filepath = path.join(dir, `${formatVersion(material.version)}.json`);
+  await fs.writeFile(filepath, JSON.stringify(material, null, 2), "utf8");
+  return material;
+}
+
+async function ensureKeyMaterial(alias: string): Promise<KeyMaterial> {
+  const current = await loadKeyMaterial(alias);
+  if (current) {
+    return current;
+  }
+  return rotateKey(alias);
+}
+
+export async function getSigner(alias: string): Promise<Signer> {
+  const normalized = normalizeAlias(alias);
+  await ensureAliasDir(normalized);
+  await ensureKeyMaterial(normalized);
+
+  return {
+    async sign(payload: Buffer | string) {
+      const latest = await ensureKeyMaterial(normalized);
+      const signature = signWithKey(bufferize(payload), latest.privateKey).toString("base64");
+      return { signature, version: latest.version };
+    },
+    async verify(payload: Buffer | string, signature: string, version?: number) {
+      const material = version !== undefined ? await loadKeyMaterial(normalized, version) : await ensureKeyMaterial(normalized);
+      if (!material) {
+        return false;
+      }
+      const isValid = verifyWithKey(bufferize(payload), Buffer.from(signature, "base64"), material.publicKey);
+      return isValid;
+    },
+    async getPublicKey(version?: number) {
+      const material = version !== undefined ? await loadKeyMaterial(normalized, version) : await ensureKeyMaterial(normalized);
+      if (!material) {
+        throw new Error(`No key material for alias ${normalized}`);
+      }
+      return { version: material.version, publicKey: material.publicKey };
+    },
+  };
+}
+
+export function verifySignatureWithMaterial(
+  material: KeyMaterial,
+  payload: Buffer | string,
+  signature: string,
+): boolean {
+  return verifyWithKey(bufferize(payload), Buffer.from(signature, "base64"), material.publicKey);
+}
+
+export function getArtifactsDirectory(): string {
+  return resolveArtifactsBase();
+}

--- a/apgms/services/api-gateway/test/kms.test.ts
+++ b/apgms/services/api-gateway/test/kms.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { createPublicKey, verify as verifyRaw } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+
+let tempDir: string;
+
+async function withFreshArtifactsDir() {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), "kms-artifacts-"));
+  process.env.KMS_ARTIFACTS_DIR = tempDir;
+}
+
+describe("kms service", () => {
+  beforeEach(async () => {
+    await withFreshArtifactsDir();
+    await import("../src/kms");
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    delete process.env.KMS_ARTIFACTS_DIR;
+  });
+
+  test("signs, verifies, and supports key rotation", async () => {
+    const kms = await import("../src/kms");
+    const payload = Buffer.from(`{"ts":${Date.now()}}`);
+    const signer = await kms.getSigner("rpt");
+    const first = await signer.sign(payload);
+
+    assert.ok(first.version >= 1);
+    assert.equal(await signer.verify(payload, first.signature, first.version), true);
+
+    const preRotationMaterial = await kms.loadKeyMaterial("rpt", first.version);
+    assert.ok(preRotationMaterial);
+
+    const rotated = await kms.rotateKey("rpt");
+    assert.equal(rotated.version, first.version + 1);
+
+    const second = await signer.sign(payload);
+    assert.equal(second.version, rotated.version);
+    assert.equal(await signer.verify(payload, second.signature, second.version), true);
+
+    const publicKey = createPublicKey(preRotationMaterial!.publicKey);
+    const valid = verifyRaw(null, payload, publicKey, Buffer.from(first.signature, "base64"));
+    assert.equal(valid, true);
+  });
+
+  test("admin key routes enforce RBAC", async () => {
+    const { buildApp } = await import("../src/index");
+    const prismaStub = {
+      user: { findMany: async () => [] },
+      bankLine: {
+        findMany: async () => [],
+        create: async ({ data }: { data: any }) => ({ id: "line", ...data }),
+      },
+    } satisfies import("../src/index").PrismaLike;
+
+    const app = await buildApp({ logger: false, prisma: prismaStub });
+
+    const rotateDenied = await app.inject({
+      method: "POST",
+      url: "/admin/keys/rotate",
+      payload: { alias: "rpt" },
+    });
+    assert.equal(rotateDenied.statusCode, 403);
+
+    const rotateAllowed = await app.inject({
+      method: "POST",
+      url: "/admin/keys/rotate",
+      payload: { alias: "rpt" },
+      headers: { "x-actor-roles": "admin" },
+    });
+    assert.equal(rotateAllowed.statusCode, 200);
+    const rotationBody = rotateAllowed.json();
+    assert.equal(rotationBody.alias, "rpt");
+    assert.equal(typeof rotationBody.version, "number");
+    assert.equal(typeof rotationBody.publicKey, "string");
+
+    const pubDenied = await app.inject({
+      method: "GET",
+      url: "/admin/keys/rpt/pub",
+    });
+    assert.equal(pubDenied.statusCode, 403);
+
+    const pubAllowed = await app.inject({
+      method: "GET",
+      url: "/admin/keys/rpt/pub",
+      headers: { "x-actor-roles": "admin" },
+    });
+    assert.equal(pubAllowed.statusCode, 200);
+    const pubBody = pubAllowed.json();
+    assert.deepEqual(pubBody, {
+      alias: "rpt",
+      version: rotationBody.version,
+      publicKey: rotationBody.publicKey,
+    });
+
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,5 @@
-﻿import { PrismaClient } from "@prisma/client";
+import pkg from "@prisma/client";
+
+const { PrismaClient } = pkg;
+
 export const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- introduce a file-backed KMS helper for signing, verification, and rotation within the API gateway
- expose admin key management routes with RBAC checks and optional Prisma injection for tests
- add a node:test harness and KMS integration tests while ignoring generated artifacts

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f48e9c0f608327b8ba425db3307b92