### PR TITLE
Add admin key management routes to API gateway

### DIFF
--- a/apgms/services/api-gateway/src/auth/ensure-admin.ts
+++ b/apgms/services/api-gateway/src/auth/ensure-admin.ts
@@ -1,0 +1,47 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+export interface CurrentUser {
+  id?: string;
+  roles?: string[];
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user?: CurrentUser;
+  }
+}
+
+const getRoles = (request: FastifyRequest): string[] => {
+  if (Array.isArray(request.user?.roles)) {
+    return request.user!.roles!;
+  }
+
+  const header = request.headers["x-user-roles"];
+  if (typeof header === "string") {
+    return header
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  if (Array.isArray(header)) {
+    return header
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+export const ensureAdmin = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> => {
+  const roles = getRoles(request);
+
+  if (!roles.includes("admin")) {
+    await reply.code(403).send({ error: "forbidden" });
+    return;
+  }
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -11,9 +11,12 @@ import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
+import adminKeyRoutes from "./routes/admin/keys";
+
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(adminKeyRoutes, { prefix: "/admin" });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/routes/admin/keys.ts
+++ b/apgms/services/api-gateway/src/routes/admin/keys.ts
@@ -1,0 +1,57 @@
+import { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+
+import { ensureAdmin } from "../../auth/ensure-admin";
+import { getSigner, rotateKey } from "../../services/keys";
+
+const rotateBodySchema = z.object({
+  alias: z.string().min(1, "alias is required"),
+});
+type RotateBody = z.infer<typeof rotateBodySchema>;
+
+const aliasParamsSchema = z.object({
+  alias: z.string().min(1, "alias is required"),
+});
+type AliasParams = z.infer<typeof aliasParamsSchema>;
+
+const adminKeyRoutes: FastifyPluginAsync = async (app) => {
+  app.post<{ Body: RotateBody }>(
+    "/keys/rotate",
+    {
+      preHandler: ensureAdmin,
+    },
+    async (request, reply) => {
+      const { alias } = rotateBodySchema.parse(request.body);
+      const signer = await rotateKey(alias);
+
+      return reply.code(201).send({
+        alias: signer.alias,
+        version: signer.version,
+        publicKey: signer.publicKey,
+      });
+    },
+  );
+
+  app.get<{ Params: AliasParams }>(
+    "/keys/:alias",
+    {
+      preHandler: ensureAdmin,
+    },
+    async (request, reply) => {
+      const { alias } = aliasParamsSchema.parse(request.params);
+      const signer = await getSigner(alias);
+
+      if (!signer) {
+        return reply.code(404).send({ error: "not_found" });
+      }
+
+      return reply.send({
+        alias: signer.alias,
+        version: signer.version,
+        publicKey: signer.publicKey,
+      });
+    },
+  );
+};
+
+export default adminKeyRoutes;

--- a/apgms/services/api-gateway/src/services/keys.ts
+++ b/apgms/services/api-gateway/src/services/keys.ts
@@ -1,0 +1,28 @@
+import { randomBytes } from "node:crypto";
+
+export interface Signer {
+  alias: string;
+  version: number;
+  publicKey: string;
+}
+
+const store = new Map<string, Signer>();
+
+const createPublicKey = (): string => randomBytes(32).toString("base64url");
+
+export const rotateKey = async (alias: string): Promise<Signer> => {
+  const current = store.get(alias);
+  const nextVersion = (current?.version ?? 0) + 1;
+  const signer: Signer = {
+    alias,
+    version: nextVersion,
+    publicKey: createPublicKey(),
+  };
+
+  store.set(alias, signer);
+  return signer;
+};
+
+export const getSigner = async (alias: string): Promise<Signer | undefined> => {
+  return store.get(alias);
+};


### PR DESCRIPTION
## Summary
- add an admin role guard that checks request metadata and headers
- expose key rotation and signer lookup endpoints via a Fastify plugin
- register the admin key plugin and back it with an in-memory signer store

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f48e9a7814832789f062d354de7814