### PR TITLE
Harden API gateway HTTP surface

### DIFF
--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -42,6 +42,15 @@ importers:
       '@fastify/cors':
         specifier: ^11.1.0
         version: 11.1.0
+      '@fastify/helmet':
+        specifier: workspace:*
+        version: link:../fastify-helmet
+      '@fastify/rate-limit':
+        specifier: workspace:*
+        version: link:../fastify-rate-limit
+      '@fastify/request-id':
+        specifier: workspace:*
+        version: link:../fastify-request-id
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -78,6 +87,12 @@ importers:
   webapp: {}
 
   worker: {}
+
+  services/fastify-helmet: {}
+
+  services/fastify-rate-limit: {}
+
+  services/fastify-request-id: {}
 
 packages:
 

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,6 +9,9 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "workspace:*",
+    "@fastify/rate-limit": "workspace:*",
+    "@fastify/request-id": "workspace:*",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,13 +7,56 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyReply, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import helmet from "@fastify/helmet";
+import rateLimit from "@fastify/rate-limit";
+import requestId from "@fastify/request-id";
+import { audit, buildCorsOriginValidator, prisma } from "@apgms/shared";
+
+type MutationHandler<T = unknown> = (
+  req: FastifyRequest,
+  rep: FastifyReply,
+) => Promise<T>;
+
+const extractHeader = (req: FastifyRequest, header: string): string | undefined => {
+  const value = req.headers[header];
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return typeof value === "string" ? value : undefined;
+};
+
+const withAudit = <T>(handler: MutationHandler<T>) => {
+  return async (req: FastifyRequest, rep: FastifyReply) => {
+    const started = Date.now();
+    try {
+      return await handler(req, rep);
+    } finally {
+      const status = rep.statusCode ?? (rep.raw.statusCode as number | undefined) ?? 500;
+      const pathLabel = req.routeOptions?.url ?? req.url;
+      const entry = audit(
+        req.method,
+        pathLabel,
+        extractHeader(req, "x-user-id"),
+        extractHeader(req, "x-org-id"),
+        status,
+      );
+      req.log.info({ audit: entry, durationMs: Date.now() - started }, "http mutation");
+    }
+  };
+};
+
+const rateLimitMax = Number(process.env.RATE_LIMIT_MAX ?? 100);
+const rateLimitWindow = process.env.RATE_LIMIT_WINDOW ?? "1 minute";
+const corsOrigin = buildCorsOriginValidator(process.env.ALLOWED_ORIGINS);
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(requestId);
+await app.register(helmet);
+await app.register(rateLimit, { max: rateLimitMax, timeWindow: rateLimitWindow });
+await app.register(cors, { origin: corsOrigin as any });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -40,30 +83,33 @@ app.get("/bank-lines", async (req) => {
 });
 
 // Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+app.post(
+  "/bank-lines",
+  withAudit(async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  }),
+);
 
 // Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
@@ -77,4 +123,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,7 +9,11 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared": ["shared/src/index.ts"],
+      "@apgms/shared/*": ["shared/src/*"],
+      "@fastify/helmet": ["services/fastify-helmet/src/index"],
+      "@fastify/rate-limit": ["services/fastify-rate-limit/src/index"],
+      "@fastify/request-id": ["services/fastify-request-id/src/index"]
     }
   },
   "include": ["src"]

--- a/apgms/services/fastify-helmet/package.json
+++ b/apgms/services/fastify-helmet/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fastify/helmet",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/apgms/services/fastify-helmet/src/index.d.ts
+++ b/apgms/services/fastify-helmet/src/index.d.ts
@@ -1,0 +1,6 @@
+import type { FastifyPluginAsync } from "fastify";
+
+declare const helmet: FastifyPluginAsync<{
+  global?: boolean;
+}>;
+export default helmet;

--- a/apgms/services/fastify-helmet/src/index.js
+++ b/apgms/services/fastify-helmet/src/index.js
@@ -1,0 +1,26 @@
+const DEFAULT_HEADERS = {
+  "X-DNS-Prefetch-Control": "off",
+  "X-Frame-Options": "SAMEORIGIN",
+  "Strict-Transport-Security": "max-age=15552000; includeSubDomains",
+  "X-Content-Type-Options": "nosniff",
+  "Referrer-Policy": "no-referrer",
+  "X-Permitted-Cross-Domain-Policies": "none",
+  "X-Download-Options": "noopen",
+  "X-XSS-Protection": "0",
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Resource-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "require-corp",
+};
+
+const helmet = async (fastify) => {
+  fastify.addHook("onSend", async (_request, reply, payload) => {
+    for (const [header, value] of Object.entries(DEFAULT_HEADERS)) {
+      if (!reply.hasHeader(header)) {
+        reply.header(header, value);
+      }
+    }
+    return payload;
+  });
+};
+
+export default helmet;

