### PR TITLE
Implement API gateway hardening

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --test --import tsx test/index.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,322 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+dotenv.config();
 
-const app = Fastify({ logger: true });
+import Fastify, { FastifyInstance, RouteOptions } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+import { registerSecurity } from "./plugins/security";
+import { registerHealthRoutes } from "./routes/health";
+import { registerWebhookRoutes } from "./routes/webhooks";
+import { authenticateRequest } from "./middleware/auth";
+import { enforceOrgScope } from "./middleware/org-scope";
+import {
+  getUsersQuerySchema,
+  getUsersResponseSchema,
+} from "./schemas/users";
+import {
+  listBankLinesQuerySchema,
+  listBankLinesResponseSchema,
+  createBankLineBodySchema,
+  createBankLineResponseSchema,
+} from "./schemas/bank-lines";
+import {
+  getOrSet,
+  IdempotencyConflictError,
+  IdempotencyInProgressError,
+  closeIdempotencyStore,
+} from "./lib/idempotency";
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+function addSecurityHandlers(routeOptions: RouteOptions): boolean {
+  const url = routeOptions.url ?? "";
+  if (url.startsWith("/healthz") || url.startsWith("/readyz") || url.startsWith("/webhooks")) {
+    return false;
   }
-});
+  const preHandlers = Array.isArray(routeOptions.preHandler)
+    ? [...routeOptions.preHandler]
+    : routeOptions.preHandler
+      ? [routeOptions.preHandler]
+      : [];
+  routeOptions.preHandler = [authenticateRequest, enforceOrgScope, ...preHandlers];
+  return true;
+}
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+function registerReplyValidation(app: FastifyInstance) {
+  app.addHook("preSerialization", (request, reply, payload, done) => {
+    const config = (reply.context as any)?.config;
+    const schema = config?.replySchema;
+    if (!schema) {
+      done(null, payload);
+      return;
+    }
+    try {
+      const parsed = schema.parse(payload);
+      done(null, parsed);
+    } catch (error) {
+      done(error as Error);
+    }
+  });
+}
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+type BankLineDto = {
+  id: string;
+  orgId: string;
+  date: string;
+  amountCents: number;
+  payee: string;
+  description: string;
+  createdAt: string;
+};
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+type CreateBankLineResult = {
+  statusCode: number;
+  body: { bankLine: BankLineDto };
+};
 
+function normalizeAmountCents(amount: unknown): number {
+  if (typeof amount === "number") {
+    return Math.trunc(amount);
+  }
+  if (typeof amount === "string") {
+    const parsed = Number(amount);
+    if (Number.isFinite(parsed)) {
+      return Math.trunc(parsed);
+    }
+  }
+  if (amount && typeof (amount as any).toString === "function") {
+    const parsed = Number((amount as any).toString());
+    if (Number.isFinite(parsed)) {
+      return Math.trunc(parsed);
+    }
+  }
+  throw new Error("invalid_amount");
+}
+
+function toBankLineDto(bankLine: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: unknown;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}): BankLineDto {
+  return {
+    id: bankLine.id,
+    orgId: bankLine.orgId,
+    date: bankLine.date.toISOString(),
+    amountCents: normalizeAmountCents(bankLine.amount),
+    payee: bankLine.payee,
+    description: bankLine.desc,
+    createdAt: bankLine.createdAt.toISOString(),
+  };
+}
+
+function toUserDto(user: {
+  id: string;
+  email: string;
+  orgId: string;
+  createdAt: Date;
+}) {
+  return {
+    id: user.id,
+    email: user.email,
+    orgId: user.orgId,
+    createdAt: user.createdAt.toISOString(),
+  };
+}
+
+function buildUsersRoute(app: FastifyInstance) {
+  app.route({
+    method: "GET",
+    url: "/users",
+    config: {
+      replySchema: getUsersResponseSchema,
+    },
+    async handler(request) {
+      const query = getUsersQuerySchema.parse(request.query ?? {});
+      const limit = query.limit ?? 50;
+
+      const prismaQuery: Parameters<typeof prisma.user.findMany>[0] = {
+        where: { orgId: request.orgId! },
+        orderBy: { createdAt: "desc" },
+        take: limit + 1,
+        select: { id: true, email: true, orgId: true, createdAt: true },
+      };
+
+      if (query.cursor) {
+        prismaQuery.cursor = { id: query.cursor };
+        prismaQuery.skip = 1;
+      }
+
+      const results = await prisma.user.findMany(prismaQuery);
+      const items = results.slice(0, limit);
+      const nextCursor = results.length > limit ? results[limit]?.id ?? null : null;
+
+      return getUsersResponseSchema.parse({
+        users: items.map(toUserDto),
+        nextCursor,
+      });
+    },
+  });
+}
+
+function buildBankLineRoutes(app: FastifyInstance) {
+  app.route({
+    method: "GET",
+    url: "/bank-lines",
+    config: {
+      replySchema: listBankLinesResponseSchema,
+    },
+    async handler(request) {
+      const query = listBankLinesQuerySchema.parse(request.query ?? {});
+      const limit = query.limit ?? 50;
+
+      const prismaQuery: Parameters<typeof prisma.bankLine.findMany>[0] = {
+        where: { orgId: request.orgId! },
+        orderBy: { date: "desc" },
+        take: limit + 1,
+      };
+
+      if (query.cursor) {
+        prismaQuery.cursor = { id: query.cursor };
+        prismaQuery.skip = 1;
+      }
+
+      const results = await prisma.bankLine.findMany(prismaQuery);
+      const items = results.slice(0, limit);
+      const nextCursor = results.length > limit ? results[limit]?.id ?? null : null;
+
+      return listBankLinesResponseSchema.parse({
+        bankLines: items.map(toBankLineDto),
+        nextCursor,
+      });
+    },
+  });
+
+  app.route({
+    method: "POST",
+    url: "/bank-lines",
+    config: {
+      replySchema: createBankLineResponseSchema,
+    },
+    async handler(request, reply) {
+      const body = createBankLineBodySchema.parse(request.body ?? {});
+      const idempotencyKey = request.headers["idempotency-key"];
+      if (typeof idempotencyKey !== "string" || idempotencyKey.trim().length === 0) {
+        return reply.code(400).send({ error: "idempotency_key_required" });
+      }
+
+      const hash = createHash("sha256").update(JSON.stringify(body)).digest("hex");
+
+      try {
+        const result = await getOrSet<CreateBankLineResult>(
+          idempotencyKey,
+          hash,
+          async () => {
+            const created = await prisma.bankLine.create({
+              data: {
+                orgId: body.orgId,
+                date: new Date(body.date),
+                amount: body.amountCents,
+                payee: body.payee,
+                desc: body.description,
+              },
+            });
+
+            return {
+              statusCode: 201,
+              body: createBankLineResponseSchema.parse({
+                bankLine: toBankLineDto(created),
+              }),
+            } satisfies CreateBankLineResult;
+          },
+        );
+
+        return reply.code(result.statusCode).send(result.body);
+      } catch (error) {
+        if (error instanceof IdempotencyConflictError) {
+          return reply.code(409).send({ error: "idempotency_conflict" });
+        }
+        if (error instanceof IdempotencyInProgressError) {
+          return reply.code(409).send({ error: "idempotency_in_progress" });
+        }
+        request.log.error({ err: error }, "failed to create bank line");
+        return reply.code(500).send({ error: "server_error" });
+      }
+    },
+  });
+}
+
+export async function buildApp() {
+  const app = Fastify({ logger: true, bodyLimit: 512 * 1024 });
+
+  await registerSecurity(app);
+  registerReplyValidation(app);
+
+  app.addHook("onRoute", addSecurityHandlers);
+
+  registerHealthRoutes(app);
+  await registerWebhookRoutes(app);
+  buildUsersRoute(app);
+  buildBankLineRoutes(app);
+
+  return app;
+}
+
+export function createShutdownHandler(app: FastifyInstance) {
+  let closing = false;
+  return async (signal: NodeJS.Signals) => {
+    if (closing) {
+      return;
+    }
+    closing = true;
+    app.log.info({ signal }, "graceful shutdown initiated");
+    try {
+      await app.close();
+      await prisma.$disconnect();
+      await closeIdempotencyStore();
+      app.log.info("shutdown complete");
+      if (process.env.NODE_ENV !== "test") {
+        process.exit(0);
+      }
+    } catch (error) {
+      app.log.error({ err: error }, "error during shutdown");
+      if (process.env.NODE_ENV !== "test") {
+        process.exit(1);
+      }
+    }
+  };
+}
+
+async function start() {
+  const app = await buildApp();
+
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  const shutdown = createShutdownHandler(app);
+  ["SIGTERM", "SIGINT"].forEach((signal) => {
+    process.once(signal as NodeJS.Signals, () => {
+      void shutdown(signal as NodeJS.Signals);
+    });
+  });
+
+  try {
+    await app.listen({ port, host });
+    app.log.info({ port, host }, "api-gateway listening");
+  } catch (error) {
+    app.log.error({ err: error }, "failed to start server");
+    await shutdown("SIGTERM");
+  }
+}
+
+if (process.env.NODE_ENV !== "test") {
+  void start();
+}

