### PR TITLE
Add gateway SLO documentation and nightly synthetic monitor

### DIFF
--- a/apgms/.github/workflows/synthetic.yml
+++ b/apgms/.github/workflows/synthetic.yml
@@ -1,0 +1,29 @@
+name: Nightly Gateway Synthetic
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  synthetic-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run synthetic monitor
+        env:
+          BASE_URL: ${{ secrets.SYNTHETIC_BASE_URL }}
+          AUTH_HEADER: ${{ secrets.SYNTHETIC_AUTH_HEADER }}
+        run: |
+          chmod +x scripts/synthetic.sh
+          ./scripts/synthetic.sh "${BASE_URL}" "${AUTH_HEADER}"
+
+      - name: Upload synthetic logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gateway-synthetic-logs
+          path: artifacts/
+          if-no-files-found: error

--- a/apgms/docs/runbooks/oncall.md
+++ b/apgms/docs/runbooks/oncall.md
@@ -1,0 +1,45 @@
+# Gateway On-Call Runbook
+
+## Escalation Policy
+1. Primary on-call (rotation in PagerDuty schedule `gateway-sre-primary`).
+2. Secondary on-call (PagerDuty schedule `gateway-sre-secondary`).
+3. Engineering manager (`@gateway-eng-manager`) for incidents exceeding 30 minutes or impacting >10% traffic.
+4. Director of Platform Engineering for Sev1 incidents or when customer commitments are at risk.
+
+Escalate immediately if:
+* The synthetic check fails twice in a row.
+* Error budget burn rate alert exceeds 4x.
+* Regulatory reporting integrations are affected.
+
+## Key Dashboards
+* **Gateway Overview** – `Grafana > Gateway > 01-Overview`: latency percentiles, availability, deployment markers.
+* **Dependency Health** – `Grafana > Gateway > 02-Dependencies`: upstream/downstream response times, saturation.
+* **Synthetic Monitors** – `Grafana > Gateway > 03-Synthetics`: `/readyz` and `/bank-lines` timings plotted with regions.
+* **Logging** – `Kibana > gateway-*` search filtered by `severity>=error` and `trace_id` from alert.
+
+## First Response Checklist
+1. **Acknowledge the page** in PagerDuty and announce in `#gateway-incident`.
+2. **Review dashboards**:
+   * Confirm latency and error rates on the Overview dashboard.
+   * Check dependency dashboard for correlated spikes.
+3. **Inspect synthetic logs** in the latest GitHub Actions artifact to validate failure context.
+4. **Check recent deploys** via the deployment marker panel; roll back if the issue aligns with a release.
+5. **Gather logs** in Kibana filtered by customer impact or trace IDs from the alert payload.
+6. **Mitigation steps**:
+   * Restart unhealthy pods via the Kubernetes runbook if readiness checks failing.
+   * Redirect traffic to the standby region if the primary region is impacted.
+   * Throttle partner traffic using API gateway rate-limits if necessary to preserve core flows.
+7. **Communicate** updates every 15 minutes in `#gateway-incident` and update the status page if required.
+8. **Post-incident**: create an incident timeline, capture customer impact, and file a postmortem within 48 hours.
+
+## Useful Commands
+```
+# Check readiness of pods
+kubectl get pods -l app=gateway -o wide
+
+# Tail logs for a specific pod
+kubectl logs deploy/gateway -c app --since=10m
+
+# Trigger synthetic check locally (requires VPN)
+./scripts/synthetic.sh https://gateway.prod.example.com "Authorization: Bearer <token>"
+```

