### PR TITLE
Enforce Prisma migration checks and sanitize logs

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -13,5 +13,7 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
       - run: pnpm i
+      - name: Check Prisma migrations
+        run: pnpm exec tsx scripts/check-migrations.ts
       - run: pnpm -r build
       - run: pnpm -r test

--- a/apgms/docs/data-retention.md
+++ b/apgms/docs/data-retention.md
@@ -1,0 +1,32 @@
+# Data Retention & PII Handling
+
+This document captures Birchal's policies for retaining data, classifying personally identifiable information (PII), and ensuring sensitive fields never leak into application logs.
+
+## Retention Durations
+
+| Data class | Examples | Retention policy |
+| ---------- | -------- | ---------------- |
+| **Product analytics (aggregated)** | Feature usage metrics, event counts | Retain for 24 months. Historical trends beyond two years are archived to cold storage without identifiers. |
+| **Operational records** | Bank lines, investment transactions, portfolio valuations | Retain for 7 years to satisfy financial services obligations. After 7 years data is anonymised and aggregated. |
+| **Customer support artefacts** | Zendesk conversations, resolution notes | Retain for 24 months after ticket close, then delete unless a legal hold applies. |
+| **Audit logs** | Authentication events, admin configuration changes | Retain raw events for 18 months, then keep an anonymised aggregate for fraud analytics. |
+| **Infrastructure telemetry** | Application metrics, uptime pings | Retain in hot storage for 90 days and aggregate beyond that horizon. |
+
+## PII Classification
+
+PII is categorised into three sensitivity tiers:
+
+- **Tier 1 – Direct identifiers**: Email addresses, legal names, phone numbers, government IDs, bank account numbers. These fields are encrypted at rest and redacted from all logs and analytics exports.
+- **Tier 2 – Quasi identifiers**: IP addresses, device identifiers, session IDs. Accessible only to authorised operations personnel and redacted from shared dashboards.
+- **Tier 3 – Derived identifiers**: Behavioural segments, scoring outputs. Stored separately from direct identifiers and expunged upon account deletion.
+
+All application code must treat Tier 1 & 2 data as confidential and avoid emitting it to stdout/stderr or third-party tools without explicit approval.
+
+## Log Redaction Policy
+
+- Application services MUST use the shared logger configuration which redacts request/response headers, bodies, database connection strings, tokens, and any fields matching `*email`, `*password`, or `*token`.
+- Any diagnostic logging of environment configuration must only report boolean flags or masked identifiers. Secrets such as `DATABASE_URL`, API keys, or session cookies are never printed.
+- Automated tests assert that logger output replaces sensitive values with `[REDACTED]` so regressions are caught in CI.
+- When ad-hoc debugging requires additional context, engineers must add temporary logs that mask PII and remove them before merging code.
+
+Adherence to these practices ensures we remain compliant with privacy regulations while still retaining the observability needed to operate the platform safely.

--- a/apgms/scripts/check-migrations.ts
+++ b/apgms/scripts/check-migrations.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from "node:child_process";
+
+const schemaPath = "shared/prisma/schema.prisma";
+const args = [
+  "exec",
+  "prisma",
+  "migrate",
+  "status",
+  `--schema=${schemaPath}`,
+  "--json",
+];
+
+const result = spawnSync("pnpm", args, {
+  env: {
+    ...process.env,
+    // Offline CI environments cannot fetch engine checksums.
+    PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING: process.env.PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING ?? "1",
+  },
+  encoding: "utf-8",
+});
+
+if (result.error) {
+  console.error("Failed to execute Prisma CLI", result.error);
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  console.error(result.stderr.trim() || "prisma migrate status exited with an error");
+  process.exit(result.status ?? 1);
+}
+
+let parsed: any;
+try {
+  parsed = JSON.parse(result.stdout.trim());
+} catch (err) {
+  console.error("Unable to parse Prisma migrate status output:");
+  console.error(result.stdout);
+  process.exit(1);
+}
+
+const databaseSchemaStatus = parsed?.databaseSchemaStatus;
+const migrationStatus = parsed?.migrationStatus;
+
+const isDatabaseValid = databaseSchemaStatus === "Valid";
+const isUpToDate = migrationStatus === "UpToDate";
+
+if (!isDatabaseValid || !isUpToDate) {
+  console.error("Database schema or migrations are out of sync.");
+  console.error(JSON.stringify({ databaseSchemaStatus, migrationStatus }, null, 2));
+  process.exit(1);
+}
+
+console.log("Prisma migrations are in sync.");

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,31 +1,54 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+
 const prisma = new PrismaClient();