--- a/apgms/services/fastify-rate-limit/package.json
+++ b/apgms/services/fastify-rate-limit/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fastify/rate-limit",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/apgms/services/fastify-rate-limit/src/index.d.ts
+++ b/apgms/services/fastify-rate-limit/src/index.d.ts
@@ -1,0 +1,19 @@
+import type { FastifyPluginAsync, FastifyRequest } from "fastify";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    rateLimit?: {
+      limit: number;
+      remaining: number;
+      reset: number;
+    };
+  }
+}
+
+declare const rateLimit: FastifyPluginAsync<{
+  max?: number;
+  timeWindow?: number | string;
+  allowList?: string[];
+}>;
+
+export default rateLimit;

--- a/apgms/services/fastify-rate-limit/src/index.js
+++ b/apgms/services/fastify-rate-limit/src/index.js
@@ -1,0 +1,93 @@
+const DEFAULT_MAX = 100;
+const DEFAULT_WINDOW_MS = 60_000;
+
+const unitMultipliers = {
+  ms: 1,
+  millisecond: 1,
+  milliseconds: 1,
+  s: 1_000,
+  second: 1_000,
+  seconds: 1_000,
+  m: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 3_600_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+};
+
+const parseTimeWindow = (value) => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const match = value.trim().match(/^(\d+)(?:\s*(ms|milliseconds?|s|seconds?|m|minutes?|h|hours?))?$/i);
+    if (match) {
+      const amount = Number(match[1]);
+      const unit = (match[2] ?? "ms").toLowerCase();
+      const multiplier = unitMultipliers[unit] ?? 1;
+      return Math.max(amount * multiplier, 1);
+    }
+  }
+
+  return DEFAULT_WINDOW_MS;
+};
+
+const resolveKey = (request) => {
+  const forwarded = request.headers["x-forwarded-for"];
+  if (typeof forwarded === "string" && forwarded.length > 0) {
+    return forwarded.split(",")[0].trim();
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0];
+  }
+  if (request.ip) {
+    return request.ip;
+  }
+  return request.socket?.remoteAddress ?? "unknown";
+};
+
+const rateLimit = async (fastify, opts = {}) => {
+  const max = typeof opts.max === "number" && opts.max > 0 ? Math.floor(opts.max) : DEFAULT_MAX;
+  const timeWindow = parseTimeWindow(opts.timeWindow);
+  const allowList = new Set(opts.allowList ?? []);
+  const hits = new Map();
+
+  fastify.decorateRequest("rateLimit", null);
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const key = resolveKey(request);
+    if (allowList.has(key)) {
+      return;
+    }
+
+    const now = Date.now();
+    let entry = hits.get(key);
+    if (!entry || entry.expiresAt <= now) {
+      entry = { count: 0, expiresAt: now + timeWindow };
+      hits.set(key, entry);
+    }
+
+    entry.count += 1;
+    const remaining = Math.max(max - entry.count, 0);
+    request.rateLimit = { limit: max, remaining, reset: entry.expiresAt };
+
+    if (entry.count > max) {
+      reply.header("Retry-After", Math.ceil((entry.expiresAt - now) / 1000));
+      return reply.code(429).send({ error: "rate_limit_exceeded" });
+    }
+  });
+
+  fastify.addHook("onSend", async (request, reply, payload) => {
+    const info = request.rateLimit;
+    if (info) {
+      reply.header("X-RateLimit-Limit", String(info.limit));
+      reply.header("X-RateLimit-Remaining", String(Math.max(info.remaining, 0)));
+      reply.header("X-RateLimit-Reset", String(Math.ceil(info.reset / 1000)));
+    }
+    return payload;
+  });
+};
+
+export default rateLimit;

--- a/apgms/services/fastify-request-id/package.json
+++ b/apgms/services/fastify-request-id/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@fastify/request-id",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  }
+}

--- a/apgms/services/fastify-request-id/src/index.d.ts
+++ b/apgms/services/fastify-request-id/src/index.d.ts
@@ -1,0 +1,8 @@
+import type { FastifyPluginAsync } from "fastify";
+
+declare const requestId: FastifyPluginAsync<{
+  header?: string;
+  generator?: () => string;
+}>;
+
+export default requestId;

