### PR TITLE
Add deterministic allocation engine and Fastify routes

### DIFF
--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - services/*
   - webapp
   - shared
+  - tests
   - worker
 
 ignoredBuiltDependencies:

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,219 @@
-﻿import path from "node:path";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import type { PrismaClient } from "@prisma/client";
+
+import { prisma as defaultPrisma } from "../../../shared/src/db";
+import {
+  computeDeterministicAllocation,
+  AllocationError,
+} from "../../../shared/src/policy-engine";
+import {
+  allocationPreviewRequestSchema,
+  allocationPreviewResponseSchema,
+} from "./schemas/allocations.preview.schema";
+import {
+  ledgerEntryInputSchema,
+  type LedgerEntry,
+  type LedgerEntryInput,
+} from "./schemas/ledger.schema";
 
 // Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+export interface LedgerRepository {
+  append(entries: LedgerEntryInput[]): Promise<LedgerEntry[]>;
+}
 
-const app = Fastify({ logger: true });
+export class InMemoryLedger implements LedgerRepository {
+  private readonly entries: LedgerEntry[] = [];
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+  async append(entries: LedgerEntryInput[]): Promise<LedgerEntry[]> {
+    const stamped = entries.map((entry) => ({
+      ...entry,
+      id: randomUUID(),
+      createdAt: new Date(),
+    }));
+    this.entries.push(...stamped);
+    return stamped;
   }
-});
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  getAll(): LedgerEntry[] {
+    return [...this.entries];
+  }
+}
+
+export interface BuildAppOptions {
+  fastifyOptions?: FastifyServerOptions;
+  prisma?: PrismaClient;
+  ledger?: LedgerRepository;
+}
+
+const normalizeLedgerInputs = (
+  orgId: string,
+  allocations: { gateId: string; amount: number }[],
+): LedgerEntryInput[] => {
+  return allocations
+    .filter((allocation) => allocation.amount > 0)
+    .map((allocation) =>
+      ledgerEntryInputSchema.parse({
+        orgId,
+        gateId: allocation.gateId,
+        amount: allocation.amount,
+      }),
+    );
+};
+
+const buildAllocationResponse = (
+  response: unknown,
+): ReturnType<typeof allocationPreviewResponseSchema.parse> => {
+  return allocationPreviewResponseSchema.parse(response);
+};
+
+export const buildApp = async (
+  options: BuildAppOptions = {},
+): Promise<FastifyInstance> => {
+  const fastifyOptions = options.fastifyOptions ?? { logger: true };
+  const app = Fastify(fastifyOptions);
+  const prisma = options.prisma ?? defaultPrisma;
+  const ledger = options.ledger ?? new InMemoryLedger();
+
+  await app.register(cors, { origin: true });
+
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.post("/allocations/preview", async (req, rep) => {
+    try {
+      const payload = allocationPreviewRequestSchema.parse(req.body);
+      const preview = computeDeterministicAllocation({
+        amount: payload.amount,
+        gates: payload.gates.map((gate) => ({
+          id: gate.id,
+          state: gate.state,
+          weight: gate.weight,
+        })),
+      });
+      const response = buildAllocationResponse(preview);
+      return rep.status(200).send(response);
+    } catch (error) {
+      if (error instanceof AllocationError) {
+        return rep.status(400).send({ error: error.message });
+      }
+      if (error instanceof Error) {
+        return rep.status(400).send({ error: error.message });
+      }
+      return rep.status(400).send({ error: "invalid_request" });
+    }
+  });
+
+  app.post("/allocations/apply", async (req, rep) => {
+    try {
+      const payload = allocationPreviewRequestSchema.parse(req.body);
+      const preview = computeDeterministicAllocation({
+        amount: payload.amount,
+        gates: payload.gates.map((gate) => ({
+          id: gate.id,
+          state: gate.state,
+          weight: gate.weight,
+        })),
+      });
+
+      const ledgerInputs = normalizeLedgerInputs(payload.orgId, preview.allocations);
+      const entries = await ledger.append(ledgerInputs);
+
+      const response = {
+        ...preview,
+        ledgerEntries: entries,
+      };
+
+      return rep.status(201).send(response);
+    } catch (error) {
+      if (error instanceof AllocationError) {
+        return rep.status(400).send({ error: error.message });
+      }
+      if (error instanceof Error) {
+        return rep.status(400).send({ error: error.message });
+      }
+      return rep.status(400).send({ error: "invalid_request" });
+    }
+  });
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === __filename;
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+if (isMainModule) {
+  buildApp()
+    .then((app) =>
+      app.listen({ port, host }).catch((err) => {
+        app.log.error(err);
+        process.exit(1);
+      }),
+    )
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/apgms/services/api-gateway/src/schemas/allocations.preview.schema.ts
+++ b/apgms/services/api-gateway/src/schemas/allocations.preview.schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const gateStateSchema = z.enum(["open", "closed", "suspended"]);
+
+export const gateConfigSchema = z.object({
+  id: z.string().min(1, "Gate id is required"),
+  state: gateStateSchema,
+  weight: z
+    .number({ invalid_type_error: "Weight must be a number" })
+    .int("Weight must be an integer")
+    .nonnegative("Weight must be non-negative"),
+});
+
+export const allocationPreviewRequestSchema = z.object({
+  orgId: z.string().min(1, "orgId is required"),
+  amount: z
+    .number({ invalid_type_error: "Amount must be a number" })
+    .int("Amount must be an integer")
+    .nonnegative("Amount must be non-negative"),
+  gates: z.array(gateConfigSchema).min(1, "At least one gate is required"),
+});
+
+export const allocationRecordSchema = z.object({
+  gateId: z.string(),
+  amount: z.number().int().nonnegative(),
+  state: gateStateSchema,
+});
+
+export const allocationPreviewResponseSchema = z.object({
+  amount: z.number().int().nonnegative(),
+  allocations: z.array(allocationRecordSchema),
+});
+
+export type AllocationPreviewRequest = z.infer<typeof allocationPreviewRequestSchema>;
+export type AllocationRecord = z.infer<typeof allocationRecordSchema>;
+export type AllocationPreviewResponse = z.infer<typeof allocationPreviewResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/ledger.schema.ts
+++ b/apgms/services/api-gateway/src/schemas/ledger.schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { allocationRecordSchema } from "./allocations.preview.schema";
+
+export const ledgerEntryInputSchema = allocationRecordSchema.pick({
+  gateId: true,
+  amount: true,
+}).extend({
+  orgId: z.string().min(1, "orgId is required"),
+});
+
+export const ledgerEntrySchema = ledgerEntryInputSchema.extend({
+  id: z.string(),
+  createdAt: z.date(),
+});
+
+export type LedgerEntryInput = z.infer<typeof ledgerEntryInputSchema>;
+export type LedgerEntry = z.infer<typeof ledgerEntrySchema>;

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./policy-engine";

--- a/apgms/shared/src/policy-engine/index.ts
+++ b/apgms/shared/src/policy-engine/index.ts
@@ -1,0 +1,139 @@
+export type GateState = "open" | "closed" | "suspended";
+
+export interface GateConfig {
+  id: string;
+  state: GateState;
+  weight: number;
+}
+
+export interface AllocationRequest {
+  amount: number;
+  gates: GateConfig[];
+}
+
+export interface AllocationRecord {
+  gateId: string;
+  amount: number;
+  state: GateState;
+}
+
+export interface AllocationResult {
+  allocations: AllocationRecord[];
+  amount: number;
+}
+
+export class AllocationError extends Error {}
+
+const sortGates = (gates: GateConfig[]): GateConfig[] =>
+  [...gates].sort((a, b) => a.id.localeCompare(b.id));
+
+const assertSafeInteger = (value: bigint) => {
+  if (value > BigInt(Number.MAX_SAFE_INTEGER) || value < BigInt(Number.MIN_SAFE_INTEGER)) {
+    throw new AllocationError("Value exceeds safe integer bounds");
+  }
+};
+
+const toBigInt = (value: number): bigint => {
+  if (!Number.isFinite(value)) {
+    throw new AllocationError("Amount must be a finite number");
+  }
+  if (!Number.isInteger(value)) {
+    throw new AllocationError("Amount must be an integer");
+  }
+  if (Math.abs(value) > Number.MAX_SAFE_INTEGER) {
+    throw new AllocationError("Amount exceeds safe integer bounds");
+  }
+  return BigInt(value);
+};
+
+const toWeight = (value: number): bigint => {
+  if (!Number.isFinite(value)) {
+    throw new AllocationError("Weight must be finite");
+  }
+  if (!Number.isInteger(value)) {
+    throw new AllocationError("Weight must be an integer");
+  }
+  if (value < 0) {
+    throw new AllocationError("Weight must be non-negative");
+  }
+  if (value > Number.MAX_SAFE_INTEGER) {
+    throw new AllocationError("Weight exceeds safe integer bounds");
+  }
+  return BigInt(value);
+};
+
+export const computeDeterministicAllocation = (
+  request: AllocationRequest,
+): AllocationResult => {
+  const amount = toBigInt(request.amount);
+  if (amount < 0n) {
+    throw new AllocationError("Amount must be non-negative");
+  }
+  const sorted = sortGates(request.gates);
+  if (sorted.length === 0) {
+    return { allocations: [], amount: Number(amount) };
+  }
+
+  const openGates = sorted.filter((gate) => gate.state === "open");
+  const weightMap = new Map<string, bigint>();
+  let totalWeight = 0n;
+  for (const gate of openGates) {
+    const weight = toWeight(gate.weight);
+    weightMap.set(gate.id, weight);
+    totalWeight += weight;
+  }
+
+  if (amount > 0n && totalWeight === 0n) {
+    throw new AllocationError("No open gates with weight to allocate");
+  }
+
+  const allocationMap = new Map<string, bigint>();
+  for (const gate of sorted) {
+    allocationMap.set(gate.id, 0n);
+  }
+
+  let remainder = amount;
+  if (totalWeight > 0n) {
+    for (const gate of openGates) {
+      const weight = weightMap.get(gate.id) ?? 0n;
+      if (weight === 0n) {
+        continue;
+      }
+      const share = (amount * weight) / totalWeight;
+      allocationMap.set(gate.id, share);
+      remainder -= share;
+    }
+
+    if (remainder > 0n) {
+      for (const gate of openGates) {
+        if (remainder === 0n) {
+          break;
+        }
+        const weight = weightMap.get(gate.id) ?? 0n;
+        if (weight === 0n) {
+          continue;
+        }
+        const current = allocationMap.get(gate.id) ?? 0n;
+        allocationMap.set(gate.id, current + 1n);
+        remainder -= 1n;
+      }
+    }
+  }
+
+  if (remainder !== 0n) {
+    throw new AllocationError("Invariant violation: allocations did not conserve");
+  }
+
+  const allocations: AllocationRecord[] = sorted.map((gate) => {
+    const value = allocationMap.get(gate.id) ?? 0n;
+    assertSafeInteger(value);
+    return {
+      gateId: gate.id,
+      amount: Number(value),
+      state: gate.state,
+    };
+  });
+
+  assertSafeInteger(amount);
+  return { allocations, amount: Number(amount) };
+};

--- a/apgms/tests/package.json
+++ b/apgms/tests/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@apgms/tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@apgms/api-gateway": "workspace:*",
+    "@apgms/shared": "workspace:*",
+    "fast-check": "^3.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.3"
+  }
+}

--- a/apgms/tests/tests/policy-engine.spec.ts
+++ b/apgms/tests/tests/policy-engine.spec.ts
@@ -1,0 +1,157 @@
+import fc from "fast-check";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  computeDeterministicAllocation,
+  AllocationError,
+} from "../../shared/src/policy-engine";
+import {
+  buildApp,
+  InMemoryLedger,
+} from "../../services/api-gateway/src/index";
+
+const gateStateArb = fc.constantFrom("open", "closed", "suspended");
+
+const gateArb = fc.record({
+  id: fc.string({ minLength: 1, maxLength: 12 }),
+  state: gateStateArb,
+  weight: fc.integer({ min: 0, max: 20 }),
+});
+
+const allocationRequestArb = fc.record({
+  amount: fc.integer({ min: 0, max: 100_000 }),
+  gates: fc.array(gateArb, { minLength: 1, maxLength: 8 }),
+});
+
+const validAllocationRequestArb = allocationRequestArb.filter(
+  (request) =>
+    request.amount === 0 ||
+    request.gates.some((gate) => gate.state === "open" && gate.weight > 0),
+);
+
+describe("policy engine", () => {
+  it("is deterministic, conserves amount, and respects invariants", async () => {
+    await fc.assert(
+      fc.asyncProperty(validAllocationRequestArb, async (request) => {
+        const allocationA = computeDeterministicAllocation(request);
+        const allocationB = computeDeterministicAllocation({ ...request });
+
+        expect(allocationA).toEqual(allocationB);
+
+        const totalAllocated = allocationA.allocations.reduce(
+          (sum, record) => sum + record.amount,
+          0,
+        );
+        expect(totalAllocated).toBe(request.amount);
+
+        for (const record of allocationA.allocations) {
+          expect(record.amount).toBeGreaterThanOrEqual(0);
+          const gate = request.gates.find((g) => g.id === record.gateId);
+          if (!gate || gate.state !== "open" || gate.weight === 0) {
+            expect(record.amount).toBe(0);
+          }
+        }
+      }),
+      { numRuns: 10_000 },
+    );
+  });
+
+  it("throws when amount is positive and no open gates are available", () => {
+    const request = {
+      amount: 42,
+      gates: [
+        { id: "a", state: "closed" as const, weight: 10 },
+        { id: "b", state: "suspended" as const, weight: 0 },
+      ],
+    };
+    expect(() => computeDeterministicAllocation(request)).toThrow(AllocationError);
+  });
+});
+
+describe("allocation routes", () => {
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+  });
+
+  it("previews allocations deterministically", async () => {
+    process.env.NODE_ENV = "test";
+    const ledger = new InMemoryLedger();
+    const app = await buildApp({
+      fastifyOptions: { logger: false },
+      ledger,
+    });
+
+    const payload = {
+      orgId: "org-1",
+      amount: 100,
+      gates: [
+        { id: "ops", state: "open" as const, weight: 1 },
+        { id: "rnd", state: "open" as const, weight: 1 },
+        { id: "compliance", state: "closed" as const, weight: 5 },
+      ],
+    };
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/allocations/preview",
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = response.json();
+      expect(body.amount).toBe(payload.amount);
+      expect(body.allocations).toEqual([
+        { gateId: "compliance", amount: 0, state: "closed" },
+        { gateId: "ops", amount: 50, state: "open" },
+        { gateId: "rnd", amount: 50, state: "open" },
+      ]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("applies allocations and records ledger entries", async () => {
+    process.env.NODE_ENV = "test";
+    const ledger = new InMemoryLedger();
+    const app = await buildApp({
+      fastifyOptions: { logger: false },
+      ledger,
+    });
+
+    const payload = {
+      orgId: "org-2",
+      amount: 101,
+      gates: [
+        { id: "ops", state: "open" as const, weight: 1 },
+        { id: "rnd", state: "open" as const, weight: 1 },
+        { id: "finance", state: "open" as const, weight: 1 },
+      ],
+    };
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/allocations/apply",
+        payload,
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = response.json();
+      const ledgerEntries = body.ledgerEntries;
+      expect(Array.isArray(ledgerEntries)).toBe(true);
+      expect(ledgerEntries.length).toBeGreaterThan(0);
+
+      const saved = ledger.getAll();
+      expect(saved.length).toBe(ledgerEntries.length);
+      expect(saved.every((entry) => entry.orgId === payload.orgId)).toBe(true);
+      const totalAllocated = body.allocations.reduce(
+        (sum: number, record: { amount: number }) => sum + record.amount,
+        0,
+      );
+      expect(totalAllocated).toBe(payload.amount);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/apgms/tests/tsconfig.json
+++ b/apgms/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "types": ["vitest/globals"],
+    "baseUrl": "."
+  },
+  "include": ["tests/**/*.ts"]
+}

--- a/apgms/tests/vitest.config.ts
+++ b/apgms/tests/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    watch: false,
+    environment: "node",
+    testTimeout: 20000,
+    dangerouslyIgnoreUnhandledErrors: false,
+  },
+});


### PR DESCRIPTION
## Summary
- implement a deterministic allocation policy engine that enforces conservation and non-negative invariants
- add Fastify allocation preview/apply routes with zod validation and an in-memory ledger repository
- introduce a tests workspace with fast-check property coverage and API route tests

## Testing
- pnpm test *(fails: vitest not installed in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4a464dccc83279107410b861dc61e