### PR TITLE
Add legal documentation and CI link verification

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -15,3 +15,14 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  legal-docs:
+    name: Legal Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Check legal document links
+        working-directory: apgms
+        run: node scripts/check-legal-links.js

--- a/apgms/README.md
+++ b/apgms/README.md
@@ -6,3 +6,9 @@ pnpm -r build
 docker compose up -d
 pnpm -r test
 pnpm -w exec playwright test
+
+## Legal
+
+- [Terms of Service](docs/legal/terms.md)
+- [Privacy Policy](docs/legal/privacy.md)
+- [Data Processing Agreement](docs/legal/dpa.md)

--- a/apgms/docs/legal/dpa.md
+++ b/apgms/docs/legal/dpa.md
@@ -1,0 +1,10 @@
+# Data Processing Agreement
+
+## Sub-processor Oversight
+Customer data exports initiated through the [`POST /admin/data/export`](../../services/api-gateway/src/index.ts) endpoint are restricted to contracted sub-processors and logged for transparency. Partners receiving export data must comply with encryption-at-rest and transit controls defined in this agreement.
+
+## Data Deletion Assistance
+We provide verifiable deletion support for controllers using the [`POST /admin/data/delete`](../../services/api-gateway/src/index.ts) endpoint. Completed deletions generate attestations that controllers may furnish to auditors on request.
+
+## Breach Cooperation
+In the event that export or deletion activities expose a notifiable incident, both parties will adhere to the [NDB runbook](../runbooks/ndb.md) for coordinated investigation, notification, and remediation.

--- a/apgms/docs/legal/privacy.md
+++ b/apgms/docs/legal/privacy.md
@@ -1,0 +1,10 @@
+# Privacy Policy
+
+## Individual Rights Management
+We honour access and portability rights by exposing the [`POST /admin/data/export`](../../services/api-gateway/src/index.ts) endpoint to tenant administrators. Each export request is authenticated with admin credentials, recorded in the privacy register, and delivered through encrypted channels within seven days.
+
+## Erasure Requests
+Deletion requests are orchestrated via the [`POST /admin/data/delete`](../../services/api-gateway/src/index.ts) endpoint. Successful completion triggers downstream purge tasks and confirmation notices to the requester. Audit logs of deletion events are retained for compliance validation.
+
+## Notifiable Data Breach (NDB) Alignment
+If an export or deletion flow reveals unauthorised disclosure, the incident response must follow the [NDB runbook](../runbooks/ndb.md). The runbook enumerates containment steps, regulator notifications, and customer communications required under the Australian Privacy Act.

--- a/apgms/docs/legal/terms.md
+++ b/apgms/docs/legal/terms.md
@@ -1,0 +1,10 @@
+# Terms of Service
+
+## Data Access and Portability
+Authorized administrators can initiate complete account exports by calling the [`POST /admin/data/export`](../../services/api-gateway/src/index.ts) endpoint. Export packages are delivered through the secure admin channel and logged for audit purposes. Completed exports must be retained for 30 days to support dispute resolution.
+
+## Data Deletion
+Right-to-erasure requests are processed through the [`POST /admin/data/delete`](../../services/api-gateway/src/index.ts) endpoint. Administrators must confirm requester authority before submitting the deletion job and retain proof in the ticketing system. Deletion workflows also include dependent system scrubs managed by the platform SRE team.
+
+## Incident Management
+Any suspected privacy incident uncovered during export or deletion handling must follow the [Notifiable Data Breach runbook](../runbooks/ndb.md). The runbook documents triage, escalation, and reporting timelines under the Australian NDB scheme.

--- a/apgms/docs/runbooks/ndb.md
+++ b/apgms/docs/runbooks/ndb.md
@@ -1,0 +1,7 @@
+# Notifiable Data Breach (NDB) Runbook
+
+1. **Triage** – Confirm the incident source, identify affected records, and engage the privacy officer within two hours.
+2. **Containment** – Disable compromised export or deletion credentials, suspend related admin endpoints, and capture forensic logs.
+3. **Assessment** – Within 30 hours determine whether individuals are at risk of serious harm and document findings in the breach register.
+4. **Notification** – Notify the OAIC and impacted customers within 72 hours when serious harm is likely, providing remediation guidance and contact channels.
+5. **Remediation** – Coordinate corrective actions, monitor endpoint hardening, and issue a post-incident review summarising lessons learned.

--- a/apgms/scripts/check-legal-links.js
+++ b/apgms/scripts/check-legal-links.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const readmePath = path.resolve(__dirname, '..', 'README.md');
+const readme = fs.readFileSync(readmePath, 'utf8');
+
+const requiredLinks = [
+  ['(docs/legal/terms.md)', '(apgms/docs/legal/terms.md)'],
+  ['(docs/legal/privacy.md)', '(apgms/docs/legal/privacy.md)'],
+  ['(docs/legal/dpa.md)', '(apgms/docs/legal/dpa.md)'],
+];
+
+const missing = requiredLinks.filter(([primary, alt]) => {
+  return !readme.includes(primary) && !readme.includes(alt);
+}).map(([primary]) => primary);
+
+if (missing.length > 0) {
+  console.error('Missing legal document links in README:', missing.join(', '));
+  process.exit(1);
+}
+
+console.log('All required legal document links are present in README.');


### PR DESCRIPTION
## Summary
- add Terms, Privacy, and DPA legal documents that reference the admin export/delete endpoints and the NDB runbook
- publish the NDB runbook and link the legal documents from the project README
- add a Node-based link check script and wire it into CI via a Legal Docs job

## Testing
- node apgms/scripts/check-legal-links.js

------
https://chatgpt.com/codex/tasks/task_e_68f4aa550f508327a91e822cf21a9c75