### PR TITLE
Add environment scaffolding and key rotation tooling

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------
+# Copy this file to `.env` and fill in secrets for local development.
+# Values are read by scripts and services via process.env.
+# -----------------------------------------------------------------------------
+
+# Postgres connection strings used by Prisma migrations and the API gateway.
+DATABASE_URL="postgresql://apgms:apgms@localhost:5432/apgms?schema=public"
+SHADOW_DATABASE_URL="postgresql://apgms:apgms@localhost:5432/apgms_shadow?schema=public"
+
+# JWT signing secret. Generate a strong value with `pnpm tsx scripts/key-rotate.ts`.
+JWT_SECRET="replace-with-output-from-key-rotate"
+
+# Redis connection string for background workers / rate limits.
+REDIS_URL="redis://localhost:6379"
+
+# Comma-separated list of origins allowed to call the API gateway. Use `*` to allow all.
+ALLOWED_ORIGINS="http://localhost:3000"
+
+# Optional override for the Fastify listen port.
+PORT="3000"

--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -3,7 +3,24 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      REDIS_URL: ${{ secrets.REDIS_URL }}
+      ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
     steps:
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for var in DATABASE_URL JWT_SECRET REDIS_URL ALLOWED_ORIGINS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Missing required secret: $var"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:

--- a/apgms/.github/workflows/e2e.yml
+++ b/apgms/.github/workflows/e2e.yml
@@ -3,7 +3,24 @@ on: [workflow_dispatch]
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      REDIS_URL: ${{ secrets.REDIS_URL }}
+      ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
     steps:
+      - name: Validate required secrets
+        run: |
+          missing=0
+          for var in DATABASE_URL JWT_SECRET REDIS_URL ALLOWED_ORIGINS; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Missing required secret: $var"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/README.md
+++ b/apgms/README.md
@@ -1,8 +1,63 @@
-﻿# APGMS
+# APGMS
 
-Quickstart:
-pnpm i
-pnpm -r build
+## Environment setup
+
+1. Install dependencies:
+   ```sh
+   pnpm install
+   ```
+2. Copy the example environment file and fill in secrets:
+   ```sh
+   cp .env.example .env
+   ```
+3. Generate a strong JWT signing secret when rotating credentials:
+   ```sh
+   pnpm tsx scripts/key-rotate.ts
+   ```
+   The script prints the new secret to `stdout`. Update `JWT_SECRET` in your `.env` file (or secret manager) with the generated value.
+4. Load the environment variables into your shell before running services:
+   ```sh
+   set -a
+   source .env
+   set +a
+   ```
+   On Windows PowerShell, run:
+   ```powershell
+   Get-Content .env | foreach { if ($_.Trim() -and -not $_.StartsWith('#')) { $name, $value = $_.Split('='); Set-Item -Path Env:$name -Value $value.Trim('"') } }
+   ```
+
+## Running locally
+
+Spin up the infrastructure and execute the workspace scripts:
+
+```sh
 docker compose up -d
+pnpm -r build
 pnpm -r test
 pnpm -w exec playwright test
+```
+
+## Rotating JWT secrets
+
+You can customise the key size and encoding when generating a new secret:
+
+```sh
+pnpm tsx scripts/key-rotate.ts --bytes 48 --format hex
+```
+
+The PowerShell wrapper forwards all arguments:
+
+```powershell
+./scripts/key-rotate.ps1 --bytes 48 --format hex
+```
+
+## Required CI/CD secrets
+
+The GitHub workflows expect the following environment variables to be supplied as repository or environment secrets:
+
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `REDIS_URL`
+- `ALLOWED_ORIGINS`
+
+Workflows will fail fast if any of these values are missing.

--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -42,9 +42,6 @@ importers:
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
       fastify:
         specifier: ^5.6.1
         version: 5.6.1
@@ -80,162 +77,6 @@ importers:
   worker: {}
 
 packages:
-
-  '@esbuild/aix-ppc64@0.25.10':
-    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
-  '@esbuild/android-arm64@0.25.10':
-    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.25.10':
-    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
-  '@esbuild/android-x64@0.25.10':
-    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/darwin-arm64@0.25.10':
-    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.25.10':
-    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/freebsd-arm64@0.25.10':
-    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.25.10':
-    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/linux-arm64@0.25.10':
-    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.25.10':
-    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-ia32@0.25.10':
-    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.25.10':
-    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-mips64el@0.25.10':
-    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.25.10':
-    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-riscv64@0.25.10':
-    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.25.10':
-    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.25.10':
-    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/netbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-x64@0.25.10':
-    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
-  '@esbuild/openbsd-arm64@0.25.10':
-    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.25.10':
-    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openharmony-arm64@0.25.10':
-    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/sunos-x64@0.25.10':
-    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
-  '@esbuild/win32-arm64@0.25.10':
-    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-ia32@0.25.10':
-    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.25.10':
-    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
 
   '@fastify/ajv-compiler@4.0.2':
     resolution: {integrity: sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==}
