### PR TITLE
Add webhook idempotency safeguards and replay tests

### DIFF
--- a/apgms/eval/redteam/03_tool_abuse.json
+++ b/apgms/eval/redteam/03_tool_abuse.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "tool-abuse-replay",
+    "description": "Reuse an Idempotency-Key to coerce the gateway into replaying a webhook side effect.",
+    "request": {
+      "method": "POST",
+      "path": "/webhooks",
+      "headers": {
+        "Idempotency-Key": "fixed-key",
+        "X-Nonce": "nonce-123",
+        "X-Timestamp": "1690000000000",
+        "X-Signature": "deadbeef"
+      },
+      "body": {
+        "action": "trigger_payout"
+      }
+    },
+    "expected": {
+      "status": 409,
+      "error": "replay_detected"
+    }
+  }
+]

--- a/apgms/eval/redteam/04_stale.json
+++ b/apgms/eval/redteam/04_stale.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "stale-timestamp",
+    "description": "Submit a webhook with an expired timestamp to bypass nonce protections.",
+    "request": {
+      "method": "POST",
+      "path": "/webhooks",
+      "headers": {
+        "Idempotency-Key": "stale-key",
+        "X-Nonce": "nonce-expired",
+        "X-Timestamp": "1500000000000",
+        "X-Signature": "deadbeef"
+      },
+      "body": {
+        "action": "import_transactions"
+      }
+    },
+    "expected": {
+      "status": 400,
+      "error": "stale_timestamp"
+    }
+  }
+]

--- a/apgms/eval/redteam/05_bad_sig.json
+++ b/apgms/eval/redteam/05_bad_sig.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "bad-signature",
+    "description": "Attempt to forge a webhook by providing a mismatched HMAC signature.",
+    "request": {
+      "method": "POST",
+      "path": "/webhooks",
+      "headers": {
+        "Idempotency-Key": "sig-key",
+        "X-Nonce": "nonce-sig",
+        "X-Timestamp": "1690000000000",
+        "X-Signature": "not-the-right-signature"
+      },
+      "body": {
+        "action": "sweep_funds"
+      }
+    },
+    "expected": {
+      "status": 401,
+      "error": "invalid_signature"
+    }
+  }
+]

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,14 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import idempotencyPlugin from "./plugins/idempotency";
+import webhooksRoute from "./routes/webhooks";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(idempotencyPlugin);
+await app.register(webhooksRoute);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,80 @@
+import { FastifyPluginAsync } from "fastify";
+
+type StoredResponse = {
+  statusCode: number;
+  payload: unknown;
+  headers: Record<string, string>;
+};
+
+const store = new Map<string, StoredResponse>();
+
+const normalizeHeaderValue = (value: unknown): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v)).join(", ");
+  }
+
+  return typeof value === "string" ? value : String(value);
+};
+
+const idempotencyPlugin: FastifyPluginAsync = async (app) => {
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.method !== "POST") {
+      return;
+    }
+
+    const key = request.headers["idempotency-key"];
+    if (typeof key !== "string" || key.length === 0) {
+      return;
+    }
+
+    const cached = store.get(key);
+    if (!cached) {
+      return;
+    }
+
+    reply.code(cached.statusCode);
+    reply.headers({ ...cached.headers });
+    return reply.send(cached.payload);
+  });
+
+  app.addHook("onSend", async (request, reply, payload) => {
+    if (request.method !== "POST") {
+      return payload;
+    }
+
+    const key = request.headers["idempotency-key"];
+    if (typeof key !== "string" || key.length === 0) {
+      return payload;
+    }
+
+    if (reply.statusCode >= 200 && reply.statusCode < 400) {
+      const headers = Object.entries(reply.getHeaders()).reduce<Record<string, string>>(
+        (acc, [name, value]) => {
+          const normalized = normalizeHeaderValue(value);
+          if (normalized !== undefined) {
+            acc[name] = normalized;
+          }
+          return acc;
+        },
+        {}
+      );
+
+      store.set(key, {
+        statusCode: reply.statusCode,
+        payload,
+        headers,
+      });
+    }
+
+    return payload;
+  });
+};
+
+export default idempotencyPlugin;
+export const __internal = {
+  clear: () => store.clear(),
+};

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,103 @@
+import crypto from "node:crypto";
+import { FastifyPluginAsync } from "fastify";
+
+const NONCE_WINDOW_MS = 5 * 60 * 1000;
+const nonceStore = new Map<string, number>();
+
+const cleanupNonces = (now: number) => {
+  for (const [nonce, timestamp] of nonceStore.entries()) {
+    if (now - timestamp > NONCE_WINDOW_MS) {
+      nonceStore.delete(nonce);
+    }
+  }
+};
+
+const safeCompare = (a: string, b: string): boolean => {
+  const aBuffer = Buffer.from(a, "utf8");
+  const bBuffer = Buffer.from(b, "utf8");
+
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(aBuffer, bBuffer);
+};
+
+export const computeSignature = (
+  secret: string,
+  nonce: string,
+  timestamp: string,
+  payload: string
+): string => {
+  const hmac = crypto.createHmac("sha256", secret);
+  hmac.update(`${nonce}:${timestamp}:${payload}`);
+  return hmac.digest("hex");
+};
+
+export const stringifyPayload = (body: unknown): string => {
+  if (typeof body === "string") {
+    return body;
+  }
+
+  return JSON.stringify(body ?? {});
+};
+
+const webhooksRoute: FastifyPluginAsync = async (app) => {
+  app.post("/webhooks", async (request, reply) => {
+    const secret = process.env.WEBHOOK_SECRET;
+    if (!secret) {
+      request.log.error("WEBHOOK_SECRET not configured");
+      return reply.code(500).send({ error: "server_error" });
+    }
+
+    const nonceHeader = request.headers["x-nonce"];
+    const timestampHeader = request.headers["x-timestamp"];
+    const signatureHeader = request.headers["x-signature"];
+
+    if (typeof nonceHeader !== "string" || nonceHeader.length === 0) {
+      return reply.code(400).send({ error: "missing_nonce" });
+    }
+
+    if (typeof timestampHeader !== "string" || timestampHeader.length === 0) {
+      return reply.code(400).send({ error: "missing_timestamp" });
+    }
+
+    if (typeof signatureHeader !== "string" || signatureHeader.length === 0) {
+      return reply.code(400).send({ error: "missing_signature" });
+    }
+
+    const now = Date.now();
+    const requestTimestamp = Number(timestampHeader);
+    if (!Number.isFinite(requestTimestamp)) {
+      return reply.code(400).send({ error: "invalid_timestamp" });
+    }
+
+    const timestampMs = requestTimestamp;
+    cleanupNonces(now);
+
+    if (now - timestampMs > NONCE_WINDOW_MS || timestampMs - now > NONCE_WINDOW_MS) {
+      return reply.code(400).send({ error: "stale_timestamp" });
+    }
+
+    if (nonceStore.has(nonceHeader)) {
+      return reply.code(409).send({ error: "replay_detected" });
+    }
+
+    const payload = stringifyPayload(request.body);
+    const expectedSignature = computeSignature(secret, nonceHeader, timestampHeader, payload);
+
+    if (!safeCompare(expectedSignature, signatureHeader)) {
+      return reply.code(401).send({ error: "invalid_signature" });
+    }
+
+    nonceStore.set(nonceHeader, timestampMs);
+
+    return reply.code(202).send({ received: true });
+  });
+};
+
+export const __internal = {
+  clearNonces: () => nonceStore.clear(),
+};
+
+export default webhooksRoute;

