### PR TITLE
Add threat model documentation and control linting

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
 jobs:
   build:
@@ -15,3 +15,24 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  controls-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm install
+      - name: Lint control mappings
+        run: pnpm exec tsx scripts/lint-controls.ts
+      - name: Upload control map artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: control-maps
+          path: |
+            docs/asvs-map.csv
+            docs/osf-map.csv

--- a/apgms/docs/asvs-map.csv
+++ b/apgms/docs/asvs-map.csv
@@ -1,0 +1,5 @@
+control_id,description,status,evidence_link
+ASVS-1.2.2,Verify secrets and credentials are only loaded from secure environment configuration,PASS,services/api-gateway/src/index.ts
+ASVS-3.2.1,Verify the application uses parameterized queries or ORM protections for database access,PASS,services/api-gateway/src/index.ts
+ASVS-4.3.3,Verify API responses return generic error information without leaking stack traces,PASS,services/api-gateway/src/index.ts
+ASVS-9.1.1,Verify security events are logged to an append-only audit store,NA,services/audit/src/index.ts

--- a/apgms/docs/osf-map.csv
+++ b/apgms/docs/osf-map.csv
@@ -1,0 +1,5 @@
+control_id,description,status,evidence_link
+OSF-DS-1,Ensure data sources are accessed through authenticated service accounts,PASS,infra/terraform
+OSF-APP-2,Maintain centralized configuration management for runtime secrets,PASS,infra/helm
+OSF-LOG-3,Generate operational audit events for settlement processing,NA,services/audit/src/index.ts
+OSF-OPS-4,Enforce CI checks to guardrail security control regressions,PASS,.github/workflows/ci.yml

--- a/apgms/docs/threat-model.md
+++ b/apgms/docs/threat-model.md
@@ -1,0 +1,30 @@
+# APGMS Threat Model
+
+## System Context
+- **Primary Users:** Platform operators manage bank lines and org data via the Fastify API Gateway and supporting services.
+- **Key Assets:** Organization profiles, bank line records, Prisma-managed database credentials, CI/CD secrets, and audit evidence.
+- **Entry Points:** Public Fastify endpoints (`services/api-gateway/src/index.ts`), background workers (`worker/src/index.ts`), service-to-service REST calls, and developer tooling invoked from CI pipelines.
+
+## Trust Boundaries
+1. **External Partner Boundary:** Requests originate from merchant partners and auditors across the public internet before hitting the API Gateway.
+2. **Internal Service Boundary:** Authenticated service calls across the Kubernetes namespace using shared packages under `shared/` and secrets delivered through environment variables.
+3. **Data Persistence Boundary:** PostgreSQL instances accessed through Prisma clients instantiated in `shared/src/db.ts` with per-service credentials.
+4. **Operations Boundary:** Developer laptops and CI/CD pipelines that run migrations and deploy workloads defined in `infra/`.
+
+## STRIDE Analysis
+
+| Component | Threat | Description | Mitigations |
+|-----------|--------|-------------|-------------|
+| API Gateway (`services/api-gateway/src/index.ts`) | Spoofing | Attackers reuse leaked API tokens to impersonate partner tenants. | Enforce authentication middleware on every route and validate tenant ownership before reading or writing records.
+| API Gateway (`services/api-gateway/src/index.ts`) | Tampering | JSON payloads could be altered in transit or replayed. | Require TLS termination at the ingress, validate request bodies with schema checks, and record idempotency keys for mutating actions.
+| Audit Service (`services/audit/src/index.ts`) | Repudiation | Partners may deny submitting financial records after settlement. | Persist append-only audit entries and associate each entry with actor IDs and request IDs stored in immutable storage.
+| Payments Service (`services/payments/src/index.ts`) | Information Disclosure | Over-broad queries could leak bank lines between organizations. | Scope Prisma queries to the requesting org ID and ensure access control checks before returning results.
+| Worker (`worker/src/index.ts`) | Denial of Service | Malformed queue messages overwhelm worker resources. | Validate message schema before processing, enforce concurrency limits, and apply exponential backoff on retry.
+| Infrastructure as Code (`infra/terraform`) | Elevation of Privilege | Misconfigurations could grant excessive database or Kubernetes privileges. | Enforce peer reviews on IaC changes and provision least-privilege service accounts with automated scanning.
+
+## Mitigation Roadmap
+- Build automated regression tests verifying authorization on every API route that accesses multi-tenant data.
+- Integrate rate limiting and anomaly detection at ingress to absorb sudden traffic spikes.
+- Expand audit logging coverage to include configuration changes and administrative actions.
+- Periodically rotate database credentials and verify rotation in CI using smoke tests.
+- Adopt runtime security monitoring to detect abuse of worker queues and long-running tasks.

--- a/apgms/scripts/lint-controls.ts
+++ b/apgms/scripts/lint-controls.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface ControlRecord {
+  file: string;
+  line: number;
+  controlId: string;
+  description: string;
+  status: string;
+  evidence: string;
+}
+
+const CSV_FILES = [
+  "docs/asvs-map.csv",
+  "docs/osf-map.csv",
+];
+
+const ALLOWED_STATUSES = new Set(["PASS", "FAIL", "NA"]);
+
+function parseCsv(file: string): ControlRecord[] {
+  const abs = resolve(process.cwd(), file);
+  const raw = readFileSync(abs, "utf8");
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  if (lines.length <= 1) {
+    return [];
+  }
+
+  const records: ControlRecord[] = [];
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    const parts = line.split(",");
+    if (parts.length < 4) {
+      throw new Error(`Invalid row in ${file} at line ${i + 1}: ${line}`);
+    }
+    const [controlId, description, status, evidence] = parts.map((value) => value.trim());
+    records.push({
+      file,
+      line: i + 1,
+      controlId,
+      description,
+      status,
+      evidence,
+    });
+  }
+  return records;
+}
+
+const violations: string[] = [];
+
+for (const csv of CSV_FILES) {
+  const records = parseCsv(csv);
+  for (const record of records) {
+    if (!ALLOWED_STATUSES.has(record.status)) {
+      violations.push(
+        `${record.file}:${record.line} ${record.controlId} has invalid status "${record.status}". Expected PASS, FAIL, or NA.`,
+      );
+      continue;
+    }
+    if (record.status !== "NA" && record.status !== "PASS") {
+      violations.push(
+        `${record.file}:${record.line} ${record.controlId} is marked ${record.status}. Required controls must be PASS.`,
+      );
+    }
+    if (!record.evidence) {
+      violations.push(`${record.file}:${record.line} ${record.controlId} is missing an evidence link.`);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Control lint failed:\n" + violations.join("\n"));
+  process.exit(1);
+}
+
+console.log("All control mappings passed lint.");


### PR DESCRIPTION
## Summary
- add STRIDE-oriented threat model documentation for APGMS
- document ASVS and OSF control coverage with evidence links
- enforce control status checks in CI and publish mapping artifacts

## Testing
- pnpm exec tsx scripts/lint-controls.ts

------
https://chatgpt.com/codex/tasks/task_e_68f4aee7e3688327bc30c35e0fc58bb7