--- a/apgms/services/api-gateway/src/lib/idempotency.ts
+++ b/apgms/services/api-gateway/src/lib/idempotency.ts
@@ -1,0 +1,164 @@
+type RedisLike = {
+  get(key: string): Promise<string | null>;
+  set(
+    key: string,
+    value: string,
+    mode?: "NX" | "XX",
+    durationMode?: "EX" | "PX",
+    duration?: number,
+  ): Promise<string | null>;
+  del(key: string): Promise<number>;
+  quit(): Promise<unknown>;
+};
+
+class InMemoryRedis implements RedisLike {
+  private store = new Map<string, { value: string; expiresAt: number | null }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(
+    key: string,
+    value: string,
+    mode?: "NX" | "XX",
+    durationMode?: "EX" | "PX",
+    duration?: number,
+  ): Promise<string | null> {
+    const exists = await this.get(key);
+    if (mode === "NX" && exists !== null) {
+      return null;
+    }
+    if (mode === "XX" && exists === null) {
+      return null;
+    }
+    let expiresAt: number | null = null;
+    if (durationMode && duration) {
+      const ttlMs = durationMode === "EX" ? duration * 1000 : duration;
+      expiresAt = Date.now() + ttlMs;
+    }
+    this.store.set(key, { value, expiresAt });
+    return "OK";
+  }
+
+  async del(key: string): Promise<number> {
+    const hadKey = this.store.delete(key);
+    return hadKey ? 1 : 0;
+  }
+
+  async quit(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+let redisClient: RedisLike | null = null;
+let redisInitializationAttempted = false;
+
+export class IdempotencyConflictError extends Error {
+  constructor() {
+    super("idempotency_key_conflict");
+    this.name = "IdempotencyConflictError";
+  }
+}
+
+export class IdempotencyInProgressError extends Error {
+  constructor() {
+    super("idempotency_in_progress");
+    this.name = "IdempotencyInProgressError";
+  }
+}
+
+async function getRedis(): Promise<RedisLike> {
+  if (!redisClient) {
+    const url = process.env.IDEMPOTENCY_REDIS_URL;
+    if (url && !redisInitializationAttempted) {
+      redisInitializationAttempted = true;
+      try {
+        const module = await import("ioredis");
+        const Redis = module.default as any;
+        redisClient = new Redis(url, { lazyConnect: true });
+      } catch (error) {
+        console.warn("Failed to initialize Redis, falling back to in-memory store", error);
+      }
+    }
+    if (!redisClient) {
+      redisClient = new InMemoryRedis();
+    }
+  }
+  return redisClient;
+}
+
+const IDEMPOTENCY_PREFIX = "idempotency:key:";
+const IDEMPOTENCY_LOCK_PREFIX = "idempotency:lock:";
+const DEFAULT_TTL_SECONDS = 60 * 10;
+
+export async function getOrSet<T>(
+  key: string,
+  hash: string,
+  compute: () => Promise<T>,
+  ttlSeconds = DEFAULT_TTL_SECONDS,
+): Promise<T> {
+  const client = await getRedis();
+  const redisKey = `${IDEMPOTENCY_PREFIX}${key}`;
+  const lockKey = `${IDEMPOTENCY_LOCK_PREFIX}${key}`;
+
+  const existingRaw = await client.get(redisKey);
+  if (existingRaw) {
+    const parsed = JSON.parse(existingRaw) as { hash: string; value: T };
+    if (parsed.hash !== hash) {
+      throw new IdempotencyConflictError();
+    }
+    return parsed.value;
+  }
+
+  const acquired = await client.set(lockKey, hash, "NX", "EX", 30);
+  if (acquired === null) {
+    throw new IdempotencyInProgressError();
+  }
+
+  try {
+    const result = await compute();
+    await client.set(
+      redisKey,
+      JSON.stringify({ hash, value: result }),
+      "EX",
+      ttlSeconds,
+    );
+    return result;
+  } finally {
+    await client.del(lockKey);
+  }
+}
+
+export async function rememberNonce(
+  nonce: string,
+  ttlSeconds: number,
+): Promise<boolean> {
+  const client = await getRedis();
+  const key = `idempotency:nonce:${nonce}`;
+  const stored = await client.set(key, "1", "NX", "EX", ttlSeconds);
+  return stored === "OK";
+}
+
+export async function closeIdempotencyStore() {
+  if (redisClient) {
+    await redisClient.quit();
+    redisClient = null;
+    redisInitializationAttempted = false;
+  }
+}
+
+export function __resetInMemoryIdempotencyStore() {
+  if (redisClient instanceof InMemoryRedis) {
+    redisClient = null;
+  }
+  redisInitializationAttempted = false;
+}

--- a/apgms/services/api-gateway/src/middleware/auth.ts
+++ b/apgms/services/api-gateway/src/middleware/auth.ts
@@ -1,0 +1,126 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { FastifyReply, FastifyRequest } from "fastify";
+
+type JwtPayload = {
+  sub?: string;
+  orgId?: string;
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+};
+
+function base64UrlDecode(segment: string) {
+  return Buffer.from(segment, "base64url").toString("utf8");
+}
+
+function getJwtSecret(): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SECRET must be configured");
+  }
+  return secret;
+}
+
+function parseJwt(token: string): { header: Record<string, unknown>; payload: JwtPayload; signature: string; raw: string } {
+  const [headerSegment, payloadSegment, signatureSegment] = token.split(".");
+  if (!headerSegment || !payloadSegment || !signatureSegment) {
+    throw new Error("invalid_token_structure");
+  }
+  const header = JSON.parse(base64UrlDecode(headerSegment)) as Record<string, unknown>;
+  const payload = JSON.parse(base64UrlDecode(payloadSegment)) as JwtPayload;
+  return {
+    header,
+    payload,
+    signature: signatureSegment,
+    raw: `${headerSegment}.${payloadSegment}`,
+  };
+}
+
+function assertPayload(payload: JwtPayload) {
+  if (!payload.sub) {
+    throw new Error("JWT payload missing subject");
+  }
+  if (!payload.orgId) {
+    throw new Error("JWT payload missing orgId");
+  }
+  const issuer = process.env.JWT_ISS;
+  if (issuer && payload.iss !== issuer) {
+    throw new Error("invalid_issuer");
+  }
+  const audience = process.env.JWT_AUD;
+  if (audience) {
+    const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    if (!audiences.includes(audience)) {
+      throw new Error("invalid_audience");
+    }
+  }
+  if (payload.exp && Date.now() / 1000 > payload.exp) {
+    throw new Error("token_expired");
+  }
+  if (payload.nbf && Date.now() / 1000 < payload.nbf) {
+    throw new Error("token_not_ready");
+  }
+  return { userId: payload.sub, orgId: payload.orgId };
+}
+
+function verifyJwt(token: string) {
+  const { header, payload, signature, raw } = parseJwt(token);
+  if (header.alg !== "HS256") {
+    throw new Error("unsupported_algorithm");
+  }
+  const expected = createHmac("sha256", getJwtSecret())
+    .update(raw)
+    .digest("base64url");
+  const expectedBuf = Buffer.from(expected);
+  const providedBuf = Buffer.from(signature);
+  if (
+    expectedBuf.length !== providedBuf.length ||
+    !timingSafeEqual(expectedBuf, providedBuf)
+  ) {
+    throw new Error("invalid_signature");
+  }
+  return assertPayload(payload);
+}
+
+function resolveDevIdentity(req: FastifyRequest) {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
+  const user = req.headers["x-apgms-dev-user"];
+  const org = req.headers["x-apgms-dev-org"];
+  if (typeof user === "string" && typeof org === "string") {
+    return { userId: user, orgId: org };
+  }
+  return null;
+}
+
+export async function authenticateRequest(
+  req: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const authHeader = req.headers.authorization;
+
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    const token = authHeader.slice("Bearer ".length).trim();
+    try {
+      const { userId, orgId } = verifyJwt(token);
+      req.userId = userId;
+      req.orgId = orgId;
+      return;
+    } catch (err) {
+      req.log.warn({ err }, "failed to verify jwt");
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+  }
+
+  const devIdentity = resolveDevIdentity(req);
+  if (devIdentity) {
+    req.userId = devIdentity.userId;
+    req.orgId = devIdentity.orgId;
+    return;
+  }
+
+  return reply.code(401).send({ error: "unauthorized" });
+}