--- a/test/replay.spec.ts
+++ b/test/replay.spec.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import Module from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import idempotencyPlugin, { __internal as idempotencyInternal } from "../apgms/services/api-gateway/src/plugins/idempotency";
+import webhooksRoute, {
+  __internal as webhookInternal,
+  computeSignature,
+  stringifyPayload,
+} from "../apgms/services/api-gateway/src/routes/webhooks";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+process.env.NODE_PATH = [
+  path.resolve(__dirname, "../apgms/node_modules"),
+  process.env.NODE_PATH ?? "",
+]
+  .filter(Boolean)
+  .join(path.delimiter);
+Module._initPaths();
+
+const buildApp = async () => {
+  const { default: Fastify } = await import("../apgms/node_modules/fastify/fastify.js");
+  const app = Fastify();
+  await app.register(idempotencyPlugin);
+  await app.register(webhooksRoute);
+  await app.ready();
+  return app;
+};
+
+const resetState = () => {
+  process.env.WEBHOOK_SECRET = "test-secret";
+  idempotencyInternal.clear();
+  webhookInternal.clearNonces();
+};
+
+test("rejects replayed nonce", async (t) => {
+  resetState();
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const payload = { event: "invoice.created" };
+  const nonce = "nonce-replay";
+  const timestamp = String(Date.now());
+  const signature = computeSignature(
+    process.env.WEBHOOK_SECRET!,
+    nonce,
+    timestamp,
+    stringifyPayload(payload)
+  );
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/webhooks",
+    headers: {
+      "x-nonce": nonce,
+      "x-timestamp": timestamp,
+      "x-signature": signature,
+      "idempotency-key": "key-one",
+    },
+    payload,
+  });
+
+  assert.equal(first.statusCode, 202);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/webhooks",
+    headers: {
+      "x-nonce": nonce,
+      "x-timestamp": timestamp,
+      "x-signature": signature,
+      "idempotency-key": "key-two",
+    },
+    payload,
+  });
+
+  assert.equal(second.statusCode, 409);
+  assert.deepEqual(JSON.parse(second.payload), { error: "replay_detected" });
+});
+
+test("rejects stale timestamps", async (t) => {
+  resetState();
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const payload = { event: "invoice.created" };
+  const nonce = "nonce-stale";
+  const timestamp = String(Date.now() - 10 * 60 * 1000);
+  const signature = computeSignature(
+    process.env.WEBHOOK_SECRET!,
+    nonce,
+    timestamp,
+    stringifyPayload(payload)
+  );
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks",
+    headers: {
+      "x-nonce": nonce,
+      "x-timestamp": timestamp,
+      "x-signature": signature,
+      "idempotency-key": "key-three",
+    },
+    payload,
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.payload), { error: "stale_timestamp" });
+});
+
+test("rejects bad signatures", async (t) => {
+  resetState();
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  const payload = { event: "invoice.created" };
+  const nonce = "nonce-bad";
+  const timestamp = String(Date.now());
+  const signature = "definitely-not-valid";
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/webhooks",
+    headers: {
+      "x-nonce": nonce,
+      "x-timestamp": timestamp,
+      "x-signature": signature,
+      "idempotency-key": "key-four",
+    },
+    payload,
+  });
+
+  assert.equal(response.statusCode, 401);
+  assert.deepEqual(JSON.parse(response.payload), { error: "invalid_signature" });
+});


### PR DESCRIPTION
## Summary
- add a Fastify idempotency plugin to cache successful POST responses by Idempotency-Key
- implement the webhook route with HMAC verification, timestamp freshness checks, and nonce replay tracking
- author red-team JSON scenarios and a node:test suite that covers replay, stale timestamp, and bad signature handling

## Testing
- pnpm -C apgms exec tsx --test ../test/replay.spec.ts
- pnpm -C apgms exec tsc --noEmit *(fails: existing PrismaClient typings missing from @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68f4a462526083279b82d5b7cff8ac11