### PR TITLE
Add MFA enforcement middleware and documentation

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm test
+      - name: Upload MFA documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-mfa-docs
+          path: docs/security/MFA.md

--- a/apgms/docs/security/MFA.md
+++ b/apgms/docs/security/MFA.md
@@ -1,0 +1,45 @@
+# Multi-factor Authentication Posture
+
+## Identity Provider Configuration
+
+1. **Enable MFA policies**
+   - Require time-based one-time password (TOTP) or WebAuthn authenticators for the `admin` application profile.
+   - Enforce step-up rules so that any session requesting the `https://api.apgms.local/admin` audience is prompted for a registered MFA factor when the session is older than 12 hours or the last login lacked an MFA assurance.
+2. **Allowed factors**
+   - TOTP applications that support RFC 6238 (e.g., Google Authenticator, 1Password, Authy).
+   - WebAuthn security keys or platform authenticators with resident keys enabled.
+3. **Session lifetime**
+   - Set a maximum MFA lifetime of 24 hours and force re-authentication after inactivity of 12 hours for administrator scopes.
+
+## Claim Mapping
+
+- Map the organisation identifier to the `org` claim (or the custom claim `https://apgms.io/org`).
+- Include MFA assurance data using:
+  - `amr` array entries (e.g., `pwd`, `mfa`, `hwk`).
+  - `acr` level strings. Configure a value equal to or higher than `urn:mfa` when a strong factor was verified.
+- Ensure administrator groups resolve to tokens carrying the `admin` scope and MFA claims.
+
+## Admin Routes Requiring MFA
+
+The following API Gateway routes enforce the MFA middleware and deny access when the MFA claim is missing:
+
+- `GET /admin/keys`
+- Any additional route registered under the `/admin/*` prefix automatically inherits the MFA requirement via the shared guard middleware.
+
+## Local Testing
+
+Run the unit tests to verify the middleware behaviour:
+
+```bash
+pnpm install
+pnpm test:root
+pnpm test
+```
+
+Alternatively, run the focused test file:
+
+```bash
+pnpm exec tsx --test tests/auth.mfa.spec.ts
+```
+
+A successful run should report one failing request (403) for non-MFA tokens and one passing request (200) for MFA-bearing tokens.

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,23 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "webapp", "shared", "worker"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm run test:root && pnpm -r run test",
+    "test:root": "tsx --test tests/auth.mfa.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import registerAdminRoutes from "./routes/admin/index.js";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(registerAdminRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/middleware/auth.ts
+++ b/apgms/services/api-gateway/src/middleware/auth.ts
@@ -1,0 +1,232 @@
+import crypto from "node:crypto";
+import { FastifyReply, FastifyRequest, PreHandlerHookHandler } from "fastify";
+
+const MFA_MIN_ACR = "urn:mfa";
+
+export interface AuthContext {
+  sub: string;
+  org: string;
+  email?: string;
+  amr?: string[];
+  acr?: string;
+  token: string;
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    auth?: AuthContext;
+  }
+}
+
+type JwtHeader = {
+  alg: string;
+  typ?: string;
+  kid?: string;
+};
+
+type JwtPayload = {
+  sub?: unknown;
+  iss?: unknown;
+  aud?: unknown;
+  exp?: unknown;
+  nbf?: unknown;
+  iat?: unknown;
+  email?: unknown;
+  org?: unknown;
+  orgId?: unknown;
+  [key: string]: unknown;
+};
+
+function normalizeOrgClaim(payload: JwtPayload): string | undefined {
+  const orgCandidates = [payload.org, payload.orgId, payload["https://apgms.io/org"]];
+  for (const candidate of orgCandidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function buildVerificationOptions() {
+  return {
+    issuer: process.env.OIDC_ISSUER,
+    audience: process.env.OIDC_AUDIENCE,
+  };
+}
+
+function resolveSecret(): Buffer {
+  const secret = process.env.JWT_SECRET ?? "dev-secret";
+  return Buffer.from(secret, "utf8");
+}
+
+function decodeSegment(segment: string): Buffer {
+  return Buffer.from(segment, "base64url");
+}
+
+function parseHeader(segment: string): JwtHeader {
+  try {
+    const header = JSON.parse(decodeSegment(segment).toString("utf8")) as JwtHeader;
+    if (!header || typeof header.alg !== "string") {
+      throw new Error("invalid_header");
+    }
+    return header;
+  } catch (error) {
+    throw new Error("invalid_header");
+  }
+}
+
+function parsePayload(segment: string): JwtPayload {
+  try {
+    return JSON.parse(decodeSegment(segment).toString("utf8")) as JwtPayload;
+  } catch (error) {
+    throw new Error("invalid_payload");
+  }
+}
+
+function verifySignature(input: string, signature: string, secret: Buffer) {
+  const expected = crypto.createHmac("sha256", secret).update(input).digest();
+  const provided = Buffer.from(signature, "base64url");
+  if (expected.length !== provided.length) {
+    throw new Error("invalid_signature");
+  }
+  if (!crypto.timingSafeEqual(expected, provided)) {
+    throw new Error("invalid_signature");
+  }
+}
+
+function assertTemporalClaims(payload: JwtPayload) {
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp === "number" && now >= payload.exp) {
+    throw new Error("token_expired");
+  }
+  if (typeof payload.nbf === "number" && now < payload.nbf) {
+    throw new Error("token_not_active");
+  }
+}
+
+function assertIssuer(payload: JwtPayload, issuer?: string) {
+  if (!issuer) {
+    return;
+  }
+  if (payload.iss !== issuer) {
+    throw new Error("invalid_issuer");
+  }
+}
+
+function assertAudience(payload: JwtPayload, audience?: string) {
+  if (!audience) {
+    return;
+  }
+  const claim = payload.aud;
+  if (typeof claim === "string" && claim === audience) {
+    return;
+  }
+  if (Array.isArray(claim) && claim.includes(audience)) {
+    return;
+  }
+  throw new Error("invalid_audience");
+}
+
+async function verifyAccessToken(token: string): Promise<AuthContext> {
+  const secret = resolveSecret();
+  const options = buildVerificationOptions();
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("malformed_token");
+  }
+
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const header = parseHeader(encodedHeader);
+  if (header.alg !== "HS256") {
+    throw new Error("unsupported_algorithm");
+  }
+
+  verifySignature(`${encodedHeader}.${encodedPayload}`, signature, secret);
+  const payload = parsePayload(encodedPayload);
+
+  assertTemporalClaims(payload);
+  assertIssuer(payload, options.issuer);
+  assertAudience(payload, options.audience);
+
+  const sub = typeof payload.sub === "string" ? payload.sub : undefined;
+  const org = normalizeOrgClaim(payload);
+
+  if (!sub) {
+    throw new Error("token_missing_sub");
+  }
+  if (!org) {
+    throw new Error("token_missing_org");
+  }
+
+  const amr = Array.isArray(payload.amr)
+    ? payload.amr.filter((value): value is string => typeof value === "string")
+    : undefined;
+
+  const acr = typeof payload.acr === "string" ? payload.acr : undefined;
+  const email = typeof payload.email === "string" ? payload.email : undefined;
+
+  return {
+    sub,
+    org,
+    email,
+    amr,
+    acr,
+    token,
+  };
+}
+
+function unauthorized(rep: FastifyReply) {
+  void rep.code(401).send({ error: "unauthorized" });
+}
+
+function forbidden(rep: FastifyReply) {
+  void rep.code(403).send({ error: "mfa_required" });
+}
+
+function hasMfaContext(auth: AuthContext): boolean {
+  if (auth.amr && auth.amr.some((value) => typeof value === "string" && value.toLowerCase() === "mfa")) {
+    return true;
+  }
+  if (auth.acr) {
+    const normalized = auth.acr.toLowerCase();
+    if (normalized === MFA_MIN_ACR) {
+      return true;
+    }
+    if (normalized.localeCompare(MFA_MIN_ACR, undefined, { sensitivity: "base" }) >= 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export const requireMFA: PreHandlerHookHandler = async (req: FastifyRequest, rep: FastifyReply) => {
+  const authorization = req.headers.authorization;
+  if (!authorization || !authorization.toLowerCase().startsWith("bearer ")) {
+    unauthorized(rep);
+    return;
+  }
+
+  const token = authorization.slice(7).trim();
+  if (!token) {
+    unauthorized(rep);
+    return;
+  }
+
+  let auth: AuthContext;
+  try {
+    auth = await verifyAccessToken(token);
+  } catch (error) {
+    req.log.warn({ err: error }, "JWT verification failed");
+    unauthorized(rep);
+    return;
+  }
+
+  if (!hasMfaContext(auth)) {
+    forbidden(rep);
+    return;
+  }
+
+  req.auth = auth;
+};
+
+export { verifyAccessToken };

--- a/apgms/services/api-gateway/src/routes/admin/_guard.ts
+++ b/apgms/services/api-gateway/src/routes/admin/_guard.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from "fastify";
+import { requireMFA } from "../../middleware/auth.js";
+
+export function applyAdminGuard(app: FastifyInstance) {
+  app.addHook("preHandler", requireMFA);
+}

--- a/apgms/services/api-gateway/src/routes/admin/index.ts
+++ b/apgms/services/api-gateway/src/routes/admin/index.ts
@@ -1,0 +1,15 @@
+import { FastifyInstance } from "fastify";
+import { applyAdminGuard } from "./_guard.js";
+
+export default async function registerAdminRoutes(app: FastifyInstance) {
+  app.register(async (admin) => {
+    applyAdminGuard(admin);
+
+    admin.get("/keys", async () => {
+      return {
+        keys: [],
+        message: "admin_mfa_required",
+      };
+    });
+  }, { prefix: "/admin" });
+}

--- a/apgms/tests/auth.mfa.spec.ts
+++ b/apgms/tests/auth.mfa.spec.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { test } from "node:test";
+import Fastify from "fastify";
+import registerAdminRoutes from "../services/api-gateway/src/routes/admin/index.js";
+
+const ISSUER = "https://idp.example.com/tenant";
+const AUDIENCE = "https://api.apgms.local/admin";
+
+process.env.JWT_SECRET = "test-secret";
+process.env.OIDC_ISSUER = ISSUER;
+process.env.OIDC_AUDIENCE = AUDIENCE;
+
+function toBase64Url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+function signToken(claims?: { amr?: string[]; acr?: string }) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload = {
+    org: "org-123",
+    email: "admin@example.com",
+    sub: "user-123",
+    iss: ISSUER,
+    aud: AUDIENCE,
+    iat: issuedAt,
+    exp: issuedAt + 300,
+    ...(claims?.amr ? { amr: claims.amr } : {}),
+    ...(claims?.acr ? { acr: claims.acr } : {}),
+  };
+
+  const headerSegment = toBase64Url(header);
+  const payloadSegment = toBase64Url(payload);
+  const input = `${headerSegment}.${payloadSegment}`;
+  const signature = crypto.createHmac("sha256", process.env.JWT_SECRET!).update(input).digest("base64url");
+  return `${input}.${signature}`;
+}
+
+function buildApp() {
+  const app = Fastify({ logger: false });
+  app.register(registerAdminRoutes);
+  return app;
+}
+
+test("/admin/keys rejects tokens without MFA", async (t) => {
+  const app = buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.ready();
+
+  const token = signToken({ amr: ["pwd"] });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/admin/keys",
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  });
+
+  assert.equal(response.statusCode, 403);
+  const body = response.json();
+  assert.equal(body.error, "mfa_required");
+});
+
+test("/admin/keys allows tokens with MFA claims", async (t) => {
+  const app = buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.ready();
+
+  const token = signToken({ amr: ["pwd", "mfa"], acr: "urn:mfa" });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/admin/keys",
+    headers: {
+      authorization: `Bearer ${token}`,
+    },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const body = response.json();
+  assert.deepEqual(body, {
+    keys: [],
+    message: "admin_mfa_required",
+  });
+});


### PR DESCRIPTION
## Summary
- add JWT-based authentication middleware that enforces MFA context for all /admin routes
- guard the admin key route and cover the behaviour with new unit tests
- document IdP MFA configuration and publish the MFA guide as a CI artifact

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4a9c4e7188327bea7b46057bc5b5f