--- a/apgms/services/api-gateway/src/middleware/org-scope.ts
+++ b/apgms/services/api-gateway/src/middleware/org-scope.ts
@@ -1,0 +1,33 @@
+import { FastifyReply, FastifyRequest } from "fastify";
+
+type ScopedRequest = FastifyRequest & {
+  body?: { orgId?: string };
+  params?: { orgId?: string };
+  query?: { orgId?: string };
+};
+
+function extractOrgId(req: ScopedRequest): string | undefined {
+  const fromParams = req.params && typeof req.params === "object" ? (req.params as any).orgId : undefined;
+  if (typeof fromParams === "string") {
+    return fromParams;
+  }
+  const fromQuery = req.query && typeof req.query === "object" ? (req.query as any).orgId : undefined;
+  if (typeof fromQuery === "string") {
+    return fromQuery;
+  }
+  const fromBody = req.body && typeof req.body === "object" ? (req.body as any).orgId : undefined;
+  if (typeof fromBody === "string") {
+    return fromBody;
+  }
+  return undefined;
+}
+
+export async function enforceOrgScope(req: FastifyRequest, reply: FastifyReply) {
+  if (!req.orgId) {
+    return reply.code(401).send({ error: "unauthorized" });
+  }
+  const targetOrgId = extractOrgId(req as ScopedRequest);
+  if (targetOrgId && targetOrgId !== req.orgId) {
+    return reply.code(403).send({ error: "forbidden" });
+  }
+}

