### PR TITLE
Add prompt scaffold templates and usage guide

### DIFF
--- a/apgms/prompts/templates/README.md
+++ b/apgms/prompts/templates/README.md
@@ -1,0 +1,32 @@
+# Prompt Template Scaffolds
+
+The templates in this directory define a modular prompt stack. Assemble final prompts by layering files in the following order:
+
+1. `system.md` – establishes core role, capabilities, and operational guardrails.
+2. `style.md` – constrains tone, formatting, and reusable phrasing.
+3. `context.md` – injects project specifics and environmental signals.
+4. `task.md` – defines the concrete work request and acceptance criteria.
+5. `validator.md` – outlines how the response will be evaluated.
+
+## Usage
+
+1. Duplicate each template into a working location.
+2. Replace every `{{placeholder}}` token with context-appropriate content.
+3. Concatenate the populated segments in the order above, separating sections with blank lines.
+4. Deliver the combined prompt to the assistant along with any supporting artifacts.
+
+## Example Snippets
+
+```markdown
+# System Prompt Template
+- Define the assistant's role as: **Security Release Coordinator**
+- Primary capabilities: triage vulnerability reports, draft advisories, coordinate patches
+```
+
+```markdown
+# Task Prompt Template
+## Objective
+- Summarize the end goal: Ship patched containers for CVE-XXXX-YYYY across all environments.
+```
+
+Use these scaffolds as building blocks to rapidly produce consistent, multi-layered instructions.

--- a/apgms/prompts/templates/context.md
+++ b/apgms/prompts/templates/context.md
@@ -1,0 +1,24 @@
+# Context Prompt Template
+
+## Project Snapshot
+- Repository / product name: {{project_name}}
+- High-level description: {{project_summary}}
+- Current release / sprint: {{current_release}}
+
+## Recent Activity
+- Last merged changes: {{recent_changes}}
+- Known issues or incidents: {{known_issues}}
+
+## Environment Notes
+- Runtime or platform specifics: {{platform_details}}
+- Configuration flags / feature toggles: {{feature_flags}}
+- Data sources or APIs: {{data_sources}}
+
+## Stakeholders & Users
+- Primary users: {{primary_users}}
+- Stakeholder expectations: {{stakeholder_expectations}}
+
+## Reference Materials
+- Architecture diagrams: {{architecture_links}}
+- Documentation links: {{documentation_links}}
+- Reusable prompt snippets: {{prompt_snippets}}

--- a/apgms/prompts/templates/style.md
+++ b/apgms/prompts/templates/style.md
@@ -1,0 +1,23 @@
+# Style Prompt Template
+
+## Tone & Voice
+- Preferred tone descriptors: {{tone_descriptors}}
+- Persona keywords or phrases: {{persona_keywords}}
+
+## Structural Preferences
+- Paragraph length guidance: {{paragraph_guidance}}
+- Bullet / list usage: {{list_guidance}}
+- Code or math formatting rules: {{formatting_rules}}
+
+## Language Requirements
+- Vocabulary constraints: {{vocabulary_constraints}}
+- Jargon usage policy: {{jargon_policy}}
+- Inclusive language reminders: {{inclusive_language}}
+
+## Quality Checks
+- Proofreading checklist: {{proofreading_checklist}}
+- Localization or translation notes: {{localization_notes}}
+
+## Reusable Snippets
+- Greetings or sign-offs: {{greetings}}
+- Boilerplate disclaimers: {{disclaimers}}

--- a/apgms/prompts/templates/system.md
+++ b/apgms/prompts/templates/system.md
@@ -1,0 +1,19 @@
+# System Prompt Template
+
+## Purpose
+- Define the assistant's role as: **{{role_description}}**
+
+## Capabilities & Boundaries
+- Primary capabilities: {{capabilities_list}}
+- Explicit limitations or refusals: {{limitations_list}}
+- Safety & compliance reminders: {{safety_requirements}}
+
+## Response Contract
+- Output format: {{required_format}}
+- Prohibited content: {{prohibited_content}}
+- Fallback / escalation instructions: {{fallback_instructions}}
+
+## Operational Settings
+- Default language: {{default_language}}
+- Persona tone: {{persona_tone}}
+- Additional environmental context: {{environment_notes}}

--- a/apgms/prompts/templates/task.md
+++ b/apgms/prompts/templates/task.md
@@ -1,0 +1,27 @@
+# Task Prompt Template
+
+## Objective
+- Summarize the end goal: {{task_goal}}
+- Success criteria / definition of done: {{success_criteria}}
+
+## Inputs
+- Primary artifacts or files to inspect: {{key_artifacts}}
+- External references or tickets: {{references}}
+
+## Deliverables
+- Expected outputs: {{expected_outputs}}
+- Non-deliverables (explicitly out of scope): {{out_of_scope}}
+
+## Constraints
+- Time or budget limits: {{constraints}}
+- Required tools or commands: {{required_tools}}
+- Dependencies / blockers: {{dependencies}}
+
+## Milestones
+1. {{milestone_one}}
+2. {{milestone_two}}
+3. {{milestone_three}}
+
+## Review & Handover
+- Reviewers / approvers: {{reviewers}}
+- Handoff instructions: {{handoff_instructions}}

--- a/apgms/prompts/templates/validator.md
+++ b/apgms/prompts/templates/validator.md
@@ -1,0 +1,23 @@
+# Validator Prompt Template
+
+## Validation Goals
+- Checklist items to confirm: {{validation_checklist}}
+- Acceptance thresholds / tolerances: {{acceptance_thresholds}}
+
+## Review Procedure
+1. Preparation steps: {{preparation_steps}}
+2. Validation actions: {{validation_actions}}
+3. Post-validation follow-up: {{follow_up}}
+
+## Evidence Collection
+- Required logs or artifacts: {{required_artifacts}}
+- Screenshot / recording instructions: {{evidence_instructions}}
+
+## Decision Matrix
+- Pass criteria summary: {{pass_summary}}
+- Fail criteria summary: {{fail_summary}}
+- Escalation path: {{escalation_path}}
+
+## Sign-off
+- Responsible validator: {{validator_name}}
+- Date & time of completion: {{completion_timestamp}}


### PR DESCRIPTION
## Summary
- add fill-in-the-blank templates for system, style, context, task, and validator prompts
- document template assembly order and usage guidance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f4c7adf3c88327840b3c56a2bdff49