--- a/apgms/services/fastify-request-id/src/index.js
+++ b/apgms/services/fastify-request-id/src/index.js
@@ -1,0 +1,18 @@
+import { randomUUID } from "node:crypto";
+
+const defaultGenerator = () => randomUUID();
+
+const requestId = async (fastify, opts = {}) => {
+  const headerName = (opts.header ?? "request-id").toLowerCase();
+  const generator = typeof opts.generator === "function" ? opts.generator : defaultGenerator;
+
+  fastify.addHook("onRequest", async (request, reply) => {
+    const incoming = request.headers[headerName];
+    const candidate = Array.isArray(incoming) ? incoming[0] : incoming;
+    const id = typeof candidate === "string" && candidate.length > 0 ? candidate : generator();
+    request.id = id;
+    reply.header(headerName, id);
+  });
+};
+
+export default requestId;

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,3 @@
-﻿// shared
+export * from "./db";
+export * from "./security/audit";
+export * from "./security/cors";

--- a/apgms/shared/src/security/audit.ts
+++ b/apgms/shared/src/security/audit.ts
@@ -1,0 +1,55 @@
+export interface AuditLogEntry {
+  timestamp: string;
+  method: string;
+  path: string;
+  status: number;
+  userId?: string;
+  orgId?: string;
+}
+
+type NullableString = string | null | undefined;
+
+const PII_PATTERNS: Array<{ regex: RegExp; replacement: string }> = [
+  { regex: /([A-Za-z0-9._%+-]+)@([A-Za-z0-9.-]+\.[A-Za-z]{2,})/g, replacement: "[redacted-email]" },
+  { regex: /\b\d{9,}\b/g, replacement: "[redacted-number]" },
+];
+
+const redactString = (value: NullableString): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  return PII_PATTERNS.reduce((current, pattern) => current.replace(pattern.regex, pattern.replacement), value);
+};
+
+const sanitizePath = (rawPath: string): string => {
+  const [path] = rawPath.split("?");
+  return redactString(path) ?? path;
+};
+
+export const audit = (
+  method: string,
+  path: string,
+  userId: NullableString,
+  orgId: NullableString,
+  status: number,
+): AuditLogEntry => {
+  const entry: AuditLogEntry = {
+    timestamp: new Date().toISOString(),
+    method: method.toUpperCase(),
+    path: sanitizePath(path),
+    status,
+  };
+
+  const redactedUser = redactString(userId);
+  if (redactedUser) {
+    entry.userId = redactedUser;
+  }
+
+  const redactedOrg = redactString(orgId);
+  if (redactedOrg) {
+    entry.orgId = redactedOrg;
+  }
+
+  return entry;
+};

--- a/apgms/shared/src/security/cors.ts
+++ b/apgms/shared/src/security/cors.ts
@@ -1,0 +1,46 @@
+const WILDCARD = "*";
+
+type CorsCallback = (err: Error | null, allow?: boolean) => void;
+export type OriginValidator = (origin: string | undefined, cb: CorsCallback) => void;
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const parseAllowedOrigins = (envValue?: string): string[] => {
+  if (!envValue) {
+    return [];
+  }
+
+  return envValue
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+};
+
+const compileWildcard = (pattern: string): RegExp => {
+  const escaped = escapeRegExp(pattern);
+  const regexSource = `^${escaped.replace(/\\\*/g, ".*")}$`;
+  return new RegExp(regexSource);
+};
+
+export const buildCorsOriginValidator = (envValue?: string): OriginValidator => {
+  const allowedOrigins = parseAllowedOrigins(envValue);
+  const allowAll = allowedOrigins.includes(WILDCARD);
+  const exactMatches = new Set(allowedOrigins.filter((origin) => !origin.includes("*")));
+  const wildcardMatchers = allowedOrigins
+    .filter((origin) => !exactMatches.has(origin) && origin.includes("*"))
+    .map((origin) => compileWildcard(origin));
+
+  return (origin: string | undefined, cb: CorsCallback) => {
+    if (!origin) {
+      cb(null, true);
+      return;
+    }
+
+    if (allowAll || exactMatches.has(origin) || wildcardMatchers.some((regex) => regex.test(origin))) {
+      cb(null, true);
+      return;
+    }
+
+    cb(new Error("Origin not allowed"), false);
+  };
+};


### PR DESCRIPTION
## Summary
- add shared security helpers for CORS allowlists and audit logging
- introduce local Fastify plugins for helmet, rate limiting, and request IDs and wire them into the gateway
- update the API gateway to apply security middleware, enforce rate limits, and log audited mutations

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4d3cee94c8327a54e0d9ec06055a0