### PR TITLE
feat(api-gateway): add security middleware and tests

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/security.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -8,12 +8,12 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import securityPlugin from "./plugins/security.js";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(securityPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,82 @@
+import cors from "@fastify/cors";
+import type { FastifyPluginAsync, FastifyRequest } from "fastify";
+
+const BODY_LIMIT_BYTES = 512 * 1024;
+const RATE_LIMIT_MAX = 100;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+type RateLimitBucket = {
+  count: number;
+  resetAt: number;
+};
+
+const securityPlugin: FastifyPluginAsync = async (fastify) => {
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  await fastify.register(cors, {
+    origin: allowedOrigins.length > 0 ? allowedOrigins : true,
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+  });
+
+  const buckets = new Map<string, RateLimitBucket>();
+
+  const cleanupInterval = setInterval(() => {
+    const now = Date.now();
+    for (const [key, bucket] of buckets) {
+      if (bucket.resetAt <= now) {
+        buckets.delete(key);
+      }
+    }
+  }, RATE_LIMIT_WINDOW_MS);
+  cleanupInterval.unref?.();
+
+  const rateLimitKey = (request: FastifyRequest) => {
+    const route = request.routerPath ?? request.routeOptions.url ?? request.raw.url ?? "unknown";
+    return `${request.ip}:${request.method}:${route}`;
+  };
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    const now = Date.now();
+    const key = rateLimitKey(request);
+    const bucket = buckets.get(key);
+
+    if (!bucket || bucket.resetAt <= now) {
+      buckets.set(key, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+      return;
+    }
+
+    bucket.count += 1;
+
+    if (bucket.count > RATE_LIMIT_MAX) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      reply.header("Retry-After", String(retryAfterSeconds));
+      reply.code(429);
+      await reply.send({ error: "rate_limit_exceeded" });
+      return reply;
+    }
+  });
+
+  fastify.addHook("onRoute", (routeOptions) => {
+    routeOptions.bodyLimit = routeOptions.bodyLimit === undefined
+      ? BODY_LIMIT_BYTES
+      : Math.min(routeOptions.bodyLimit, BODY_LIMIT_BYTES);
+  });
+
+  fastify.addHook("onClose", async () => {
+    clearInterval(cleanupInterval);
+    buckets.clear();
+  });
+};
+
+const wrapAsFastifyPlugin = <T extends FastifyPluginAsync>(plugin: T, name: string): T => {
+  const skipOverride = Symbol.for("skip-override");
+  const displayName = Symbol.for("fastify.display-name");
+  (plugin as any)[skipOverride] = true;
+  (plugin as any)[displayName] = name;
+  return plugin;
+};
+
+export default wrapAsFastifyPlugin(securityPlugin, "security");

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+import Fastify from "fastify";
+import securityPlugin from "../src/plugins/security.js";
+
+const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+
+after(() => {
+  if (originalAllowedOrigins === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+  }
+});
+
+const buildApp = async () => {
+  const app = Fastify({ logger: false });
+  await app.register(securityPlugin);
+  return app;
+};
+
+test("allows configured origins to complete CORS preflight", async () => {
+  process.env.ALLOWED_ORIGINS = "https://example.com";
+  const app = await buildApp();
+
+  app.options("/cors", async () => ({ ok: true }));
+  await app.ready();
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/cors",
+    headers: {
+      origin: "https://example.com",
+      "access-control-request-method": "GET",
+    },
+  });
+
+  assert.equal(response.statusCode, 204);
+  assert.equal(response.headers["access-control-allow-origin"], "https://example.com");
+
+  await app.close();
+});
+
+test("returns 429 when an IP exceeds the rate limit for a route", async () => {
+  process.env.ALLOWED_ORIGINS = "";
+  const app = await buildApp();
+
+  app.get("/limited", async () => ({ ok: true }));
+  await app.ready();
+
+  for (let i = 0; i < 100; i += 1) {
+    const okResponse = await app.inject({
+      method: "GET",
+      url: "/limited",
+      remoteAddress: "203.0.113.5",
+    });
+    assert.equal(okResponse.statusCode, 200);
+  }
+
+  const blocked = await app.inject({
+    method: "GET",
+    url: "/limited",
+    remoteAddress: "203.0.113.5",
+  });
+
+  assert.equal(blocked.statusCode, 429);
+  assert.ok(Number(blocked.headers["retry-after"]) >= 1);
+
+  await app.close();
+});
+
+test("rejects payloads that exceed the 512KB body limit", async () => {
+  process.env.ALLOWED_ORIGINS = "";
+  const app = await buildApp();
+
+  app.post("/payload", async () => ({ ok: true }));
+  await app.ready();
+
+  const oversizedPayload = "a".repeat(512 * 1024 + 1);
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/payload",
+    payload: oversizedPayload,
+    headers: { "content-type": "text/plain" },
+  });
+
+  assert.equal(response.statusCode, 413);
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- add a reusable Fastify security plugin that configures CORS, request rate limiting, and a 512KB payload ceiling
- wire the plugin into the API gateway bootstrap and expose a package test script
- cover the new behaviour with node:test specs for CORS preflight, rate limiting, and payload rejection

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4a45c37948327a3997440fe17c4b2