### PR TITLE
Add healthz and readiness endpoints to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/health.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,88 @@
+import "./env";
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { healthRoutes } from "./routes/health";
+
+type PrismaClientLike = {
+  $queryRaw: (...args: any[]) => Promise<unknown>;
+  user: { findMany: (...args: any[]) => Promise<unknown[]> };
+  bankLine: {
+    findMany: (...args: any[]) => Promise<unknown[]>;
+    create: (...args: any[]) => Promise<unknown>;
+  };
+};
+
+interface BuildDependencies {
+  prisma?: PrismaClientLike;
+}
+
+let sharedPrismaPromise: Promise<PrismaClientLike> | null = null;
+
+async function loadSharedPrisma(): Promise<PrismaClientLike> {
+  if (!sharedPrismaPromise) {
+    sharedPrismaPromise = import("../../../shared/src/db").then(
+      (mod) => mod.prisma as PrismaClientLike,
+    );
+  }
+  return sharedPrismaPromise;
+}
+
+export async function buildApp(deps: BuildDependencies = {}) {
+  const prisma = deps.prisma ?? (await loadSharedPrisma());
+  const app = Fastify({ logger: true });
+
+  await app.register(cors, { origin: true });
+  await app.register(healthRoutes, { prisma });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/env.ts
+++ b/apgms/services/api-gateway/src/env.ts
@@ -1,0 +1,8 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import dotenv from "dotenv";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,15 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
+import { buildApp } from "./app";
+import { setupGracefulShutdown } from "./shutdown";
 
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await buildApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
+const removeSignalHandlers = setupGracefulShutdown(app);
+
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
+  removeSignalHandlers();
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,26 @@
+import type { FastifyPluginAsync } from "fastify";
+
+type PrismaReadinessClient = {
+  $queryRaw: (...args: any[]) => Promise<unknown>;
+};
+
+export interface HealthRoutesOptions {
+  prisma: PrismaReadinessClient;
+}
+
+export const healthRoutes: FastifyPluginAsync<HealthRoutesOptions> = async (
+  app,
+  options,
+) => {
+  app.get("/healthz", async () => ({ status: "ok" }));
+
+  app.get("/readyz", async (req, rep) => {
+    try {
+      await options.prisma.$queryRaw`SELECT 1`;
+      return { status: "ready" };
+    } catch (error) {
+      req.log.error({ err: error }, "readiness check failed");
+      return rep.status(503).send({ status: "not_ready" });
+    }
+  });
+};

--- a/apgms/services/api-gateway/src/shutdown.ts
+++ b/apgms/services/api-gateway/src/shutdown.ts
@@ -1,0 +1,71 @@
+import type { FastifyInstance } from "fastify";
+type ShutdownProcess = Pick<NodeJS.Process, "on" | "off" | "exit">;
+type PrismaShutdownClient = {
+  $disconnect: () => Promise<void>;
+};
+
+export function setupGracefulShutdown(
+  app: FastifyInstance,
+  proc: ShutdownProcess = process,
+  prisma?: PrismaShutdownClient,
+) {
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  let shuttingDown = false;
+
+  let sharedPrismaPromise: Promise<PrismaShutdownClient> | null = null;
+
+  const resolvePrisma = async () => {
+    if (prisma) {
+      return prisma;
+    }
+    if (!sharedPrismaPromise) {
+      sharedPrismaPromise = import("../../../shared/src/db").then(
+        (mod) => mod.prisma as PrismaShutdownClient,
+      );
+    }
+    prisma = await sharedPrismaPromise;
+    return prisma;
+  };
+
+  const handler = async (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    app.log.info({ signal }, "received shutdown signal");
+
+    try {
+      await app.close();
+      app.log.info("fastify closed");
+    } catch (error) {
+      app.log.error({ err: error }, "failed to close fastify");
+    }
+
+    try {
+      const client = await resolvePrisma();
+      await client.$disconnect();
+      app.log.info("prisma disconnected");
+    } catch (error) {
+      app.log.error({ err: error }, "failed to disconnect prisma");
+    }
+
+    proc.exit(0);
+  };
+
+  const wrappedHandler = (signal: NodeJS.Signals) => {
+    handler(signal).catch((error) => {
+      app.log.error({ err: error }, "error during graceful shutdown");
+      proc.exit(1);
+    });
+  };
+
+  for (const signal of signals) {
+    proc.on(signal, wrappedHandler);
+  }
+
+  return () => {
+    for (const signal of signals) {
+      proc.off(signal, wrappedHandler);
+    }
+  };
+}

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,115 @@
+import test, { mock } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { buildApp } from "../src/app";
+import { setupGracefulShutdown } from "../src/shutdown";
+
+type PrismaMock = {
+  $queryRaw: (...args: any[]) => Promise<unknown>;
+  $disconnect: () => Promise<void>;
+  user: { findMany: (...args: any[]) => Promise<unknown[]> };
+  bankLine: {
+    findMany: (...args: any[]) => Promise<unknown[]>;
+    create: (...args: any[]) => Promise<unknown>;
+  };
+};
+
+const createPrismaMock = (): PrismaMock => ({
+  $queryRaw: async () => 1,
+  $disconnect: async () => {},
+  user: { findMany: async () => [] },
+  bankLine: {
+    findMany: async () => [],
+    create: async () => ({}),
+  },
+});
+
+class FakeProcess extends EventEmitter {
+  exitCode: number | undefined;
+
+  exit(code?: number) {
+    this.exitCode = code ?? 0;
+  }
+}
+
+test("readyz reflects database connectivity", async (t) => {
+  const prisma = createPrismaMock();
+  const app = await buildApp({ prisma });
+  await app.ready();
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  const failingMock = mock.method(prisma, "$queryRaw", () => {
+    throw new Error("db down");
+  });
+
+  t.after(() => {
+    failingMock.mock.restore();
+  });
+
+  let response = await app.inject({ method: "GET", url: "/readyz" });
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.json(), { status: "not_ready" });
+
+  failingMock.mock.restore();
+
+  const successMock = mock.method(prisma, "$queryRaw", async () => 1);
+  t.after(() => {
+    successMock.mock.restore();
+  });
+
+  response = await app.inject({ method: "GET", url: "/readyz" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { status: "ready" });
+
+  successMock.mock.restore();
+});
+
+test("graceful shutdown closes Fastify and disconnects Prisma", async () => {
+  const prisma = createPrismaMock();
+  const app = await buildApp({ prisma });
+  await app.ready();
+
+  let fastifyClosed = false;
+  let prismaDisconnected = false;
+
+  const originalClose = app.close.bind(app);
+  const closeMock = mock.method(app, "close", async () => {
+    fastifyClosed = true;
+    await originalClose();
+  });
+
+  const originalDisconnect = prisma.$disconnect.bind(prisma);
+  const disconnectMock = mock.method(prisma, "$disconnect", async () => {
+    prismaDisconnected = true;
+    await originalDisconnect();
+  });
+
+  const fakeProcess = new FakeProcess();
+  let exitCode: number | undefined;
+  fakeProcess.exit = (code?: number) => {
+    assert.ok(fastifyClosed, "Fastify should be closed before exit");
+    assert.ok(prismaDisconnected, "Prisma should be disconnected before exit");
+    exitCode = code ?? 0;
+  };
+
+  const cleanup = setupGracefulShutdown(app, fakeProcess as unknown as NodeJS.Process, prisma);
+
+  fakeProcess.emit("SIGTERM");
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(closeMock.mock.callCount(), 1);
+  assert.equal(disconnectMock.mock.callCount(), 1);
+  assert.equal(exitCode, 0);
+
+  cleanup();
+  assert.equal(fakeProcess.listenerCount("SIGTERM"), 0);
+  assert.equal(fakeProcess.listenerCount("SIGINT"), 0);
+
+  await app.close();
+
+  closeMock.mock.restore();
+  disconnectMock.mock.restore();
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,3 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 export const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- refactor the gateway bootstrap into a reusable Fastify app builder that registers new /healthz and /readyz routes with Prisma-backed readiness checks
- add signal handlers that close the Fastify server and disconnect Prisma before exiting
- cover readiness transitions and graceful shutdown behaviour with a node:test suite

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4a45f919483279bfe513d21fde85e