--- a/apgms/services/api-gateway/src/plugins/security.ts
+++ b/apgms/services/api-gateway/src/plugins/security.ts
@@ -1,0 +1,94 @@
+import cors from "@fastify/cors";
+import { FastifyInstance } from "fastify";
+
+const BODY_LIMIT = 512 * 1024;
+const RATE_LIMIT = 100;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+
+function parseAllowlist(): string[] {
+  const raw = process.env.CORS_ALLOWLIST ?? "";
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+}
+
+async function securityPlugin(app: FastifyInstance) {
+  const allowlist = parseAllowlist();
+  const isOriginAllowed = (origin: string) =>
+    allowlist.length > 0 && allowlist.includes(origin);
+  const rateWindow = new Map<
+    string,
+    {
+      count: number;
+      expiresAt: number;
+    }
+  >();
+
+  await app.register(cors, {
+    origin(origin, cb) {
+      if (!origin) {
+        cb(null, true);
+        return;
+      }
+      if (isOriginAllowed(origin)) {
+        cb(null, true);
+        return;
+      }
+      cb(null, false);
+    },
+    credentials: true,
+  });
+
+  app.addHook("onRequest", async (request, reply) => {
+    if (request.url.startsWith("/healthz") || request.url.startsWith("/readyz")) {
+      return;
+    }
+    const originHeader = request.headers.origin;
+    if (originHeader) {
+      const originValue = Array.isArray(originHeader) ? originHeader[0] : originHeader;
+      if (!isOriginAllowed(originValue)) {
+        if (request.method === "OPTIONS") {
+          return reply.code(403).send({ error: "cors_not_allowed" });
+        }
+      }
+    }
+    const forwardedFor = request.headers["x-forwarded-for"];
+    const realIp = request.headers["x-real-ip"];
+    const headerIp = Array.isArray(realIp)
+      ? realIp[0]
+      : typeof realIp === "string"
+        ? realIp
+        : Array.isArray(forwardedFor)
+          ? forwardedFor[0]
+          : typeof forwardedFor === "string"
+            ? forwardedFor.split(",")[0].trim()
+            : undefined;
+    const key = headerIp && headerIp.length > 0 ? headerIp : request.ip;
+    const now = Date.now();
+    const record = rateWindow.get(key);
+    if (!record || record.expiresAt <= now) {
+      rateWindow.set(key, { count: 1, expiresAt: now + RATE_LIMIT_WINDOW_MS });
+      return;
+    }
+    record.count += 1;
+    rateWindow.set(key, record);
+    if (record.count > RATE_LIMIT) {
+      return reply.code(429).send({ error: "rate_limit_exceeded" });
+    }
+  });
+
+  app.addHook("onRoute", (routeOptions) => {
+    if (!routeOptions.bodyLimit || routeOptions.bodyLimit > BODY_LIMIT) {
+      routeOptions.bodyLimit = BODY_LIMIT;
+    }
+  });
+
+  app.addHook("onClose", () => {
+    rateWindow.clear();
+  });
+}
+
+export async function registerSecurity(app: FastifyInstance) {
+  await securityPlugin(app);
+}

