### PR TITLE
Add API gateway env validation and key rotation utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Core runtime configuration for APGMS services
+NODE_ENV=development
+PORT=3000
+
+# CORS configuration (comma-separated list or "*")
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:5173
+
+# Database connectivity
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/apgms
+SHADOW_DATABASE_URL=postgresql://postgres:postgres@localhost:5433/apgms_shadow
+
+# Cache / background processing
+REDIS_URL=redis://localhost:6379
+
+# API request constraints
+RATE_LIMIT_MAX=1000
+REQUEST_BODY_LIMIT=1mb
+
+# JWT authentication (run scripts/key-rotate.ps1 to generate keys)
+JWT_ISSUER=https://auth.local.dev/
+JWT_AUDIENCE=apgms-clients
+JWT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\\nREPLACE_WITH_KEY_FROM_ROTATION_SCRIPT\\n-----END PRIVATE KEY-----"
+JWT_PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\\nREPLACE_WITH_KEY_FROM_ROTATION_SCRIPT\\n-----END PUBLIC KEY-----"
+
+# Observability
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/apgms/README.md
+++ b/apgms/README.md
@@ -1,8 +1,40 @@
-﻿# APGMS
+# APGMS
 
-Quickstart:
-pnpm i
-pnpm -r build
-docker compose up -d
-pnpm -r test
-pnpm -w exec playwright test
+## Quickstart
+
+1. Install dependencies: `pnpm i`
+2. Copy the sample environment file and customise it: `cp ../.env.example ../.env`
+3. Build all workspaces: `pnpm -r build`
+4. Start supporting infrastructure: `docker compose up -d`
+5. Run the test suites: `pnpm -r test`
+6. (Optional) Run browser tests: `pnpm -w exec playwright test`
+
+## Environment configuration
+
+The services rely on a `.env` file located at the repository root. An example configuration is provided in `.env.example` and covers the required variables:
+
+- `NODE_ENV`, `PORT` – runtime mode and listen port for the API gateway.
+- `ALLOWED_ORIGINS` – comma-separated list for CORS (`*` allows all origins).
+- `DATABASE_URL`, `SHADOW_DATABASE_URL` – Prisma primary and shadow databases.
+- `REDIS_URL` – connection string for caching / background jobs.
+- `RATE_LIMIT_MAX`, `REQUEST_BODY_LIMIT` – request shaping limits enforced by Fastify plugins.
+- `JWT_ISSUER`, `JWT_AUDIENCE`, `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY` – JWT verification configuration.
+- `OTEL_EXPORTER_OTLP_ENDPOINT` – optional OpenTelemetry collector endpoint.
+
+Populate the `.env` file before starting any service. The API gateway validates these values at startup and exits with a descriptive error when something is missing or malformed.
+
+## Rotating JWT signing keys
+
+Use the PowerShell script at `scripts/key-rotate.ps1` to generate a fresh RSA key pair and update the `.env` file automatically:
+
+```powershell
+pwsh ./scripts/key-rotate.ps1
+```
+
+The script writes the new key material to `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` (escaped for `.env` consumption) and prints the location that was updated. Pass `-EnvPath` to target a different file:
+
+```powershell
+pwsh ./scripts/key-rotate.ps1 -EnvPath ../configs/.env.staging
+```
+
+After rotating the key, redeploy or restart any services that cache the previous key so that newly issued tokens become valid and previously issued tokens are rejected.

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "build": "tsc --noEmit",
+    "test": "tsx --test test/jwt-rotation.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,96 @@
+import { config as loadEnv } from "dotenv";
+import { z } from "zod";
+
+const dotenvResult = loadEnv();
+
+if (dotenvResult.error && (dotenvResult.error as NodeJS.ErrnoException).code !== "ENOENT") {
+  throw new Error(`Unable to load environment variables: ${dotenvResult.error.message}`);
+}
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
+  PORT: z
+    .preprocess((value) => {
+      if (value === undefined || value === "") {
+        return 3000;
+      }
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : value;
+    }, z.number().int().min(0).max(65535)),
+  ALLOWED_ORIGINS: z
+    .preprocess((value) => {
+      if (typeof value !== "string") return value;
+      const trimmed = value.trim();
+      if (trimmed === "*") {
+        return ["*"];
+      }
+      return trimmed
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter((origin) => origin.length > 0);
+    },
+    z.array(z.string()).nonempty("ALLOWED_ORIGINS must include at least one origin or be '*'")
+  ),
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  SHADOW_DATABASE_URL: z.string().min(1).optional(),
+  REDIS_URL: z.string().min(1, "REDIS_URL is required"),
+  RATE_LIMIT_MAX: z.preprocess((value) => {
+    if (value === undefined || value === "") {
+      return undefined;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : value;
+  }, z.number().int().positive()),
+  REQUEST_BODY_LIMIT: z.string().min(1, "REQUEST_BODY_LIMIT is required"),
+  JWT_ISSUER: z.string().min(1, "JWT_ISSUER is required"),
+  JWT_AUDIENCE: z.string().min(1, "JWT_AUDIENCE is required"),
+  JWT_PRIVATE_KEY: z.preprocess((value) =>
+    typeof value === "string" ? value.replace(/\\n/g, "\n") : value,
+  z.string().min(1, "JWT_PRIVATE_KEY is required")),
+  JWT_PUBLIC_KEY: z.preprocess((value) =>
+    typeof value === "string" ? value.replace(/\\n/g, "\n") : value,
+  z.string().min(1, "JWT_PUBLIC_KEY is required")),
+  OTEL_EXPORTER_OTLP_ENDPOINT: z.string().url("OTEL_EXPORTER_OTLP_ENDPOINT must be a valid URL").optional(),
+});
+
+const parsedEnv = envSchema.safeParse(process.env);
+
+if (!parsedEnv.success) {
+  const fieldErrors = parsedEnv.error.flatten().fieldErrors;
+  const formErrors = parsedEnv.error.flatten().formErrors;
+
+  const messages = [
+    ...Object.entries(fieldErrors).flatMap(([field, errors]) =>
+      (errors ?? []).map((message) => `${field}: ${message}`),
+    ),
+    ...formErrors,
+  ];
+
+  const header = "❌ Invalid environment configuration";
+  const details = messages.length > 0 ? messages.join("\n  - ") : parsedEnv.error.message;
+  console.error(`${header}:\n  - ${details}`);
+  process.exit(1);
+}
+
+const rawEnv = parsedEnv.data;
+
+const allowAllOrigins = rawEnv.ALLOWED_ORIGINS.length === 1 && rawEnv.ALLOWED_ORIGINS[0] === "*";
+
+export const config = Object.freeze({
+  NODE_ENV: rawEnv.NODE_ENV,
+  PORT: rawEnv.PORT,
+  ALLOWED_ORIGINS: rawEnv.ALLOWED_ORIGINS,
+  DATABASE_URL: rawEnv.DATABASE_URL,
+  SHADOW_DATABASE_URL: rawEnv.SHADOW_DATABASE_URL,
+  REDIS_URL: rawEnv.REDIS_URL,
+  RATE_LIMIT_MAX: rawEnv.RATE_LIMIT_MAX,
+  REQUEST_BODY_LIMIT: rawEnv.REQUEST_BODY_LIMIT,
+  JWT_ISSUER: rawEnv.JWT_ISSUER,
+  JWT_AUDIENCE: rawEnv.JWT_AUDIENCE,
+  JWT_PRIVATE_KEY: rawEnv.JWT_PRIVATE_KEY,
+  JWT_PUBLIC_KEY: rawEnv.JWT_PUBLIC_KEY,
+  OTEL_EXPORTER_OTLP_ENDPOINT: rawEnv.OTEL_EXPORTER_OTLP_ENDPOINT,
+  corsOrigin: allowAllOrigins ? true : rawEnv.ALLOWED_ORIGINS,
+});
+
+export type AppConfig = typeof config;

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,22 +1,14 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
-
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { config } from "./config";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(cors, { origin: config.corsOrigin });
 
 // sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.log.info({ databaseConfigured: Boolean(config.DATABASE_URL) }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -70,11 +62,10 @@ app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
