### PR TITLE
Add prompt validation and evaluation gates to CI

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
 jobs:
   build:
@@ -15,3 +15,61 @@ jobs:
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+  prompt-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: npm run prompt:lint
+      - run: npm run prompt:validate
+  golden:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: npm run golden
+      - name: Upload golden evaluation report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-report
+          path: eval/golden-report.json
+          if-no-files-found: error
+  red-team:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+      - run: pnpm i
+      - run: npm run redteam
+      - name: Upload red-team evaluation report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: redteam-report
+          path: eval/redteam-report.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add prompt validation, golden, and red-team jobs to CI workflow
- upload evaluation reports as artifacts for golden and red-team jobs

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_68f4c7fa0674832796b28b545455f8ca