### PR TITLE
Add resilient HTTP client wrapper and k6 load test

### DIFF
--- a/apgms/README.md
+++ b/apgms/README.md
@@ -1,8 +1,32 @@
-﻿# APGMS
+# APGMS
 
 Quickstart:
-pnpm i
-pnpm -r build
-docker compose up -d
-pnpm -r test
-pnpm -w exec playwright test
+- pnpm i
+- pnpm -r build
+- docker compose up -d
+- pnpm -r test
+- pnpm -w exec playwright test
+
+## Load & resilience testing
+
+### k6 smoke/load scenarios
+
+A k6 script that exercises the `/health`, `/users`, and `/bank-lines` endpoints lives in `scripts/k6/load.js`. The script reads `API_BASE_URL`, `VUS`, and `DURATION` from the environment (defaults to `http://localhost:3000`, `5`, and `1m`).
+
+Run the bundled scenario locally after seeding sample data:
+
+```bash
+pnpm exec k6 run scripts/k6/load.js
+```
+
+You can also launch the PowerShell helper, which forwards the parameters as environment variables:
+
+```powershell
+./scripts/k6-load.ps1 -ApiBaseUrl http://localhost:3000 -Vus 10 -Duration 5m
+```
+
+Set `LOAD_TEST_ORG_ID`, `LOAD_TEST_AMOUNT`, `LOAD_TEST_PAYEE`, or `LOAD_TEST_DESC` to control the payload used when creating bank lines.
+
+### Resilience-focused unit tests
+
+Outbound client retry and circuit-breaker behaviour is covered by `pnpm --filter @apgms/connectors test`.

--- a/apgms/scripts/k6-load.ps1
+++ b/apgms/scripts/k6-load.ps1
@@ -1,1 +1,14 @@
-﻿# k6-load script
+Param(
+    [string]$ApiBaseUrl = "http://localhost:3000",
+    [string]$Scenario = "smoke",
+    [int]$Vus = 5,
+    [string]$Duration = "1m"
+)
+
+$env:API_BASE_URL = $ApiBaseUrl
+$env:VUS = $Vus
+$env:DURATION = $Duration
+
+Write-Host "Running k6 scenario '$Scenario' against $ApiBaseUrl with $Vus VUs for $Duration"
+
+pnpm exec k6 run --tag scenario=$Scenario scripts/k6/load.js

--- a/apgms/scripts/k6/load.js
+++ b/apgms/scripts/k6/load.js
@@ -1,0 +1,107 @@
+import http from "k6/http";
+import { check, group, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const baseUrl = __ENV.API_BASE_URL ?? "http://localhost:3000";
+const vus = Number(__ENV.VUS ?? 5);
+const duration = __ENV.DURATION ?? "1m";
+
+export const errorRate = new Rate("api_error_rate");
+export const bankLineDuration = new Trend("bank_line_duration", true);
+
+export const options = {
+  scenarios: {
+    smoke: {
+      executor: "constant-vus",
+      vus,
+      duration,
+      gracefulStop: "5s",
+    },
+  },
+  thresholds: {
+    http_req_failed: ["rate<0.05"],
+    http_req_duration: ["p(95)<750"],
+    api_error_rate: ["rate<0.05"],
+    bank_line_duration: ["avg<500", "p(95)<1000"],
+  },
+};
+
+function withJsonHeaders(params = {}) {
+  const headers = Object.assign({}, params.headers, {
+    "Content-Type": "application/json",
+  });
+  return { ...params, headers };
+}
+
+function ensureOk(response, message) {
+  const passed = check(response, {
+    [message]: (res) => res.status >= 200 && res.status < 300,
+  });
+  if (!passed) {
+    errorRate.add(1);
+  }
+  return passed;
+}
+
+export default function run() {
+  group("health-check", () => {
+    const response = http.get(`${baseUrl}/health`);
+    ensureOk(response, "health endpoint is healthy");
+    sleep(1);
+  });
+
+  group("list-users", () => {
+    const response = http.get(`${baseUrl}/users`);
+    ensureOk(response, "users endpoint responds");
+
+    check(response, {
+      "users payload is array": (res) => {
+        try {
+          const body = res.json();
+          return Array.isArray(body?.users);
+        } catch (error) {
+          return false;
+        }
+      },
+    });
+    sleep(1);
+  });
+
+  group("bank-line-flow", () => {
+    const listResponse = http.get(`${baseUrl}/bank-lines?take=5`);
+    ensureOk(listResponse, "bank line listing succeeds");
+
+    const payload = {
+      orgId: __ENV.LOAD_TEST_ORG_ID ?? "demo-org",
+      date: new Date().toISOString(),
+      amount: Number(__ENV.LOAD_TEST_AMOUNT ?? 10.5),
+      payee: __ENV.LOAD_TEST_PAYEE ?? "k6 smoke test",
+      desc: __ENV.LOAD_TEST_DESC ?? "automated load test",
+    };
+
+    const start = Date.now();
+    const createResponse = http.post(
+      `${baseUrl}/bank-lines`,
+      JSON.stringify(payload),
+      withJsonHeaders(),
+    );
+    const durationMs = Date.now() - start;
+    bankLineDuration.add(durationMs);
+
+    const created = ensureOk(createResponse, "bank line creation succeeds");
+    if (created) {
+      check(createResponse, {
+        "created bank line echoes amount": (res) => {
+          try {
+            const body = res.json();
+            return Number(body?.amount) === payload.amount;
+          } catch (error) {
+            return false;
+          }
+        },
+      });
+    }
+
+    sleep(1);
+  });
+}

--- a/apgms/services/connectors/package.json
+++ b/apgms/services/connectors/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@apgms/connectors",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx --test test/httpClient.test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "workspace:*",
+    "tsx": "workspace:*",
+    "typescript": "workspace:*"
+  }
+}