+const port = config.PORT;
 const host = "0.0.0.0";
 
 app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/test/jwt-rotation.test.ts
+++ b/apgms/services/api-gateway/test/jwt-rotation.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { createSign, createVerify, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+function generateRsaKeyPairPem() {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+
+  return { privateKeyPem: privateKey, publicKeyPem: publicKey };
+}
+
+function createJwtLikeToken(payload: Record<string, unknown>, privateKeyPem: string) {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const message = `${header}.${body}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(message);
+  signer.end();
+
+  const signature = signer.sign(privateKeyPem).toString("base64url");
+  return `${message}.${signature}`;
+}
+
+function verifyJwtLikeToken(token: string, publicKeyPem: string) {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("token is not a valid JWT structure");
+  }
+
+  const [headerEncoded, payloadEncoded, signatureEncoded] = segments;
+  const message = `${headerEncoded}.${payloadEncoded}`;
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(message);
+  verifier.end();
+
+  const signature = Buffer.from(signatureEncoded, "base64url");
+  const verified = verifier.verify(publicKeyPem, signature);
+  if (!verified) {
+    throw new Error("signature verification failed");
+  }
+
+  return JSON.parse(Buffer.from(payloadEncoded, "base64url").toString("utf8"));
+}
+
+test("rotated JWT keys invalidate existing tokens", () => {
+  const firstPair = generateRsaKeyPairPem();
+  const secondPair = generateRsaKeyPairPem();
+
+  assert.notStrictEqual(firstPair.privateKeyPem, secondPair.privateKeyPem);
+  assert.notStrictEqual(firstPair.publicKeyPem, secondPair.publicKeyPem);
+
+  const payload = { sub: "user-123", aud: "apgms-clients", iss: "https://auth.local.dev/" };
+
+  const token = createJwtLikeToken(payload, firstPair.privateKeyPem);
+
+  const decoded = verifyJwtLikeToken(token, firstPair.publicKeyPem);
+  assert.equal(decoded.sub, payload.sub);
+
+  assert.throws(() => verifyJwtLikeToken(token, secondPair.publicKeyPem), /signature verification failed/);
+
+  const rotatedToken = createJwtLikeToken(payload, secondPair.privateKeyPem);
+  const rotatedDecoded = verifyJwtLikeToken(rotatedToken, secondPair.publicKeyPem);
+  assert.equal(rotatedDecoded.sub, payload.sub);
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test", "types"]
 }

--- a/apgms/services/api-gateway/types/prisma.d.ts
+++ b/apgms/services/api-gateway/types/prisma.d.ts
@@ -1,0 +1,6 @@
+declare module "@prisma/client" {
+  export class PrismaClient {
+    $disconnect(): Promise<void>;
+    [key: string]: any;
+  }
+}

--- a/scripts/key-rotate.ps1
+++ b/scripts/key-rotate.ps1
@@ -1,0 +1,74 @@
+param(
+    [string]$EnvPath = $(Join-Path (Split-Path -Path $PSScriptRoot -Parent) ".env")
+)
+
+function ConvertTo-Pem {
+    param(
+        [byte[]]$Bytes,
+        [string]$Header,
+        [string]$Footer
+    )
+
+    $base64 = [System.Convert]::ToBase64String($Bytes)
+    $builder = New-Object System.Text.StringBuilder
+
+    for ($offset = 0; $offset -lt $base64.Length; $offset += 64) {
+        $lineLength = [System.Math]::Min(64, $base64.Length - $offset)
+        [void]$builder.AppendLine($base64.Substring($offset, $lineLength))
+    }
+
+    return "$Header`n$($builder.ToString())$Footer`n"
+}
+
+function Set-EnvValue {
+    param(
+        [string]$Content,
+        [string]$Key,
+        [string]$Value
+    )
+
+    $escapedValue = $Value -replace "`r?`n", "\\n"
+    $line = "$Key=\"$escapedValue\""
+
+    if ([string]::IsNullOrWhiteSpace($Content)) {
+        return "$line`n"
+    }
+
+    if ([System.Text.RegularExpressions.Regex]::IsMatch($Content, "(?m)^$Key=.*$")) {
+        return [System.Text.RegularExpressions.Regex]::Replace($Content, "(?m)^$Key=.*$", $line)
+    }
+
+    if (-not $Content.EndsWith("`n")) {
+        $Content += "`n"
+    }
+
+    return "$Content$line`n"
+}
+
+$resolvedEnvPath = $EnvPath
+if (-not (Test-Path -Path $resolvedEnvPath)) {
+    $resolvedEnvPath = Join-Path (Get-Location) $EnvPath
+}
+
+$envDirectory = Split-Path -Path $resolvedEnvPath -Parent
+if (-not (Test-Path -Path $envDirectory)) {
+    New-Item -ItemType Directory -Path $envDirectory -Force | Out-Null
+}
+
+$rsa = [System.Security.Cryptography.RSA]::Create(2048)
+$privateKeyPem = ConvertTo-Pem -Bytes $rsa.ExportPkcs8PrivateKey() -Header "-----BEGIN PRIVATE KEY-----" -Footer "-----END PRIVATE KEY-----"
+$publicKeyPem = ConvertTo-Pem -Bytes $rsa.ExportSubjectPublicKeyInfo() -Header "-----BEGIN PUBLIC KEY-----" -Footer "-----END PUBLIC KEY-----"
+
+$currentContent = ""
+if (Test-Path -Path $resolvedEnvPath) {
+    $currentContent = Get-Content -Path $resolvedEnvPath -Raw
+}
+
+$currentContent = Set-EnvValue -Content $currentContent -Key "JWT_PRIVATE_KEY" -Value $privateKeyPem
+$currentContent = Set-EnvValue -Content $currentContent -Key "JWT_PUBLIC_KEY" -Value $publicKeyPem
+
+Set-Content -Path $resolvedEnvPath -Value $currentContent -Encoding UTF8
+
+Write-Host "✅ JWT signing keys rotated." -ForegroundColor Green
+Write-Host "Updated $resolvedEnvPath with a new key pair." -ForegroundColor Green
+Write-Host "Redeploy or restart any services that cache the previous key to begin using the new material." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- add a repository-level `.env.example` and document required configuration plus rotation steps
- introduce a zod-backed config loader for the API gateway and consume it from the Fastify bootstrap
- add a PowerShell key rotation script and a unit test that verifies rotated RSA keys reject stale JWTs

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4d3d696608327b946a69fdc73dc42