### PR TITLE
Add migration drift check and data governance docs

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -3,6 +3,20 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -13,5 +27,10 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
       - run: pnpm i
+      - name: Check Prisma migrations are in sync
+        run: pnpm -w exec prisma migrate status --schema shared/prisma/schema.prisma
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/app?schema=public
+          SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/app?schema=shadow
       - run: pnpm -r build
       - run: pnpm -r test

--- a/apgms/docs/architecture/data-governance.md
+++ b/apgms/docs/architecture/data-governance.md
@@ -1,0 +1,39 @@
+# Data governance
+
+This document describes how we manage retention and privacy for structured data that flows through the platform. The scope covers the primary tables defined in `shared/prisma/schema.prisma` and the operational data that backs the API gateway.
+
+## Data retention
+
+| Dataset | Purpose | Retention policy |
+| --- | --- | --- |
+| `Org` records | Tenant bootstrap and authorisation | Retained indefinitely while the organisation is an active customer. Soft-delete logic is planned for off-boarding; backups honour the same policy. |
+| `User` records | Account provisioning and audit | Retained while the owning organisation is active. Accounts are disabled after 90 days of inactivity and deleted 30 days after deactivation. |
+| `BankLine` records | Transaction history ingest and reconciliation | Retained for seven (7) years to satisfy statutory audit expectations. Older rows are archived to cold storage with the same protection guarantees. |
+
+Backups inherit the above timeframes and are encrypted by the underlying database service. Restore requests are restricted to the platform SRE rotation and must be approved through the incident workflow.
+
+## PII handling and access controls
+
+* PII (email addresses, transaction metadata) is only available to services with an explicit need-to-know. Prisma client access is centralised in `shared/src/db.ts` to ensure future cross-cutting controls can be applied in one place.
+* Runtime secrets such as `DATABASE_URL` are injected through the deployment environment, never committed to the repository, and rotated quarterly.
+* Application logs are redacted by default via Fastify/Pino redaction so that emails, tokens and passwords are masked before emission.
+
+## Encryption expectations
+
+* **In transit:** All traffic terminates behind managed TLS. Internal service-to-service communication must also negotiate TLS (mTLS for production clusters).
+* **At rest:** PostgreSQL storage relies on the cloud provider's disk encryption (AES-256). Prisma connections should enforce `sslmode=require` (production) to guarantee encrypted links.
+* **Secrets at rest:** Deployment credentials live in the platform secret manager with audit logging enabled. Local development uses `.env` files stored outside of version control.
+
+## Field-level encryption and hashing
+
+We evaluated Prisma client middleware and column-level encryption for `User.email`, potential authentication tokens and other identifiers. Implementing deterministic hashing/encryption would require:
+
+1. Introducing a key management pattern (KMS envelope keys with rotation semantics).
+2. Applying Prisma middleware (or database native encryption) to transparently hash/encrypt on write and decrypt on read.
+3. Updating query patterns (e.g. lookups by email) to use hashed columns or secure search indexes.
+
+The work is outside the current MVP scope but is critical for hardening before launch.
+
+### Follow-up ticket
+
+See `docs/architecture/tickets/field-level-encryption.md` for the implementation plan that should be scheduled once the MVP stabilises.

--- a/apgms/docs/architecture/tickets/field-level-encryption.md
+++ b/apgms/docs/architecture/tickets/field-level-encryption.md
@@ -1,0 +1,28 @@
+# Follow-up: field-level protection for sensitive identifiers
+
+## Summary
+Implement deterministic hashing or encryption for sensitive columns (starting with `User.email` and future authentication tokens) so they are not stored in plaintext while preserving the ability to perform equality lookups.
+
+## Scope
+
+* Add a dedicated key hierarchy using the platform KMS (envelope encryption per environment).
+* Introduce Prisma middleware that hashes/encrypts before write and reverses (if needed) on read.
+* Backfill existing data safely and migrate legacy clients.
+* Update API contracts and validation to operate on hashed/encoded values where appropriate.
+* Extend automated tests to assert redaction and reversible behaviour for authorised services.
+
+## Dependencies
+
+* Decision on KMS provider and rotation cadence.
+* Alignment with compliance to ensure hashing/encryption aligns with audit expectations.
+
+## Out of scope (for now)
+
+* Searchable encryption for free-text fields.
+* Re-encrypting historical backups (handled via retention policy in the interim).
+
+## Acceptance criteria
+
+1. Emails and similar identifiers are never stored nor logged in plaintext.
+2. Operational tooling (support, reporting) continues to function with hashed lookups.
+3. Documentation in `docs/architecture/data-governance.md` is updated with the final approach.

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -11,12 +11,35 @@ import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
-const app = Fastify({ logger: true });
+const app = Fastify({
+  logger: {
+    level: process.env.LOG_LEVEL ?? "info",
+    redact: {
+      paths: [
+        "req.headers.authorization",
+        "req.headers.cookie",
+        "req.body.password",
+        "req.body.email",
+        "req.body.token",
+        "req.body.refreshToken",
+        "req.body.accessToken",
+        "res.body.token",
+        "res.body.accessToken",
+        "res.body.refreshToken",
+        "*.token",
+        "*.secret",
+        "*.password",
+        "*.email",
+      ],
+      censor: "[REDACTED]",
+    },
+  },
+});
 
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+// sanity log: confirm env is loaded without leaking secrets
+app.log.info({ databaseUrlConfigured: Boolean(process.env.DATABASE_URL) }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 


### PR DESCRIPTION
## Summary
- add a Postgres service container and Prisma migration status check to CI
- configure the API gateway logger to redact sensitive values and avoid leaking secrets
- document retention/PII handling, encryption expectations, and capture a follow-up ticket for field-level protection

## Testing
- pnpm -r test
- pnpm -r build

------
https://chatgpt.com/codex/tasks/task_e_68f4ce9ffa488327b32589a79cea1d3a