### PR TITLE
Add admin privacy tooling and documentation

### DIFF
--- a/apgms/docs/privacy.md
+++ b/apgms/docs/privacy.md
@@ -1,0 +1,49 @@
+# APP 12/13 Request Handling
+
+This document outlines how Birchal satisfies Australian Privacy Principles (APP) 12 and 13 covering access to, and correction of, personal information.
+
+## Overview
+- **APP 12** gives individuals the right to access personal information we hold about them.
+- **APP 13** requires us to correct personal information to ensure it is accurate, up-to-date, and complete.
+- All requests are tracked in the Privacy ServiceDesk queue with the label `app-12-13`.
+
+## Intake process
+1. Requests may arrive via support@birchal.com, the privacy webform, or regulator correspondence.
+2. Support triages within one business day and escalates to the Privacy Officer.
+3. The Privacy Officer logs the request with: requester name, contact details, relationship to Birchal, verification status, and due date.
+
+## Identity verification
+- For customers, request confirmation from the registered email or phone on file.
+- For authorised representatives, obtain a signed authority letter less than 12 months old.
+- Log verification steps in the request ticket. If identity cannot be verified, respond with refusal citing APP 12.3.
+
+## Locating information
+1. Query the data inventory for systems tagged with the requester's organisation ID.
+2. Run `/admin/export/:orgId` in the API Gateway (with an approved admin token) to gather structured exports.
+3. Collect additional artefacts: audit logs, support transcripts, manual files stored in Google Drive.
+4. Store copies in the encrypted privacy evidence folder with restricted permissions.
+
+## Responding to access requests (APP 12)
+- Default timeframe: 30 calendar days.
+- Provide a summary report including:
+  - Data sources accessed.
+  - Categories of personal information (contact details, transaction history, audit events).
+  - Any redactions and the reason for withholding (e.g. another individual's privacy).
+- Use the customer notification template in `runbooks/ndb.md` if the request stems from a breach incident.
+- Deliver securely via the customer portal or encrypted email (password shared via phone).
+
+## Responding to correction requests (APP 13)
+1. Validate the requested changes and supporting evidence.
+2. Update authoritative systems (CRM, registry, billing) and log the fields changed.
+3. Issue a confirmation email detailing the updates made.
+4. If refusing to correct, provide written reasons, available complaint mechanisms, and contact information for the OAIC.
+
+## Escalation and reporting
+- Notify the Chief Privacy Officer if the request relates to more than 100 individuals or involves regulator oversight.
+- Breach the timeframe? file an incident and inform the requester of the delay and revised completion date.
+- Quarterly metrics: number of APP 12 requests, response time distribution, number of corrections, and refusals with reasons.
+
+## Record keeping
+- Retain all correspondence, exports, and correction evidence for seven years.
+- Store final responses in the Privacy ServiceDesk ticket and tag with `closed-app-12-13`.
+- Update this procedure annually or after any significant regulatory change.

--- a/apgms/runbooks/ndb.md
+++ b/apgms/runbooks/ndb.md
@@ -1,0 +1,69 @@
+# Notifiable Data Breach (NDB) Runbook
+
+This runbook guides the incident commander through the steps required when a potential Notifiable Data Breach (NDB) is identified.
+
+## 1. Confirm the incident
+- Validate the report with the on-call security engineer.
+- Gather scope: affected systems, records, and time window.
+- Determine whether the incident triggers the NDB scheme (serious harm test).
+
+## 2. Contain and preserve evidence
+- Isolate impacted infrastructure while maintaining availability for critical services.
+- Capture forensic artifacts (logs, snapshots, database exports) and store them in the incident bucket.
+- Rotate credentials that may have been exposed.
+
+## 3. Escalate internally
+- Page the executive sponsor (COO) and security lead.
+- Spin up the incident channel `#inc-ndb-<date>` with the communication lead and legal counsel.
+- Assign owners for customer comms, regulator comms, forensics, and remediation.
+
+## 4. Prepare notifications
+Complete these templates before sending and store drafts in the incident drive.
+
+### 4.1 Customer notification (email)
+```
+Subject: Important security update regarding your Birchal account
+
+Hi <Customer Name>,
+
+We recently detected unauthorised access to a Birchal system that may have exposed information linked to your organisation <Org Name>. The data affected includes <Data Types>. At this time we have no evidence of misuse.
+
+What we are doing
+- Contained the incident at <Containment Time>.
+- Enabled enhanced monitoring and rotated all relevant credentials.
+
+What you should do
+- Reset passwords for Birchal-connected accounts.
+- Review recent activity for anything unfamiliar and report anything suspicious to us immediately.
+
+We have reported the incident to the OAIC in accordance with the Notifiable Data Breaches scheme. If you have questions please reply to this email or call our hotline on <Hotline Number>.
+
+Regards,
+Birchal Security Team
+```
+
+### 4.2 Regulator notification (OAIC portal)
+```
+Incident summary: <One-line description>
+Date discovered: <UTC timestamp>
+Likely harm: <Risk summary>
+Containment actions: <Short list>
+Number of individuals affected: <Count/estimate>
+Points of contact: <Legal counsel + incident commander>
+Supporting documents: Upload incident timeline and preliminary impact assessment.
+```
+
+### 4.3 Internal announcement (Slack)
+```
+Heads-up: we have declared an NDB incident (INC-<number>). All external communications must be coordinated through #inc-ndb-<date>. Do not share customer names or incident details outside that channel. Next update at <time>.
+```
+
+## 5. Execute notifications
+- Send regulator notification within 72 hours of confirmation.
+- Email impacted customers after legal review and before public disclosure.
+- Update the status page template with an incident summary and remediation steps.
+
+## 6. Post-incident activities
+- Run the full retrospective within 7 days.
+- Capture lessons learned and preventive actions in Jira.
+- Update affected runbooks, playbooks, and controls.

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/privacy.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,232 @@
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
+import cors from "@fastify/cors";
+import type { Org, User, BankLine, PrismaClient } from "@prisma/client";
+
+import { maskError, maskObject } from "@apgms/shared";
+
+const ADMIN_HEADER = "x-admin-token";
+
+export interface CreateAppOptions {
+  prisma?: PrismaClient;
+}
+
+export interface AdminOrgExport {
+  org: {
+    id: string;
+    name: string;
+    createdAt: string;
+    deletedAt: string | null;
+  };
+  users: Array<{
+    id: string;
+    email: string;
+    createdAt: string;
+  }>;
+  bankLines: Array<{
+    id: string;
+    date: string;
+    amount: number;
+    payee: string;
+    desc: string;
+    createdAt: string;
+  }>;
+}
+
+type ExportableOrg = Org & { users: User[]; lines: BankLine[] };
+
+type PrismaLike = Pick<
+  PrismaClient,
+  | "org"
+  | "user"
+  | "bankLine"
+  | "orgTombstone"
+  | "$transaction"
+>;
+
+let cachedPrisma: PrismaClient | null = null;
+
+async function loadDefaultPrisma(): Promise<PrismaLike> {
+  if (!cachedPrisma) {
+    const module = (await import("@apgms/shared/src/db")) as { prisma: PrismaClient };
+    cachedPrisma = module.prisma;
+  }
+  return cachedPrisma as PrismaLike;
+}
+
+export async function createApp(options: CreateAppOptions = {}): Promise<FastifyInstance> {
+  const prisma = (options.prisma as PrismaLike | undefined) ?? (await loadDefaultPrisma());
+
+  const app = Fastify({ logger: true });
+
+  app.register(cors, { origin: true });
+
+  app.log.info(maskObject({ DATABASE_URL: process.env.DATABASE_URL }), "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error({ err: maskError(e) }, "failed to create bank line");
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.get("/admin/export/:orgId", async (req, rep) => {
+    if (!requireAdmin(req, rep)) {
+      return;
+    }
+    const { orgId } = req.params as { orgId: string };
+    const org = await prisma.org.findUnique({
+      where: { id: orgId },
+      include: { users: true, lines: true },
+    });
+    if (!org) {
+      return rep.code(404).send({ error: "org_not_found" });
+    }
+
+    const exportPayload = buildOrgExport(org as ExportableOrg);
+    return rep.send({ export: exportPayload });
+  });
+
+  app.delete("/admin/delete/:orgId", async (req, rep) => {
+    if (!requireAdmin(req, rep)) {
+      return;
+    }
+    const { orgId } = req.params as { orgId: string };
+    const org = await prisma.org.findUnique({
+      where: { id: orgId },
+      include: { users: true, lines: true },
+    });
+    if (!org) {
+      return rep.code(404).send({ error: "org_not_found" });
+    }
+    if (org.deletedAt) {
+      return rep.code(409).send({ error: "already_deleted" });
+    }
+
+    const exportPayload = buildOrgExport(org as ExportableOrg);
+    const deletedAt = new Date();
+    const tombstonePayload: AdminOrgExport = {
+      ...exportPayload,
+      org: { ...exportPayload.org, deletedAt: deletedAt.toISOString() },
+    };
+
+    await prisma.$transaction(async (tx) => {
+      await tx.org.update({
+        where: { id: orgId },
+        data: { deletedAt },
+      });
+      await tx.user.deleteMany({ where: { orgId } });
+      await tx.bankLine.deleteMany({ where: { orgId } });
+      await tx.orgTombstone.create({
+        data: {
+          orgId,
+          payload: tombstonePayload,
+        },
+      });
+    });
+
+    return rep.send({ status: "deleted", deletedAt: deletedAt.toISOString() });
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+function requireAdmin(req: FastifyRequest, rep: FastifyReply): boolean {
+  const configuredToken = process.env.ADMIN_TOKEN;
+  if (!configuredToken) {
+    req.log.error("ADMIN_TOKEN is not configured");
+    void rep.code(500).send({ error: "admin_config_missing" });
+    return false;
+  }
+
+  const provided = req.headers[ADMIN_HEADER] ?? req.headers[ADMIN_HEADER.toUpperCase() as keyof typeof req.headers];
+  const providedValue = Array.isArray(provided) ? provided[0] : provided;
+
+  if (providedValue !== configuredToken) {
+    void rep.code(403).send({ error: "forbidden" });
+    return false;
+  }
+  return true;
+}
+
+function buildOrgExport(org: ExportableOrg): AdminOrgExport {
+  return {
+    org: {
+      id: org.id,
+      name: org.name,
+      createdAt: org.createdAt.toISOString(),
+      deletedAt: org.deletedAt ? org.deletedAt.toISOString() : null,
+    },
+    users: org.users.map((user) => ({
+      id: user.id,
+      email: user.email,
+      createdAt: user.createdAt.toISOString(),
+    })),
+    bankLines: org.lines.map((line) => ({
+      id: line.id,
+      date: line.date.toISOString(),
+      amount: normaliseAmount(line.amount),
+      payee: line.payee,
+      desc: line.desc,
+      createdAt: line.createdAt.toISOString(),
+    })),
+  };
+}
+
+function normaliseAmount(amount: unknown): number {
+  if (typeof amount === "number") {
+    return amount;
+  }
+  if (typeof amount === "string") {
+    const parsed = Number(amount);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  if (amount && typeof (amount as any).toNumber === "function") {
+    try {
+      return (amount as any).toNumber();
+    } catch {
+      return 0;
+    }
+  }
+  return 0;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,65 +7,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await createApp();
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });

--- a/apgms/services/api-gateway/test/privacy.spec.ts
+++ b/apgms/services/api-gateway/test/privacy.spec.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, test } from "node:test";
+import { randomUUID } from "node:crypto";
+
+import type { FastifyInstance } from "fastify";
+import type { BankLine, Org, PrismaClient, User } from "@prisma/client";
+
+import { createApp, type AdminOrgExport } from "../src/app";
+
+const ADMIN_TOKEN = "test-admin-token";
+
+type OrgState = Org & { deletedAt: Date | null };
+
+type State = {
+  orgs: OrgState[];
+  users: User[];
+  bankLines: BankLine[];
+  tombstones: Array<{ id: string; orgId: string; payload: AdminOrgExport; createdAt: Date }>;
+};
+
+type TransactionCallback<T> = (tx: PrismaLike) => Promise<T>;
+
+type PrismaLike = Pick<
+  PrismaClient,
+  | "org"
+  | "user"
+  | "bankLine"
+  | "orgTombstone"
+  | "$transaction"
+>;
+
+type Stub = {
+  client: PrismaLike;
+  state: State;
+};
+
+let app: FastifyInstance;
+let stub: Stub;
+
+beforeEach(async () => {
+  process.env.ADMIN_TOKEN = ADMIN_TOKEN;
+  stub = createPrismaStub();
+  app = await createApp({ prisma: stub.client as unknown as PrismaClient });
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+test("admin export requires a valid admin token", async (t) => {
+  const response = await app.inject({
+    method: "GET",
+    url: "/admin/export/example-org",
+  });
+  assert.equal(response.statusCode, 403);
+});
+
+test("admin export returns organisation data without secrets", async (t) => {
+  seedOrgWithData(stub.state, {
+    orgId: "org-123",
+    userId: "user-456",
+    lineId: "line-789",
+  });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/admin/export/org-123",
+    headers: { "x-admin-token": ADMIN_TOKEN },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json() as { export: AdminOrgExport };
+  assert.ok(body.export);
+  assert.equal(body.export.org.id, "org-123");
+  assert.equal(body.export.users.length, 1);
+  assert.deepEqual(body.export.users[0], {
+    id: "user-456",
+    email: "someone@example.com",
+    createdAt: stub.state.users[0].createdAt.toISOString(),
+  });
+  assert.equal(body.export.bankLines.length, 1);
+  assert.equal(body.export.bankLines[0].amount, 1200);
+  assert.equal(body.export.bankLines[0].date, stub.state.bankLines[0].date.toISOString());
+  assert.equal(body.export.org.deletedAt, null);
+});
+
+test("deleting an organisation soft-deletes data and records a tombstone", async (t) => {
+  seedOrgWithData(stub.state, {
+    orgId: "delete-me",
+    userId: "delete-user",
+    lineId: "delete-line",
+  });
+
+  const response = await app.inject({
+    method: "DELETE",
+    url: "/admin/delete/delete-me",
+    headers: { "x-admin-token": ADMIN_TOKEN },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { status: string; deletedAt: string };
+  assert.equal(payload.status, "deleted");
+  assert.ok(Date.parse(payload.deletedAt));
+
+  const org = stub.state.orgs.find((o) => o.id === "delete-me");
+  assert.ok(org);
+  assert.ok(org.deletedAt instanceof Date);
+
+  assert.equal(stub.state.users.filter((u) => u.orgId === "delete-me").length, 0);
+  assert.equal(stub.state.bankLines.filter((l) => l.orgId === "delete-me").length, 0);
+  assert.equal(stub.state.tombstones.length, 1);
+  const tombstone = stub.state.tombstones[0];
+  assert.equal(tombstone.orgId, "delete-me");
+  assert.equal(tombstone.payload.org.id, "delete-me");
+  assert.equal(typeof tombstone.payload.org.deletedAt, "string");
+  assert.ok(tombstone.payload.org.deletedAt && Date.parse(tombstone.payload.org.deletedAt));
+});
+
+function createPrismaStub(initial?: Partial<State>): Stub {
+  const state: State = {
+    orgs: initial?.orgs ?? [],
+    users: initial?.users ?? [],
+    bankLines: initial?.bankLines ?? [],
+    tombstones: initial?.tombstones ?? [],
+  };
+
+  const client: PrismaLike = {
+    org: {
+      findUnique: async ({ where, include }) => {
+        const org = state.orgs.find((o) => o.id === where.id);
+        if (!org) return null;
+        if (include?.users || include?.lines) {
+          return {
+            ...org,
+            users: state.users.filter((user) => user.orgId === org.id),
+            lines: state.bankLines.filter((line) => line.orgId === org.id),
+          } as unknown as Org;
+        }
+        return { ...org } as Org;
+      },
+      update: async ({ where, data }) => {
+        const org = state.orgs.find((o) => o.id === where.id);
+        if (!org) throw new Error("Org not found");
+        Object.assign(org, data);
+        return { ...org } as Org;
+      },
+    },
+    user: {
+      findMany: async ({ select, orderBy }) => {
+        let users = [...state.users];
+        if (orderBy?.createdAt === "desc") {
+          users.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+        }
+        if (select) {
+          return users.map((user) => pick(user, select));
+        }
+        return users;
+      },
+      deleteMany: async ({ where }) => {
+        const initialLength = state.users.length;
+        state.users = state.users.filter((user) => user.orgId !== where?.orgId);
+        return { count: initialLength - state.users.length };
+      },
+    },
+    bankLine: {
+      findMany: async ({ orderBy, take }) => {
+        let lines = [...state.bankLines];
+        if (orderBy?.date === "desc") {
+          lines.sort((a, b) => b.date.getTime() - a.date.getTime());
+        }
+        if (typeof take === "number") {
+          lines = lines.slice(0, take);
+        }
+        return lines;
+      },
+      create: async ({ data }) => {
+        const created = {
+          id: data.id ?? randomUUID(),
+          orgId: data.orgId!,
+          date: data.date as Date,
+          amount: data.amount as any,
+          payee: data.payee!,
+          desc: data.desc!,
+          createdAt: data.createdAt ?? new Date(),
+        } as unknown as BankLine;
+        state.bankLines.push(created);
+        return created;
+      },
+      deleteMany: async ({ where }) => {
+        const initialLength = state.bankLines.length;
+        state.bankLines = state.bankLines.filter((line) => line.orgId !== where?.orgId);
+        return { count: initialLength - state.bankLines.length };
+      },
+    },
+    orgTombstone: {
+      create: async ({ data }) => {
+        const record = {
+          id: data.id ?? randomUUID(),
+          orgId: data.orgId!,
+          payload: data.payload as AdminOrgExport,
+          createdAt: data.createdAt ?? new Date(),
+        };
+        state.tombstones.push(record);
+        return record;
+      },
+    },
+    $transaction: async <T>(callback: TransactionCallback<T>) => {
+      return callback(client);
+    },
+  } as unknown as PrismaLike;
+
+  return { client, state };
+}
+
+function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lineId: string }) {
+  const createdAt = new Date("2024-01-01T00:00:00Z");
+  state.orgs.push({
+    id: ids.orgId,
+    name: "Example Org",
+    createdAt,
+    deletedAt: null,
+  } as OrgState);
+  state.users.push({
+    id: ids.userId,
+    email: "someone@example.com",
+    password: "hashed-password",
+    orgId: ids.orgId,
+    createdAt,
+  } as User);
+  state.bankLines.push({
+    id: ids.lineId,
+    orgId: ids.orgId,
+    date: new Date("2024-02-02T00:00:00Z"),
+    amount: 1200 as any,
+    payee: "Vendor",
+    desc: "Invoice",
+    createdAt,
+  } as BankLine);
+}
+
+function pick<T>(value: T, select: Record<string, boolean>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, include] of Object.entries(select)) {
+    if (include && key in (value as any)) {
+      result[key] = (value as any)[key];
+    }
+  }
+  return result;
+}

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -3,6 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts"
+  },
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
     "build": "echo building shared"

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -11,8 +11,10 @@ model Org {
   id        String   @id @default(cuid())
   name      String
   createdAt DateTime @default(now())
+  deletedAt DateTime?
   users     User[]
   lines     BankLine[]
+  tombstones OrgTombstone[]
 }
 
 model User {
@@ -32,5 +34,13 @@ model BankLine {
   amount    Decimal
   payee     String
   desc      String
+  createdAt DateTime @default(now())
+}
+
+model OrgTombstone {
+  id        String   @id @default(cuid())
+  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId     String
+  payload   Json
   createdAt DateTime @default(now())
 }

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,1 @@
-﻿// shared
+export * from "./masking";

--- a/apgms/shared/src/masking.ts
+++ b/apgms/shared/src/masking.ts
@@ -1,0 +1,107 @@
+const SENSITIVE_KEY_PATTERNS = [
+  "password",
+  "token",
+  "secret",
+  "key",
+  "authorization",
+  "cookie",
+  "session",
+  "database_url",
+  "databaseurl",
+  "dsn",
+];
+
+const MASK = "***redacted***";
+
+function shouldMaskKey(key: string | undefined): boolean {
+  if (!key) return false;
+  const normalised = key.toLowerCase();
+  return SENSITIVE_KEY_PATTERNS.some((pattern) => normalised.includes(pattern));
+}
+
+function maskString(value: string): string {
+  if (!value) {
+    return MASK;
+  }
+  if (value.length <= 8) {
+    return MASK;
+  }
+  const start = value.slice(0, 4);
+  const end = value.slice(-2);
+  return `${start}${"*".repeat(Math.max(3, value.length - 6))}${end}`;
+}
+
+function maskValue(value: unknown, key?: string): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") {
+    return shouldMaskKey(key) ? MASK : maskPotentialSecret(value, key);
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => maskValue(item, key));
+  }
+  if (typeof value === "object") {
+    return maskObject(value as Record<string, unknown>);
+  }
+  return value;
+}
+
+function maskPotentialSecret(value: string, key?: string): string {
+  if (shouldMaskKey(key)) {
+    return MASK;
+  }
+  if (/password|secret|token|key/i.test(value)) {
+    return MASK;
+  }
+  if (/^postgres(?:ql)?:\/\//i.test(value) || /^mongodb:\/\//i.test(value)) {
+    return maskString(value);
+  }
+  if (value.length > 32) {
+    return maskString(value);
+  }
+  return value;
+}
+
+export function maskObject<T>(input: T): T {
+  if (input == null) {
+    return input;
+  }
+  if (Array.isArray(input)) {
+    return input.map((value) => maskValue(value)) as unknown as T;
+  }
+  if (typeof input !== "object") {
+    return maskValue(input) as T;
+  }
+
+  const entries = Object.entries(input as Record<string, unknown>).map(([key, value]) => [
+    key,
+    maskValue(value, key),
+  ]);
+
+  return Object.fromEntries(entries) as T;
+}
+
+export function maskError(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    const serialised: Record<string, unknown> = {
+      name: err.name,
+      message: err.message,
+    };
+    if (err.stack) {
+      serialised.stack = err.stack.split("\n").slice(0, 5).join("\n");
+    }
+    if ((err as any).cause) {
+      serialised.cause = maskValue((err as any).cause);
+    }
+    return maskObject(serialised);
+  }
+  if (typeof err === "object" && err !== null) {
+    return maskObject(err as Record<string, unknown>);
+  }
+  return { error: maskValue(err) };
+}


### PR DESCRIPTION
## Summary
- add admin-only export and delete routes in the API gateway, wiring in soft deletes and tombstones
- introduce shared masking utilities and workspace wiring to keep secrets out of logs
- document APP 12/13 handling alongside the Notifiable Data Breach runbook templates

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4a46ce178832783cd8f92d98716a2