### PR TITLE
Expand CI workflows with dedicated test jobs

### DIFF
--- a/apgms/.github/pull_request_template.md
+++ b/apgms/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+- 
+
+## Testing
+- 
+
+## Evidence
+Provide links to CI outputs, reports, or artifacts for the following (if applicable):
+- [ ] Contracts: 
+- [ ] Red Team: 
+- [ ] Golden: 
+- [ ] Unit: 
+- [ ] E2E: 
+- [ ] SBOM: 
+- [ ] Docker Health: 

--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,17 +1,221 @@
-﻿name: CI
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  PNPM_VERSION: '9'
+  NODE_VERSION: '18'
+
 jobs:
-  build:
+  contracts:
+    name: Contracts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
-          version: 9
-      - uses: actions/setup-node@v4
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run contracts suite
+        run: pnpm run contracts
+      - name: Upload contracts artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: contracts-artifacts
+          path: |
+            artifacts/contracts
+            reports/contracts
+            coverage
+          if-no-files-found: ignore
+
+  red-team:
+    name: Red Team
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run red team suite
+        run: pnpm run red-team
+      - name: Upload red team artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: red-team-artifacts
+          path: |
+            artifacts/red-team
+            reports/red-team
+            coverage
+          if-no-files-found: ignore
+
+  golden:
+    name: Golden Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run golden tests
+        run: pnpm run golden
+      - name: Upload golden artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-artifacts
+          path: |
+            artifacts/golden
+            reports/golden
+            coverage
+          if-no-files-found: ignore
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run unit tests
+        run: pnpm run unit
+      - name: Upload unit test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-artifacts
+          path: |
+            artifacts/unit
+            reports/unit
+            coverage
+          if-no-files-found: ignore
+
+  e2e:
+    name: End-to-End Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run end-to-end tests
+        run: pnpm run e2e
+      - name: Upload end-to-end artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts
+          path: |
+            artifacts/e2e
+            reports/e2e
+            playwright-report
+          if-no-files-found: ignore
+
+  sbom:
+    name: SBOM Generation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Generate SBOM
+        run: pnpm run sbom
+      - name: Upload SBOM artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-artifacts
+          path: |
+            sbom
+            reports/sbom
+          if-no-files-found: ignore
+
+  docker-health:
+    name: Docker Health Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run docker health checks
+        run: pnpm run docker-health
+      - name: Upload docker health artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-health-artifacts
+          path: |
+            artifacts/docker-health
+            reports/docker-health
+            logs/docker
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- split the CI workflow into dedicated contracts, red-team, golden, unit, e2e, sbom, and docker-health jobs with cached pnpm setup
- ensure every job installs dependencies, runs its pnpm script, and uploads artifacts for later review
- add a pull request template that calls for evidence links to each job's outputs

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f4a476c344832797183720535d849e