### PR TITLE
feat(api-gateway): add ops endpoints and observability

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,8 +9,17 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/instrumentation-fastify": "^0.45.1",
+    "@opentelemetry/instrumentation-http": "^0.51.1",
+    "@opentelemetry/resources": "^1.18.1",
+    "@opentelemetry/sdk-node": "^0.51.1",
+    "@opentelemetry/semantic-conventions": "^1.25.1",
+    "@prisma/instrumentation": "^6.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "ioredis": "^5.4.1",
+    "prom-client": "^15.1.3",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/plugins/metrics.ts
+++ b/apgms/services/api-gateway/src/plugins/metrics.ts
@@ -1,0 +1,42 @@
+import type { FastifyPluginAsync } from "fastify";
+import { Histogram, Registry, collectDefaultMetrics } from "prom-client";
+
+const REQUEST_START = Symbol("requestStart");
+
+const metricsPlugin: FastifyPluginAsync = async (fastify) => {
+  const register = new Registry();
+  collectDefaultMetrics({ register });
+
+  const httpRequestDuration = new Histogram({
+    name: "http_request_duration_seconds",
+    help: "Duration of HTTP requests in seconds",
+    labelNames: ["method", "route", "status_code"],
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5],
+    registers: [register],
+  });
+
+  fastify.addHook("onRequest", (request, _reply, done) => {
+    (request as any)[REQUEST_START] = process.hrtime.bigint();
+    done();
+  });
+
+  fastify.addHook("onResponse", (request, reply, done) => {
+    const start = (request as any)[REQUEST_START] as bigint | undefined;
+    if (start) {
+      const durationNs = Number(process.hrtime.bigint() - start);
+      const durationSeconds = durationNs / 1e9;
+      const route = request.routeOptions?.url ?? request.raw.url ?? "unknown";
+      httpRequestDuration
+        .labels(request.method, route, reply.statusCode.toString())
+        .observe(durationSeconds);
+    }
+    done();
+  });
+
+  fastify.get("/metrics", async (_request, reply) => {
+    reply.header("Content-Type", register.contentType);
+    return reply.send(await register.metrics());
+  });
+};
+
+export default metricsPlugin;

--- a/apgms/services/api-gateway/src/plugins/otel.ts
+++ b/apgms/services/api-gateway/src/plugins/otel.ts
@@ -1,0 +1,45 @@
+import type { FastifyPluginAsync } from "fastify";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
+import { FastifyInstrumentation } from "@opentelemetry/instrumentation-fastify";
+import { PrismaInstrumentation } from "@prisma/instrumentation";
+
+let sdk: NodeSDK | undefined;
+
+const otelPlugin: FastifyPluginAsync = async (fastify) => {
+  if (process.env.NODE_ENV === "test" || process.env.OTEL_DISABLED === "1") {
+    return;
+  }
+
+  if (!sdk) {
+    sdk = new NodeSDK({
+      resource: new Resource({
+        [SemanticResourceAttributes.SERVICE_NAME]:
+          process.env.OTEL_SERVICE_NAME ?? "api-gateway",
+      }),
+      instrumentations: [
+        new HttpInstrumentation(),
+        new FastifyInstrumentation(),
+        new PrismaInstrumentation(),
+      ],
+    });
+
+    try {
+      await sdk.start();
+      fastify.log.info("OpenTelemetry SDK started");
+    } catch (error) {
+      fastify.log.error({ err: error }, "Failed to start OpenTelemetry SDK");
+    }
+  }
+
+  fastify.addHook("onClose", async () => {
+    if (sdk) {
+      await sdk.shutdown();
+      sdk = undefined;
+    }
+  });
+};
+
+export default otelPlugin;

--- a/apgms/services/api-gateway/src/routes/ops/health.ts
+++ b/apgms/services/api-gateway/src/routes/ops/health.ts
@@ -1,0 +1,7 @@
+import type { FastifyPluginAsync } from "fastify";
+
+const healthRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.get("/health", async () => ({ status: "ok" }));
+};
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/src/routes/ops/ready.ts
+++ b/apgms/services/api-gateway/src/routes/ops/ready.ts
@@ -1,0 +1,57 @@
+import type { FastifyPluginAsync } from "fastify";
+import Redis from "ioredis";
+import { prisma } from "@apgms/shared/db";
+
+const redisUrl = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
+const redis = new Redis(redisUrl, { lazyConnect: true });
+
+const readyRoutes: FastifyPluginAsync = async (fastify) => {
+  const connectRedis = async () => {
+    if (
+      redis.status === "wait" ||
+      redis.status === "connecting" ||
+      redis.status === "reconnecting" ||
+      redis.status === "end"
+    ) {
+      try {
+        await redis.connect();
+      } catch (error) {
+        fastify.log.warn({ err: error }, "Failed to connect to Redis");
+      }
+    }
+  };
+
+  fastify.addHook("onReady", async () => {
+    await connectRedis();
+  });
+
+  if (redis.listeners("error").length === 0) {
+    redis.on("error", (error) => {
+      fastify.log.error({ err: error }, "Redis connection error");
+    });
+  }
+
+  fastify.addHook("onClose", async () => {
+    if (redis.status !== "end") {
+      await redis.quit();
+    }
+  });
+
+  fastify.get("/ready", async (request, reply) => {
+    try {
+      await connectRedis();
+      await prisma.$queryRaw`SELECT 1`;
+      if (redis.status !== "ready") {
+        throw new Error("redis_not_ready");
+      }
+      return { status: "ready" };
+    } catch (error) {
+      request.log.warn({ err: error }, "Readiness check failed");
+      reply.code(503);
+      return { status: "starting" };
+    }
+  });
+};
+
+export default readyRoutes;
+export { redis };


### PR DESCRIPTION
## Summary
- add health and readiness routes that surface service and dependency status
- expose Prometheus metrics and initialize OpenTelemetry HTTP/Prisma spans
- configure the API gateway with redacted logging and new observability plugins

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4d3ddeac48327aa5a59a411b21267