### PR TITLE
Add retention policy enforcement and log redaction

### DIFF
--- a/apgms/docs/Retention-Policy.md
+++ b/apgms/docs/Retention-Policy.md
@@ -1,0 +1,23 @@
+# Data Retention Policy
+
+This document outlines the retention requirements for data classes handled by APGMS. Retention timers start from the `createdAt` timestamp unless otherwise stated.
+
+| Data Class | Examples | Retention Window | Rationale |
+| ---------- | -------- | ---------------- | --------- |
+| Operational Logs | HTTP request logs, application diagnostics | 30 days | Support debugging and availability triage while limiting exposure of transient PII. |
+| Audit Trail (FIN/PII) | `AuditLog` records describing user and system actions | 7 years | Regulatory obligations for financial systems and dispute investigation. |
+| Financial Artifacts | `BankLine`, reconciliation exports, ledger snapshots | 7 years | Aligns with AU tax guidance for financial records. |
+| Blob Storage Artifacts | `BlobObject` metadata for exported files or reports | 180 days | Ensure large files are rotated after distribution obligations complete. |
+| User Authentication Data | Password hashes, active session tokens | 90 days after user deletion | Allow security incident response while minimizing risk. |
+
+## Purge Behaviour
+
+The purge worker enforces the policy by deleting records older than the configured window. Dry-run mode provides counts without mutating storage to support auditing changes to the schedule.
+
+| Target | Window | Implementation Notes |
+| ------ | ------ | ------------------- |
+| `prisma.auditLog` | 7 years | `createdAt` field is used to determine age. |
+| `prisma.blobObject` | 180 days | Removes metadata for orphaned blobs; downstream storage GC handles actual objects. |
+| `prisma.appLog` | 30 days | Backed by operational logging store; only metadata is retained for short-term diagnostics. |
+
+All deletions are logged through the redacting logger to avoid leaking PII during enforcement operations.

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,27 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test && node --import tsx --test tests/redaction.spec.ts tests/retention.spec.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -10,8 +10,10 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { createAppLogger } from "./lib/log";
 
 const app = Fastify({ logger: true });
+createAppLogger(app.log as any);
 
 await app.register(cors, { origin: true });
 
@@ -77,4 +79,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/lib/log.ts
+++ b/apgms/services/api-gateway/src/lib/log.ts
@@ -1,0 +1,81 @@
+const EMAIL_REGEX = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const BSB_REGEX = /\b\d{3}-\d{3}\b/g;
+const ACCOUNT_REGEX = /(\b(?:acc(?:ount)?|acct)\s*[=:]?\s*)(\d{6,12})/gi;
+const TOKEN_REGEX = /(\b(?:token|api[_-]?key)\s*[=:]?\s*)([A-Za-z0-9._-]{6,})/gi;
+const BEARER_REGEX = /(Bearer\s+)[A-Za-z0-9._-]{6,}/gi;
+
+const MASK = "***REDACTED***";
+
+export type LoggerMethod = (...args: unknown[]) => unknown;
+export type LoggerLike = Record<string, unknown> & {
+  child?: (...args: unknown[]) => LoggerLike;
+};
+
+export function redactString(value: string): string {
+  let result = value.replace(EMAIL_REGEX, (match) => {
+    const [, domain] = match.split("@");
+    return `***@${domain}`;
+  });
+
+  result = result.replace(BSB_REGEX, "***-***");
+  result = result.replace(ACCOUNT_REGEX, (_, prefix: string, digits: string) => {
+    const visible = digits.slice(-2);
+    return `${prefix}***${visible}`;
+  });
+  result = result.replace(TOKEN_REGEX, (_, prefix: string) => `${prefix}${MASK}`);
+  result = result.replace(BEARER_REGEX, (_, prefix: string) => `${prefix}${MASK}`);
+
+  return result;
+}
+
+export function redactValue<T>(value: T): T {
+  if (typeof value === "string") {
+    return redactString(value) as unknown as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactValue(item)) as unknown as T;
+  }
+
+  if (value && typeof value === "object") {
+    const clone: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      clone[key] = redactValue(val);
+    }
+    return clone as T;
+  }
+
+  return value;
+}
+
+const LEVELS = ["fatal", "error", "warn", "info", "debug", "trace"]; 
+
+export function applyLogRedaction<T extends LoggerLike>(logger: T): T {
+  for (const level of LEVELS) {
+    const method = logger[level];
+    if (typeof method === "function") {
+      const original = method.bind(logger);
+      Object.defineProperty(logger, level, {
+        value: (...args: unknown[]) => original(...args.map((arg) => redactValue(arg))),
+        writable: true,
+      });
+    }
+  }
+
+  if (typeof logger.child === "function") {
+    const originalChild = logger.child.bind(logger);
+    Object.defineProperty(logger, "child", {
+      value: (...args: unknown[]) => {
+        const childLogger = originalChild(...args);
+        return applyLogRedaction(childLogger);
+      },
+      writable: true,
+    });
+  }
+
+  return logger;
+}
+
+export function createAppLogger<T extends LoggerLike>(baseLogger: T): T {
+  return applyLogRedaction(baseLogger);
+}

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -1,36 +1,86 @@
 generator client {
   provider = "prisma-client-js"
 }
