### PR TITLE
feat: enforce mfa posture on admin routes

### DIFF
--- a/apgms/docs/IDP-MFA.md
+++ b/apgms/docs/IDP-MFA.md
@@ -1,0 +1,54 @@
+# MFA Posture for Admin Routes
+
+This service enforces multi-factor authentication (MFA) for every request that targets `*/admin/*` routes. The middleware validates OpenID Connect (OIDC) ID tokens issued by the configured identity provider and requires proof of MFA through either the Authentication Method Reference (`amr`) claim or the Authentication Context Class Reference (`acr`) claim.
+
+## Identity Provider Configuration
+
+Configure your IdP to issue the following claims in ID tokens for the API gateway:
+
+- **Issuer (`iss`)** – must match `OIDC_ISSUER`.
+- **Audience (`aud`)** – must contain `OIDC_AUDIENCE`.
+- **Organisation (`orgId` or `org_id`)** – identifies the tenant.
+- **Roles (`roles`)** – space or comma separated string or array of granted roles.
+- **Authentication Method Reference (`amr`)** – should include `mfa` when MFA was performed.
+- **Authentication Context Class Reference (`acr`)** – optional numeric strength indicator such as `urn:acr:2fa`.
+
+The API gateway expects the following environment variables at runtime:
+
+```bash
+export OIDC_ISSUER="https://issuer.example.com"
+export OIDC_AUDIENCE="api://default"
+export JWT_SHARED_SECRET="super-secret-hs256-key"
+```
+
+`JWT_SHARED_SECRET` must match the symmetric signing key used by the IdP for HS256 tokens (or be replaced with the appropriate verification material when migrating to asymmetric keys).
+
+## MFA Evaluation Rules
+
+The middleware derives `req.context.mfa` using the rules below:
+
+1. If `amr` is an array or delimited string containing `mfa`, MFA is satisfied.
+2. Otherwise, if `acr` matches `urn:acr:{level}fa` where `level` is greater than or equal to `2`, MFA is satisfied.
+3. If neither claim satisfies the above, the request is treated as single-factor.
+
+Requests to `/admin/*` endpoints without MFA evidence are rejected with HTTP 403.
+
+## Example ID Token Payload
+
+```json
+{
+  "iss": "https://issuer.example.com",
+  "aud": "api://default",
+  "sub": "user-123",
+  "orgId": "org-1",
+  "roles": ["admin"],
+  "amr": ["pwd", "mfa"],
+  "acr": "urn:acr:2fa",
+  "exp": 1735689600,
+  "iat": 1735686000
+}
+```
+
+## Claims Emission for CI
+
+Use `pnpm --filter @apgms/api-gateway run emit-claims <token>` to decode an ID token during CI. The script writes the parsed claims to `artifacts/claims.json`, enabling automated evidence collection for compliance checks.

--- a/apgms/scripts/emit-claims.ts
+++ b/apgms/scripts/emit-claims.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const token = process.argv[2];
+
+if (!token) {
+  console.error("Usage: pnpm run emit-claims <jwt>");
+  process.exitCode = 1;
+  process.exit(1);
+}
+
+const [, payload] = token.split(".");
+if (!payload) {
+  console.error("Invalid token");
+  process.exitCode = 1;
+  process.exit(1);
+}
+
+const decodeBase64Url = (value: string) => {
+  value = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
+  return Buffer.from(padded, "base64");
+};
+
+const findRepoRoot = (start: string): string => {
+  let current = start;
+  while (true) {
+    const hasWorkspace = existsSync(path.join(current, "pnpm-workspace.yaml"));
+    const hasGit = existsSync(path.join(current, ".git"));
+    if (hasWorkspace || hasGit) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return start;
+    }
+    current = parent;
+  }
+};
+
+const main = async () => {
+  const decoded = decodeBase64Url(payload).toString("utf-8");
+
+  let claims: unknown;
+  try {
+    claims = JSON.parse(decoded);
+  } catch (error) {
+    console.error("Failed to parse token payload", error);
+    process.exitCode = 1;
+    process.exit(1);
+  }
+
+  const artifactsDir = path.join(findRepoRoot(process.cwd()), "artifacts");
+  await fs.mkdir(artifactsDir, { recursive: true });
+  const artifactPath = path.join(artifactsDir, "claims.json");
+  await fs.writeFile(artifactPath, JSON.stringify(claims, null, 2) + "\n", "utf-8");
+
+  console.log(`Wrote claims to ${artifactPath}`);
+};
+
+main().catch((error) => {
+  console.error("Failed to emit claims", error);
+  process.exitCode = 1;
+  process.exit(1);
+});

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test tests/auth.spec.ts",
+    "emit-claims": "tsx ../../scripts/emit-claims.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,5 +1,5 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import dotenv from "dotenv";
 
 // Load repo-root .env from src/
