### PR TITLE
feat: add API gateway schema validation and contract tests

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/contracts.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,134 @@
+import Fastify, { type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import type { PrismaClient, BankLine, User } from "@prisma/client";
+import {
+  createBankLineRequestSchema,
+  createBankLineResponseSchema,
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+  listUsersResponseSchema,
+  type CreateBankLineRequest,
+  type CreateBankLineResponse,
+  type ListBankLinesQuery,
+  type ListBankLinesResponse,
+  type ListUsersResponse,
+  withSchema,
+} from "./schemas";
+
+type Dependencies = {
+  prisma: PrismaClient;
+};
+
+type BankLineRecord = Pick<BankLine, "id" | "orgId" | "date" | "amount" | "payee" | "desc" | "createdAt">;
+type UserRecord = Pick<User, "email" | "orgId" | "createdAt">;
+
+function serializeBankLine(line: BankLineRecord): CreateBankLineResponse {
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amount: line.amount.toString(),
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+}
+
+function serializeBankLines(lines: BankLineRecord[]): ListBankLinesResponse["lines"] {
+  return lines.map(serializeBankLine);
+}
+
+function serializeUsers(users: UserRecord[]): ListUsersResponse["users"] {
+  return users.map((user) => ({
+    email: user.email,
+    orgId: user.orgId,
+    createdAt: user.createdAt.toISOString(),
+  }));
+}
+
+let cachedPrisma: PrismaClient | undefined;
+
+async function resolvePrisma(deps: Partial<Dependencies>) {
+  if (deps.prisma) {
+    return deps.prisma;
+  }
+
+  if (!cachedPrisma) {
+    const module = await import("@apgms/shared/src/db");
+    cachedPrisma = module.prisma;
+  }
+
+  return cachedPrisma;
+}
+
+export async function createApp(
+  deps: Partial<Dependencies> = {},
+  options: FastifyServerOptions = {},
+) {
+  const prisma = await resolvePrisma(deps);
+  const app = Fastify({ logger: true, ...options });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get(
+    "/users",
+    withSchema<undefined, undefined, undefined, ListUsersResponse>(
+      { response: listUsersResponseSchema },
+      async () => {
+        const users = await prisma.user.findMany({
+          select: { email: true, orgId: true, createdAt: true },
+          orderBy: { createdAt: "desc" },
+        });
+
+        return { users: serializeUsers(users) };
+      },
+    ),
+  );
+
+  app.get(
+    "/bank-lines",
+    withSchema<ListBankLinesQuery, undefined, undefined, ListBankLinesResponse>(
+      { query: listBankLinesQuerySchema, response: listBankLinesResponseSchema },
+      async ({ parsed }) => {
+        const take = parsed.query?.take ?? 20;
+        const lines = await prisma.bankLine.findMany({
+          orderBy: { date: "desc" },
+          take,
+        });
+
+        return { lines: serializeBankLines(lines) };
+      },
+    ),
+  );
+
+  app.post(
+    "/bank-lines",
+    withSchema<undefined, CreateBankLineRequest, undefined, CreateBankLineResponse>(
+      { body: createBankLineRequestSchema, response: createBankLineResponseSchema },
+      async ({ parsed, rep }) => {
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: parsed.body.orgId,
+            date: parsed.body.date,
+            amount: parsed.body.amount,
+            payee: parsed.body.payee,
+            desc: parsed.body.desc,
+          },
+        });
+
+        rep.code(201);
+        return serializeBankLine(created);
+      },
+    ),
+  );
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,74 +7,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { createApp } from "./app";
 
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await createApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/src/schemas/bankLines.ts
+++ b/apgms/services/api-gateway/src/schemas/bankLines.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amount: z.string(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export const listBankLinesQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+export const listBankLinesResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+export const createBankLineRequestSchema = z.object({
+  orgId: z.string().min(1),
+  date: z.coerce.date(),
+  amount: z.coerce.number(),
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const createBankLineResponseSchema = bankLineSchema;
+
+export type ListBankLinesQuery = z.infer<typeof listBankLinesQuerySchema>;
+export type ListBankLinesResponse = z.infer<typeof listBankLinesResponseSchema>;
+export type CreateBankLineRequest = z.infer<typeof createBankLineRequestSchema>;
+export type CreateBankLineResponse = z.infer<typeof createBankLineResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/index.ts
+++ b/apgms/services/api-gateway/src/schemas/index.ts
@@ -1,0 +1,3 @@
+export * from "./users";
+export * from "./bankLines";
+export * from "./withSchema";

--- a/apgms/services/api-gateway/src/schemas/users.ts
+++ b/apgms/services/api-gateway/src/schemas/users.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const listUsersResponseSchema = z.object({
+  users: z.array(
+    z.object({
+      email: z.string().email(),
+      orgId: z.string(),
+      createdAt: z.string().datetime(),
+    }),
+  ),
+});
+
+export type ListUsersResponse = z.infer<typeof listUsersResponseSchema>;

--- a/apgms/services/api-gateway/src/schemas/withSchema.ts
+++ b/apgms/services/api-gateway/src/schemas/withSchema.ts
@@ -1,0 +1,80 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { z } from "zod";
+
+type SchemaBundle<Q, B, P, R> = {
+  query?: z.ZodType<Q>;
+  body?: z.ZodType<B>;
+  params?: z.ZodType<P>;
+  response: z.ZodType<R>;
+};
+
+type Parsed<Q, B, P> = {
+  query: Q;
+  body: B;
+  params: P;
+};
+
+type Handler<Q, B, P, R> = (context: {
+  req: FastifyRequest;
+  rep: FastifyReply;
+  parsed: Parsed<Q, B, P>;
+}) => Promise<R> | R;
+
+function respondBadRequest(rep: FastifyReply, error: z.ZodError) {
+  return rep.code(400).send({
+    error: "bad_request",
+    issues: error.flatten(),
+  });
+}
+
+export function withSchema<
+  Q = undefined,
+  B = undefined,
+  P = undefined,
+  R = unknown,
+>(schema: SchemaBundle<Q, B, P, R>, handler: Handler<Q, B, P, R>) {
+  return async function withValidatedSchema(req: FastifyRequest, rep: FastifyReply) {
+    const queryResult = schema.query?.safeParse(req.query ?? {}) as
+      | z.SafeParseReturnType<unknown, Q>
+      | undefined;
+    if (queryResult && !queryResult.success) {
+      return respondBadRequest(rep, queryResult.error);
+    }
+
+    const bodyResult = schema.body?.safeParse(req.body ?? {}) as
+      | z.SafeParseReturnType<unknown, B>
+      | undefined;
+    if (bodyResult && !bodyResult.success) {
+      return respondBadRequest(rep, bodyResult.error);
+    }
+
+    const paramsResult = schema.params?.safeParse(req.params ?? {}) as
+      | z.SafeParseReturnType<unknown, P>
+      | undefined;
+    if (paramsResult && !paramsResult.success) {
+      return respondBadRequest(rep, paramsResult.error);
+    }
+
+    const parsed: Parsed<Q, B, P> = {
+      query: queryResult?.data as Q,
+      body: bodyResult?.data as B,
+      params: paramsResult?.data as P,
+    };
+
+    const result = await handler({ req, rep, parsed });
+    const responseResult = schema.response.safeParse(result);
+
+    if (!responseResult.success) {
+      req.log.error({ issues: responseResult.error.flatten() }, "response schema validation failed");
+      if (process.env.NODE_ENV === "production") {
+        if (!rep.sent) {
+          return rep.code(500).send({ error: "internal_server_error" });
+        }
+        return;
+      }
+      throw new Error(`Response validation failed: ${responseResult.error.message}`);
+    }
+
+    return responseResult.data;
+  };
+}

--- a/apgms/services/api-gateway/test/contracts.spec.ts
+++ b/apgms/services/api-gateway/test/contracts.spec.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { FastifyInstance } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+import { createApp } from "../src/app";
+
+const prismaMock = {
+  user: {
+    findMany: async () => [
+      { email: "founder@example.com", orgId: "org-1", createdAt: new Date("2024-01-01T00:00:00.000Z") },
+    ],
+  },
+  bankLine: {
+    findMany: async () => [
+      {
+        id: "line-1",
+        orgId: "org-1",
+        date: new Date("2024-01-02T00:00:00.000Z"),
+        amount: 1500.25,
+        payee: "Acme",
+        desc: "Office fit-out",
+        createdAt: new Date("2024-01-03T00:00:00.000Z"),
+      },
+    ],
+    create: async ({ data }: { data: any }) => ({
+      id: "line-2",
+      orgId: data.orgId,
+      date: data.date,
+      amount: data.amount,
+      payee: data.payee,
+      desc: data.desc,
+      createdAt: new Date("2024-01-04T00:00:00.000Z"),
+    }),
+  },
+} satisfies Partial<PrismaClient>;
+
+test("rejects malformed bank line payloads", async (t) => {
+  const app = (await createApp({ prisma: prismaMock as PrismaClient }, { logger: false })) as FastifyInstance;
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-1",
+      date: "not-a-date",
+      amount: "abc",
+      payee: "",
+    },
+  });
+
+  assert.equal(response.statusCode, 400);
+  const body = response.json();
+  assert.equal(body.error, "bad_request");
+});
+
+test("responds with schema conformant payloads", async (t) => {
+  const app = (await createApp({ prisma: prismaMock as PrismaClient }, { logger: false })) as FastifyInstance;
+  t.after(() => app.close());
+
+  const usersResponse = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(usersResponse.statusCode, 200);
+  const usersBody = usersResponse.json();
+  assert.deepEqual(usersBody, {
+    users: [
+      {
+        email: "founder@example.com",
+        orgId: "org-1",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      },
+    ],
+  });
+
+  const linesResponse = await app.inject({ method: "GET", url: "/bank-lines" });
+  assert.equal(linesResponse.statusCode, 200);
+  const linesBody = linesResponse.json();
+  assert.deepEqual(linesBody, {
+    lines: [
+      {
+        id: "line-1",
+        orgId: "org-1",
+        date: "2024-01-02T00:00:00.000Z",
+        amount: "1500.25",
+        payee: "Acme",
+        desc: "Office fit-out",
+        createdAt: "2024-01-03T00:00:00.000Z",
+      },
+    ],
+  });
+
+  const createResponse = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-1",
+      date: "2024-01-05T00:00:00.000Z",
+      amount: "2500.50",
+      payee: "Birchal",
+      desc: "Investment",
+    },
+  });
+
+  assert.equal(createResponse.statusCode, 201);
+  const createBody = createResponse.json();
+  assert.deepEqual(createBody, {
+    id: "line-2",
+    orgId: "org-1",
+    date: "2024-01-05T00:00:00.000Z",
+    amount: "2500.5",
+    payee: "Birchal",
+    desc: "Investment",
+    createdAt: "2024-01-04T00:00:00.000Z",
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add Zod request and response schemas for users and bank line endpoints
- wrap handlers with schema-aware validator that normalises data and guards responses
- add contract tests ensuring malformed payloads are rejected and happy paths meet the contract

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4a45ee2608327bf6e4e0f3df45703