@@ -406,11 +247,6 @@ packages:
     resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
     engines: {node: '>=20'}
 
-  fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   get-tsconfig@4.12.0:
     resolution: {integrity: sha512-LScr2aNr2FbjAjZh2C6X6BxRx1/x+aTDExct/xyq2XKbYOiG5c0aK7pMsSuyc0brz3ibr/lbQiHD9jzt4lccJw==}
 
@@ -576,84 +412,6 @@ packages:
 
 snapshots:
 
-  '@esbuild/aix-ppc64@0.25.10':
-    optional: true
-
-  '@esbuild/android-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/android-arm@0.25.10':
-    optional: true
-
-  '@esbuild/android-x64@0.25.10':
-    optional: true
-
-  '@esbuild/darwin-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/darwin-x64@0.25.10':
-    optional: true
-
-  '@esbuild/freebsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-arm@0.25.10':
-    optional: true
-
-  '@esbuild/linux-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/linux-loong64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-mips64el@0.25.10':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-riscv64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-s390x@0.25.10':
-    optional: true
-
-  '@esbuild/linux-x64@0.25.10':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/netbsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.25.10':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/sunos-x64@0.25.10':
-    optional: true
-
-  '@esbuild/win32-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/win32-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/win32-x64@0.25.10':
-    optional: true
-
   '@fastify/ajv-compiler@4.0.2':
     dependencies:
       ajv: 8.17.1
@@ -789,34 +547,7 @@ snapshots:
 
   empathic@2.0.0: {}
 
-  esbuild@0.25.10:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.10
-      '@esbuild/android-arm': 0.25.10
-      '@esbuild/android-arm64': 0.25.10
-      '@esbuild/android-x64': 0.25.10
-      '@esbuild/darwin-arm64': 0.25.10
-      '@esbuild/darwin-x64': 0.25.10
-      '@esbuild/freebsd-arm64': 0.25.10
-      '@esbuild/freebsd-x64': 0.25.10
-      '@esbuild/linux-arm': 0.25.10
-      '@esbuild/linux-arm64': 0.25.10
-      '@esbuild/linux-ia32': 0.25.10
-      '@esbuild/linux-loong64': 0.25.10
-      '@esbuild/linux-mips64el': 0.25.10
-      '@esbuild/linux-ppc64': 0.25.10
-      '@esbuild/linux-riscv64': 0.25.10
-      '@esbuild/linux-s390x': 0.25.10
-      '@esbuild/linux-x64': 0.25.10
-      '@esbuild/netbsd-arm64': 0.25.10
-      '@esbuild/netbsd-x64': 0.25.10
-      '@esbuild/openbsd-arm64': 0.25.10
-      '@esbuild/openbsd-x64': 0.25.10
-      '@esbuild/openharmony-arm64': 0.25.10
-      '@esbuild/sunos-x64': 0.25.10
-      '@esbuild/win32-arm64': 0.25.10
-      '@esbuild/win32-ia32': 0.25.10
-      '@esbuild/win32-x64': 0.25.10
+  esbuild@0.25.10: {}
 
   exsolve@1.0.7: {}
 
@@ -872,9 +603,6 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2
       safe-regex2: 5.0.0
-
-  fsevents@2.3.3:
-    optional: true
 
   get-tsconfig@4.12.0:
     dependencies:
@@ -1017,8 +745,6 @@ snapshots:
     dependencies:
       esbuild: 0.25.10
       get-tsconfig: 4.12.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   typescript@5.9.3: {}
 

--- a/apgms/scripts/key-rotate.ps1
+++ b/apgms/scripts/key-rotate.ps1
@@ -1,1 +1,15 @@
-﻿# key-rotate script
+param(
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$ForwardedArgs
+)
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+
+Push-Location $repoRoot
+try {
+  pnpm exec tsx scripts/key-rotate.ts @ForwardedArgs
+}
+finally {
+  Pop-Location
+}