--- a/apgms/docs/slo.md
+++ b/apgms/docs/slo.md
@@ -1,0 +1,46 @@
+# Gateway Service SLOs
+
+## Overview
+The gateway exposes the API surface for customer and partner applications. This document captures our
+Service Level Objectives (SLOs), alert thresholds, and the policies governing how we consume the
+resulting error budget.
+
+## SLO Summary
+| SLO | Target | Measurement Window | Data Source |
+| --- | --- | --- | --- |
+| p95 request latency | ≤ 300 ms | trailing 30 days | `gateway_request_duration_seconds` histogram exported to Prometheus |
+| Availability | ≥ 99.9 % | trailing 30 days | `gateway_request_total` counter with success label |
+
+### Latency Objective
+* **User experience**: interactivity for high-traffic flows (`/bank-lines`, `/payments/*`).
+* **Budget**: No more than 5% of requests may exceed 300 ms over the 30-day window.
+
+### Availability Objective
+* **User experience**: mission-critical API availability for banks, partners, and internal apps.
+* **Budget**: Maximum 43m 12s of unavailability during a 30-day period (99.9% availability).
+
+## Error Budget Policy
+1. Track budget burn using a 30-day rolling window on both latency and availability.
+2. If we consume **25%** of the error budget in 7 consecutive days, freeze non-critical launches
+   and require a burn analysis within 48 hours.
+3. If we consume **50%** of the budget in 7 consecutive days, initiate a production change review
+   and require director approval for new deployments.
+4. If the full budget is exhausted, halt all non-emergency changes until burn is <50% and a detailed
+   post-incident review is completed.
+
+## Alert Thresholds
+| Condition | Threshold | Rationale | Action |
+| --- | --- | --- | --- |
+| Fast-burn latency | 2% of requests over 300 ms for 15 minutes | Early warning ahead of budget consumption | Page on-call, investigate downstream latency |
+| Fast-burn availability | Error ratio >0.1% for 15 minutes | Detect sub-SLO availability drops | Page on-call, verify upstream dependencies |
+| Error budget burn rate | 2x over 1 hour | Tracks exhaustion trends | Page SRE lead, schedule burn review |
+| Synthetic readiness failure | Any `/readyz` or `/bank-lines` response >200 ms or non-2xx | Catch localized degradation | Page on-call via synthetic alert |
+
+## Observability Requirements
+* Expose Prometheus metrics: latency histogram, request counters, and error categorization.
+* Emit structured logs including `trace_id`, `customer_id`, and upstream dependency timings.
+* Ensure dashboards overlay latency percentiles with deployment markers and dependency health.
+
+## Review Cadence
+* Revisit SLO targets quarterly, factoring in traffic patterns and feature changes.
+* Validate alert thresholds monthly to ensure page load corresponds to user impact.

--- a/apgms/scripts/synthetic.sh
+++ b/apgms/scripts/synthetic.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${1:-${BASE_URL:-"https://gateway.prod.example.com"}}
+AUTH_HEADER=${2:-${AUTH_HEADER:-""}}
+READYZ_MAX=${READYZ_MAX:-0.20}   # seconds
+BANK_LINES_MAX=${BANK_LINES_MAX:-0.45} # seconds
+LOG_DIR=${LOG_DIR:-artifacts}
+TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+LOG_FILE="${LOG_DIR}/synthetic-${TIMESTAMP}.log"
+
+mkdir -p "${LOG_DIR}"
+
+log() {
+  printf '%s %s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$1" | tee -a "${LOG_FILE}"
+}
+
+curl_check() {
+  local path=$1
+  local threshold=$2
+  local header_flag=()
+  if [[ -n "${AUTH_HEADER}" ]]; then
+    header_flag=(-H "${AUTH_HEADER}")
+  fi
+
+  local url="${BASE_URL%/}${path}"
+  local output
+  if ! output=$(curl -sS -o /tmp/synthetic_body.$$ -w '%{http_code} %{time_total}' "${header_flag[@]}" "$url"); then
+    log "ERROR ${path} curl_failed"
+    rm -f /tmp/synthetic_body.$$
+    return 1
+  fi
+  rm -f /tmp/synthetic_body.$$
+
+  local status duration
+  read -r status duration <<<"${output}"
+  log "INFO ${path} status=${status} duration=${duration}s threshold=${threshold}s"
+  if [[ $status != 2* && $status != 3* ]]; then
+    log "ERROR ${path} unexpected_status=${status}"
+    return 1
+  fi
+  if ! awk -v d="${duration}" -v t="${threshold}" 'BEGIN {exit (d<=t ? 0 : 1)}'; then
+    log "ERROR ${path} latency_breach duration=${duration}s threshold=${threshold}s"
+    return 1
+  fi
+  return 0
+}
+
+log "INFO synthetic_start base_url=${BASE_URL}"
+status=0
+
+if ! curl_check "/readyz" "${READYZ_MAX}"; then
+  status=1
+fi
+
+if ! curl_check "/bank-lines" "${BANK_LINES_MAX}"; then
+  status=1
+fi
+
+if [[ ${status} -eq 0 ]]; then
+  log "INFO synthetic_success"
+else
+  log "ERROR synthetic_failure"
+fi
+
+exit ${status}


### PR DESCRIPTION
## Summary
- document gateway latency and availability SLOs with alert thresholds and error budget policy
- add on-call runbook covering escalation path, dashboards, and mitigation steps
- provide nightly synthetic workflow curling /readyz and /bank-lines with log artifacts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4aa33995883279f1f9476207353db