--- a/apgms/services/api-gateway/src/routes/health.ts
+++ b/apgms/services/api-gateway/src/routes/health.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+
+export function registerHealthRoutes(app: FastifyInstance) {
+  app.get("/healthz", async () => ({ ok: true }));
+
+  app.get("/readyz", async (request, reply) => {
+    try {
+      await prisma.$queryRaw`SELECT 1`;
+      return reply.code(200).send({ ready: true });
+    } catch (error) {
+      request.log.error({ err: error }, "database readiness check failed");
+      return reply.code(503).send({ ready: false, reason: "database_unreachable" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/routes/webhooks.ts
+++ b/apgms/services/api-gateway/src/routes/webhooks.ts
@@ -1,0 +1,67 @@
+import crypto from "node:crypto";
+import { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { rememberNonce } from "../lib/idempotency";
+
+const WEBHOOK_TTL_SECONDS = 60 * 5;
+
+const webhookPayloadSchema = z
+  .object({
+    timestamp: z.coerce.number(),
+    nonce: z.string().min(8),
+    hmac: z.string().min(32),
+  })
+  .passthrough();
+
+const webhookResponseSchema = z.object({ received: z.boolean() });
+
+function computeSignature(secret: string, body: Record<string, unknown>) {
+  const sortedEntries = Object.entries(body)
+    .filter(([key]) => key !== "hmac")
+    .sort(([a], [b]) => a.localeCompare(b));
+  const payload = JSON.stringify(Object.fromEntries(sortedEntries));
+  return crypto.createHmac("sha256", secret).update(payload).digest("hex");
+}
+
+export async function registerWebhookRoutes(app: FastifyInstance) {
+  app.route({
+    method: "POST",
+    url: "/webhooks/payto",
+    config: {
+      replySchema: webhookResponseSchema,
+    },
+    async handler(request, reply) {
+      const parsed = webhookPayloadSchema.parse(request.body ?? {});
+
+      const secret = process.env.HMAC_SECRET;
+      if (!secret) {
+        request.log.error("HMAC_SECRET must be configured");
+        return reply.code(500).send({ error: "server_error" });
+      }
+
+      const now = Date.now();
+      if (Math.abs(now - parsed.timestamp * 1000) > WEBHOOK_TTL_SECONDS * 1000) {
+        return reply.code(409).send({ error: "stale_signature" });
+      }
+
+      const expected = computeSignature(secret, parsed);
+      const expectedBuf = Buffer.from(expected, "hex");
+      const providedBuf = Buffer.from(parsed.hmac, "hex");
+      if (
+        expectedBuf.length !== providedBuf.length ||
+        !crypto.timingSafeEqual(expectedBuf, providedBuf)
+      ) {
+        return reply.code(401).send({ error: "invalid_signature" });
+      }
+
+      const nonceAccepted = await rememberNonce(parsed.nonce, WEBHOOK_TTL_SECONDS);
+      if (!nonceAccepted) {
+        return reply.code(409).send({ error: "nonce_replayed" });
+      }
+
+      request.log.info({ event: parsed }, "webhook received");
+
+      return reply.code(202).send({ received: true });
+    },
+  });
+}

--- a/apgms/services/api-gateway/src/schemas/bank-lines.ts
+++ b/apgms/services/api-gateway/src/schemas/bank-lines.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import {
+  cuidSchema,
+  isoDateSchema,
+  moneyCentsCoerceSchema,
+  moneyCentsSchema,
+  orgIdSchema,
+  positiveIntSchema,
+} from "./common";
+
+export const listBankLinesQuerySchema = z.object({
+  orgId: orgIdSchema,
+  limit: positiveIntSchema.max(200).optional(),
+  cursor: z.string().cuid().optional(),
+});
+
+export const bankLineSchema = z.object({
+  id: cuidSchema,
+  orgId: orgIdSchema,
+  date: isoDateSchema,
+  amountCents: moneyCentsSchema,
+  payee: z.string(),
+  description: z.string(),
+  createdAt: isoDateSchema,
+});
+
+export const listBankLinesResponseSchema = z.object({
+  bankLines: z.array(bankLineSchema),
+  nextCursor: z.string().cuid().nullable(),
+});
+
+export const createBankLineBodySchema = z.object({
+  orgId: orgIdSchema,
+  date: isoDateSchema,
+  amountCents: moneyCentsCoerceSchema,
+  payee: z.string().min(1),
+  description: z.string().min(1),
+});
+
+export const createBankLineResponseSchema = z.object({
+  bankLine: bankLineSchema,
+});

--- a/apgms/services/api-gateway/src/schemas/common.ts
+++ b/apgms/services/api-gateway/src/schemas/common.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const emailSchema = z.string().email();
+export const cuidSchema = z.string().cuid();
+export const orgIdSchema = cuidSchema;
+export const isoDateSchema = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), "Invalid ISO date");
+export const moneyCentsSchema = z
+  .number({ invalid_type_error: "amount must be a number" })
+  .int();
+export const moneyCentsCoerceSchema = z
+  .coerce.number({ invalid_type_error: "amount must be a number" })
+  .int();
+export const positiveIntSchema = z.coerce.number().int().positive();

--- a/apgms/services/api-gateway/src/schemas/users.ts
+++ b/apgms/services/api-gateway/src/schemas/users.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { cuidSchema, emailSchema, isoDateSchema, orgIdSchema, positiveIntSchema } from "./common";
+
+export const getUsersQuerySchema = z.object({
+  orgId: orgIdSchema,
+  limit: positiveIntSchema.max(200).optional(),
+  cursor: z.string().cuid().optional(),
+});
+
+export const userSchema = z.object({
+  id: cuidSchema,
+  email: emailSchema,
+  orgId: orgIdSchema,
+  createdAt: isoDateSchema,
+});
+
+export const getUsersResponseSchema = z.object({
+  users: z.array(userSchema),
+  nextCursor: z.string().cuid().nullable(),
+});

--- a/apgms/services/api-gateway/src/types/fastify.d.ts
+++ b/apgms/services/api-gateway/src/types/fastify.d.ts
@@ -1,0 +1,8 @@
+import "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    userId?: string;
+    orgId?: string;
+  }
+}

--- a/apgms/services/api-gateway/src/types/ioredis.d.ts
+++ b/apgms/services/api-gateway/src/types/ioredis.d.ts
@@ -1,0 +1,15 @@
+declare module "ioredis" {
+  export default class Redis {
+    constructor(url: string, options?: Record<string, unknown>);
+    get(key: string): Promise<string | null>;
+    set(
+      key: string,
+      value: string,
+      mode?: "NX" | "XX",
+      durationMode?: "EX" | "PX",
+      duration?: number,
+    ): Promise<string | null>;
+    del(key: string): Promise<number>;
+    quit(): Promise<unknown>;
+  }
+}

--- a/apgms/services/api-gateway/test/authz.spec.ts
+++ b/apgms/services/api-gateway/test/authz.spec.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { prismaMock } from "./setup";
+import { buildApp } from "../src/index";
+import { TEST_ORG_ID, createJwt, fakeDecimal } from "./utils";
+
+describe("authorization", () => {
+  const routes = [
+    { method: "GET", url: "/users", query: { orgId: TEST_ORG_ID } },
+    { method: "GET", url: "/bank-lines", query: { orgId: TEST_ORG_ID } },
+    {
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: TEST_ORG_ID,
+        date: new Date().toISOString(),
+        amountCents: 1000,
+        payee: "Vendor",
+        description: "Invoice",
+      },
+      headers: { "idempotency-key": "key-123" },
+    },
+  ] as const;
+
+  it("denies anonymous access", async () => {
+    for (const route of routes) {
+      const app = await buildApp();
+      if (route.url === "/users") {
+        prismaMock.user.findMany.mockResolvedValue([]);
+      }
+      if (route.url === "/bank-lines" && route.method === "GET") {
+        prismaMock.bankLine.findMany.mockResolvedValue([]);
+      }
+      if (route.method === "POST") {
+        prismaMock.bankLine.create.mockResolvedValue({
+          id: "clbanklinetest00000000001",
+          orgId: route.payload.orgId,
+          date: new Date(route.payload.date),
+          amount: fakeDecimal(route.payload.amountCents),
+          payee: route.payload.payee,
+          desc: route.payload.description,
+          createdAt: new Date(),
+        });
+      }
+      const response = await app.inject({
+        method: route.method,
+        url: route.url,
+        query: (route as any).query,
+        payload: (route as any).payload,
+        headers: (route as any).headers,
+      });
+      assert.strictEqual(response.statusCode, 401);
+      await app.close();
+    }
+  });
+
+  it("blocks cross-tenant access", async () => {
+    for (const route of routes) {
+      const app = await buildApp();
+      prismaMock.user.findMany.mockResolvedValue([]);
+      prismaMock.bankLine.findMany.mockResolvedValue([]);
+      prismaMock.bankLine.create.mockResolvedValue({
+        id: "clbanklinetest00000000001",
+        orgId: "ckorg1test00000000000099",
+        date: new Date(),
+        amount: fakeDecimal(1000),
+        payee: "Vendor",
+        desc: "Invoice",
+        createdAt: new Date(),
+      });
+      const token = await createJwt(TEST_ORG_ID);
+      const headers = {
+        ...(route as any).headers,
+        authorization: `Bearer ${token}`,
+      } as Record<string, string>;
+
+      const response = await app.inject({
+        method: route.method,
+        url: route.url,
+        query: route.url === "/users" || route.url === "/bank-lines"
+          ? { orgId: "ckorg1test00000000000099" }
+          : undefined,
+        payload:
+          route.method === "POST"
+            ? {
+                ...(route as any).payload,
+                orgId: "ckorg1test00000000000099",
+              }
+            : undefined,
+        headers,
+      });
+      assert.strictEqual(response.statusCode, 403);
+      await app.close();
+    }
+  });
+
+  it("allows tenant access when scopes match", async () => {
+    for (const route of routes) {
+      const app = await buildApp();
+    if (route.url === "/users") {
+      prismaMock.user.findMany.mockResolvedValue([
+        {
+          id: "ckuser12345678901234567890",
+          email: "user@example.com",
+          orgId: route.query.orgId,
+          createdAt: new Date(),
+        },
+      ]);
+    }
+    if (route.url === "/bank-lines" && route.method === "GET") {
+      prismaMock.bankLine.findMany.mockResolvedValue([
+        {
+          id: "clbankline123456789012345678",
+          orgId: route.query.orgId,
+          date: new Date(),
+          amount: fakeDecimal(1234),
+          payee: "Vendor",
+            desc: "Invoice",
+            createdAt: new Date(),
+          },
+        ]);
+      }
+    if (route.method === "POST") {
+      prismaMock.bankLine.create.mockResolvedValue({
+        id: "clbanklinecreated1234567890",
+        orgId: route.payload.orgId,
+        date: new Date(route.payload.date),
+        amount: fakeDecimal(route.payload.amountCents),
+        payee: route.payload.payee,
+          desc: route.payload.description,
+          createdAt: new Date(),
+        });
+      }
+      const token = await createJwt(TEST_ORG_ID);
+      const headers = {
+        ...(route as any).headers,
+        authorization: `Bearer ${token}`,
+      } as Record<string, string>;
+
+      const response = await app.inject({
+        method: route.method,
+        url: route.url,
+        query: (route as any).query,
+        payload: (route as any).payload,
+        headers,
+      });
+      assert.ok([200, 201, 202].includes(response.statusCode));
+      await app.close();
+    }
+  });
+});

--- a/apgms/services/api-gateway/test/contracts.spec.ts
+++ b/apgms/services/api-gateway/test/contracts.spec.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { prismaMock } from "./setup";
+import { buildApp } from "../src/index";
+import { TEST_ORG_ID, createJwt, fakeDecimal } from "./utils";
+
+describe("contracts", () => {
+  it("returns bank lines matching the public contract", async () => {
+    const app = await buildApp();
+    const token = await createJwt(TEST_ORG_ID);
+    prismaMock.bankLine.findMany.mockResolvedValue([
+      {
+        id: "clbanklinevalid123456789012",
+        orgId: TEST_ORG_ID,
+        date: new Date("2024-01-01T00:00:00Z"),
+        amount: fakeDecimal(2500),
+        payee: "Vendor",
+        desc: "Invoice",
+        createdAt: new Date("2024-01-02T00:00:00Z"),
+      },
+    ]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/bank-lines",
+      query: { orgId: TEST_ORG_ID },
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    assert.strictEqual(response.statusCode, 200);
+    const payload = response.json();
+    assert.strictEqual(payload.bankLines.length, 1);
+    assert.deepStrictEqual(payload.bankLines[0], {
+      id: "clbanklinevalid123456789012",
+      orgId: TEST_ORG_ID,
+      date: "2024-01-01T00:00:00.000Z",
+      amountCents: 2500,
+      payee: "Vendor",
+      description: "Invoice",
+      createdAt: "2024-01-02T00:00:00.000Z",
+    });
+    assert.strictEqual(payload.nextCursor, null);
+    await app.close();
+  });
+
+  it("fails fast when bank line payload violates the schema", async () => {
+    const app = await buildApp();
+    const token = await createJwt(TEST_ORG_ID);
+    prismaMock.bankLine.findMany.mockResolvedValue([
+      {
+        id: "clbanklinebad1234567890123",
+        orgId: TEST_ORG_ID,
+        date: new Date(),
+        amount: fakeDecimal(10),
+        payee: "Vendor",
+        desc: null,
+        createdAt: new Date(),
+      } as any,
+    ]);
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/bank-lines",
+      query: { orgId: TEST_ORG_ID },
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+    assert.ok(response.statusCode >= 500);
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { prismaMock } from "./setup";
+import { buildApp, createShutdownHandler } from "../src/index";
+
+describe("health endpoints", () => {
+  it("reports liveness", async () => {
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/healthz" });
+    assert.strictEqual(response.statusCode, 200);
+    assert.deepStrictEqual(response.json(), { ok: true });
+    await app.close();
+  });
+
+  it("reports readiness when the database is reachable", async () => {
+    prismaMock.$queryRaw.mockResolvedValue([{ ok: 1 }]);
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/readyz" });
+    assert.strictEqual(response.statusCode, 200);
+    assert.deepStrictEqual(response.json(), { ready: true });
+    await app.close();
+  });
+
+  it("returns not ready when the database is unreachable", async () => {
+    prismaMock.$queryRaw.mockRejectedValue(new Error("connection refused"));
+    const app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/readyz" });
+    assert.strictEqual(response.statusCode, 503);
+    const payload = response.json();
+    assert.strictEqual(payload.ready, false);
+    await app.close();
+  });
+
+  it("closes resources gracefully on shutdown", async () => {
+    const app = await buildApp();
+    const shutdown = createShutdownHandler(app);
+    await shutdown("SIGTERM");
+    assert.ok(prismaMock.$disconnect.calls.length > 0);
+  });
+});

--- a/apgms/services/api-gateway/test/index.test.ts
+++ b/apgms/services/api-gateway/test/index.test.ts
@@ -1,0 +1,5 @@
+import "./authz.spec";
+import "./security.spec";
+import "./contracts.spec";
+import "./webhooks.spec";
+import "./health.spec";

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { prismaMock } from "./setup";
+import { buildApp } from "../src/index";
+import { TEST_ORG_ID, createJwt, fakeDecimal } from "./utils";
+
+describe("security plugin", () => {
+  it("allows preflight requests for allowlisted origins", async () => {
+    process.env.CORS_ALLOWLIST = "https://allowed.example";
+    const app = await buildApp();
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/users",
+      headers: {
+        origin: "https://allowed.example",
+        "access-control-request-method": "GET",
+      },
+    });
+    assert.strictEqual(response.statusCode, 204);
+    await app.close();
+  });
+
+  it("blocks preflight requests for non-allowlisted origins", async () => {
+    process.env.CORS_ALLOWLIST = "https://allowed.example";
+    const app = await buildApp();
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/users",
+      headers: {
+        origin: "https://denied.example",
+        "access-control-request-method": "GET",
+      },
+    });
+    assert.strictEqual(response.statusCode, 403);
+    await app.close();
+  });
+
+  it("applies rate limiting per IP", async () => {
+    process.env.CORS_ALLOWLIST = "https://allowed.example";
+    const app = await buildApp();
+    prismaMock.user.findMany.mockResolvedValue([]);
+    const token = await createJwt(TEST_ORG_ID);
+
+    for (let i = 0; i < 100; i += 1) {
+      const okResponse = await app.inject({
+        method: "GET",
+        url: "/users",
+        query: { orgId: TEST_ORG_ID },
+        headers: { authorization: `Bearer ${token}`, "x-real-ip": "203.0.113.10" },
+      });
+      assert.strictEqual(okResponse.statusCode, 200);
+    }
+
+    const limitedResponse = await app.inject({
+      method: "GET",
+      url: "/users",
+      query: { orgId: TEST_ORG_ID },
+      headers: { authorization: `Bearer ${token}`, "x-real-ip": "203.0.113.10" },
+    });
+    assert.strictEqual(limitedResponse.statusCode, 429);
+    await app.close();
+  });
+
+  it("rejects payloads exceeding the body limit", async () => {
+    process.env.CORS_ALLOWLIST = "https://allowed.example";
+    const app = await buildApp();
+    prismaMock.bankLine.create.mockResolvedValue({
+      id: "line_large",
+      orgId: TEST_ORG_ID,
+      date: new Date(),
+      amount: fakeDecimal(1000),
+      payee: "Vendor",
+      desc: "Invoice",
+      createdAt: new Date(),
+    });
+    const token = await createJwt(TEST_ORG_ID);
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "idempotency-key": "oversize-test",
+        "content-type": "application/json",
+      },
+      payload: {
+        orgId: TEST_ORG_ID,
+        date: new Date().toISOString(),
+        amountCents: 1000,
+        payee: "Vendor",
+        description: "x".repeat(600 * 1024),
+      },
+    });
+    assert.strictEqual(response.statusCode, 413);
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/test/setup.ts
+++ b/apgms/services/api-gateway/test/setup.ts
@@ -1,0 +1,96 @@
+import { beforeEach } from "node:test";
+
+export const prismaMock = {
+  user: {
+    findMany: jestableFn(),
+  },
+  bankLine: {
+    findMany: jestableFn(),
+    create: jestableFn(),
+  },
+  $queryRaw: jestableFn(() => Promise.resolve([{ ok: 1 }])),
+  $disconnect: jestableFn(() => Promise.resolve()),
+};
+
+function jestableFn<T extends (...args: any[]) => any>(impl?: T) {
+  let handler: (...args: any[]) => any = impl ?? (() => Promise.resolve());
+  const onceQueue: Array<(...args: any[]) => any> = [];
+  const calls: any[][] = [];
+  const fn = (...args: any[]) => {
+    calls.push(args);
+    if (onceQueue.length > 0) {
+      return onceQueue.shift()!(...args);
+    }
+    return handler(...args);
+  };
+  fn.mockResolvedValue = (value: any) => {
+    handler = () => Promise.resolve(value);
+  };
+  fn.mockResolvedValueOnce = (value: any) => {
+    onceQueue.push(() => Promise.resolve(value));
+  };
+  fn.mockRejectedValue = (error: any) => {
+    handler = () => Promise.reject(error);
+  };
+  fn.mockRejectedValueOnce = (error: any) => {
+    onceQueue.push(() => Promise.reject(error));
+  };
+  fn.mockReset = () => {
+    handler = impl ?? (() => Promise.resolve());
+    onceQueue.length = 0;
+    calls.length = 0;
+  };
+  fn.mockClear = () => {
+    handler = impl ?? (() => Promise.resolve());
+    onceQueue.length = 0;
+    calls.length = 0;
+  };
+  fn.mockImplementation = (next: any) => {
+    handler = next;
+  };
+  fn.mockImplementationOnce = (next: any) => {
+    onceQueue.push(next);
+  };
+  (fn as any).calls = calls;
+
+  return fn as T & {
+    mockResolvedValue(value: any): void;
+    mockResolvedValueOnce(value: any): void;
+    mockRejectedValue(error: any): void;
+    mockRejectedValueOnce(error: any): void;
+    mockReset(): void;
+    mockClear(): void;
+    mockImplementation(next: (...args: any[]) => any): void;
+    mockImplementationOnce(next: (...args: any[]) => any): void;
+    calls: any[][];
+  };
+}
+
+export function resetTestState() {
+  prismaMock.user.findMany.mockReset();
+  prismaMock.user.findMany.mockResolvedValue([]);
+  prismaMock.bankLine.findMany.mockReset();
+  prismaMock.bankLine.findMany.mockResolvedValue([]);
+  prismaMock.bankLine.create.mockReset();
+  prismaMock.$queryRaw.mockReset();
+  prismaMock.$queryRaw.mockResolvedValue([{ ok: 1 }]);
+  prismaMock.$disconnect.mockReset();
+  process.env.NODE_ENV = "test";
+  process.env.JWT_SECRET = process.env.JWT_SECRET ?? "test-secret";
+  process.env.JWT_ISS = process.env.JWT_ISS ?? "test-issuer";
+  process.env.JWT_AUD = process.env.JWT_AUD ?? "test-audience";
+  process.env.HMAC_SECRET = process.env.HMAC_SECRET ?? "test-hmac";
+  process.env.CORS_ALLOWLIST = "https://allowed.test";
+  (globalThis as any).__APGMS_PRISMA__ = prismaMock;
+}
+
+export function registerCommonHooks() {
+  resetTestState();
+  beforeEach(() => {
+    resetTestState();
+  });
+}
+
+registerCommonHooks();
+
+export type PrismaMock = typeof prismaMock;

--- a/apgms/services/api-gateway/test/utils.ts
+++ b/apgms/services/api-gateway/test/utils.ts
@@ -1,0 +1,33 @@
+import { createHmac } from "node:crypto";
+
+function base64UrlEncode(value: string) {
+  return Buffer.from(value).toString("base64url");
+}
+
+export async function createJwt(orgId: string, userId = "user_123") {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload = {
+    orgId,
+    sub: userId,
+    iss: process.env.JWT_ISS,
+    aud: process.env.JWT_AUD,
+    iat: issuedAt,
+    exp: issuedAt + 60 * 60,
+  };
+  const header = { alg: "HS256", typ: "JWT" };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = createHmac("sha256", process.env.JWT_SECRET ?? "test-secret")
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .digest("base64url");
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}
+
+export const TEST_ORG_ID = "ckorg1test00000000000001";
+
+export function fakeDecimal(value: number) {
+  return {
+    toString: () => value.toString(),
+    valueOf: () => value,
+  };
+}

--- a/apgms/services/api-gateway/test/webhooks.spec.ts
+++ b/apgms/services/api-gateway/test/webhooks.spec.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { describe, it } from "node:test";
+import "./setup";
+import { buildApp } from "../src/index";
+
+function signPayload(payload: Record<string, unknown>) {
+  const entries = Object.entries(payload)
+    .filter(([key]) => key !== "hmac")
+    .sort(([a], [b]) => a.localeCompare(b));
+  const serialized = JSON.stringify(Object.fromEntries(entries));
+  return crypto
+    .createHmac("sha256", process.env.HMAC_SECRET ?? "test-hmac")
+    .update(serialized)
+    .digest("hex");
+}
+
+describe("webhook security", () => {
+  it("accepts valid webhook payloads", async () => {
+    const app = await buildApp();
+    const basePayload = {
+      timestamp: Math.floor(Date.now() / 1000),
+      nonce: crypto.randomUUID(),
+      event: { type: "payto.settled", amount: 1000 },
+    };
+    const hmac = signPayload(basePayload);
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/payto",
+      payload: { ...basePayload, hmac },
+    });
+    assert.strictEqual(response.statusCode, 202);
+    await app.close();
+  });
+
+  it("rejects stale timestamps", async () => {
+    const app = await buildApp();
+    const basePayload = {
+      timestamp: Math.floor((Date.now() - 6 * 60 * 1000) / 1000),
+      nonce: crypto.randomUUID(),
+      event: { type: "payto.settled" },
+    };
+    const hmac = signPayload(basePayload);
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/payto",
+      payload: { ...basePayload, hmac },
+    });
+    assert.strictEqual(response.statusCode, 409);
+    await app.close();
+  });
+
+  it("prevents nonce replay attempts", async () => {
+    const app = await buildApp();
+    const nonce = crypto.randomUUID();
+    const firstPayload = {
+      timestamp: Math.floor(Date.now() / 1000),
+      nonce,
+      event: { type: "payto.settled" },
+    };
+    const firstHmac = signPayload(firstPayload);
+    const firstResponse = await app.inject({
+      method: "POST",
+      url: "/webhooks/payto",
+      payload: { ...firstPayload, hmac: firstHmac },
+    });
+    assert.strictEqual(firstResponse.statusCode, 202);
+
+    const secondPayload = {
+      timestamp: Math.floor(Date.now() / 1000),
+      nonce,
+      event: { type: "payto.settled" },
+    };
+    const secondHmac = signPayload(secondPayload);
+    const replayResponse = await app.inject({
+      method: "POST",
+      url: "/webhooks/payto",
+      payload: { ...secondPayload, hmac: secondHmac },
+    });
+    assert.strictEqual(replayResponse.statusCode, 409);
+    await app.close();
+  });
+
+  it("rejects invalid HMAC signatures", async () => {
+    const app = await buildApp();
+    const payload = {
+      timestamp: Math.floor(Date.now() / 1000),
+      nonce: crypto.randomUUID(),
+      event: { type: "payto.settled" },
+      hmac: crypto.randomBytes(32).toString("hex"),
+    };
+    const response = await app.inject({
+      method: "POST",
+      url: "/webhooks/payto",
+      payload,
+    });
+    assert.strictEqual(response.statusCode, 401);
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,20 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import type { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __APGMS_PRISMA__: PrismaClient | undefined;
+}
+
+const globalAny = globalThis as typeof globalThis & {
+  __APGMS_PRISMA__?: PrismaClient;
+};
+
+let prismaInstance = globalAny.__APGMS_PRISMA__;
+
+if (!prismaInstance) {
+  const { PrismaClient } = await import("@prisma/client");
+  prismaInstance = new PrismaClient();
+  globalAny.__APGMS_PRISMA__ = prismaInstance;
+}
+
+export const prisma = prismaInstance;


### PR DESCRIPTION
## Summary
- add authentication/org scope middleware, schemas, and Prisma-aware bootstrap for the API gateway
- register security plugin with CORS allowlist, rate limiting, body limits, and webhook/idempotency handling
- cover health checks, authz, contracts, security, and webhook flows with node:test suites

## Testing
- FASTIFY_LOG_LEVEL=warn pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68f4b5b5e66483279bc52c3dd905431a