### PR TITLE
Add bank lines v1 routes with Redis idempotency

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "DATABASE_URL=postgresql://apgms:apgms@localhost:5432/apgms REDIS_URL=redis://localhost:6379 tsx --test test/**/*.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,61 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import { prisma } from "@apgms/shared/src/db";
+import bankLinesRoutes from "./routes/v1/bank-lines";
 
-const app = Fastify({ logger: true });
+export async function createApp(): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+  app.decorateRequest("org", null);
+
+  app.addHook("preHandler", async (request, reply) => {
+    const orgIdHeader = request.headers["x-org-id"];
+    if (typeof orgIdHeader !== "string" || !orgIdHeader.trim()) {
+      reply.code(401).send({ error: "unauthorized" });
+      return reply;
+    }
+    request.org = { id: orgIdHeader };
   });
-  return { users };
-});
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
+  await app.register(bankLinesRoutes);
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+  return app;
+}
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const app = await createApp();
 
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });
+}

--- a/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
@@ -1,0 +1,145 @@
+import pkg from "@prisma/client";
+import type { Prisma as PrismaTypes } from "@prisma/client";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { prisma } from "@apgms/shared/src/db";
+import {
+  IdempotencyInProgressError,
+  withIdempotency,
+} from "@apgms/shared/src/idempotency";
+
+const { Prisma } = pkg;
+
+type BankLineResponse = {
+  id: string;
+  orgId: string;
+  date: string;
+  amount: string;
+  payee: string;
+  desc: string;
+  createdAt: string;
+};
+
+const listQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+  cursor: z.string().cuid().optional(),
+});
+
+const createBodySchema = z
+  .object({
+    date: z
+      .string()
+      .transform((value, ctx) => {
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid date" });
+          return z.NEVER;
+        }
+        return parsed;
+      }),
+    amount: z
+      .union([z.number(), z.string()])
+      .transform((value, ctx) => {
+        try {
+          return new Prisma.Decimal(value as PrismaTypes.Decimal.ValueType);
+        } catch {
+          ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid amount" });
+          return z.NEVER;
+        }
+      }),
+    payee: z.string().trim().min(1).max(255),
+    desc: z.string().trim().min(1).max(1024),
+  })
+  .strict();
+
+function serializeBankLine(line: {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: PrismaTypes.Decimal;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}): BankLineResponse {
+  return {
+    id: line.id,
+    orgId: line.orgId,
+    date: line.date.toISOString(),
+    amount: line.amount.toString(),
+    payee: line.payee,
+    desc: line.desc,
+    createdAt: line.createdAt.toISOString(),
+  };
+}
+
+export default async function bankLinesRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/v1/bank-lines", async (request, reply) => {
+    const { limit, cursor } = listQuerySchema.parse(request.query ?? {});
+
+    const lines = await prisma.bankLine.findMany({
+      where: { orgId: request.org.id },
+      orderBy: [
+        { date: "desc" },
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+      take: limit + 1,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+
+    let nextCursor: string | null = null;
+    if (lines.length > limit) {
+      const nextLine = lines.pop();
+      nextCursor = nextLine ? nextLine.id : null;
+    }
+
+    return reply.send({
+      data: lines.map(serializeBankLine),
+      nextCursor,
+    });
+  });
+
+  app.post("/v1/bank-lines", async (request, reply) => {
+    const idempotencyKey = request.headers["idempotency-key"];
+    if (typeof idempotencyKey !== "string" || !idempotencyKey.trim()) {
+      return reply.code(400).send({ error: "missing_idempotency_key" });
+    }
+
+    const parsedBody = createBodySchema.safeParse(request.body ?? {});
+    if (!parsedBody.success) {
+      return reply.code(400).send({ error: "invalid_body", details: parsedBody.error.format() });
+    }
+
+    try {
+      const { reused, value } = await withIdempotency(
+        `${request.org.id}:${idempotencyKey}`,
+        async () => {
+          const created = await prisma.bankLine.create({
+            data: {
+              orgId: request.org.id,
+              date: parsedBody.data.date,
+              amount: parsedBody.data.amount,
+              payee: parsedBody.data.payee,
+              desc: parsedBody.data.desc,
+            },
+          });
+
+          const payload = serializeBankLine(created);
+          return { statusCode: 201, payload };
+        },
+      );
+
+      const response = reply.code(value.statusCode);
+      if (reused) {
+        response.header("x-idempotent-replay", "true");
+      }
+      return response.send(value.payload);
+    } catch (error) {
+      if (error instanceof IdempotencyInProgressError) {
+        return reply.code(409).send({ error: "idempotency_in_progress" });
+      }
+      request.log.error(error);
+      return reply.code(500).send({ error: "internal_server_error" });
+    }
+  });
+}