+
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider          = "postgresql"
+  url               = env("DATABASE_URL")
   shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
 }
 
+/// @class("FIN")
 model Org {
   id        String   @id @default(cuid())
+  /// @class("FIN")
   name      String
   createdAt DateTime @default(now())
   users     User[]
   lines     BankLine[]
 }
 
+/// @class("PII")
 model User {
   id        String   @id @default(cuid())
+  /// @class("PII")
   email     String   @unique
+  /// @class("PII")
   password  String
   createdAt DateTime @default(now())
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  /// @class("FIN")
   orgId     String
 }
 
+/// @class("FIN")
 model BankLine {
   id        String   @id @default(cuid())
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  /// @class("FIN")
   orgId     String
+  /// @class("FIN")
   date      DateTime
+  /// @class("FIN")
   amount    Decimal
+  /// @class("PII", "FIN")
   payee     String
+  /// @class("FIN")
   desc      String
+  createdAt DateTime @default(now())
+}
+
+/// @class("PII")
+model AuditLog {
+  id        String   @id @default(cuid())
+  /// @class("PII")
+  actorEmail String
+  action    String
+  /// @class("PII")
+  subjectId String?
+  /// @class("PII")
+  payload   Json?
+  createdAt DateTime @default(now())
+}
+
+/// @class("FIN")
+model BlobObject {
+  id        String   @id @default(cuid())
+  /// @class("FIN")
+  bucket    String
+  /// @class("FIN")
+  key       String
+  /// @class("FIN")
+  checksum  String?
+  createdAt DateTime @default(now())
+}
+
+/// @class("PII")
+model AppLog {
+  id        String   @id @default(cuid())
+  /// @class("PII")
+  level     String
+  /// @class("PII")
+  message   String
+  /// @class("PII")
+  context   Json?
   createdAt DateTime @default(now())
 }

