### PR TITLE
Add legal policy pages and link validation

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,6 +1,20 @@
 ﻿name: CI
 on: [push, pull_request]
 jobs:
+  legal-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx tsx scripts/link-check.ts
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/apgms/docs/NDB-Runbook.md
+++ b/apgms/docs/NDB-Runbook.md
@@ -1,0 +1,79 @@
+# Notifiable Data Breach (NDB) Runbook
+
+This runbook supports APGMS teams in responding to potential or confirmed notifiable data breaches under the Australian Privacy Act.
+
+## Phase 1 — Assess (0 to 24 hours)
+
+1. **Detect & Log**
+   - Capture alert details in the incident tracker and assign an incident commander (IC).
+   - Preserve volatile evidence (logs, session IDs, and system snapshots).
+2. **Initial Assessment**
+   - IC coordinates with Security Operations (SecOps) and Privacy Officer to determine if personal information is involved.
+   - Classify the impact using the APGMS severity matrix; escalate to Executive Sponsor for SEV1 or higher.
+3. **Decision Point**
+   - Within 24 hours decide whether the event is likely to result in serious harm.
+   - If unclear, proceed with containment while continuing investigation.
+
+## Phase 2 — Contain (24 to 72 hours)
+
+1. **Immediate Controls**
+   - Disable compromised accounts, rotate credentials, and isolate affected systems.
+   - Apply emergency patches or configuration changes approved by the IC.
+2. **Data Handling**
+   - Validate the scope of impacted records, including any exports triggered via `/privacy/export`.
+   - Confirm deletion or suppression requests via `/privacy/delete` complete successfully for affected individuals.
+3. **Stakeholder Updates**
+   - Provide twice-daily updates to Executives, Legal, and Product via the incident Slack channel.
+   - Prepare a draft OAIC notification and customer messaging for review.
+
+## Phase 3 — Notify & Remediate (within 72 hours)
+
+1. **OAIC Notice**
+   - Submit notification to the Office of the Australian Information Commissioner (OAIC) using the template below.
+   - Coordinate with Legal to issue customer communications.
+2. **Customer Communication**
+   - Deliver direct notices to impacted individuals, including recommended protective actions.
+   - Update the APGMS status page and investor portal banner.
+3. **Post-Incident Review**
+   - Within 5 business days conduct a retrospective to capture lessons learned and backlog remediation tasks.
+   - Update the risk register and privacy impact assessments.
+
+## OAIC Notification Template
+
+```
+Subject: APGMS Notifiable Data Breach Notification — <Incident ID>
+
+To the Office of the Australian Information Commissioner,
+
+APGMS reports a notifiable data breach identified on <Date/Time>. The incident involved <Summary of incident> affecting <Number of individuals> individuals.
+
+We have taken the following steps:
+1. Containment actions: <Containment summary>
+2. Assessment findings: <Key findings>
+3. Communications: <Customer notification plan>
+
+Individuals at risk may take the following recommended actions:
+- <Suggested action 1>
+- <Suggested action 2>
+
+Primary contact for this incident:
+- Name: <Incident Commander>
+- Title: <Role>
+- Email: <Email>
+- Phone: <Phone>
+
+APGMS will provide updates as new information becomes available.
+
+Regards,
+APGMS Privacy Office
+```
+
+## Contact Tree
+
+- **Incident Commander (IC):** Security Operations on-call (PagerDuty escalation `SecOps-Primary`).
+- **Privacy Officer:** privacy@apgms.example — accountable for OAIC liaison and customer notifications.
+- **Legal Counsel:** legal@apgms.example — reviews regulatory filings and contractual commitments.
+- **CTO:** cto@apgms.example — approves remediation spend and executive communications.
+- **Customer Success Lead:** success@apgms.example — coordinates investor communications and portal updates.
+
+Document owner: Privacy Officer. Review cadence: quarterly or after any privacy incident.