--- a/apgms/services/api-gateway/src/types/fastify.d.ts
+++ b/apgms/services/api-gateway/src/types/fastify.d.ts
@@ -1,0 +1,9 @@
+import "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    org: {
+      id: string;
+    };
+  }
+}

--- a/apgms/services/api-gateway/test/routes/bank-lines.test.ts
+++ b/apgms/services/api-gateway/test/routes/bank-lines.test.ts
@@ -1,0 +1,187 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { FastifyInstance } from "fastify";
+import { prisma } from "@apgms/shared/src/db";
+import {
+  idempotencyRedis,
+  shutdownIdempotency,
+} from "@apgms/shared/src/idempotency";
+import { createApp } from "../../src/index";
+
+const TEST_ORG_ID = "org-test";
+const OTHER_ORG_ID = "org-other";
+
+async function ensureOrgs() {
+  await prisma.org.upsert({
+    where: { id: TEST_ORG_ID },
+    update: {},
+    create: { id: TEST_ORG_ID, name: "Test Org" },
+  });
+  await prisma.org.upsert({
+    where: { id: OTHER_ORG_ID },
+    update: {},
+    create: { id: OTHER_ORG_ID, name: "Other Org" },
+  });
+}
+
+describe("/v1/bank-lines routes", { concurrency: false }, () => {
+  let app: FastifyInstance;
+
+  before(async () => {
+    await ensureOrgs();
+    app = await createApp();
+  });
+
+  beforeEach(async () => {
+    await idempotencyRedis.flushdb();
+    await prisma.bankLine.deleteMany({ where: { orgId: { in: [TEST_ORG_ID, OTHER_ORG_ID] } } });
+  });
+
+  after(async () => {
+    await app.close();
+    await prisma.bankLine.deleteMany({ where: { orgId: { in: [TEST_ORG_ID, OTHER_ORG_ID] } } });
+    await prisma.org.deleteMany({ where: { id: { in: [TEST_ORG_ID, OTHER_ORG_ID] } } });
+    await shutdownIdempotency();
+    await prisma.$disconnect();
+  });
+
+  it("returns paginated bank lines for the authenticated org", async () => {
+    const now = new Date("2025-01-01T12:00:00.000Z");
+    const oneDay = 24 * 60 * 60 * 1000;
+
+    const newest = await prisma.bankLine.create({
+      data: {
+        orgId: TEST_ORG_ID,
+        date: new Date(now.getTime()),
+        amount: 2500.5,
+        payee: "Birchal",
+        desc: "Capital injection",
+      },
+    });
+    const middle = await prisma.bankLine.create({
+      data: {
+        orgId: TEST_ORG_ID,
+        date: new Date(now.getTime() - oneDay),
+        amount: -199.99,
+        payee: "CloudCo",
+        desc: "SaaS subscription",
+      },
+    });
+    await prisma.bankLine.create({
+      data: {
+        orgId: TEST_ORG_ID,
+        date: new Date(now.getTime() - oneDay * 2),
+        amount: 1050.0,
+        payee: "Acme",
+        desc: "Office refit",
+      },
+    });
+
+    await prisma.bankLine.create({
+      data: {
+        orgId: OTHER_ORG_ID,
+        date: new Date(now.getTime()),
+        amount: 999.0,
+        payee: "ShouldNotSee",
+        desc: "Hidden",
+      },
+    });
+
+    const firstPage = await app.inject({
+      method: "GET",
+      url: "/v1/bank-lines?limit=2",
+      headers: { "x-org-id": TEST_ORG_ID },
+    });
+
+    assert.strictEqual(firstPage.statusCode, 200);
+    const firstPayload = firstPage.json() as {
+      data: Array<{ id: string; orgId: string }>;
+      nextCursor: string | null;
+    };
+
+    assert.strictEqual(firstPayload.data.length, 2);
+    assert.ok(firstPayload.data.every((item) => item.orgId === TEST_ORG_ID));
+    assert.strictEqual(firstPayload.data[0].id, newest.id);
+    assert.strictEqual(firstPayload.data[1].id, middle.id);
+    assert.ok(firstPayload.nextCursor);
+
+    const secondPage = await app.inject({
+      method: "GET",
+      url: `/v1/bank-lines?limit=2&cursor=${firstPayload.nextCursor}`,
+      headers: { "x-org-id": TEST_ORG_ID },
+    });
+
+    assert.strictEqual(secondPage.statusCode, 200);
+    const secondPayload = secondPage.json() as {
+      data: Array<{ id: string; orgId: string }>;
+      nextCursor: string | null;
+    };
+
+    assert.strictEqual(secondPayload.data.length, 1);
+    assert.strictEqual(secondPayload.data[0].orgId, TEST_ORG_ID);
+    assert.strictEqual(secondPayload.nextCursor, null);
+  });
+
+  it("returns 400 when validation fails", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/bank-lines",
+      headers: {
+        "x-org-id": TEST_ORG_ID,
+        "Idempotency-Key": "validation-case",
+      },
+      payload: {
+        date: "not-a-date",
+        amount: "not-a-number",
+        payee: "",
+        desc: "",
+      },
+    });
+
+    assert.strictEqual(response.statusCode, 400);
+    const body = response.json() as { error: string };
+    assert.strictEqual(body.error, "invalid_body");
+  });
+
+  it("replays the original response when the idempotency key is reused", async () => {
+    const payload = {
+      date: "2025-01-05T10:00:00.000Z",
+      amount: "1200.75",
+      payee: "Launch Supplies",
+      desc: "New hire equipment",
+    };
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/v1/bank-lines",
+      headers: {
+        "x-org-id": TEST_ORG_ID,
+        "Idempotency-Key": "idem-key",
+      },
+      payload,
+    });
+
+    assert.strictEqual(first.statusCode, 201);
+    const firstBody = first.json() as { id: string };
+
+    const second = await app.inject({
+      method: "POST",
+      url: "/v1/bank-lines",
+      headers: {
+        "x-org-id": TEST_ORG_ID,
+        "Idempotency-Key": "idem-key",
+      },
+      payload,
+    });
+
+    assert.strictEqual(second.statusCode, 201);
+    const replayBody = second.json() as { id: string };
+    assert.strictEqual(replayBody.id, firstBody.id);
+    assert.strictEqual(second.headers["x-idempotent-replay"], "true");
+
+    const createdCount = await prisma.bankLine.count({
+      where: { orgId: TEST_ORG_ID, payee: payload.payee },
+    });
+    assert.strictEqual(createdCount, 1);
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,5 @@
-﻿import { PrismaClient } from "@prisma/client";
+import pkg from "@prisma/client";
+
+const { PrismaClient } = pkg;
+
 export const prisma = new PrismaClient();