--- a/apgms/services/connectors/src/httpClient.ts
+++ b/apgms/services/connectors/src/httpClient.ts
@@ -1,0 +1,323 @@
+export type HttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "HEAD"
+  | "OPTIONS";
+
+export type ResponseType = "json" | "text" | "buffer" | "none";
+
+export interface HttpClientOptions {
+  baseUrl?: string;
+  defaultHeaders?: HeadersInit;
+  timeout?: number;
+  maxRetries?: number;
+  retryDelay?: number;
+  logger?: Pick<Console, "debug" | "warn" | "error">;
+  circuitBreaker?: Partial<CircuitBreakerOptions>;
+}
+
+export interface RequestOptions {
+  path?: string;
+  url?: string;
+  method?: HttpMethod;
+  headers?: HeadersInit;
+  body?: unknown;
+  timeout?: number;
+  maxRetries?: number;
+  retryDelay?: number;
+  responseType?: ResponseType;
+  signal?: AbortSignal;
+}
+
+export interface HttpResponse<T = unknown> {
+  status: number;
+  headers: Record<string, string>;
+  data: T;
+  url: string;
+}
+
+export interface CircuitBreakerOptions {
+  failureThreshold: number;
+  successThreshold: number;
+  resetTimeout: number;
+}
+
+const DEFAULT_BREAKER_OPTIONS: CircuitBreakerOptions = {
+  failureThreshold: 5,
+  successThreshold: 2,
+  resetTimeout: 10_000,
+};
+
+export class CircuitBreakerOpenError extends Error {
+  constructor(message = "Circuit breaker is open") {
+    super(message);
+    this.name = "CircuitBreakerOpenError";
+  }
+}
+
+export class HttpClientError extends Error {
+  public readonly status?: number;
+  public readonly attempt: number;
+  public readonly retryable: boolean;
+  public readonly response?: Response;
+
+  constructor(
+    message: string,
+    options: {
+      status?: number;
+      attempt: number;
+      retryable: boolean;
+      response?: Response;
+    },
+  ) {
+    super(message);
+    this.name = "HttpClientError";
+    this.status = options.status;
+    this.attempt = options.attempt;
+    this.retryable = options.retryable;
+    this.response = options.response;
+  }
+}
+
+class SimpleCircuitBreaker {
+  private readonly failureThreshold: number;
+  private readonly successThreshold: number;
+  private readonly resetTimeout: number;
+
+  private state: "closed" | "open" | "half-open" = "closed";
+  private failureCount = 0;
+  private successCount = 0;
+  private nextAttempt = 0;
+
+  constructor(options?: Partial<CircuitBreakerOptions>) {
+    const resolved = { ...DEFAULT_BREAKER_OPTIONS, ...options };
+    this.failureThreshold = resolved.failureThreshold;
+    this.successThreshold = resolved.successThreshold;
+    this.resetTimeout = resolved.resetTimeout;
+  }
+
+  async run<T>(action: () => Promise<T>): Promise<T> {
+    if (this.state === "open") {
+      if (Date.now() >= this.nextAttempt) {
+        this.state = "half-open";
+      } else {
+        throw new CircuitBreakerOpenError();
+      }
+    }
+
+    try {
+      const result = await action();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure();
+      throw error;
+    }
+  }
+
+  private onSuccess(): void {
+    if (this.state === "half-open") {
+      this.successCount += 1;
+      if (this.successCount >= this.successThreshold) {
+        this.reset();
+      }
+    } else {
+      this.reset();
+    }
+  }
+
+  private onFailure(): void {
+    this.failureCount += 1;
+
+    if (this.state === "half-open") {
+      this.trip();
+      return;
+    }
+
+    if (this.failureCount >= this.failureThreshold) {
+      this.trip();
+    }
+  }
+
+  private reset(): void {
+    this.failureCount = 0;
+    this.successCount = 0;
+    this.state = "closed";
+    this.nextAttempt = 0;
+  }
+
+  private trip(): void {
+    this.state = "open";
+    this.successCount = 0;
+    this.nextAttempt = Date.now() + this.resetTimeout;
+  }
+}
+
+function mergeHeaders(base?: HeadersInit, extra?: HeadersInit): HeadersInit {
+  const headers = new Headers(base ?? {});
+  if (extra) {
+    const toMerge = new Headers(extra);
+    toMerge.forEach((value, key) => {
+      headers.set(key, value);
+    });
+  }
+  return headers;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toUrl(baseUrl: string, options: RequestOptions): string {
+  if (options.url) {
+    return options.url;
+  }
+  const path = options.path ?? "";
+  if (!baseUrl) {
+    throw new Error("A baseUrl must be configured when using relative paths");
+  }
+  const joined = new URL(path.replace(/^\//, ""), baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`);
+  return joined.toString();
+}
+
+export class HttpClient {
+  private readonly baseUrl: string;
+  private readonly defaultHeaders: HeadersInit;
+  private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly retryDelay: number;
+  private readonly breaker: SimpleCircuitBreaker;
+  private readonly logger?: Pick<Console, "debug" | "warn" | "error">;
+
+  constructor(options: HttpClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? "";
+    this.defaultHeaders = options.defaultHeaders ?? {};
+    this.timeout = options.timeout ?? 5_000;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.retryDelay = options.retryDelay ?? 250;
+    this.logger = options.logger;
+    this.breaker = new SimpleCircuitBreaker(options.circuitBreaker);
+  }
+
+  async request<T = unknown>(options: RequestOptions): Promise<HttpResponse<T>> {
+    return this.breaker.run(async () => this.executeWithRetries<T>(options));
+  }
+
+  private async executeWithRetries<T>(options: RequestOptions): Promise<HttpResponse<T>> {
+    const maxRetries = options.maxRetries ?? this.maxRetries;
+    const retryDelay = options.retryDelay ?? this.retryDelay;
+    let attempt = 0;
+    let lastError: unknown;
+
+    while (attempt <= maxRetries) {
+      try {
+        return await this.performRequest<T>(options, attempt + 1);
+      } catch (error) {
+        lastError = error;
+        const httpError = error instanceof HttpClientError ? error : undefined;
+
+        if (!httpError?.retryable || attempt === maxRetries) {
+          throw error;
+        }
+
+        this.logger?.warn?.(
+          `HTTP request failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${retryDelay}ms: ${httpError.message}`,
+        );
+        await delay(retryDelay);
+      }
+      attempt += 1;
+    }
+
+    throw lastError instanceof Error ? lastError : new Error("HTTP request failed");
+  }
+
+  private async performRequest<T>(options: RequestOptions, attempt: number): Promise<HttpResponse<T>> {
+    const url = toUrl(this.baseUrl, options);
+    const method = options.method ?? "GET";
+    const responseType = options.responseType ?? "json";
+    const timeout = options.timeout ?? this.timeout;
+
+    const headers = mergeHeaders(this.defaultHeaders, options.headers);
+    const controller = new AbortController();
+    const signal = options.signal ?? controller.signal;
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    let body = options.body;
+    if (body && typeof body === "object" && !(body instanceof ArrayBuffer) && !(body instanceof URLSearchParams)) {
+      body = JSON.stringify(body);
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+      }
+    }
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: body as BodyInit | null | undefined,
+        signal,
+      });
+
+      if (!response.ok) {
+        const retryable = this.isRetryableStatus(response.status);
+        throw new HttpClientError(`Request to ${url} failed with status ${response.status}`, {
+          status: response.status,
+          attempt,
+          retryable,
+          response,
+        });
+      }
+
+      const data = await this.parseResponse<T>(response, responseType);
+      return {
+        status: response.status,
+        headers: Object.fromEntries(response.headers.entries()),
+        data,
+        url,
+      };
+    } catch (error) {
+      if (error instanceof HttpClientError) {
+        throw error;
+      }
+
+      if ((error as Error).name === "AbortError") {
+        throw new HttpClientError(`Request to ${url} timed out after ${timeout}ms`, {
+          attempt,
+          retryable: true,
+        });
+      }
+
+      throw new HttpClientError(`Request to ${url} failed: ${(error as Error).message}`, {
+        attempt,
+        retryable: true,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private isRetryableStatus(status: number): boolean {
+    if (status >= 500) return true;
+    return status === 408 || status === 425 || status === 429;
+  }
+
+  private async parseResponse<T>(response: Response, responseType: ResponseType): Promise<T> {
+    switch (responseType) {
+      case "json":
+        if (response.status === 204) {
+          return undefined as T;
+        }
+        return (await response.json()) as T;
+      case "text":
+        return (await response.text()) as T;
+      case "buffer":
+        return (await response.arrayBuffer()) as T;
+      case "none":
+      default:
+        return undefined as T;
+    }
+  }
+}

--- a/apgms/services/connectors/src/index.ts
+++ b/apgms/services/connectors/src/index.ts
@@ -1,1 +1,1 @@
-﻿console.log('connectors service');
+export * from "./httpClient";

--- a/apgms/services/connectors/test/httpClient.test.ts
+++ b/apgms/services/connectors/test/httpClient.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import {
+  CircuitBreakerOpenError,
+  HttpClient,
+  HttpClientError,
+} from "../src/httpClient";
+
+const BASE_URL = "https://example.test";
+
+function mockAbortError(): Error {
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+test("retries stop after the configured number of attempts", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let callCount = 0;
+  globalThis.fetch = async () => {
+    callCount += 1;
+    throw mockAbortError();
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new HttpClient({ baseUrl: BASE_URL, maxRetries: 2, timeout: 10 });
+
+  await assert.rejects(client.request({ path: "/fail" }), (error) => {
+    assert.ok(error instanceof HttpClientError);
+    assert.equal(error.retryable, true);
+    assert.equal(error.attempt, 3);
+    return true;
+  });
+
+  assert.equal(callCount, 3);
+});
+
+test("successful responses are returned with parsed JSON payloads", async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new HttpClient({ baseUrl: BASE_URL });
+  const response = await client.request<{ ok: boolean }>({ path: "/health" });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(response.data, { ok: true });
+  assert.equal(response.url, `${BASE_URL}/health`);
+});
+
+test("the circuit breaker opens after repeated failures", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let callCount = 0;
+  globalThis.fetch = async () => {
+    callCount += 1;
+    throw new Error("network down");
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const client = new HttpClient({
+    baseUrl: BASE_URL,
+    maxRetries: 0,
+    circuitBreaker: {
+      failureThreshold: 2,
+      successThreshold: 1,
+      resetTimeout: 1000,
+    },
+  });
+
+  await assert.rejects(client.request({ path: "/unstable" }), HttpClientError);
+  await assert.rejects(client.request({ path: "/unstable" }), HttpClientError);
+  await assert.rejects(client.request({ path: "/unstable" }), CircuitBreakerOpenError);
+
+  assert.equal(callCount, 2);
+});
+
+test("the circuit breaker allows recovery after the reset timeout", async (t) => {
+  const originalFetch = globalThis.fetch;
+  let callCount = 0;
+
+  const client = new HttpClient({
+    baseUrl: BASE_URL,
+    maxRetries: 0,
+    circuitBreaker: {
+      failureThreshold: 1,
+      successThreshold: 1,
+      resetTimeout: 50,
+    },
+  });
+
+  globalThis.fetch = async () => {
+    callCount += 1;
+    throw new Error("network down");
+  };
+
+  await assert.rejects(client.request({ path: "/flaky" }), HttpClientError);
+  await assert.rejects(client.request({ path: "/flaky" }), CircuitBreakerOpenError);
+
+  await sleep(60);
+
+  globalThis.fetch = async () => {
+    callCount += 1;
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const response = await client.request<{ ok: boolean }>({ path: "/flaky" });
+  assert.deepEqual(response.data, { ok: true });
+  assert.equal(callCount, 2);
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+});

--- a/apgms/services/connectors/tsconfig.json
+++ b/apgms/services/connectors/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2021", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["node"],
+    "baseUrl": "../../",
+    "paths": {
+      "@apgms/shared/*": ["shared/src/*"]
+    }
+  },
+  "include": ["src", "test"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add a configurable HTTP client wrapper with retry and circuit-breaker behaviour for outbound calls
- cover the new client with resilience-focused unit tests
- provide a k6 smoke/load script plus documentation and helper updates for running it

## Testing
- pnpm --filter @apgms/connectors test

------
https://chatgpt.com/codex/tasks/task_e_68f4cea04800832784c4e9f6bd3448ff