### PR TITLE
Add Docker builds and release documentation for gateway and tax engine

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apgms
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -12,6 +16,38 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+          cache-dependency-path: apgms/pnpm-lock.yaml
       - run: pnpm i
       - run: pnpm -r build
       - run: pnpm -r test
+
+  docker-images:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - image: api-gateway
+            dockerfile: ./apgms/services/api-gateway/Dockerfile
+          - image: tax-engine
+            dockerfile: ./apgms/services/tax-engine/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: ./apgms
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ github.sha }}

--- a/apgms/docker-compose.yml
+++ b/apgms/docker-compose.yml
@@ -1,4 +1,4 @@
-﻿services:
+services:
   postgres:
     image: postgres:15
     environment:
@@ -9,3 +9,23 @@
   redis:
     image: redis:7
     ports: ['6379:6379']
+  api-gateway:
+    build:
+      context: .
+      dockerfile: services/api-gateway/Dockerfile
+    image: apgms/api-gateway:local
+    environment:
+      PORT: 3000
+      DATABASE_URL: postgresql://apgms:apgms@postgres:5432/apgms
+    ports: ['3000:3000']
+    depends_on:
+      - postgres
+      - redis
+  tax-engine:
+    build:
+      context: .
+      dockerfile: services/tax-engine/Dockerfile
+    image: apgms/tax-engine:local
+    environment:
+      PORT: 8000
+    ports: ['8000:8000']

--- a/apgms/docs/architecture/release.md
+++ b/apgms/docs/architecture/release.md
@@ -1,0 +1,43 @@
+# Release Process
+
+This document describes how we prepare and publish releases for the API gateway and tax engine services. It covers versioning, container image publication, and the checklist we follow for deployments to production environments.
+
+## Versioning strategy
+
+We follow a lightweight semantic versioning approach:
+
+- **Major (X.y.z)** — backwards-incompatible API or database changes.
+- **Minor (x.Y.z)** — backwards-compatible functionality, new endpoints, or infrastructure changes.
+- **Patch (x.y.Z)** — bug fixes, dependency updates, or internal-only changes.
+
+Each production deploy increments the appropriate segment. Tags in Git use the format `vX.Y.Z` and are pushed from the `main` branch. Container images are additionally tagged with the git SHA by CI; version tags should be pushed manually when creating a release.
+
+## Release cadence
+
+Releases are created as needed. When a change is ready for production it should be merged to `main`, after which the steps in the checklist below are followed. Emergency fixes can be released immediately after validation.
+
+## Deployment checklist
+
+1. **Validate the change set**
+   - Confirm CI (unit, integration, and container builds) completed successfully for the merge commit.
+   - Review the diff to ensure all migrations and configuration changes are included.
+2. **Prepare the release**
+   - Decide the next semantic version number based on the changes.
+   - Update changelog or release notes with key items (API changes, migrations, infrastructure updates).
+3. **Tag the release**
+   - Checkout the target commit on `main`.
+   - Create and push the git tag `vX.Y.Z`.
+   - Verify that CI publishes images tagged with the git SHA (`ghcr.io/<org>/<service>:<sha>`).
+4. **Deploy services**
+   - Pull the tagged images for `api-gateway` and `tax-engine` from GHCR.
+   - Apply any infrastructure or configuration updates required for the release.
+   - Roll out the new containers to the target environment (staging, then production).
+5. **Post-deploy validation**
+   - Check service health endpoints (`/health`) and logs.
+   - Run smoke tests through the Fastify gateway and tax engine APIs.
+   - Monitor metrics and alerts for at least one full error budget window.
+6. **Close the release**
+   - Communicate release completion to stakeholders.
+   - File follow-up issues for any deferred work or remediation.
+
+Following this checklist ensures that each release is well-understood, versioned correctly, and traceable back to the underlying commit and container image.

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:20-slim AS base
+WORKDIR /app
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+# Install dependencies for the API gateway and its workspace deps
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY services/api-gateway/package.json services/api-gateway/
+COPY shared/package.json shared/
+RUN pnpm install --filter @apgms/api-gateway... --frozen-lockfile --prod=false
+
+# Copy the rest of the source required at runtime
+COPY shared ./shared
+COPY services/api-gateway ./services/api-gateway
+
+FROM node:20-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy application code and dependencies from the builder stage
+COPY --from=base /app/node_modules ./node_modules
+COPY --from=base /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=base /app/package.json ./package.json
+COPY --from=base /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+COPY --from=base /app/shared ./shared
+COPY --from=base /app/services/api-gateway ./services/api-gateway
+
+EXPOSE 3000
+CMD ["node", "--loader", "tsx", "services/api-gateway/src/index.ts"]

--- a/apgms/services/tax-engine/Dockerfile
+++ b/apgms/services/tax-engine/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.10-slim AS builder
+WORKDIR /opt/app
+RUN pip install --no-cache-dir poetry
+
+COPY services/tax-engine/pyproject.toml ./
+RUN poetry export --without-hashes -f requirements.txt -o requirements.txt
+RUN pip install --no-cache-dir --prefix /install -r requirements.txt
+
+FROM python:3.10-slim AS runner
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder /install /usr/local
+COPY services/tax-engine/app ./app
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfiles for the Fastify API gateway and tax engine services
- update docker-compose to run the new service containers alongside the data stores
- extend CI to build images on every push and document the release workflow and checklist

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4cea040f483278757ba7958254e39