### PR TITLE
Add request logging and tracing to API gateway

### DIFF
--- a/apgms/services/api-gateway/.gitignore
+++ b/apgms/services/api-gateway/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/app.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,160 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Fastify, { type FastifyBaseLogger, type FastifyInstance } from "fastify";
+import type { FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import dotenv from "dotenv";
+
+import { setupTracing } from "./tracing";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+export interface CreateAppOptions {
+  logger?: FastifyServerOptions["logger"];
+  enableTracing?: boolean;
+  prisma?: PrismaClient;
+}
+
+type RequestWithStart = {
+  __startTimeNs?: bigint;
+};
+
+type PrismaClient = typeof import("../../../shared/src/db").prisma;
+
+function extractOrgId(request: import("fastify").FastifyRequest): string | undefined {
+  const headerOrg = request.headers["x-org-id"] ?? request.headers["x-orgid"];
+  if (typeof headerOrg === "string") {
+    return headerOrg;
+  }
+  if (Array.isArray(headerOrg)) {
+    return headerOrg[0];
+  }
+
+  const body = request.body;
+  if (body && typeof body === "object" && "orgId" in body) {
+    const value = (body as Record<string, unknown>).orgId;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  const query = request.query;
+  if (query && typeof query === "object" && "orgId" in query) {
+    const value = (query as Record<string, unknown>).orgId;
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+export async function createApp(options: CreateAppOptions = {}): Promise<FastifyInstance> {
+  const enableTracing = options.enableTracing ?? process.env.ENABLE_OTEL_TRACES === "true";
+  const logger: FastifyServerOptions["logger"] = options.logger ?? true;
+  const prismaClient = options.prisma ?? (await import("../../../shared/src/db")).prisma;
+
+  const app = Fastify({ logger });
+
+  const tracing = enableTracing ? setupTracing("api-gateway", app.log as FastifyBaseLogger) : undefined;
+
+  await app.register(cors, { origin: true });
+
+  app.addHook("onRequest", (request, _reply, done) => {
+    (request as typeof request & RequestWithStart).__startTimeNs = process.hrtime.bigint();
+    if (tracing) {
+      tracing.onRequest(request);
+    }
+    done();
+  });
+
+  app.addHook("onResponse", async (request, reply) => {
+    const start = (request as typeof request & RequestWithStart).__startTimeNs;
+    const latencyNs = start !== undefined ? Number(process.hrtime.bigint() - start) : undefined;
+    const latencyMs = latencyNs !== undefined ? latencyNs / 1_000_000 : undefined;
+
+    const orgId = extractOrgId(request) ?? null;
+    const route = request.routeOptions?.url ?? request.routerPath ?? request.raw.url;
+
+    if (tracing) {
+      await tracing.onResponse(request, reply);
+    }
+
+    request.log.info(
+      {
+        requestId: request.id,
+        orgId,
+        route,
+        status: reply.statusCode,
+        latencyMs,
+      },
+      "request completed",
+    );
+  });
+
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prismaClient.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prismaClient.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prismaClient.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  if (tracing) {
+    app.addHook("onClose", async () => {
+      await tracing.shutdown();
+    });
+  }
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,74 +1,6 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
+import { createApp } from "./app";
 
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await createApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
@@ -77,4 +9,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/tracing.ts
+++ b/apgms/services/api-gateway/src/tracing.ts
@@ -1,0 +1,125 @@
+import { randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from "fastify";
+
+const TRACE_OUTPUT_PATH = path.resolve(process.cwd(), "artifacts/traces.json");
+
+interface RecordedSpan {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  name: string;
+  kind: "SERVER";
+  startTime: string;
+  endTime?: string;
+  attributes: Record<string, unknown>;
+  status: { code: 0 | 1 | 2; message?: string };
+}
+
+const SPAN_SYMBOL = Symbol("otelSpan");
+
+interface SpanContext {
+  span: RecordedSpan;
+  startTime: number;
+}
+
+function generateId(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function toIsoTimestamp(time: number): string {
+  return new Date(time).toISOString();
+}
+
+class TraceRecorder {
+  private spans: RecordedSpan[] = [];
+
+  async record(span: RecordedSpan): Promise<void> {
+    this.spans.push(span);
+    await this.flush();
+  }
+
+  async flush(): Promise<void> {
+    await fs.mkdir(path.dirname(TRACE_OUTPUT_PATH), { recursive: true });
+    await fs.writeFile(TRACE_OUTPUT_PATH, JSON.stringify(this.spans, null, 2), "utf8");
+  }
+}
+
+export interface TracingController {
+  onRequest: (request: FastifyRequest) => void;
+  onResponse: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  shutdown: () => Promise<void>;
+}
+
+export function setupTracing(serviceName: string, logger: FastifyBaseLogger): TracingController {
+  const recorder = new TraceRecorder();
+  logger.info({ traceOutput: TRACE_OUTPUT_PATH }, "otel tracing enabled");
+
+  async function persistSpan(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    const context = (request as FastifyRequest & { [SPAN_SYMBOL]?: SpanContext })[SPAN_SYMBOL];
+    if (!context) {
+      return;
+    }
+
+    const route = request.routeOptions?.url ?? request.routerPath ?? request.raw.url;
+    const endTime = Date.now();
+    const durationMs = endTime - context.startTime;
+
+    context.span.name = route ?? context.span.name;
+    context.span.endTime = toIsoTimestamp(endTime);
+    context.span.attributes = {
+      ...context.span.attributes,
+      "http.method": request.method,
+      "http.target": request.raw.url,
+      "http.route": route,
+      "http.status_code": reply.statusCode,
+      "fastify.route": route,
+      "service.name": serviceName,
+      "http.server_latency_ms": durationMs,
+    };
+    context.span.status = {
+      code: reply.statusCode >= 400 ? 2 : 1,
+    };
+
+    await recorder.record(context.span);
+    delete (request as FastifyRequest & { [SPAN_SYMBOL]?: SpanContext })[SPAN_SYMBOL];
+  }
+
+  return {
+    onRequest: (request: FastifyRequest) => {
+      const start = Date.now();
+      const traceId = generateId(16);
+      const spanId = generateId(8);
+      const span: RecordedSpan = {
+        traceId,
+        spanId,
+        parentSpanId: null,
+        name: request.raw.url,
+        kind: "SERVER",
+        startTime: toIsoTimestamp(start),
+        attributes: {},
+        status: { code: 0 },
+      };
+      (request as FastifyRequest & { [SPAN_SYMBOL]?: SpanContext })[SPAN_SYMBOL] = {
+        span,
+        startTime: start,
+      };
+    },
+    onResponse: async (request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        await persistSpan(request, reply);
+      } catch (error) {
+        logger.error({ err: error }, "failed to record otel span");
+      }
+    },
+    shutdown: async () => {
+      try {
+        await recorder.flush();
+      } catch (error) {
+        logger.error({ err: error }, "failed to write otel spans on shutdown");
+      }
+    },
+  };
+}

--- a/apgms/services/api-gateway/test/app.test.ts
+++ b/apgms/services/api-gateway/test/app.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { createApp } from "../src/app";
+import type { CreateAppOptions } from "../src/app";
+import type { FastifyServerOptions } from "fastify";
+
+const TRACE_OUTPUT_PATH = path.resolve(process.cwd(), "artifacts/traces.json");
+
+type LogEntry = {
+  msg: string;
+  route?: string;
+  orgId?: string | null;
+  status?: number;
+  requestId?: string;
+  latencyMs?: number;
+};
+
+type PrismaStub = {
+  user: { findMany: () => Promise<unknown[]> };
+  bankLine: {
+    findMany: () => Promise<unknown[]>;
+    create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+  };
+};
+
+function createTestLogger(collected: LogEntry[]): FastifyServerOptions["logger"] {
+  return {
+    level: "info",
+    stream: {
+      write(msg: string) {
+        const value = msg.toString().trim();
+        if (!value) return;
+        for (const line of value.split("\n")) {
+          try {
+            collected.push(JSON.parse(line));
+          } catch {
+            // ignore non-JSON lines
+          }
+        }
+      },
+    },
+  } satisfies FastifyServerOptions["logger"];
+}
+
+function createPrismaStub(): PrismaStub {
+  return {
+    user: {
+      findMany: async () => [],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async ({ data }) => ({ id: "stub-line", ...data }),
+    },
+  };
+}
+
+test("logs request metadata in structured form", async () => {
+  await fs.rm(TRACE_OUTPUT_PATH, { force: true });
+
+  const logs: LogEntry[] = [];
+  const logger = createTestLogger(logs);
+  const prisma = createPrismaStub() as unknown as NonNullable<CreateAppOptions["prisma"]>;
+  const app = await createApp({ logger, enableTracing: false, prisma });
+
+  await app.inject({
+    method: "GET",
+    url: "/health",
+    headers: { "x-org-id": "org-123" },
+  });
+
+  await app.close();
+
+  const requestLog = logs.find((entry) => entry.msg === "request completed" && entry.route === "/health");
+
+  assert.ok(requestLog, "expected request log entry to be present");
+  assert.equal(requestLog.orgId, "org-123");
+  assert.equal(requestLog.route, "/health");
+  assert.equal(requestLog.status, 200);
+  assert.equal(typeof requestLog.requestId, "string");
+  assert.equal(typeof requestLog.latencyMs, "number");
+});
+
+test("emits otel traces to artifacts when enabled", async () => {
+  await fs.rm(TRACE_OUTPUT_PATH, { force: true });
+
+  const logs: LogEntry[] = [];
+  const logger = createTestLogger(logs);
+  const prisma = createPrismaStub() as unknown as NonNullable<CreateAppOptions["prisma"]>;
+  const app = await createApp({ logger, enableTracing: true, prisma });
+
+  await app.inject({ method: "GET", url: "/health" });
+
+  await app.close();
+
+  const contents = await fs.readFile(TRACE_OUTPUT_PATH, "utf8");
+  const spans = JSON.parse(contents) as Array<Record<string, any>>;
+
+  assert.ok(Array.isArray(spans));
+  assert.ok(spans.length > 0, "expected at least one span to be exported");
+  const hasHealthSpan = spans.some(
+    (span) => span.attributes?.["http.target"] === "/health" || span.attributes?.["fastify.route"] === "/health",
+  );
+  assert.ok(hasHealthSpan, "expected a span for the /health route");
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,7 @@
-﻿import { PrismaClient } from "@prisma/client";
+import prismaPackage from "@prisma/client";
+
+type PrismaModule = typeof import("@prisma/client");
+
+const { PrismaClient } = prismaPackage as PrismaModule;
+
 export const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- add a reusable Fastify app factory that records structured request logs and supports injectable Prisma clients
- implement lightweight tracing instrumentation that writes OTEL-style spans to `artifacts/traces.json` when enabled
- cover logging and tracing paths with Node test cases and wire up the local test runner configuration

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4a469f0f48327a001cd44964af58a