### PR TITLE
Add KMS policy and automated backup/restore drill

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
 jobs:
   build:
@@ -15,3 +15,22 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  backup-restore-drill:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm test
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backup-artifacts
+          path: artifacts/backup
+          if-no-files-found: error

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -5,3 +5,5 @@ coverage/
 .DS_Store
 .vscode/
 **/__pycache__/
+
+artifacts/

--- a/apgms/docs/KMS-Policy.md
+++ b/apgms/docs/KMS-Policy.md
@@ -1,0 +1,29 @@
+# APGMS KMS Policy
+
+## Key Aliases
+- `rpt-signing`: signs Regulatory Proof Tokens (RPTs) issued by the platform.
+- `rpt-audit`: encrypts and decrypts audit logs related to RPT issuance.
+- `ops-breakglass`: emergency key used only for disaster recovery of the signing hierarchy.
+
+## Rotation Cadence
+- All production keys rotate every **90 days**.
+- Rotation windows are scheduled at least one week in advance and executed during the Tuesday maintenance window.
+- Non-production environments follow the same cadence but may batch rotate multiple aliases on the same day.
+
+## Approval Workflow
+1. Key custodian opens a change ticket specifying alias, planned rotation date, and validation steps.
+2. Security operations reviews the ticket and provides written approval.
+3. Dual control is enforced: one engineer performs the rotation while a second reviewer observes and signs off in the ticket.
+4. Post-rotation validation includes updating dependent services with the new key material and confirming successful signature verification.
+
+## Recovery Procedures
+- Key artifacts generated during rotation are stored under `artifacts/kms/` and backed up via the `scripts/backup-kms.sh` procedure.
+- Disaster recovery uses `scripts/restore-kms.sh` to restore the most recent tarball into the runtime `artifacts/kms/` directory.
+- The `ops-breakglass` alias remains sealed in an offline vault. Access requires approval from both the CISO and the head of engineering.
+- After recovery, services must re-run health checks to ensure signature validation succeeds with the restored material.
+
+## Audit Requirements
+- Every rotation event appends a JSON record that includes alias, timestamp, version, and checksum of the generated key material.
+- Rotation and recovery tickets are retained for at least 24 months.
+- Weekly audit scripts compare the list of expected aliases with the actual artifacts in `artifacts/kms/` to detect drift.
+- The backup/restore drill in CI verifies that RPT chains remain valid after a full restore and serves as an automated control for this policy.

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,22 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "webapp", "shared", "worker"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test && tsx tests/restore-chain.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/backup-db.sh
+++ b/apgms/scripts/backup-db.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+BACKUP_DIR="artifacts/backup/db"
+BACKUP_FILE="${1:-$BACKUP_DIR/dump.sql}"
+
+mkdir -p "$(dirname "$BACKUP_FILE")"
+
+pg_dump "$DATABASE_URL" >"$BACKUP_FILE"
+
+echo "Database backup written to $BACKUP_FILE"

--- a/apgms/scripts/backup-kms.sh
+++ b/apgms/scripts/backup-kms.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_DIR="artifacts/kms"
+BACKUP_DIR="artifacts/backup"
+ARCHIVE="${1:-$BACKUP_DIR/kms.tar.gz}"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "KMS artifacts directory $SOURCE_DIR not found" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$ARCHIVE")"
+
+tar -czf "$ARCHIVE" -C "$SOURCE_DIR" .
+
+echo "KMS backup written to $ARCHIVE"

--- a/apgms/scripts/restore-db.sh
+++ b/apgms/scripts/restore-db.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "DATABASE_URL is required" >&2
+  exit 1
+fi
+
+BACKUP_FILE="${1:-artifacts/backup/db/dump.sql}"
+
+if [[ ! -f "$BACKUP_FILE" ]]; then
+  echo "Backup file $BACKUP_FILE not found" >&2
+  exit 1
+fi
+
+psql "$DATABASE_URL" <"$BACKUP_FILE"
+
+echo "Database restored from $BACKUP_FILE"

