### PR TITLE
Add shared Zod schemas and enable Fastify validation

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -11,6 +11,7 @@
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "fastify-type-provider-zod": "^4.1.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,61 +9,152 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  ZodTypeProvider,
+} from "fastify-type-provider-zod";
 import { prisma } from "../../../shared/src/db";
+import {
+  bankLineCreateBodySchema,
+  bankLineCreateResponseSchema,
+  bankLineListQuerySchema,
+  bankLineListResponseSchema,
+  healthResponseSchema,
+  listUsersResponseSchema,
+} from "../../../shared/src/schemas";
+import {
+  normalizeValidationError,
+  validationErrorResponseSchema,
+} from "../../../shared/src/errors";
 
-const app = Fastify({ logger: true });
+const app = Fastify({ logger: true }).withTypeProvider<ZodTypeProvider>();
+
+app.setValidatorCompiler(validatorCompiler);
+app.setSerializerCompiler(serializerCompiler);
 
 await app.register(cors, { origin: true });
+
+app.setErrorHandler((error, request, reply) => {
+  const validationError = normalizeValidationError(error);
+  if (validationError) {
+    reply.status(400).send(validationError);
+    return;
+  }
+
+  request.log.error(error);
+  const statusCode = typeof error.statusCode === "number" ? error.statusCode : 500;
+  reply.status(statusCode).send({ error: "internal_server_error" });
+});
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+app.get(
+  "/health",
+  {
+    schema: {
+      response: {
+        200: healthResponseSchema,
+      },
+    },
+  },
+  async () => ({ ok: true, service: "api-gateway" })
+);
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
+app.get(
+  "/users",
+  {
+    schema: {
+      response: {
+        200: listUsersResponseSchema,
+      },
+    },
+  },
+  async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
+    return {
+      users: users.map((user) => ({
+        email: user.email,
+        orgId: user.orgId,
+        createdAt: user.createdAt.toISOString(),
+      })),
     };
+  }
+);
+
+const toBankLineResponse = (line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: { toString(): string };
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}) => ({
+  id: line.id,
+  orgId: line.orgId,
+  date: line.date.toISOString(),
+  amount: line.amount.toString(),
+  payee: line.payee,
+  desc: line.desc,
+  createdAt: line.createdAt.toISOString(),
+});
+
+app.get(
+  "/bank-lines",
+  {
+    schema: {
+      querystring: bankLineListQuerySchema,
+      response: {
+        200: bankLineListResponseSchema,
+        400: validationErrorResponseSchema,
+      },
+    },
+  },
+  async (req) => {
+    const take = req.query.take ?? 20;
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+
+    return { lines: lines.map(toBankLineResponse) };
+  }
+);
+
+app.post(
+  "/bank-lines",
+  {
+    schema: {
+      body: bankLineCreateBodySchema,
+      response: {
+        201: bankLineCreateResponseSchema,
+        400: validationErrorResponseSchema,
+      },
+    },
+  },
+  async (req, rep) => {
+    const { orgId, date, amount, payee, desc } = req.body;
+    const amountAsString = typeof amount === "number" ? amount.toString() : amount;
+
     const created = await prisma.bankLine.create({
       data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
+        orgId,
+        date: new Date(date),
+        amount: amountAsString,
+        payee,
+        desc,
       },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+
+    return rep.code(201).send({ line: toBankLineResponse(created) });
   }
-});
+);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +168,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -8,7 +8,8 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/src/errors.ts
+++ b/apgms/shared/src/errors.ts
@@ -1,0 +1,29 @@
+import { z, ZodError } from "zod";
+
+export const validationIssueSchema = z.object({
+  path: z.string(),
+  message: z.string(),
+});
+
+export const validationErrorResponseSchema = z.object({
+  error: z.literal("validation_error"),
+  issues: z.array(validationIssueSchema),
+});
+
+export type ValidationErrorResponse = z.infer<typeof validationErrorResponseSchema>;
+
+export const normalizeValidationError = (error: unknown): ValidationErrorResponse | null => {
+  if (!(error instanceof ZodError)) {
+    return null;
+  }
+
+  const issues = error.issues.map((issue) => ({
+    path: issue.path.length ? issue.path.join(".") : "<root>",
+    message: issue.message,
+  }));
+
+  return {
+    error: "validation_error",
+    issues,
+  };
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,3 @@
-﻿// shared
+export * from "./db";
+export * from "./errors";
+export * from "./schemas";

--- a/apgms/shared/src/schemas/bankLine.ts
+++ b/apgms/shared/src/schemas/bankLine.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const bankLineSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime({ offset: true }),
+  amount: z.string(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+export type BankLine = z.infer<typeof bankLineSchema>;
+
+export const bankLineListQuerySchema = z.object({
+  take: z.coerce.number().int().min(1).max(200).optional(),
+});
+
+export const bankLineListResponseSchema = z.object({
+  lines: z.array(bankLineSchema),
+});
+
+export const bankLineCreateBodySchema = z.object({
+  orgId: z.string().min(1),
+  date: z.string().datetime({ offset: true }),
+  amount: z.union([
+    z.number(),
+    z
+      .string()
+      .min(1)
+      .regex(/^[-+]?\d+(?:\.\d+)?$/, "Amount must be a valid number"),
+  ]),
+  payee: z.string().min(1),
+  desc: z.string().min(1),
+});
+
+export const bankLineCreateResponseSchema = z.object({
+  line: bankLineSchema,
+});
+
+export type BankLineListQuery = z.infer<typeof bankLineListQuerySchema>;
+export type BankLineListResponse = z.infer<typeof bankLineListResponseSchema>;
+export type BankLineCreateBody = z.infer<typeof bankLineCreateBodySchema>;
+export type BankLineCreateResponse = z.infer<typeof bankLineCreateResponseSchema>;

--- a/apgms/shared/src/schemas/index.ts
+++ b/apgms/shared/src/schemas/index.ts
@@ -1,0 +1,3 @@
+export * from "./bankLine";
+export * from "./system";
+export * from "./user";

--- a/apgms/shared/src/schemas/system.ts
+++ b/apgms/shared/src/schemas/system.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const healthResponseSchema = z.object({
+  ok: z.literal(true),
+  service: z.string(),
+});
+
+export type HealthResponse = z.infer<typeof healthResponseSchema>;

--- a/apgms/shared/src/schemas/user.ts
+++ b/apgms/shared/src/schemas/user.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const userSummarySchema = z.object({
+  email: z.string().email(),
+  orgId: z.string(),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+export const listUsersResponseSchema = z.object({
+  users: z.array(userSummarySchema),
+});
+
+export type UserSummary = z.infer<typeof userSummarySchema>;
+export type ListUsersResponse = z.infer<typeof listUsersResponseSchema>;


### PR DESCRIPTION
## Summary
- add reusable Zod schemas for health, user, and bank line payloads plus a shared validation error normalizer
- configure the API gateway to use Fastify's Zod type provider and shared schemas for request/response validation
- normalize route responses and update workspace package manifests with the required dependencies

## Testing
- pnpm install *(fails: registry returned 403 when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68f4cea608608327aa21829e72604603