--- a/apgms/tests/redaction.spec.ts
+++ b/apgms/tests/redaction.spec.ts
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createAppLogger, redactString, redactValue } from "../services/api-gateway/src/lib/log";
+
+test("redactString masks PII patterns", () => {
+  const input = "user alice@example.com token=abcdef123456 BSB 123-456 acc=123456789";
+  const output = redactString(input);
+
+  assert.ok(output.includes("***@example.com"));
+  assert.ok(!output.includes("alice@example.com"));
+  assert.ok(output.includes("***-***"));
+  assert.ok(!output.includes("123-456"));
+  assert.ok(output.includes("token=***REDACTED***"));
+  assert.ok(!output.includes("abcdef123456"));
+  assert.ok(output.includes("acc=***89"));
+});
+
+test("redactValue walks objects recursively", () => {
+  const result = redactValue({
+    user: { email: "bob@example.com" },
+    accounts: ["acct=987654321"],
+  });
+
+  assert.deepEqual(result, {
+    user: { email: "***@example.com" },
+    accounts: ["acct=***21"],
+  });
+});
+
+test("logger output redacts structured payloads", () => {
+  const lines: Array<unknown[]> = [];
+  const baseLogger = {
+    info: (...args: unknown[]) => {
+      lines.push(args);
+    },
+    child: () => baseLogger,
+  };
+
+  const logger = createAppLogger(baseLogger);
+  logger.info({ email: "carol@example.com", details: "BSB 999-111" }, "Authorization: Bearer abcdefghijk");
+
+  assert.equal(lines.length, 1);
+  const [payload, message] = lines[0];
+  assert.deepEqual(payload, { email: "***@example.com", details: "BSB ***-***" });
+  assert.equal(message, "Authorization: Bearer ***REDACTED***");
+});

--- a/apgms/tests/retention.spec.ts
+++ b/apgms/tests/retention.spec.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { purgeRetention, type RetentionClient, type RetentionModel } from "../worker/src/purge";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const YEAR_MS = 365 * DAY_MS;
+
+class MockAuditModel implements RetentionModel {
+  public records: Array<{ id: string; createdAt: Date }>;
+
+  constructor(records: Array<{ id: string; createdAt: Date }>) {
+    this.records = records;
+  }
+
+  async deleteMany({ where }: { where: Record<string, any> }) {
+    const cutoff: Date = where.createdAt.lt;
+    const before = this.records.length;
+    this.records = this.records.filter((record) => record.createdAt >= cutoff);
+    return { count: before - this.records.length };
+  }
+
+  async count({ where }: { where: Record<string, any> }) {
+    const cutoff: Date = where.createdAt.lt;
+    return this.records.filter((record) => record.createdAt < cutoff).length;
+  }
+}
+
+const now = new Date("2030-01-01T00:00:00.000Z");
+const oldAudit = new Date(now.getTime() - 8 * YEAR_MS);
+const recentAudit = new Date(now.getTime() - 30 * DAY_MS);
+
+test("purgeRetention reports matches without deleting in dry-run", async () => {
+  const auditModel = new MockAuditModel([
+    { id: "old", createdAt: oldAudit },
+    { id: "recent", createdAt: recentAudit },
+  ]);
+
+  const client: RetentionClient = {
+    auditLog: auditModel,
+  };
+
+  const summary = await purgeRetention(client, { dryRun: true, now });
+  const auditRule = summary.find((entry) => entry.model === "auditLog");
+
+  assert.deepEqual(auditRule, {
+    model: "auditLog",
+    classification: "audit",
+    matched: 1,
+    dryRun: true,
+  });
+  assert.equal(auditModel.records.length, 2);
+});
+
+test("purgeRetention deletes only aged audit records", async () => {
+  const auditModel = new MockAuditModel([
+    { id: "old", createdAt: oldAudit },
+    { id: "recent", createdAt: recentAudit },
+  ]);
+
+  const client: RetentionClient = {
+    auditLog: auditModel,
+  };
+
+  const summary = await purgeRetention(client, { dryRun: false, now });
+  const auditRule = summary.find((entry) => entry.model === "auditLog");
+
+  assert.deepEqual(auditRule, {
+    model: "auditLog",
+    classification: "audit",
+    deleted: 1,
+    dryRun: false,
+  });
+  assert.deepEqual(auditModel.records, [{ id: "recent", createdAt: recentAudit }]);
+});

