### PR TITLE
feat: add PayTo gate routing and scheduler

### DIFF
--- a/apgms/services/payments/package.json
+++ b/apgms/services/payments/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@apgms/payments",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./adapters/payto.mock": "./src/adapters/payto.mock.ts"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "node --test --import tsx test/*.spec.ts"
+  },
+  "dependencies": {
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/services/payments/src/adapters/payto.mock.ts
+++ b/apgms/services/payments/src/adapters/payto.mock.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import {
+  PaytoAgreement,
+  PaytoAgreementInput,
+  PaytoRemittanceRequest,
+} from '../../../../shared/src/payto.js';
+
+export interface PaytoRemittance extends PaytoRemittanceRequest {
+  remitId: string;
+  processedAt: string;
+}
+
+export type PaytoAuditBlobType =
+  | 'payto.agreement.created'
+  | 'payto.remittance.processed';
+
+export interface PaytoAuditBlob<TPayload = unknown> {
+  id: string;
+  type: PaytoAuditBlobType;
+  occurredAt: string;
+  payload: TPayload;
+}
+
+const agreements = new Map<string, PaytoAgreement>();
+const remittances = new Map<string, PaytoRemittance>();
+const auditTrail: PaytoAuditBlob[] = [];
+
+export function createAgreement(input: PaytoAgreementInput): PaytoAgreement {
+  const agreementId = input.agreementId ?? randomUUID();
+  const agreement: PaytoAgreement = {
+    ...input,
+    agreementId,
+    createdAt: new Date().toISOString(),
+  };
+
+  agreements.set(agreementId, agreement);
+  writeAuditBlob('payto.agreement.created', agreement);
+  return agreement;
+}
+
+export function remit(input: PaytoRemittanceRequest): PaytoRemittance {
+  const agreement = agreements.get(input.agreementId);
+
+  if (!agreement) {
+    throw new Error(`Unknown agreement: ${input.agreementId}`);
+  }
+
+  const remitId = input.remitId ?? randomUUID();
+  const remittance: PaytoRemittance = {
+    ...input,
+    remitId,
+    processedAt: new Date().toISOString(),
+  };
+
+  remittances.set(remitId, remittance);
+  writeAuditBlob('payto.remittance.processed', {
+    ...remittance,
+    agreement,
+  });
+
+  return remittance;
+}
+
+export function getAgreement(agreementId: string): PaytoAgreement | undefined {
+  return agreements.get(agreementId);
+}
+
+export function listRemittances(): PaytoRemittance[] {
+  return Array.from(remittances.values()).map((entry) => ({ ...entry }));
+}
+
+export function getAuditTrail(): PaytoAuditBlob[] {
+  return auditTrail.map((blob) => ({ ...blob }));
+}
+
+export function resetPaytoMockState(): void {
+  agreements.clear();
+  remittances.clear();
+  auditTrail.splice(0, auditTrail.length);
+}
+
+function writeAuditBlob<TPayload>(type: PaytoAuditBlobType, payload: TPayload): void {
+  auditTrail.push({
+    id: randomUUID(),
+    type,
+    occurredAt: new Date().toISOString(),
+    payload,
+  });
+}

--- a/apgms/services/payments/src/index.ts
+++ b/apgms/services/payments/src/index.ts
@@ -1,1 +1,2 @@
-﻿console.log('payments service');
+export * from './adapters/payto.mock.js';
+export * from './routes/payto.js';

--- a/apgms/services/payments/src/routes/payto.ts
+++ b/apgms/services/payments/src/routes/payto.ts
@@ -1,0 +1,96 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import {
+  enqueueRemittance,
+  getGateState,
+  PaytoAgreementInput,
+  PaytoRemittanceRequest,
+} from '../../../../shared/src/payto.js';
+import { createAgreement, getAgreement, remit } from '../adapters/payto.mock.js';
+
+const ADMIN_HEADER = 'x-admin-token';
+export const DEFAULT_ADMIN_TOKEN = 'letmein';
+
+const agreementSchema = z.object({
+  agreementId: z.string().uuid().optional(),
+  payerId: z.string().min(1),
+  payeeId: z.string().min(1),
+  limit: z.number().positive(),
+  description: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+const remittanceSchema = z.object({
+  remitId: z.string().uuid().optional(),
+  agreementId: z.string().uuid(),
+  amount: z.number().positive(),
+  currency: z.string().min(1),
+  metadata: z.record(z.any()).optional(),
+});
+
+type AgreementBody = z.infer<typeof agreementSchema>;
+type RemittanceBody = z.infer<typeof remittanceSchema>;
+
+export async function registerPaytoRoutes(app: FastifyInstance): Promise<void> {
+  app.post('/payto/agreements', async (request, reply) => {
+    if (!isAdmin(request)) {
+      return reply.code(403).send({ error: 'ADMIN_REQUIRED' });
+    }
+
+    const parsed = agreementSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'INVALID_BODY', details: parsed.error.flatten() });
+    }
+
+    const agreement = createAgreement(parsed.data as PaytoAgreementInput);
+    return reply.code(201).send({ agreement });
+  });
+
+  app.post('/payto/remit', async (request, reply) => {
+    if (!isAdmin(request)) {
+      return reply.code(403).send({ error: 'ADMIN_REQUIRED' });
+    }
+
+    const parsed = remittanceSchema.safeParse(request.body);
+
+    if (!parsed.success) {
+      return reply.code(400).send({ error: 'INVALID_BODY', details: parsed.error.flatten() });
+    }
+
+    const gateState = getGateState();
+    const remitRequest = parsed.data as PaytoRemittanceRequest;
+
+    if (!getAgreement(remitRequest.agreementId)) {
+      return reply.code(404).send({ error: 'AGREEMENT_NOT_FOUND' });
+    }
+
+    if (gateState === 'OPEN') {
+      try {
+        const remittance = remit(remitRequest);
+        return reply.code(202).send({ status: 'processed', remittance });
+      } catch (error) {
+        return reply.code(500).send({ error: 'REMIT_FAILED', message: (error as Error).message });
+      }
+    }
+
+    const queued = enqueueRemittance(remitRequest);
+    return reply.code(202).send({ status: 'queued', gate: gateState, remittance: queued });
+  });
+}
+
+function isAdmin(request: FastifyRequest): boolean {
+  const token = request.headers[ADMIN_HEADER] as string | undefined;
+  const expected = process.env.PAYMENTS_ADMIN_TOKEN ?? DEFAULT_ADMIN_TOKEN;
+  return token === expected;
+}
+
+export async function buildPaymentsServer(): Promise<FastifyInstance> {
+  const { default: Fastify } = await import('fastify');
+  const app = Fastify();
+  await registerPaytoRoutes(app);
+  return app;
+}
+
+export type PaytoAgreementResponse = AgreementBody;
+export type PaytoRemittanceResponse = RemittanceBody;

