### PR TITLE
Implement API gateway authentication and org scoping

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/authz.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,71 +10,94 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { authMiddleware } from "./middleware/auth";
+import { orgScopeMiddleware } from "./middleware/org-scope";
 
-const app = Fastify({ logger: true });
+export function buildApp() {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  const shouldSkip = (reqPath?: string) => reqPath?.startsWith("/healthz") ?? false;
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+  app.addHook("preHandler", async (req, reply) => {
+    if (shouldSkip(req.raw.url) || reply.sent) {
+      return;
+    }
+    await authMiddleware(req, reply);
+    if (!reply.sent) {
+      await orgScopeMiddleware(req, reply);
+    }
   });
-  return { users };
-});
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
+  app.get("/healthz", async () => ({ ok: true, service: "api-gateway" }));
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  // List users (email + org)
+  app.get("/users", async (req) => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      where: { orgId: req.orgId },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      where: { orgId: req.orgId },
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId?: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: req.orgId!,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+if (process.env.NODE_ENV !== "test") {
+  const app = buildApp();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });
+}
 

--- a/apgms/services/api-gateway/src/middleware/auth.ts
+++ b/apgms/services/api-gateway/src/middleware/auth.ts
@@ -1,0 +1,219 @@
+import { createPublicKey, createVerify, type JsonWebKey } from "node:crypto";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+export type JwtPayload = {
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  [key: string]: unknown;
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    orgId?: string;
+    roles: string[];
+    tokenPayload?: JwtPayload;
+  }
+}
+
+const keyCache = new Map<string, ReturnType<typeof createPublicKey>>();
+let loadingPromise: Promise<void> | null = null;
+
+async function fetchJwks() {
+  const jwksUri = process.env.OIDC_JWKS_URI;
+  if (!jwksUri) {
+    throw new Error("OIDC_JWKS_URI environment variable is required for JWT verification");
+  }
+
+  const res = await fetch(jwksUri);
+  if (!res.ok) {
+    throw new Error(`Unable to download JWKS: ${res.status} ${res.statusText}`);
+  }
+
+  const body = await res.json();
+  const keys = Array.isArray(body?.keys) ? (body.keys as JsonWebKey[]) : [];
+  keyCache.clear();
+  for (const jwk of keys) {
+    if (!jwk.kty) {
+      continue;
+    }
+    try {
+      const key = createPublicKey({ key: jwk, format: "jwk" });
+      keyCache.set(jwk.kid ?? `__default_${keyCache.size}`, key);
+    } catch {
+      // Ignore invalid keys
+    }
+  }
+}
+
+async function ensureKeys() {
+  if (keyCache.size > 0) {
+    return;
+  }
+  if (!loadingPromise) {
+    loadingPromise = fetchJwks().finally(() => {
+      loadingPromise = null;
+    });
+  }
+  await loadingPromise;
+}
+
+async function resolveKey(kid?: string) {
+  await ensureKeys();
+  let key = kid ? keyCache.get(kid) : keyCache.values().next().value;
+  if (!key) {
+    await fetchJwks();
+    key = kid ? keyCache.get(kid) : keyCache.values().next().value;
+  }
+  if (!key) {
+    throw new Error("No signing keys available");
+  }
+  return key;
+}
+
+function base64UrlToBuffer(segment: string) {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+  const padded = normalized + "=".repeat(pad);
+  return Buffer.from(padded, "base64");
+}
+
+function parseToken(token: string) {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("Invalid JWT structure");
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = segments;
+  const header = JSON.parse(base64UrlToBuffer(encodedHeader).toString("utf8")) as {
+    alg: string;
+    kid?: string;
+  };
+  const payload = JSON.parse(base64UrlToBuffer(encodedPayload).toString("utf8")) as JwtPayload;
+  const signature = base64UrlToBuffer(encodedSignature);
+  return {
+    header,
+    payload,
+    signature,
+    signingInput: `${encodedHeader}.${encodedPayload}`,
+  };
+}
+
+function verifyTimestamps(payload: JwtPayload) {
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp === "number" && now >= payload.exp) {
+    throw new Error("Token expired");
+  }
+  if (typeof payload.nbf === "number" && now < payload.nbf) {
+    throw new Error("Token not yet valid");
+  }
+}
+
+function assertAudience(payload: JwtPayload) {
+  const expectedAudience = process.env.OIDC_AUDIENCE;
+  if (!expectedAudience) {
+    return;
+  }
+  const { aud } = payload;
+  if (Array.isArray(aud)) {
+    if (!aud.includes(expectedAudience)) {
+      throw new Error("Invalid audience");
+    }
+    return;
+  }
+  if (typeof aud === "string") {
+    if (aud !== expectedAudience) {
+      throw new Error("Invalid audience");
+    }
+    return;
+  }
+  throw new Error("Audience missing");
+}
+
+function assertIssuer(payload: JwtPayload) {
+  const expectedIssuer = process.env.OIDC_ISSUER;
+  if (!expectedIssuer) {
+    return;
+  }
+  if (payload.iss !== expectedIssuer) {
+    throw new Error("Invalid issuer");
+  }
+}
+
+function extractOrgId(payload: JwtPayload): string | undefined {
+  const direct = payload.orgId ?? (payload as Record<string, unknown>).org_id;
+  if (typeof direct === "string" && direct.length > 0) {
+    return direct;
+  }
+  for (const [key, value] of Object.entries(payload)) {
+    if (key.endsWith("/org_id") && typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function extractRoles(payload: JwtPayload): string[] {
+  const candidate = (payload as Record<string, unknown>).roles;
+  if (Array.isArray(candidate)) {
+    return candidate.filter((entry): entry is string => typeof entry === "string");
+  }
+  if (typeof candidate === "string") {
+    return candidate.split(/[\s,]+/).filter(Boolean);
+  }
+  const realmAccess = (payload as Record<string, any>).realm_access;
+  if (realmAccess && Array.isArray(realmAccess.roles)) {
+    return realmAccess.roles.filter((role: unknown): role is string => typeof role === "string");
+  }
+  return [];
+}
+
+export async function authMiddleware(req: FastifyRequest, reply: FastifyReply) {
+  req.roles = [];
+  const authorization = req.headers.authorization;
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    reply.code(401).send({ error: "unauthorized" });
+    return;
+  }
+
+  const token = authorization.slice("Bearer ".length).trim();
+  if (!token) {
+    reply.code(401).send({ error: "unauthorized" });
+    return;
+  }
+
+  try {
+    const { header, payload, signature, signingInput } = parseToken(token);
+    if (header.alg !== "RS256") {
+      throw new Error(`Unsupported JWT algorithm: ${header.alg}`);
+    }
+    const key = await resolveKey(header.kid);
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(signingInput);
+    verifier.end();
+    const verified = verifier.verify(key, signature);
+    if (!verified) {
+      throw new Error("JWT signature verification failed");
+    }
+
+    verifyTimestamps(payload);
+    assertIssuer(payload);
+    assertAudience(payload);
+
+    const orgId = extractOrgId(payload);
+    if (!orgId) {
+      reply.code(403).send({ error: "forbidden" });
+      return;
+    }
+
+    req.orgId = orgId;
+    req.roles = extractRoles(payload);
+    req.tokenPayload = payload;
+  } catch (error) {
+    req.log.warn({ err: error }, "JWT verification failed");
+    if (!reply.sent) {
+      reply.code(401).send({ error: "unauthorized" });
+    }
+  }
+}

--- a/apgms/services/api-gateway/src/middleware/org-scope.ts
+++ b/apgms/services/api-gateway/src/middleware/org-scope.ts
@@ -1,0 +1,41 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+function extractOrgIds(candidate: unknown): string[] {
+  if (!candidate || typeof candidate !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(candidate)) {
+    return candidate.flatMap(extractOrgIds);
+  }
+
+  const value = (candidate as Record<string, unknown>).orgId;
+  if (typeof value === "string" && value.length > 0) {
+    return [value];
+  }
+
+  return [];
+}
+
+export async function orgScopeMiddleware(req: FastifyRequest, reply: FastifyReply) {
+  if (!req.orgId) {
+    reply.code(401).send({ error: "unauthorized" });
+    return;
+  }
+
+  const ids = new Set<string>();
+  for (const source of [req.params, req.query, req.body]) {
+    for (const id of extractOrgIds(source)) {
+      ids.add(id);
+    }
+  }
+
+  if (ids.size === 0) {
+    return;
+  }
+
+  if (ids.size > 1 || !ids.has(req.orgId)) {
+    reply.code(403).send({ error: "forbidden" });
+    return;
+  }
+}

--- a/apgms/services/api-gateway/test/authz.spec.ts
+++ b/apgms/services/api-gateway/test/authz.spec.ts
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { createPublicKey, createSign, generateKeyPairSync, type JsonWebKey } from "node:crypto";
+
+process.env.APGMS_FAKE_PRISMA = "1";
+process.env.NODE_ENV = "test";
+
+import type { buildApp as BuildAppFn } from "../src/index";
+import type { prisma as PrismaInstance } from "../../../shared/src/db";
+
+type PrismaModule = typeof import("../../../shared/src/db");
+
+type PrismaUserFindMany = PrismaInstance["user"]["findMany"];
+type PrismaBankLineFindMany = PrismaInstance["bankLine"]["findMany"];
+type PrismaBankLineCreate = PrismaInstance["bankLine"]["create"];
+
+type TestContext = {
+  signToken: (orgId: string, roles?: string[]) => string;
+  close: () => Promise<void>;
+};
+
+let prisma: PrismaInstance;
+let buildApp: typeof BuildAppFn;
+let originalUserFindMany: PrismaUserFindMany;
+let originalBankLineFindMany: PrismaBankLineFindMany;
+let originalBankLineCreate: PrismaBankLineCreate;
+
+async function loadModules() {
+  if (!prisma || !buildApp) {
+    const shared = (await import("../../../shared/src/db")) as PrismaModule;
+    prisma = shared.prisma as PrismaInstance;
+    const gateway = await import("../src/index");
+    buildApp = gateway.buildApp;
+    originalUserFindMany = prisma.user.findMany;
+    originalBankLineFindMany = prisma.bankLine.findMany;
+    originalBankLineCreate = prisma.bankLine.create;
+  }
+}
+
+async function setupAuth(): Promise<TestContext> {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { format: "pem", type: "spki" },
+    privateKeyEncoding: { format: "pem", type: "pkcs8" },
+  });
+
+  const jwk = createPublicKey(publicKey).export({ format: "jwk" }) as JsonWebKey;
+  jwk.kid = "test";
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+
+  const server = createServer((req, res) => {
+    if (req.url === "/.well-known/jwks.json") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ keys: [jwk] }));
+      return;
+    }
+    res.writeHead(404).end();
+  });
+
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const jwksUri = `http://127.0.0.1:${port}/.well-known/jwks.json`;
+
+  process.env.OIDC_JWKS_URI = jwksUri;
+  process.env.OIDC_ISSUER = "https://issuer.test";
+  process.env.OIDC_AUDIENCE = "api://gateway";
+
+  const signToken = (orgId: string, roles: string[] = []) => {
+    const now = Math.floor(Date.now() / 1000);
+    const header = {
+      alg: "RS256" as const,
+      typ: "JWT",
+      kid: "test",
+    };
+    const payload = {
+      iss: process.env.OIDC_ISSUER,
+      aud: process.env.OIDC_AUDIENCE,
+      iat: now,
+      exp: now + 60 * 60,
+      orgId,
+      roles,
+    };
+    const encode = (input: unknown) =>
+      Buffer.from(JSON.stringify(input), "utf8").toString("base64url");
+    const signingInput = `${encode(header)}.${encode(payload)}`;
+    const signer = createSign("RSA-SHA256");
+    signer.update(signingInput);
+    signer.end();
+    const signature = signer.sign(privateKey).toString("base64url");
+    return `${signingInput}.${signature}`;
+  };
+
+  return {
+    signToken,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function testUnauthorized() {
+  const app = buildApp();
+  await app.ready();
+  const response = await app.inject({ method: "GET", url: "/users" });
+  assert.equal(response.statusCode, 401);
+  assert.deepEqual(response.json(), { error: "unauthorized" });
+  await app.close();
+}
+
+async function testForbidden(signToken: TestContext["signToken"]) {
+  let createCalled = false;
+  prisma.bankLine.create = (async () => {
+    createCalled = true;
+    throw new Error("should not create when org scope mismatches");
+  }) as PrismaBankLineCreate;
+
+  const token = signToken("org-one", ["finance:write"]);
+  const app = buildApp();
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-two",
+      date: new Date().toISOString(),
+      amount: 100,
+      payee: "ACME",
+      desc: "mismatch",
+    },
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  assert.equal(response.statusCode, 403);
+  assert.equal(createCalled, false);
+
+  await app.close();
+}
+
+async function testAuthorized(signToken: TestContext["signToken"]) {
+  let receivedWhere: any;
+  prisma.user.findMany = (async (args: any) => {
+    receivedWhere = args?.where;
+    return [
+      { email: "user@example.com", orgId: "org-one", createdAt: new Date("2024-01-01T00:00:00.000Z") },
+    ];
+  }) as PrismaUserFindMany;
+  prisma.bankLine.findMany = (async (args: any) => {
+    assert.deepEqual(args?.where, { orgId: "org-one" });
+    return [];
+  }) as PrismaBankLineFindMany;
+
+  const token = signToken("org-one", ["finance:read"]);
+  const app = buildApp();
+  await app.ready();
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(receivedWhere, { orgId: "org-one" });
+
+  const body = response.json();
+  assert.equal(body.users.length, 1);
+  assert.equal(body.users[0].email, "user@example.com");
+  assert.equal(body.users[0].orgId, "org-one");
+
+  await app.close();
+}
+
+async function main() {
+  await loadModules();
+  const { signToken, close } = await setupAuth();
+  try {
+    prisma.user.findMany = (async () => []) as PrismaUserFindMany;
+    prisma.bankLine.findMany = (async () => []) as PrismaBankLineFindMany;
+    prisma.bankLine.create = (async (args: any) => ({ ...args.data, id: "line_123" })) as PrismaBankLineCreate;
+
+    await testUnauthorized();
+
+    prisma.user.findMany = (async () => []) as PrismaUserFindMany;
+    prisma.bankLine.findMany = (async () => []) as PrismaBankLineFindMany;
+    prisma.bankLine.create = (async (args: any) => ({ ...args.data, id: "line_123" })) as PrismaBankLineCreate;
+    await testForbidden(signToken);
+
+    prisma.user.findMany = (async () => []) as PrismaUserFindMany;
+    prisma.bankLine.findMany = (async () => []) as PrismaBankLineFindMany;
+    prisma.bankLine.create = (async (args: any) => ({ ...args.data, id: "line_123" })) as PrismaBankLineCreate;
+    await testAuthorized(signToken);
+
+    console.log("authz tests passed");
+  } finally {
+    prisma.user.findMany = originalUserFindMany;
+    prisma.bankLine.findMany = originalBankLineFindMany;
+    prisma.bankLine.create = originalBankLineCreate;
+    await close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,34 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+const useMock = process.env.APGMS_FAKE_PRISMA === "1";
+
+type PrismaModuleType = typeof import("@prisma/client");
+
+type PrismaShape = {
+  user: { findMany: (...args: any[]) => Promise<any> };
+  bankLine: {
+    findMany: (...args: any[]) => Promise<any>;
+    create: (...args: any[]) => Promise<any>;
+  };
+};
+
+function createUnconfiguredMock(): PrismaShape {
+  const missing = async () => {
+    throw new Error("Prisma mock not configured");
+  };
+  return {
+    user: { findMany: missing },
+    bankLine: { findMany: missing, create: missing },
+  } as PrismaShape;
+}
+
+let prismaInstance: PrismaShape;
+
+if (useMock) {
+  prismaInstance = createUnconfiguredMock();
+} else {
+  const PrismaModule = (await import("@prisma/client")) as PrismaModuleType & { default: PrismaModuleType };
+  const Prisma = PrismaModule.default ?? (PrismaModule as PrismaModuleType);
+  const { PrismaClient } = Prisma;
+  prismaInstance = new PrismaClient() as PrismaShape;
+}
+
+export const prisma = prismaInstance;


### PR DESCRIPTION
## Summary
- add JWT verification middleware and organization scope enforcement for the gateway
- wrap all non-health routes with the new guards and scope Prisma queries to the authenticated org
- add an integration-style authz spec covering 401/403/200 flows and script to run it

## Testing
- pnpm --filter @apgms/api-gateway run test

------
https://chatgpt.com/codex/tasks/task_e_68f4a45ceef48327b8b1cbc9dd882902