--- a/apgms/scripts/restore-kms.sh
+++ b/apgms/scripts/restore-kms.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="artifacts/kms"
+ARCHIVE="${1:-artifacts/backup/kms.tar.gz}"
+
+if [[ ! -f "$ARCHIVE" ]]; then
+  echo "KMS backup archive $ARCHIVE not found" >&2
+  exit 1
+fi
+
+rm -rf "$TARGET_DIR"
+mkdir -p "$TARGET_DIR"
+
+tar -xzf "$ARCHIVE" -C "$TARGET_DIR"
+
+echo "KMS artifacts restored to $TARGET_DIR"

--- a/apgms/services/api-gateway/src/lib/kms.ts
+++ b/apgms/services/api-gateway/src/lib/kms.ts
@@ -1,0 +1,58 @@
+import { createHash, randomBytes } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export interface RotationRecord {
+  alias: string;
+  rotatedAt: string;
+  version: number;
+  materialChecksum: string;
+}
+
+const artifactsRoot = path.resolve(process.cwd(), "artifacts", "kms");
+
+async function ensureArtifactsDir() {
+  await fs.mkdir(artifactsRoot, { recursive: true });
+}
+
+function timestampLabel(date: Date) {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+export async function rotateKey(alias: string): Promise<RotationRecord> {
+  if (!alias) {
+    throw new Error("alias is required for key rotation");
+  }
+
+  await ensureArtifactsDir();
+
+  const now = new Date();
+  const rotationLabel = timestampLabel(now);
+  const filename = `${alias}-${rotationLabel}.json`;
+  const filePath = path.join(artifactsRoot, filename);
+
+  const existingEntries = await fs
+    .readdir(artifactsRoot)
+    .then((entries) => entries.filter((entry) => entry.startsWith(`${alias}-`)))
+    .catch(() => [] as string[]);
+
+  const version = existingEntries.length + 1;
+  const material = randomBytes(32).toString("hex");
+  const materialChecksum = createHash("sha256").update(material).digest("hex");
+
+  const record: RotationRecord = {
+    alias,
+    rotatedAt: now.toISOString(),
+    version,
+    materialChecksum,
+  };
+
+  const payload = {
+    ...record,
+    material,
+  };
+
+  await fs.writeFile(filePath, JSON.stringify(payload, null, 2), "utf8");
+
+  return record;
+}

--- a/apgms/tests/restore-chain.spec.ts
+++ b/apgms/tests/restore-chain.spec.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { rotateKey } from "../services/api-gateway/src/lib/kms";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const artifactsDir = path.join(repoRoot, "artifacts");
+const kmsDir = path.join(artifactsDir, "kms");
+const backupDir = path.join(artifactsDir, "backup");
+const dbBackupFile = path.join(backupDir, "db", "dump.sql");
+const kmsArchive = path.join(backupDir, "kms.tar.gz");
+const stubDbFile = path.join(artifactsDir, "stub-db.json");
+const stubBinDir = path.join(__dirname, ".stub-bin");
+
+interface RptRecord {
+  id: string;
+  prevId: string | null;
+  payload: string;
+  createdAt: string;
+  hash: string;
+}
+
+interface StubDb {
+  headId: string | null;
+  records: Record<string, RptRecord>;
+}
+
+async function ensureCleanArtifacts() {
+  await fs.rm(artifactsDir, { recursive: true, force: true });
+  await fs.mkdir(artifactsDir, { recursive: true });
+  await fs.mkdir(kmsDir, { recursive: true });
+  const initial: StubDb = { headId: null, records: {} };
+  await fs.writeFile(stubDbFile, JSON.stringify(initial, null, 2), "utf8");
+}
+
+async function loadDb(): Promise<StubDb> {
+  const raw = await fs.readFile(stubDbFile, "utf8");
+  return JSON.parse(raw) as StubDb;
+}
+
+async function saveDb(db: StubDb) {
+  await fs.writeFile(stubDbFile, JSON.stringify(db, null, 2), "utf8");
+}
+
+async function mintRpt(payload: string): Promise<string> {
+  const db = await loadDb();
+  const createdAt = new Date().toISOString();
+  const prevId = db.headId;
+  const prevHash = prevId ? db.records[prevId]?.hash ?? "" : "";
+  const id = randomUUID();
+  const hash = createHash("sha256")
+    .update([prevHash, payload, createdAt].join("|"))
+    .digest("hex");
+
+  const record: RptRecord = { id, prevId, payload, createdAt, hash };
+  db.records[id] = record;
+  db.headId = id;
+  await saveDb(db);
+  return id;
+}
+
+async function getHeadId(): Promise<string | null> {
+  const db = await loadDb();
+  return db.headId;
+}
+
+async function verifyChain(headId: string | null): Promise<boolean> {
+  if (!headId) {
+    return false;
+  }
+
+  const db = await loadDb();
+  const visited = new Set<string>();
+  let currentId: string | null = headId;
+
+  while (currentId) {
+    if (visited.has(currentId)) {
+      return false;
+    }
+
+    visited.add(currentId);
+    const current = db.records[currentId];
+
+    if (!current) {
+      return false;
+    }
+
+    const prevHash = current.prevId ? db.records[current.prevId]?.hash ?? "" : "";
+    const expectedHash = createHash("sha256")
+      .update([prevHash, current.payload, current.createdAt].join("|"))
+      .digest("hex");
+
+    if (expectedHash !== current.hash) {
+      return false;
+    }
+
+    currentId = current.prevId;
+  }
+
+  return true;
+}
+
+async function setupStubBinaries() {
+  await fs.rm(stubBinDir, { recursive: true, force: true });
+  await fs.mkdir(stubBinDir, { recursive: true });
+
+  const pgDumpScript = "#!/usr/bin/env bash\nset -euo pipefail\ncat \"$STUB_DB_FILE\"\n";
+  const psqlScript = "#!/usr/bin/env bash\nset -euo pipefail\ncat > \"$STUB_DB_FILE\"\n";
+
+  await fs.writeFile(path.join(stubBinDir, "pg_dump"), pgDumpScript, { mode: 0o755 });
+  await fs.writeFile(path.join(stubBinDir, "psql"), psqlScript, { mode: 0o755 });
+}
+
+test("backup and restore drill preserves the RPT chain", async () => {
+  await ensureCleanArtifacts();
+  await setupStubBinaries();
+
+  const env = {
+    ...process.env,
+    DATABASE_URL: "postgres://stub",
+    STUB_DB_FILE: stubDbFile,
+    PATH: `${stubBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+
+  await rotateKey("rpt-signing");
+  await rotateKey("rpt-audit");
+
+  await mintRpt("alpha");
+  await mintRpt("beta");
+  const headBefore = await mintRpt("gamma");
+
+  assert.equal(await verifyChain(headBefore), true, "pre-backup chain validation failed");
+
+  execFileSync("bash", [path.join(repoRoot, "scripts", "backup-db.sh")], {
+    cwd: repoRoot,
+    env,
+  });
+
+  execFileSync("bash", [path.join(repoRoot, "scripts", "backup-kms.sh")], {
+    cwd: repoRoot,
+    env,
+  });
+
+  await saveDb({ headId: null, records: {} });
+  await fs.rm(kmsDir, { recursive: true, force: true });
+  await fs.mkdir(kmsDir, { recursive: true });
+
+  execFileSync("bash", [path.join(repoRoot, "scripts", "restore-db.sh")], {
+    cwd: repoRoot,
+    env,
+  });
+
+  execFileSync("bash", [path.join(repoRoot, "scripts", "restore-kms.sh")], {
+    cwd: repoRoot,
+    env,
+  });
+
+  const headAfter = await getHeadId();
+
+  assert.equal(headAfter, headBefore, "head pointer changed after restore");
+  assert.equal(await verifyChain(headAfter), true, "restored chain validation failed");
+
+  const restoredKmsEntries = await fs.readdir(kmsDir);
+  assert.ok(restoredKmsEntries.length > 0, "KMS artifacts not restored");
+
+  const dbBackupExists = await fs.access(dbBackupFile).then(() => true).catch(() => false);
+  const kmsBackupExists = await fs.access(kmsArchive).then(() => true).catch(() => false);
+
+  assert.equal(dbBackupExists, true, "database backup file missing");
+  assert.equal(kmsBackupExists, true, "kms backup archive missing");
+});


### PR DESCRIPTION
## Summary
- document key aliases, rotation cadence, and audit controls in the new KMS policy
- add a rotateKey helper and database/KMS backup-restore scripts used by the restore-chain test
- introduce a CI drill that runs the restore-chain test and uploads generated backup artifacts

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4aebff4e483278b8896f2bb8d893b