--- a/apgms/scripts/key-rotate.ts
+++ b/apgms/scripts/key-rotate.ts
@@ -1,0 +1,56 @@
+import { randomBytes } from "node:crypto";
+
+type OutputFormat = "base64url" | "hex";
+
+const DEFAULT_BYTES = 64;
+const DEFAULT_FORMAT: OutputFormat = "base64url";
+
+const args = process.argv.slice(2);
+
+const usage = `Usage: pnpm tsx scripts/key-rotate.ts [--bytes <size>] [--format base64url|hex]\n\nExamples:\n  pnpm tsx scripts/key-rotate.ts\n  pnpm tsx scripts/key-rotate.ts --bytes 48 --format hex`;
+
+let bytes = DEFAULT_BYTES;
+let format: OutputFormat = DEFAULT_FORMAT;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (!arg) continue;
+
+  if (arg === "--help" || arg === "-h") {
+    console.log(usage);
+    process.exit(0);
+  }
+
+  if (arg === "--bytes" && typeof args[i + 1] !== "undefined") {
+    const next = Number.parseInt(args[i + 1]!, 10);
+    if (!Number.isFinite(next) || next <= 0) {
+      console.error(`Invalid value for --bytes: ${args[i + 1]}`);
+      console.error(usage);
+      process.exit(1);
+    }
+    bytes = next;
+    i += 1;
+    continue;
+  }
+
+  if (arg === "--format" && typeof args[i + 1] !== "undefined") {
+    const next = args[i + 1] as OutputFormat;
+    if (next !== "base64url" && next !== "hex") {
+      console.error(`Invalid value for --format: ${args[i + 1]}`);
+      console.error(usage);
+      process.exit(1);
+    }
+    format = next;
+    i += 1;
+    continue;
+  }
+
+  console.error(`Unknown argument: ${arg}`);
+  console.error(usage);
+  process.exit(1);
+}
+
+const secret = randomBytes(bytes).toString(format);
+
+console.error(`Generated ${bytes}-byte secret (${format}). Paste into your JWT_SECRET.`);
+process.stdout.write(`${secret}\n`);

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
-    "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"
   },

--- a/apgms/services/api-gateway/pnpm-lock.yaml
+++ b/apgms/services/api-gateway/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
       fastify:
         specifier: ^5.6.1
         version: 5.6.1
@@ -241,10 +238,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
-    engines: {node: '>=12'}
 
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
@@ -528,8 +521,6 @@ snapshots:
   cookie@1.0.2: {}
 
   dequal@2.0.3: {}
-
-  dotenv@16.6.1: {}
 
   esbuild@0.25.10:
     optionalDependencies:

--- a/apgms/services/api-gateway/src/config/env.ts
+++ b/apgms/services/api-gateway/src/config/env.ts
@@ -1,0 +1,47 @@
+const requiredVars = ["DATABASE_URL", "JWT_SECRET", "REDIS_URL", "ALLOWED_ORIGINS"] as const;
+
+type RequiredVar = (typeof requiredVars)[number];
+
+const readRequired = (name: RequiredVar): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+};
+
+const parseAllowedOrigins = (raw: string): true | string[] => {
+  if (raw.trim() === "*") {
+    return true;
+  }
+
+  const origins = raw
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+
+  return origins.length > 0 ? origins : true;
+};
+
+const parsePort = (value: string | undefined): number => {
+  if (value === undefined) {
+    return 3000;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`PORT must be a positive integer when provided (received: ${value})`);
+  }
+
+  return parsed;
+};
+
+export const env = {
+  databaseUrl: readRequired("DATABASE_URL"),
+  shadowDatabaseUrl: process.env.SHADOW_DATABASE_URL ?? null,
+  jwtSecret: readRequired("JWT_SECRET"),
+  redisUrl: readRequired("REDIS_URL"),
+  allowedOrigins: parseAllowedOrigins(readRequired("ALLOWED_ORIGINS")),
+  port: parsePort(process.env.PORT),
+} as const;

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,22 +1,16 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { env } from "./config/env";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(cors, { origin: env.allowedOrigins });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.log.info(
+  { DATABASE_URL: env.databaseUrl, ALLOWED_ORIGINS: env.allowedOrigins },
+  "environment loaded",
+);
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -70,11 +64,10 @@ app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
+const port = env.port;
 const host = "0.0.0.0";
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-


### PR DESCRIPTION
## Summary
- add a repository-level `.env.example` and document how to load secrets locally
- centralise API gateway configuration so it reads validated values from `process.env`
- add a JWT key rotation script and ensure CI workflows fail fast when required secrets are missing

## Testing
- pnpm tsx scripts/key-rotate.ts --bytes 16 --format hex
- pnpm --filter @apgms/api-gateway exec tsc --noEmit *(fails: Module '"@prisma/client"' has no exported member 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68f4cea35bb88327afbe128bca321b74