--- a/apgms/scripts/link-check.ts
+++ b/apgms/scripts/link-check.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+interface CheckResult {
+  readonly file: string;
+  readonly ok: boolean;
+  readonly message: string;
+}
+
+const repoRoot = path.resolve(__dirname, '..');
+const pages = [
+  'webapp/src/routes/legal/terms.tsx',
+  'webapp/src/routes/legal/privacy.tsx',
+  'webapp/src/routes/legal/dpa.tsx',
+];
+
+const requiredLinks = ['/privacy/export', '/privacy/delete'];
+const requiredPhrases = ['Data Handling'];
+
+async function verifyFile(relativePath: string): Promise<CheckResult> {
+  const fullPath = path.join(repoRoot, relativePath);
+
+  try {
+    const content = await fs.readFile(fullPath, 'utf8');
+    for (const link of requiredLinks) {
+      if (!content.includes(link)) {
+        return {
+          file: relativePath,
+          ok: false,
+          message: `Missing required link: ${link}`,
+        };
+      }
+    }
+
+    for (const phrase of requiredPhrases) {
+      if (!content.toLowerCase().includes(phrase.toLowerCase())) {
+        return {
+          file: relativePath,
+          ok: false,
+          message: `Missing required phrase: ${phrase}`,
+        };
+      }
+    }
+
+    return {
+      file: relativePath,
+      ok: true,
+      message: 'All checks passed',
+    };
+  } catch (error) {
+    return {
+      file: relativePath,
+      ok: false,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const results = await Promise.all(pages.map((page) => verifyFile(page)));
+  const failures = results.filter((result) => !result.ok);
+
+  for (const result of results) {
+    const status = result.ok ? '✅' : '❌';
+    console.log(`${status} ${result.file} — ${result.message}`);
+  }
+
+  if (failures.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/apgms/webapp/src/routes/legal/dpa.tsx
+++ b/apgms/webapp/src/routes/legal/dpa.tsx
@@ -1,0 +1,48 @@
+import type { LegalLink, LegalPage } from './terms';
+
+const exportLink: LegalLink = {
+  label: 'Administrator Export Endpoint',
+  href: '/privacy/export',
+  description: 'Submit structured export requests for all data processed on behalf of the controller.',
+};
+
+const deleteLink: LegalLink = {
+  label: 'Administrator Deletion Endpoint',
+  href: '/privacy/delete',
+  description: 'Certify erasure workflows for controller-supplied data and obtain completion attestations.',
+};
+
+const processingSummary =
+  'APGMS acts as a data processor, providing managed fundraising and investor management tooling. Processing occurs within Australian data centres with sub-processors listed in the vendor appendix. Security measures include ISO 27001-aligned controls, encryption at rest, and role-based access for support staff.';
+
+export const dpa: LegalPage = {
+  title: 'Data Processing Addendum',
+  updated: '2024-11-01',
+  sections: [
+    {
+      heading: 'Scope & Subject Matter',
+      body: [
+        'This DPA supplements the master services agreement between APGMS and the data controller, defining obligations for personal data processed by the platform.',
+        processingSummary,
+      ],
+    },
+    {
+      heading: 'Processor Obligations',
+      body: [
+        'APGMS processes personal data solely on documented controller instructions, ensures confidentiality commitments, and maintains technical and organisational measures described in Annex B.',
+        'Data transfers outside Australia require prior written approval and leverage standard contractual clauses when available.',
+      ],
+      links: [exportLink, deleteLink],
+    },
+    {
+      heading: 'Assistance & Cooperation',
+      body: [
+        'We assist controllers in meeting privacy obligations, including responding to data subject access requests, breach notifications, and DPIAs.',
+        'Incident notifications occur without undue delay and include remediation actions, impact assessments, and contact information for the appointed privacy officer.',
+      ],
+      links: [exportLink, deleteLink],
+    },
+  ],
+};
+
+export default dpa;

--- a/apgms/webapp/src/routes/legal/privacy.tsx
+++ b/apgms/webapp/src/routes/legal/privacy.tsx
@@ -1,0 +1,50 @@
+import type { LegalLink, LegalPage } from './terms';
+
+const exportLink: LegalLink = {
+  label: 'Submit Export Request',
+  href: '/privacy/export',
+  description:
+    'Use the export endpoint to generate a secure package of your personal data. We deliver results within 7 calendar days.',
+};
+
+const deleteLink: LegalLink = {
+  label: 'Submit Deletion Request',
+  href: '/privacy/delete',
+  description:
+    'Verified administrators can start a deletion workflow and receive confirmation once retention obligations are met.',
+};
+
+const privacyControlsSummary =
+  'Access controls, encryption, and immutable audit trails protect personal information. We segregate production and analytics environments, monitor for anomalous access, and document third-party processors in our vendor registry.';
+
+export const privacy: LegalPage = {
+  title: 'Privacy Policy',
+  updated: '2024-11-01',
+  sections: [
+    {
+      heading: 'Collection & Purpose',
+      body: [
+        'We collect the minimum personal information necessary to deliver APGMS services, authenticate users, and comply with financial regulations.',
+        'Data is sourced directly from customers, integrated payment providers, and operational support tickets submitted by administrators.',
+      ],
+    },
+    {
+      heading: 'Data Handling & Retention',
+      body: [
+        privacyControlsSummary,
+        'Backups are encrypted and retained for 30 days. Operational data is retained for 7 years unless a verified deletion request is approved.',
+      ],
+      links: [exportLink, deleteLink],
+    },
+    {
+      heading: 'Individual Rights',
+      body: [
+        'Customers may request confirmation of processing, access to records, corrections, and opt-out of marketing communications at any time.',
+        'All privacy requests are acknowledged within 48 hours and fulfilled within statutory SLAs. Any denials include the rationale and appeal path.',
+      ],
+      links: [exportLink, deleteLink],
+    },
+  ],
+};
+
+export default privacy;

--- a/apgms/webapp/src/routes/legal/terms.tsx
+++ b/apgms/webapp/src/routes/legal/terms.tsx
@@ -1,0 +1,83 @@
+export interface LegalLink {
+  readonly label: string;
+  readonly href: string;
+  readonly description: string;
+}
+
+export interface LegalSection {
+  readonly heading: string;
+  readonly body: readonly string[];
+  readonly links?: readonly LegalLink[];
+}
+
+export interface LegalPage {
+  readonly title: string;
+  readonly updated: string;
+  readonly sections: readonly LegalSection[];
+}
+
+const privacyLinks: readonly LegalLink[] = [
+  {
+    label: 'Request Data Export',
+    href: '/privacy/export',
+    description:
+      'Submit a formal export request via the administrative privacy endpoint to receive a machine-readable archive of your records.',
+  },
+  {
+    label: 'Request Data Deletion',
+    href: '/privacy/delete',
+    description:
+      'Trigger a deletion workflow through the administrative privacy endpoint. We confirm completion within mandated retention timelines.',
+  },
+];
+
+const dataHandlingSummary =
+  'We collect only operational account details, payment confirmations, and audit trails. All customer data is encrypted at rest, limited to least-privilege operators, and retained for the minimum statutory period (currently 7 years for financial records).';
+
+export const terms: LegalPage = {
+  title: 'Terms of Service',
+  updated: '2024-11-01',
+  sections: [
+    {
+      heading: 'Acceptance of Terms',
+      body: [
+        'By accessing the APGMS platform you agree to the service rules, acceptable use, and platform policies published herein.',
+        'Updates to these terms are communicated via email with at least 14 days notice and archived in the release notes.',
+      ],
+    },
+    {
+      heading: 'Data Handling & Privacy',
+      body: [
+        dataHandlingSummary,
+        'Customers may invoke the privacy export or deletion workflows at any time. Requests are authenticated and logged for compliance review.',
+      ],
+      links: privacyLinks,
+    },
+    {
+      heading: 'Service Availability & Support',
+      body: [
+        'Platform availability targets 99.5% monthly uptime with scheduled maintenance windows announced 72 hours in advance.',
+        'Priority incidents are triaged within 1 business hour through the on-call escalation path documented in the NDB runbook.',
+      ],
+    },
+  ],
+};
+
+export default terms;
+
+export function renderLegalPage(page: LegalPage): string {
+  const sectionHtml = page.sections
+    .map((section) => {
+      const paragraphs = section.body.map((paragraph) => `<p>${paragraph}</p>`).join('');
+      const links = (section.links ?? [])
+        .map(
+          (link) =>
+            `<li><a href="${link.href}">${link.label}</a><span class="description">${link.description}</span></li>`
+        )
+        .join('');
+      const listMarkup = links ? `<ul class="legal-links">${links}</ul>` : '';
+      return `<section><h2>${section.heading}</h2>${paragraphs}${listMarkup}</section>`;
+    })
+    .join('');
+  return `<main><h1>${page.title}</h1><p class="updated">Last updated ${page.updated}</p>${sectionHtml}</main>`;
+}


### PR DESCRIPTION
## Summary
- add legal policy page content with data handling details and privacy workflow links
- document the NDB response runbook covering assess, contain, and notify phases
- add a link-check script and CI job to ensure legal pages reference export and deletion endpoints

## Testing
- pnpm dlx tsx scripts/link-check.ts *(fails locally: registry access requires auth)*

------
https://chatgpt.com/codex/tasks/task_e_68f4afa1a3b4832797f4eb4c366aa4d2