@@ -7,74 +7,169 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import authPlugin from "./middleware/auth";
+import { orgScope, requireRole } from "./routes/_guard";
 
-const app = Fastify({ logger: true });
+type PrismaLike = {
+  user: {
+    findMany: (args: unknown) => Promise<any[]>;
+  };
+  bankLine: {
+    findMany: (args: unknown) => Promise<any[]>;
+    create: (args: { data: any }) => Promise<any>;
+  };
+};
 
-await app.register(cors, { origin: true });
+interface BuildOptions {
+  prismaClient?: PrismaLike;
+}
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+let cachedPrisma: PrismaLike | null = null;
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+const loadPrisma = async (): Promise<PrismaLike> => {
+  if (!cachedPrisma) {
+    const module = await import("../../../shared/src/db");
+    cachedPrisma = module.prisma as PrismaLike;
   }
-});
+  return cachedPrisma;
+};
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+export const buildApp = async ({ prismaClient }: BuildOptions = {}): Promise<FastifyInstance> => {
+  const db = prismaClient ?? (await loadPrisma());
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+  const app = Fastify({ logger: true });
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  await app.register(cors, { origin: true });
+  await authPlugin(app);
 
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/healthz", async () => ({ ok: true, service: "api-gateway" }));
+  app.get("/readyz", async () => ({ ready: true }));
+
+  app.get(
+    "/users",
+    { preHandler: [requireRole("admin")] },
+    async (req) => {
+      if (!req.context) {
+        throw new Error("auth context missing");
+      }
+      const { orgId } = req.context;
+      const users = await db.user.findMany({
+        where: { orgId },
+        select: { email: true, orgId: true, createdAt: true },
+        orderBy: { createdAt: "desc" },
+      });
+      return { users };
+    }
+  );
+
+  app.get(
+    "/bank-lines",
+    {
+      preHandler: [
+        orgScope((req) => {
+          const query = req.query as { orgId?: string };
+          if (query?.orgId) {
+            return query.orgId;
+          }
+          return req.context?.orgId ?? null;
+        }),
+      ],
+    },
+    async (req) => {
+      if (!req.context) {
+        throw new Error("auth context missing");
+      }
+      const take = Number((req.query as any).take ?? 20);
+      const orgId =
+        (req.query as { orgId?: string }).orgId ?? req.context.orgId;
+      const lines = await db.bankLine.findMany({
+        where: { orgId },
+        orderBy: { date: "desc" },
+        take: Math.min(Math.max(take, 1), 200),
+      });
+      return { lines };
+    }
+  );
+
+  app.post(
+    "/bank-lines",
+    {
+      preHandler: [
+        orgScope((req) => {
+          const body = req.body as { orgId?: string };
+          return body?.orgId ?? null;
+        }),
+      ],
+    },
+    async (req, rep) => {
+      try {
+        const body = req.body as {
+          orgId: string;
+          date: string;
+          amount: number | string;
+          payee: string;
+          desc: string;
+        };
+        const created = await db.bankLine.create({
+          data: {
+            orgId: body.orgId,
+            date: new Date(body.date),
+            amount: body.amount as any,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+        return rep.code(201).send(created);
+      } catch (e) {
+        req.log.error(e);
+        return rep.code(400).send({ error: "bad_request" });
+      }
+    }
+  );
+
+  app.get(
+    "/admin/reports",
+    { preHandler: [requireRole("admin")] },
+    async (req) => {
+      if (!req.context) {
+        throw new Error("auth context missing");
+      }
+      return {
+        orgId: req.context.orgId,
+        reports: [],
+      };
+    }
+  );
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};
+
+const start = async () => {
+  const app = await buildApp();
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+};
+
+const isEntryPoint = () => {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  return import.meta.url === pathToFileURL(entry).href;
+};
+
+if (isEntryPoint()) {
+  start();
+}

--- a/apgms/services/api-gateway/src/middleware/auth.ts
+++ b/apgms/services/api-gateway/src/middleware/auth.ts
@@ -1,0 +1,219 @@
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+import { createHmac } from "node:crypto";
+
+type JwtPayload = {
+  iss?: string;
+  aud?: string | string[];
+  orgId?: string;
+  org_id?: string;
+  roles?: string[] | string;
+  amr?: string[] | string;
+  acr?: string;
+  [key: string]: unknown;
+};
+
+type RequestContext = {
+  orgId: string;
+  roles: string[];
+  mfa: boolean;
+};
+
+declare module "fastify" {
+  interface FastifyRequest {
+    context: RequestContext | null;
+  }
+}
+
+const NON_PROTECTED_PATHS = new Set(["/healthz", "/readyz"]);
+
+const ensureSecret = () => {
+  const secret = process.env.JWT_SHARED_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SHARED_SECRET is not configured");
+  }
+  return secret;
+};
+
+const issuer = () => {
+  const value = process.env.OIDC_ISSUER;
+  if (!value) {
+    throw new Error("OIDC_ISSUER is not configured");
+  }
+  return value;
+};
+
+const audience = () => {
+  const value = process.env.OIDC_AUDIENCE;
+  if (!value) {
+    throw new Error("OIDC_AUDIENCE is not configured");
+  }
+  return value;
+};
+
+const isAcrMfa = (acr?: string): boolean => {
+  if (!acr) return false;
+  const match = /^urn:acr:(\d+)fa$/.exec(acr);
+  if (!match) return false;
+  const level = Number.parseInt(match[1] ?? "0", 10);
+  return Number.isFinite(level) && level >= 2;
+};
+
+const hasMfa = (payload: JwtPayload): boolean => {
+  const amrClaim = payload.amr;
+  const amrValues = Array.isArray(amrClaim)
+    ? amrClaim.map(String)
+    : typeof amrClaim === "string"
+    ? amrClaim.split(/[\s,]+/g).map((value) => value.trim()).filter(Boolean)
+    : [];
+  if (amrValues.some((value) => value.toLowerCase() === "mfa")) {
+    return true;
+  }
+  return isAcrMfa(typeof payload.acr === "string" ? payload.acr : undefined);
+};
+
+const extractOrgId = (payload: JwtPayload): string | null => {
+  if (typeof payload.orgId === "string" && payload.orgId.length > 0) {
+    return payload.orgId;
+  }
+  if (typeof payload.org_id === "string" && payload.org_id.length > 0) {
+    return payload.org_id;
+  }
+  return null;
+};
+
+const extractRoles = (payload: JwtPayload): string[] => {
+  const { roles } = payload;
+  if (Array.isArray(roles)) {
+    return roles.map(String);
+  }
+  if (typeof roles === "string" && roles.length > 0) {
+    return roles
+      .split(/[\s,]+/g)
+      .map((role) => role.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const unauthorized = (reply: FastifyReply) => {
+  reply.code(401).send({ error: "unauthorized" });
+};
+
+const forbidden = (reply: FastifyReply) => {
+  reply.code(403).send({ error: "forbidden" });
+};
+
+const shouldSkip = (request: FastifyRequest) => {
+  const url = new URL(request.url, "http://localhost");
+  if (NON_PROTECTED_PATHS.has(url.pathname)) {
+    return true;
+  }
+  return false;
+};
+
+const decodeBase64Url = (input: string) => {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    "="
+  );
+  return Buffer.from(padded, "base64");
+};
+
+const verifyJwt = (
+  token: string,
+  secretKey: Buffer,
+  expectedIssuer: string,
+  expectedAudience: string
+) => {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("invalid_token");
+  }
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const computedSignature = createHmac("sha256", secretKey)
+    .update(data)
+    .digest("base64url");
+  if (computedSignature !== signature) {
+    throw new Error("invalid_signature");
+  }
+
+  const header = JSON.parse(decodeBase64Url(encodedHeader).toString("utf-8"));
+  if (header.alg !== "HS256") {
+    throw new Error("unsupported_algorithm");
+  }
+
+  const payload = JSON.parse(
+    decodeBase64Url(encodedPayload).toString("utf-8")
+  ) as JwtPayload & { exp?: number; nbf?: number };
+
+  if (payload.iss !== expectedIssuer) {
+    throw new Error("invalid_issuer");
+  }
+
+  const audClaim = payload.aud;
+  const audValid = Array.isArray(audClaim)
+    ? audClaim.includes(expectedAudience)
+    : audClaim === expectedAudience;
+  if (!audValid) {
+    throw new Error("invalid_audience");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp === "number" && payload.exp < now) {
+    throw new Error("token_expired");
+  }
+  if (typeof payload.nbf === "number" && payload.nbf > now) {
+    throw new Error("token_inactive");
+  }
+
+  return payload as JwtPayload;
+};
+
+export const authPlugin = async (fastify: FastifyInstance) => {
+  fastify.decorateRequest("context", null);
+
+  const secretKey = Buffer.from(ensureSecret(), "utf-8");
+  const expectedIssuer = issuer();
+  const expectedAudience = audience();
+
+  fastify.addHook("preHandler", async (request, reply) => {
+    if (shouldSkip(request)) {
+      request.context = null;
+      return;
+    }
+
+    const header = request.headers.authorization;
+    if (!header || !header.startsWith("Bearer ")) {
+      unauthorized(reply);
+      return reply;
+    }
+
+    const token = header.slice("Bearer ".length).trim();
+    try {
+      const jwtPayload = verifyJwt(token, secretKey, expectedIssuer, expectedAudience);
+      const orgId = extractOrgId(jwtPayload);
+      if (!orgId) {
+        forbidden(reply);
+        return reply;
+      }
+      const roles = extractRoles(jwtPayload);
+      const mfa = hasMfa(jwtPayload);
+
+      const url = new URL(request.url, "http://localhost");
+      if (url.pathname.startsWith("/admin/") && !mfa) {
+        forbidden(reply);
+        return reply;
+      }
+
+      request.context = { orgId, roles, mfa };
+    } catch (error) {
+      request.log.warn({ err: error }, "failed to verify jwt");
+      unauthorized(reply);
+      return reply;
+    }
+  });
+};
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/routes/_guard.ts
+++ b/apgms/services/api-gateway/src/routes/_guard.ts
@@ -1,0 +1,44 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+type OrgExtractor = (request: FastifyRequest) => string | null | undefined;
+
+type Role = string;
+
+export const orgScope = (orgIdFromReq: OrgExtractor) => {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const context = request.context;
+    if (!context) {
+      reply.code(401).send({ error: "unauthorized" });
+      return reply;
+    }
+    const desiredOrgId = orgIdFromReq(request);
+    if (!desiredOrgId) {
+      reply.code(400).send({ error: "missing_org" });
+      return reply;
+    }
+    const { orgId } = context;
+    if (orgId !== desiredOrgId) {
+      reply.code(403).send({ error: "forbidden" });
+      return reply;
+    }
+  };
+};
+
+export const requireRole = (...roles: Role[]) => {
+  const expected = roles.map((role) => role.trim()).filter(Boolean);
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const context = request.context;
+    if (!context) {
+      reply.code(401).send({ error: "unauthorized" });
+      return reply;
+    }
+    const { roles: currentRoles } = context;
+    if (expected.length === 0) {
+      return;
+    }
+    if (!currentRoles.some((role) => expected.includes(role))) {
+      reply.code(403).send({ error: "forbidden" });
+      return reply;
+    }
+  };
+};

--- a/apgms/services/api-gateway/tests/auth.spec.ts
+++ b/apgms/services/api-gateway/tests/auth.spec.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { createHmac } from "node:crypto";
+import { buildApp } from "../src/index";
+
+type BankLine = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+};
+
+type User = {
+  email: string;
+  orgId: string;
+  createdAt: Date;
+};
+
+const SECRET = "test-secret";
+process.env.JWT_SHARED_SECRET = SECRET;
+process.env.OIDC_ISSUER = "https://issuer.example.com";
+process.env.OIDC_AUDIENCE = "api://default";
+
+type PrismaStub = {
+  user: {
+    findMany: (args: any) => Promise<User[]>;
+  };
+  bankLine: {
+    findMany: (args: any) => Promise<BankLine[]>;
+    create: (args: { data: any }) => Promise<BankLine>;
+  };
+};
+
+const createPrismaStub = (): PrismaStub => {
+  const bankLines: BankLine[] = [];
+  const users: User[] = [
+    { email: "admin@example.com", orgId: "org-1", createdAt: new Date("2023-01-01") },
+    { email: "user@example.com", orgId: "org-1", createdAt: new Date("2023-02-01") },
+  ];
+  return {
+    user: {
+      findMany: async (args: any) => {
+        if (args?.where?.orgId) {
+          return users.filter((user) => user.orgId === args.where.orgId);
+        }
+        return users;
+      },
+    },
+    bankLine: {
+      findMany: async (args: any) => {
+        if (args?.where?.orgId) {
+          return bankLines.filter((line) => line.orgId === args.where.orgId);
+        }
+        return bankLines;
+      },
+      create: async ({ data }) => {
+        const record: BankLine = {
+          id: String(bankLines.length + 1),
+          orgId: data.orgId,
+          date: data.date,
+          amount: Number(data.amount),
+          payee: data.payee,
+          desc: data.desc,
+        };
+        bankLines.push(record);
+        return record;
+      },
+    },
+  };
+};
+
+const base64UrlEncode = (value: string) => Buffer.from(value, "utf-8").toString("base64url");
+
+const signToken = async (claims: Record<string, any>) => {
+  const header = base64UrlEncode(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const now = Math.floor(Date.now() / 1000);
+  const payload = base64UrlEncode(
+    JSON.stringify({
+      iss: process.env.OIDC_ISSUER!,
+      aud: process.env.OIDC_AUDIENCE!,
+      iat: now,
+      exp: now + 3600,
+      ...claims,
+    })
+  );
+  const data = `${header}.${payload}`;
+  const signature = createHmac("sha256", Buffer.from(SECRET, "utf-8"))
+    .update(data)
+    .digest("base64url");
+  return `${data}.${signature}`;
+};
+
+describe("auth middleware", () => {
+  const prismaStub = createPrismaStub();
+  let app: Awaited<ReturnType<typeof buildApp>>;
+
+  before(async () => {
+    app = await buildApp({ prismaClient: prismaStub });
+    await app.ready();
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it("returns 401 when no token provided", async () => {
+    const response = await app.inject({ method: "GET", url: "/users" });
+    assert.equal(response.statusCode, 401);
+  });
+
+  it("rejects cross-tenant writes", async () => {
+    const token = await signToken({
+      sub: "user-1",
+      orgId: "org-1",
+      roles: ["user"],
+      amr: ["pwd", "mfa"],
+    });
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "org-2",
+        date: new Date().toISOString(),
+        amount: 100,
+        payee: "ACME",
+        desc: "Mismatch",
+      },
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    assert.equal(response.statusCode, 403);
+  });
+
+  it("rejects admin requests without MFA posture", async () => {
+    const token = await signToken({
+      sub: "admin-1",
+      orgId: "org-1",
+      roles: ["admin"],
+      amr: ["pwd"],
+      acr: "urn:acr:1fa",
+    });
+    const response = await app.inject({
+      method: "GET",
+      url: "/admin/reports",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    assert.equal(response.statusCode, 403);
+  });
+
+  it("allows admin requests when MFA satisfied", async () => {
+    const token = await signToken({
+      sub: "admin-1",
+      orgId: "org-1",
+      roles: ["admin"],
+      amr: ["pwd", "mfa"],
+    });
+    const response = await app.inject({
+      method: "GET",
+      url: "/admin/reports",
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    assert.equal(response.statusCode, 200);
+    const body = response.json();
+    assert.equal(body.orgId, "org-1");
+  });
+});


### PR DESCRIPTION
## Summary
- add JWT verification middleware that enforces MFA on /admin/* requests and propagates request context
- add reusable org and role guards and apply them across gateway routes
- document IdP MFA expectations, add tests for the new behaviour, and provide a script that emits decoded claims for CI evidence

## Testing
- pnpm --filter @apgms/api-gateway test
- pnpm --filter @apgms/api-gateway run emit-claims "$TOKEN"

------
https://chatgpt.com/codex/tasks/task_e_68f4aeb285588327a0d66feb35ae5579