--- a/apgms/worker/package.json
+++ b/apgms/worker/package.json
@@ -1,1 +1,18 @@
-{"name":"@apgms/worker","version":"0.1.0","type":"module","main":"dist/index.js","scripts":{"build":"echo build worker","test":"echo test worker"}}
+{
+  "name": "@apgms/worker",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "echo build worker",
+    "test": "echo test worker",
+    "purge": "tsx src/purge.ts"
+  },
+  "dependencies": {
+    "@apgms/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/worker/src/purge.ts
+++ b/apgms/worker/src/purge.ts
@@ -1,0 +1,113 @@
+import { fileURLToPath } from "node:url";
+
+export type RetentionClassification = "logs" | "audit" | "blob";
+
+export interface RetentionRule {
+  model: string;
+  field: string;
+  retentionMs: number;
+  classification: RetentionClassification;
+}
+
+export interface RetentionModel {
+  deleteMany: (args: { where: Record<string, unknown> }) => Promise<{ count: number }>;
+  count?: (args: { where: Record<string, unknown> }) => Promise<number>;
+}
+
+export interface RetentionClient {
+  [model: string]: RetentionModel | undefined;
+}
+
+export interface PurgeOptions {
+  dryRun?: boolean;
+  now?: Date;
+  logger?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+  };
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const YEAR_MS = 365 * DAY_MS;
+
+export const retentionRules: RetentionRule[] = [
+  {
+    model: "auditLog",
+    field: "createdAt",
+    retentionMs: 7 * YEAR_MS,
+    classification: "audit",
+  },
+  {
+    model: "blobObject",
+    field: "createdAt",
+    retentionMs: 180 * DAY_MS,
+    classification: "blob",
+  },
+  {
+    model: "appLog",
+    field: "createdAt",
+    retentionMs: 30 * DAY_MS,
+    classification: "logs",
+  },
+];
+
+export async function purgeRetention(
+  client: RetentionClient,
+  options: PurgeOptions = {}
+): Promise<Array<Record<string, unknown>>> {
+  const { dryRun = false, now = new Date(), logger } = options;
+  const summary: Array<Record<string, unknown>> = [];
+
+  for (const rule of retentionRules) {
+    const model = client[rule.model];
+    if (!model) {
+      logger?.warn?.({ model: rule.model }, "retention model missing");
+      continue;
+    }
+
+    const cutoff = new Date(now.getTime() - rule.retentionMs);
+    const where = { [rule.field]: { lt: cutoff } };
+
+    if (dryRun) {
+      const matched = (await model.count?.({ where })) ?? 0;
+      summary.push({
+        model: rule.model,
+        classification: rule.classification,
+        matched,
+        dryRun: true,
+      });
+      logger?.info?.({ model: rule.model, matched, dryRun: true }, "retention dry-run");
+      continue;
+    }
+
+    const result = await model.deleteMany({ where });
+    summary.push({
+      model: rule.model,
+      classification: rule.classification,
+      deleted: result.count,
+      dryRun: false,
+    });
+    logger?.info?.({ model: rule.model, deleted: result.count }, "retention purge complete");
+  }
+
+  return summary;
+}
+
+export async function runPurge(options: PurgeOptions = {}) {
+  const { prisma } = await import("../../shared/src/db");
+  return purgeRetention(prisma as unknown as RetentionClient, options);
+}
+
+if (process.argv[1]) {
+  const entry = fileURLToPath(import.meta.url);
+  const fromCli = process.argv[1] === entry;
+  if (fromCli) {
+    const dryRun = process.argv.includes("--dry-run");
+    runPurge({ dryRun, logger: console })
+      .then(() => process.exit(0))
+      .catch((error) => {
+        console.error(error);
+        process.exit(1);
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- annotate Prisma schema with data classification metadata and add audit/blob/app log models to support retention targeting
- document retention windows and provide a worker purge routine with optional dry-run execution
- introduce logger redaction utilities and node-based tests that verify both purge behaviour and masking of sensitive values

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4aeda489c83279a886f2c61855250