--- a/apgms/shared/src/idempotency.ts
+++ b/apgms/shared/src/idempotency.ts
@@ -1,0 +1,337 @@
+import net from "node:net";
+import { URL } from "node:url";
+
+const DEFAULT_REDIS_URL = "redis://localhost:6379";
+
+const redisUrlString = process.env.REDIS_URL ?? DEFAULT_REDIS_URL;
+const redisUrl = new URL(redisUrlString);
+
+type RedisReply = string | number | null | RedisReply[];
+
+type PendingCommand = {
+  resolve: (value: RedisReply) => void;
+  reject: (error: Error) => void;
+};
+
+function encodeCommand(args: (string | number)[]): string {
+  const parts = args.map((arg) => {
+    const text = String(arg);
+    return `$${Buffer.byteLength(text)}\r\n${text}\r\n`;
+  });
+  return `*${args.length}\r\n${parts.join("")}`;
+}
+
+function parseResp(buffer: Buffer): [RedisReply | Error, Buffer] | null {
+  if (buffer.length === 0) {
+    return null;
+  }
+  const prefix = buffer[0];
+  if (prefix === 43 /* + */ || prefix === 45 /* - */) {
+    const end = buffer.indexOf("\r\n");
+    if (end === -1) {
+      return null;
+    }
+    const text = buffer.slice(1, end).toString();
+    const rest = buffer.slice(end + 2);
+    if (prefix === 45) {
+      return [new Error(text), rest];
+    }
+    return [text, rest];
+  }
+  if (prefix === 58 /* : */) {
+    const end = buffer.indexOf("\r\n");
+    if (end === -1) {
+      return null;
+    }
+    const num = Number.parseInt(buffer.slice(1, end).toString(), 10);
+    const rest = buffer.slice(end + 2);
+    return [num, rest];
+  }
+  if (prefix === 36 /* $ */) {
+    const end = buffer.indexOf("\r\n");
+    if (end === -1) {
+      return null;
+    }
+    const length = Number.parseInt(buffer.slice(1, end).toString(), 10);
+    const start = end + 2;
+    if (length === -1) {
+      return [null, buffer.slice(start)];
+    }
+    const valueEnd = start + length;
+    if (buffer.length < valueEnd + 2) {
+      return null;
+    }
+    const value = buffer.slice(start, valueEnd).toString();
+    const rest = buffer.slice(valueEnd + 2);
+    return [value, rest];
+  }
+  if (prefix === 42 /* * */) {
+    const end = buffer.indexOf("\r\n");
+    if (end === -1) {
+      return null;
+    }
+    const count = Number.parseInt(buffer.slice(1, end).toString(), 10);
+    let rest = buffer.slice(end + 2);
+    if (count === -1) {
+      return [null, rest];
+    }
+    const items: RedisReply[] = [];
+    for (let i = 0; i < count; i += 1) {
+      const parsed = parseResp(rest);
+      if (!parsed) {
+        return null;
+      }
+      const [value, newRest] = parsed;
+      if (value instanceof Error) {
+        return [value, newRest];
+      }
+      items.push(value);
+      rest = newRest;
+    }
+    return [items, rest];
+  }
+  throw new Error(`Unsupported RESP prefix: ${String.fromCharCode(prefix)}`);
+}
+
+class SimpleRedisClient {
+  private socket: net.Socket | null = null;
+
+  private buffer = Buffer.alloc(0);
+
+  private readonly pending: PendingCommand[] = [];
+
+  private connectPromise: Promise<void> | null = null;
+
+  private closing = false;
+
+  constructor(private readonly url: URL) {}
+
+  private async ensureConnection(): Promise<void> {
+    if (this.socket && !this.socket.destroyed) {
+      return;
+    }
+    if (!this.connectPromise) {
+      this.connectPromise = new Promise((resolve, reject) => {
+        const socket = net.createConnection(
+          { host: this.url.hostname, port: Number(this.url.port || 6379) },
+          async () => {
+            this.socket = socket;
+            this.socket.on("data", this.handleData);
+            this.socket.on("error", this.handleSocketError);
+            this.socket.on("close", this.handleSocketClose);
+            try {
+              if (this.url.password) {
+                await this.sendCommandInternal(["AUTH", this.url.password]);
+              }
+              resolve();
+            } catch (error) {
+              this.cleanup();
+              reject(error as Error);
+            }
+          },
+        );
+        socket.once("error", (err) => {
+          if (!this.socket) {
+            reject(err);
+          }
+        });
+      }).finally(() => {
+        this.connectPromise = null;
+      });
+    }
+    return this.connectPromise;
+  }
+
+  private handleData = (chunk: Buffer) => {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    while (this.pending.length) {
+      const parsed = parseResp(this.buffer);
+      if (!parsed) {
+        break;
+      }
+      const [value, rest] = parsed;
+      this.buffer = rest;
+      const pending = this.pending.shift();
+      if (!pending) {
+        continue;
+      }
+      if (value instanceof Error) {
+        pending.reject(value);
+      } else {
+        pending.resolve(value);
+      }
+    }
+  };
+
+  private handleSocketError = (err: Error) => {
+    while (this.pending.length) {
+      this.pending.shift()?.reject(err);
+    }
+    this.cleanup();
+  };
+
+  private handleSocketClose = () => {
+    if (!this.closing) {
+      this.cleanup();
+    }
+  };
+
+  private cleanup() {
+    this.socket?.removeListener("data", this.handleData);
+    this.socket?.removeListener("error", this.handleSocketError);
+    this.socket?.removeListener("close", this.handleSocketClose);
+    this.socket = null;
+    this.buffer = Buffer.alloc(0);
+  }
+
+  private sendCommandInternal(args: (string | number)[]): Promise<RedisReply> {
+    if (!this.socket) {
+      throw new Error("Redis socket is not connected");
+    }
+    return new Promise<RedisReply>((resolve, reject) => {
+      this.pending.push({ resolve, reject });
+      this.socket!.write(encodeCommand(args));
+    });
+  }
+
+  async command(args: (string | number)[]): Promise<RedisReply> {
+    await this.ensureConnection();
+    return this.sendCommandInternal(args);
+  }
+
+  async get(key: string): Promise<string | null> {
+    const result = await this.command(["GET", key]);
+    if (result === null) {
+      return null;
+    }
+    if (typeof result === "string") {
+      return result;
+    }
+    throw new Error("Unexpected response for GET");
+  }
+
+  async set(
+    key: string,
+    value: string,
+    options?: { nx?: boolean; ex?: number },
+  ): Promise<string | null> {
+    const args: (string | number)[] = ["SET", key, value];
+    if (options?.nx) {
+      args.push("NX");
+    }
+    if (typeof options?.ex === "number") {
+      args.push("EX", options.ex);
+    }
+    const result = await this.command(args);
+    if (result === null) {
+      return null;
+    }
+    if (typeof result === "string") {
+      return result;
+    }
+    throw new Error("Unexpected response for SET");
+  }
+
+  async del(key: string): Promise<number> {
+    const result = await this.command(["DEL", key]);
+    if (typeof result === "number") {
+      return result;
+    }
+    throw new Error("Unexpected response for DEL");
+  }
+
+  async flushdb(): Promise<void> {
+    await this.command(["FLUSHDB"]);
+  }
+
+  async quit(): Promise<void> {
+    if (!this.socket || this.socket.destroyed) {
+      return;
+    }
+    this.closing = true;
+    try {
+      await this.command(["QUIT"]);
+    } catch {
+      // ignore errors during shutdown
+    } finally {
+      this.socket?.end();
+      this.cleanup();
+      this.closing = false;
+    }
+  }
+}
+
+export const idempotencyRedis = new SimpleRedisClient(redisUrl);
+
+const IDEMPOTENCY_NAMESPACE = "idempotency";
+
+export class IdempotencyInProgressError extends Error {
+  constructor(message = "An idempotent request with the same key is already in progress") {
+    super(message);
+    this.name = "IdempotencyInProgressError";
+  }
+}
+
+type PendingRecord = { status: "pending" };
+type CompletedRecord<T> = { status: "completed"; result: T };
+type StoredRecord<T> = PendingRecord | CompletedRecord<T>;
+
+export interface IdempotencyOptions {
+  ttlSeconds?: number;
+  pendingTtlSeconds?: number;
+}
+
+export interface IdempotencyResult<T> {
+  reused: boolean;
+  value: T;
+}
+
+function redisKeyFromId(key: string): string {
+  return `${IDEMPOTENCY_NAMESPACE}:${key}`;
+}
+
+export async function withIdempotency<T>(
+  key: string,
+  handler: () => Promise<T>,
+  options: IdempotencyOptions = {},
+): Promise<IdempotencyResult<T>> {
+  const redisKey = redisKeyFromId(key);
+  const pendingTtlSeconds = options.pendingTtlSeconds ?? 30;
+  const ttlSeconds = options.ttlSeconds ?? 60 * 10;
+
+  const placeholder: PendingRecord = { status: "pending" };
+  const created = await idempotencyRedis.set(redisKey, JSON.stringify(placeholder), {
+    nx: true,
+    ex: pendingTtlSeconds,
+  });
+
+  if (!created) {
+    const existingRaw = await idempotencyRedis.get(redisKey);
+    if (!existingRaw) {
+      throw new IdempotencyInProgressError();
+    }
+    const existing = JSON.parse(existingRaw) as StoredRecord<T>;
+    if (existing.status === "completed") {
+      return { reused: true, value: existing.result };
+    }
+    throw new IdempotencyInProgressError();
+  }
+
+  try {
+    const value = await handler();
+    const record: CompletedRecord<T> = { status: "completed", result: value };
+    await idempotencyRedis.set(redisKey, JSON.stringify(record), { ex: ttlSeconds });
+    return { reused: false, value };
+  } catch (error) {
+    await idempotencyRedis.del(redisKey);
+    throw error;
+  }
+}
+
+export async function clearIdempotencyKey(key: string): Promise<void> {
+  await idempotencyRedis.del(redisKeyFromId(key));
+}
+
+export async function shutdownIdempotency(): Promise<void> {
+  await idempotencyRedis.quit();
+}

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./idempotency";


### PR DESCRIPTION
## Summary
- introduce /v1/bank-lines Fastify routes with org scoping, pagination, and Redis-backed idempotent POST handling
- add a lightweight Redis client and helper in @apgms/shared to enforce Idempotency-Key usage
- wire the new router into the API gateway after auth hooks and cover it with integration tests

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: Prisma engines download blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4cea4f2488327842f13a1c989cd48