+
+const normalizeEnv = (value: string) => value.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+
+const rawEnv = process.env.SEED_ENV ?? process.env.NODE_ENV ?? "development";
+const environment = (() => {
+  const normalized = normalizeEnv(rawEnv);
+  return normalized.length > 0 ? normalized : "development";
+})();
+
+if (environment === "production" && process.env.ALLOW_PROD_SEED !== "true") {
+  console.error("Refusing to seed production environment. Set ALLOW_PROD_SEED=true to override.");
+  process.exit(1);
+}
+
+const orgId = `demo-org-${environment}`;
+const userEmail = `founder+${environment}@example.com`;
 
 async function main() {
   const org = await prisma.org.upsert({
-    where: { id: "demo-org" },
+    where: { id: orgId },
     update: {},
-    create: { id: "demo-org", name: "Demo Org" },
+    create: { id: orgId, name: `Demo Org (${environment})` },
   });
 
   await prisma.user.upsert({
-    where: { email: "founder@example.com" },
+    where: { email: userEmail },
     update: {},
-    create: { email: "founder@example.com", password: "password123", orgId: org.id },
+    create: { email: userEmail, password: "password123", orgId: org.id },
   });
 
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
+      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
+      { orgId: org.id, date: today, amount: 5000.0, payee: "Birchal", desc: "Investment received" },
     ],
     skipDuplicates: true,
   });
 
-  console.log("Seed OK");
+  console.log(`Seed OK for ${environment}`);
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test ./test/logger.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,13 +10,14 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { loggerOptions } from "./logger.js";
 
-const app = Fastify({ logger: true });
+const app = Fastify({ logger: loggerOptions });
 
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+// Sanity log: confirm env is loaded without leaking secrets
+app.log.info({ databaseUrlConfigured: Boolean(process.env.DATABASE_URL) }, "Environment configuration loaded");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 

--- a/apgms/services/api-gateway/src/logger.ts
+++ b/apgms/services/api-gateway/src/logger.ts
@@ -1,0 +1,31 @@
+import type { FastifyServerOptions } from "fastify";
+
+const REDACTION_PATHS = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  "req.headers[\"set-cookie\"]",
+  "req.body",
+  "req.params",
+  "req.query",
+  "res.headers",
+  "res.payload",
+  "DATABASE_URL",
+  "email",
+  "*.email",
+  "password",
+  "*.password",
+  "token",
+  "*.token",
+] as const;
+
+export const CENSOR = "[REDACTED]";
+
+export const loggerOptions: Exclude<FastifyServerOptions["logger"], boolean> = {
+  level: process.env.LOG_LEVEL ?? "info",
+  redact: {
+    paths: [...REDACTION_PATHS],
+    censor: CENSOR,
+  },
+};
+
+export { REDACTION_PATHS };

--- a/apgms/services/api-gateway/test/logger.test.ts
+++ b/apgms/services/api-gateway/test/logger.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { Writable } from "node:stream";
+import { test } from "node:test";
+import Fastify from "fastify";
+
+import { CENSOR, loggerOptions } from "../src/logger.js";
+
+test("logger redacts sensitive fields", async () => {
+  const lines: string[] = [];
+
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      lines.push(chunk.toString());
+      callback();
+    },
+  });
+
+  const app = Fastify({
+    logger: {
+      ...loggerOptions,
+      stream,
+    },
+  });
+
+  const email = "founder@example.com";
+  const token = "secret-token";
+  const cookie = "session=abc";
+  const databaseUrl = "postgres://user:pass@host/db";
+
+  app.log.info(
+    {
+      email,
+      nested: { email: "nested@example.com" },
+      DATABASE_URL: databaseUrl,
+      req: {
+        headers: {
+          authorization: `Bearer ${token}`,
+          cookie,
+          "set-cookie": cookie,
+        },
+        body: { email: "request@example.com", password: "super-secret" },
+        params: { token: "param-token" },
+        query: { search: "foo" },
+      },
+      res: {
+        headers: { authorization: "Bearer res-token" },
+        payload: { token: "response-token" },
+      },
+      token,
+    },
+    "sensitive log",
+  );
+
+  app.log.flush();
+
+  assert.equal(lines.length, 1, "expected a single log line");
+
+  const rawLog = lines[0];
+  const entry = JSON.parse(rawLog);
+
+  assert.equal(entry.email, CENSOR);
+  assert.equal(entry.nested.email, CENSOR);
+  assert.equal(entry.DATABASE_URL, CENSOR);
+  assert.equal(entry.token, CENSOR);
+
+  // Ensure sensitive values never reach the serialized log payload.
+  assert.ok(!rawLog.includes(email), "email leaked into logs");
+  assert.ok(!rawLog.includes(token), "token leaked into logs");
+  assert.ok(!rawLog.includes(cookie), "cookie leaked into logs");
+  assert.ok(!rawLog.includes(databaseUrl), "database url leaked into logs");
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- document Birchal's data retention timelines, PII handling tiers, and log redaction policy
- add a Prisma migration drift check script and wire it into CI
- harden the seed script to isolate environments and guard against production use
- centralise Fastify logger redaction and test that sensitive fields never hit logs

## Testing
- pnpm -r test
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4d3feb660832784fa27a6da3e727b