### PR TITLE
Add supplier attestation docs and CI linter

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,6 +1,23 @@
 ﻿name: CI
 on: [push, pull_request]
 jobs:
+  supplier-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm lint:suppliers
+      - uses: actions/upload-artifact@v4
+        with:
+          name: supplier-attestations
+          path: docs/suppliers/*.yaml
   build:
     runs-on: ubuntu-latest
     steps:

--- a/apgms/docs/suppliers/accounting.yaml
+++ b/apgms/docs/suppliers/accounting.yaml
@@ -1,0 +1,14 @@
+vendor: "Intuit QuickBooks Online"
+data_categories:
+  - "General ledger balances"
+  - "Accounts payable and receivable"
+  - "Invoice attachments metadata"
+auth: "OAuth 2.0 with refresh tokens stored in secrets manager"
+storage: "Financial extracts stored in encrypted object storage with 90-day retention."
+risks:
+  - "Financial statement tampering"
+  - "Leakage of customer invoice data"
+mitigations:
+  - "Immutable audit logs on ingestion pipeline"
+  - "Data loss prevention scanning prior to export"
+status: "approved"

--- a/apgms/docs/suppliers/payroll.yaml
+++ b/apgms/docs/suppliers/payroll.yaml
@@ -1,0 +1,14 @@
+vendor: "Gusto, Inc."
+data_categories:
+  - "Employee compensation records"
+  - "Tax withholding details"
+  - "Bank account routing info"
+auth: "SAML SSO with SCIM provisioned service account"
+storage: "Encrypted vault-backed secrets for API credentials; payroll exports stored in segregated payroll schema with restricted RBAC."
+risks:
+  - "Disclosure of PII and salary data"
+  - "Unintended payroll actions via API"
+mitigations:
+  - "Read-only integration scope with monitoring"
+  - "PII redaction pipeline before analytics processing"
+status: "approved"

--- a/apgms/docs/suppliers/pos.yaml
+++ b/apgms/docs/suppliers/pos.yaml
@@ -1,0 +1,14 @@
+vendor: "Square, Inc."
+data_categories:
+  - "Transaction totals"
+  - "Itemized sales data"
+  - "Terminal identifiers"
+auth: "OAuth 2.0 with rotating client secrets"
+storage: "Encrypted at rest within APGMS regional data lake; access restricted to finance analytics role."
+risks:
+  - "Exposure of transaction-level sales data"
+  - "Privileged API tokens misuse"
+mitigations:
+  - "Scoped OAuth tokens rotated every 30 days"
+  - "Row-level access policies enforced in data lake"
+status: "approved"

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "lint:suppliers": "pnpm exec tsx scripts/lint-suppliers.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/lint-suppliers.ts
+++ b/apgms/scripts/lint-suppliers.ts
@@ -1,0 +1,171 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import manifests from '../services/connectors/connectors.json';
+
+type ConnectorManifest = { id: string };
+
+type AttestationRecord = {
+  vendor?: unknown;
+  data_categories?: unknown;
+  auth?: unknown;
+  storage?: unknown;
+  risks?: unknown;
+  mitigations?: unknown;
+  status?: unknown;
+  [key: string]: unknown;
+};
+
+const requiredFields = [
+  'vendor',
+  'data_categories',
+  'auth',
+  'storage',
+  'risks',
+  'mitigations',
+  'status',
+] as const;
+
+type RequiredField = (typeof requiredFields)[number];
+
+const arrayFields: RequiredField[] = ['data_categories', 'risks', 'mitigations'];
+
+const repoRoot = path.resolve(__dirname, '..');
+const docsDir = path.join(repoRoot, 'docs', 'suppliers');
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseAttestation(raw: string): AttestationRecord {
+  const record: AttestationRecord = {};
+  let currentArray: RequiredField | null = null;
+
+  const lines = raw.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, '');
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    if (/^\s+-/.test(line)) {
+      if (!currentArray) {
+        throw new Error('Array item defined without a field header');
+      }
+      const value = line.replace(/^\s+-\s*/, '');
+      const entry = unquote(value);
+      if (!record[currentArray]) {
+        record[currentArray] = [];
+      }
+      (record[currentArray] as unknown[]).push(entry);
+      continue;
+    }
+
+    const match = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!match) {
+      throw new Error(`Unable to parse line: ${line}`);
+    }
+
+    const [, key, remainder] = match;
+    const field = key as RequiredField;
+    currentArray = null;
+
+    if (remainder === '') {
+      if (!arrayFields.includes(field)) {
+        throw new Error(`Field "${key}" is not configured to accept array values`);
+      }
+      record[field] = [];
+      currentArray = field;
+      continue;
+    }
+
+    record[field] = unquote(remainder);
+  }
+
+  return record;
+}
+
+async function main() {
+  const errors: string[] = [];
+  const connectors = (manifests as ConnectorManifest[]).filter((connector) => connector.id);
+  const seen = new Set<string>();
+
+  for (const connector of connectors) {
+    if (!connector.id || typeof connector.id !== 'string') {
+      errors.push('Connector manifest is missing a string "id" field.');
+      continue;
+    }
+
+    if (seen.has(connector.id)) {
+      errors.push(`Duplicate connector id detected: ${connector.id}`);
+      continue;
+    }
+
+    seen.add(connector.id);
+
+    const attestationPath = path.join(docsDir, `${connector.id}.yaml`);
+    let raw: string;
+    try {
+      raw = await fs.readFile(attestationPath, 'utf8');
+    } catch (error) {
+      errors.push(`Missing attestation file for connector "${connector.id}" at ${path.relative(repoRoot, attestationPath)}`);
+      continue;
+    }
+
+    let parsed: AttestationRecord;
+    try {
+      parsed = parseAttestation(raw);
+    } catch (error) {
+      errors.push(`Failed to parse attestation for connector "${connector.id}": ${(error as Error).message}`);
+      continue;
+    }
+
+    for (const field of requiredFields) {
+      const value = parsed[field];
+
+      if (value === undefined || value === null) {
+        errors.push(`Connector "${connector.id}" is missing required field "${field}".`);
+        continue;
+      }
+
+      if (typeof value === 'string') {
+        if (value.trim().length === 0) {
+          errors.push(`Connector "${connector.id}" has empty string for field "${field}".`);
+        }
+        continue;
+      }
+
+      if (arrayFields.includes(field)) {
+        if (!Array.isArray(value) || value.length === 0) {
+          errors.push(`Connector "${connector.id}" must provide a non-empty array for field "${field}".`);
+        } else if (value.some((item) => typeof item !== 'string' || item.trim().length === 0)) {
+          errors.push(`Connector "${connector.id}" has invalid entries in array field "${field}".`);
+        }
+        continue;
+      }
+
+      errors.push(`Connector "${connector.id}" has unsupported type for field "${field}".`);
+    }
+  }
+
+  if (connectors.length === 0) {
+    errors.push('No connectors are registered in services/connectors/connectors.json.');
+  }
+
+  if (errors.length > 0) {
+    console.error('Supplier attestation lint failed:\n');
+    for (const message of errors) {
+      console.error(` - ${message}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('Supplier attestation lint passed for connectors:', Array.from(seen).join(', '));
+}
+
+void main();

--- a/apgms/services/connectors/connectors.json
+++ b/apgms/services/connectors/connectors.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "pos",
+    "vendor": "Square",
+    "product": "Point of Sale"
+  },
+  {
+    "id": "payroll",
+    "vendor": "Gusto",
+    "product": "Payroll"
+  },
+  {
+    "id": "accounting",
+    "vendor": "Intuit",
+    "product": "QuickBooks Online"
+  }
+]

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,13 @@
-﻿console.log('connectors service');
+import manifests from '../connectors.json';
+
+export interface ConnectorManifest {
+  id: string;
+  vendor: string;
+  product: string;
+}
+
+export const connectorManifests: ConnectorManifest[] = manifests;
+
+if (process.env.NODE_ENV !== 'test') {
+  console.log('Loaded connectors:', connectorManifests.map((connector) => connector.id).join(', '));
+}


### PR DESCRIPTION
## Summary
- add supplier attestation YAMLs for the POS, payroll, and accounting connectors
- implement a supplier attestation linter and connector manifest to validate required metadata
- run the linter in CI and publish the attestation files as an artifact

## Testing
- pnpm lint:suppliers

------
https://chatgpt.com/codex/tasks/task_e_68f4af03fba88327a2acb3ef579b9dac