--- a/apgms/services/payments/test/payto.spec.ts
+++ b/apgms/services/payments/test/payto.spec.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildPaymentsServer,
+  getAuditTrail,
+  resetPaytoMockState,
+} from '../src/index.js';
+import { DEFAULT_ADMIN_TOKEN } from '../src/routes/payto.js';
+import {
+  getGateState,
+  peekRemittanceQueue,
+  resetPaytoSharedState,
+  setGateState,
+} from '../../../shared/src/payto.js';
+import { processQueuedRemittances } from '../../../worker/src/gate-scheduler.js';
+
+const ADMIN_HEADER = 'x-admin-token';
+
+const adminHeaders = {
+  'content-type': 'application/json',
+  [ADMIN_HEADER]: process.env.PAYMENTS_ADMIN_TOKEN ?? DEFAULT_ADMIN_TOKEN,
+};
+
+test('creating agreements writes audit blobs', async (t) => {
+  resetPaytoMockState();
+  resetPaytoSharedState();
+  const app = await buildPaymentsServer();
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/payto/agreements',
+    headers: adminHeaders,
+    payload: {
+      payerId: 'payer-001',
+      payeeId: 'merchant-042',
+      limit: 1000,
+      description: 'monthly subscription',
+    },
+  });
+
+  assert.equal(response.statusCode, 201);
+  const { agreement } = response.json<{ agreement: { agreementId: string } }>();
+  assert.ok(agreement.agreementId);
+
+  const auditTrail = getAuditTrail();
+  assert.equal(auditTrail.length, 1);
+  assert.equal(auditTrail[0].type, 'payto.agreement.created');
+
+  await app.close();
+});
+
+test('remittances queue behind a closed gate and are processed once opened', async (t) => {
+  resetPaytoMockState();
+  resetPaytoSharedState();
+  const app = await buildPaymentsServer();
+
+  const agreementResponse = await app.inject({
+    method: 'POST',
+    url: '/payto/agreements',
+    headers: adminHeaders,
+    payload: {
+      payerId: 'payer-007',
+      payeeId: 'merchant-777',
+      limit: 5000,
+    },
+  });
+
+  const { agreement } = agreementResponse.json<{ agreement: { agreementId: string } }>();
+
+  // Process remit while gate is open
+  const processedResponse = await app.inject({
+    method: 'POST',
+    url: '/payto/remit',
+    headers: adminHeaders,
+    payload: {
+      agreementId: agreement.agreementId,
+      amount: 125,
+      currency: 'AUD',
+    },
+  });
+
+  assert.equal(processedResponse.statusCode, 202);
+  const processedBody = processedResponse.json();
+  assert.equal(processedBody.status, 'processed');
+  assert.equal(getAuditTrail().length, 2);
+
+  // Close the gate and ensure the next remit is queued
+  setGateState('CLOSED');
+  const queuedResponse = await app.inject({
+    method: 'POST',
+    url: '/payto/remit',
+    headers: adminHeaders,
+    payload: {
+      agreementId: agreement.agreementId,
+      amount: 215,
+      currency: 'AUD',
+    },
+  });
+
+  assert.equal(queuedResponse.statusCode, 202);
+  const queuedBody = queuedResponse.json();
+  assert.equal(queuedBody.status, 'queued');
+  assert.equal(getGateState(), 'CLOSED');
+  assert.equal(peekRemittanceQueue().length, 1);
+  assert.equal(getAuditTrail().length, 2, 'audit trail should not grow while gate is closed');
+
+  // Worker processes queued remits once the gate opens
+  setGateState('OPEN');
+  const processed = await processQueuedRemittances();
+  assert.equal(processed.length, 1);
+  assert.equal(peekRemittanceQueue().length, 0);
+  assert.equal(getAuditTrail().length, 3);
+
+  await app.close();
+});
+
+test('non-admin requests are rejected', async () => {
+  resetPaytoMockState();
+  resetPaytoSharedState();
+  const app = await buildPaymentsServer();
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/payto/agreements',
+    headers: { 'content-type': 'application/json' },
+    payload: {
+      payerId: 'payer-unauthorised',
+      payeeId: 'merchant-unauthorised',
+      limit: 100,
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+
+  await app.close();
+});

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./payto": "./src/payto.ts"
+  },
   "scripts": {
     "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
     "build": "echo building shared"

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,1 @@
-﻿// shared
+export * from './payto.js';

--- a/apgms/shared/src/payto.ts
+++ b/apgms/shared/src/payto.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from 'node:crypto';
+
+export type GateState = 'OPEN' | 'CLOSED';
+
+export interface PaytoAgreementInput {
+  agreementId?: string;
+  payerId: string;
+  payeeId: string;
+  limit: number;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaytoAgreement extends PaytoAgreementInput {
+  agreementId: string;
+  createdAt: string;
+}
+
+export interface PaytoRemittanceRequest {
+  remitId?: string;
+  agreementId: string;
+  amount: number;
+  currency: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaytoQueuedRemittance extends PaytoRemittanceRequest {
+  queuedAt: string;
+}
+
+const remittanceQueue: PaytoQueuedRemittance[] = [];
+let gateState: GateState = 'OPEN';
+
+export function getGateState(): GateState {
+  return gateState;
+}
+
+export function setGateState(state: GateState): void {
+  gateState = state;
+}
+
+export function enqueueRemittance(request: PaytoRemittanceRequest): PaytoQueuedRemittance {
+  const queued: PaytoQueuedRemittance = {
+    ...request,
+    remitId: request.remitId ?? randomUUID(),
+    queuedAt: new Date().toISOString(),
+  };
+
+  remittanceQueue.push(queued);
+  return queued;
+}
+
+export function peekRemittanceQueue(): PaytoQueuedRemittance[] {
+  return remittanceQueue.map((entry) => ({ ...entry }));
+}
+
+export function drainRemittanceQueue(): PaytoQueuedRemittance[] {
+  const drained = remittanceQueue.splice(0, remittanceQueue.length);
+  return drained.map((entry) => ({ ...entry }));
+}
+
+export function resetPaytoSharedState(): void {
+  remittanceQueue.splice(0, remittanceQueue.length);
+  gateState = 'OPEN';
+}

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,15 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "node --test --import tsx test/*.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/worker/src/gate-scheduler.ts
+++ b/apgms/worker/src/gate-scheduler.ts
@@ -1,0 +1,27 @@
+import { drainRemittanceQueue, getGateState, PaytoRemittanceRequest } from '../../shared/src/payto.js';
+import { remit } from '../../services/payments/src/adapters/payto.mock.js';
+import type { PaytoRemittance } from '../../services/payments/src/adapters/payto.mock.js';
+
+export async function processQueuedRemittances(): Promise<PaytoRemittance[]> {
+  if (getGateState() !== 'OPEN') {
+    return [];
+  }
+
+  const queued = drainRemittanceQueue();
+  const processed: PaytoRemittance[] = [];
+
+  for (const entry of queued) {
+    const request: PaytoRemittanceRequest = {
+      agreementId: entry.agreementId,
+      amount: entry.amount,
+      currency: entry.currency,
+      metadata: entry.metadata,
+      remitId: entry.remitId,
+    };
+
+    const result = remit(request);
+    processed.push(result);
+  }
+
+  return processed;
+}

--- a/apgms/worker/test/gate-scheduler.spec.ts
+++ b/apgms/worker/test/gate-scheduler.spec.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createAgreement,
+  getAuditTrail,
+  resetPaytoMockState,
+} from '../../services/payments/src/index.js';
+import {
+  enqueueRemittance,
+  getGateState,
+  peekRemittanceQueue,
+  resetPaytoSharedState,
+  setGateState,
+} from '../../shared/src/payto.js';
+import { processQueuedRemittances } from '../src/gate-scheduler.js';
+
+test('scheduler waits for gate to open before processing remittances', async () => {
+  resetPaytoMockState();
+  resetPaytoSharedState();
+
+  const agreement = createAgreement({
+    payerId: 'payer-gate',
+    payeeId: 'merchant-gate',
+    limit: 800,
+  });
+
+  setGateState('CLOSED');
+  enqueueRemittance({
+    agreementId: agreement.agreementId,
+    amount: 75,
+    currency: 'AUD',
+  });
+
+  assert.equal(getGateState(), 'CLOSED');
+  assert.equal(peekRemittanceQueue().length, 1);
+
+  const closedResult = await processQueuedRemittances();
+  assert.equal(closedResult.length, 0);
+  assert.equal(peekRemittanceQueue().length, 1, 'queue should remain untouched while gate is closed');
+  assert.equal(getAuditTrail().length, 1, 'no new audit blob should be written while gate closed');
+
+  setGateState('OPEN');
+  const openResult = await processQueuedRemittances();
+  assert.equal(openResult.length, 1);
+  assert.equal(peekRemittanceQueue().length, 0);
+  assert.equal(getAuditTrail().length, 2);
+});
+
+test('scheduler drains multiple remittances in FIFO order', async () => {
+  resetPaytoMockState();
+  resetPaytoSharedState();
+
+  const agreement = createAgreement({
+    payerId: 'payer-fifo',
+    payeeId: 'merchant-fifo',
+    limit: 1200,
+  });
+
+  setGateState('CLOSED');
+  const first = enqueueRemittance({
+    agreementId: agreement.agreementId,
+    amount: 30,
+    currency: 'AUD',
+  });
+  const second = enqueueRemittance({
+    agreementId: agreement.agreementId,
+    amount: 45,
+    currency: 'AUD',
+  });
+
+  setGateState('OPEN');
+  const processed = await processQueuedRemittances();
+  assert.equal(processed.length, 2);
+  assert.deepEqual(
+    processed.map((entry) => entry.remitId),
+    [first.remitId, second.remitId],
+    'processed remittances should keep queue order',
+  );
+  assert.equal(getAuditTrail().length, 3);
+});


### PR DESCRIPTION
## Summary
- add an in-memory PayTo adapter with audit logging and shared gate/queue helpers
- expose admin-protected Fastify routes to create agreements or queue/remit payments based on gate state
- implement a worker-side gate scheduler plus tests covering gate behavior and audit output

## Testing
- pnpm --filter @apgms/payments test
- pnpm --filter @apgms/worker test

------
https://chatgpt.com/codex/tasks/task_e_68f4a468b1b88327a0d188dfa988eea7