### PR TITLE
Add comprehensive test suites and CI coverage gates

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,8 +1,41 @@
-﻿name: CI
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
 jobs:
-  build:
+  quality:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: apgms_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/apgms_test?schema=public
+      SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/apgms_test_shadow?schema=public
+      REDIS_URL: redis://localhost:6379/0
+      START_TEST_SERVICES: "false"
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -10,8 +43,26 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+          node-version: "20"
+          cache: "pnpm"
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Wait for database
+        run: |
+          for i in {1..30}; do
+            if pg_isready -h localhost -p 5432 -U postgres; then
+              exit 0
+            fi
+            sleep 2
+          done
+          exit 1
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Run tests
+        run: pnpm -r test
+      - name: Check Prisma migrate status
+        run: pnpm exec prisma migrate status --schema shared/prisma/schema.prisma

--- a/apgms/docs/openapi.json
+++ b/apgms/docs/openapi.json
@@ -1,0 +1,163 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "APGMS API Gateway",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Health response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "service": { "type": "string" }
+                  },
+                  "required": ["ok", "service"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "summary": "List users in caller org",
+        "responses": {
+          "200": {
+            "description": "List of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "email": { "type": "string", "format": "email" },
+                          "orgId": { "type": "string" },
+                          "createdAt": { "type": "string", "format": "date-time" }
+                        },
+                        "required": ["email", "orgId", "createdAt"]
+                      }
+                    }
+                  },
+                  "required": ["users"]
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "orgAuth": [] }]
+      }
+    },
+    "/bank-lines": {
+      "get": {
+        "summary": "List bank lines",
+        "parameters": [
+          {
+            "name": "take",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 200 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of bank lines",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "lines": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/BankLine" }
+                    }
+                  },
+                  "required": ["lines"]
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "orgAuth": [] }]
+      },
+      "post": {
+        "summary": "Create bank line",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "date": { "type": "string", "format": "date-time" },
+                  "amount": { "type": "number" },
+                  "payee": { "type": "string" },
+                  "desc": { "type": "string" }
+                },
+                "required": ["date", "amount", "payee", "desc"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created bank line",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BankLine" }
+              }
+            }
+          },
+          "200": {
+            "description": "Existing bank line returned for idempotency",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BankLine" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        },
+        "security": [{ "orgAuth": [] }]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BankLine": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "orgId": { "type": "string" },
+          "date": { "type": "string", "format": "date-time" },
+          "amount": { "type": "number" },
+          "payee": { "type": "string" },
+          "desc": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "orgId", "date", "amount", "payee", "desc", "createdAt"]
+      }
+    },
+    "securitySchemes": {
+      "orgAuth": {
+        "type": "apiKey",
+        "name": "x-org-id",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,24 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "webapp", "shared", "worker", "tests"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "lint": "pnpm -r --if-present run lint",
+    "typecheck": "pnpm -r --if-present run typecheck"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -75,6 +75,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  tests: {}
+
   webapp: {}
 
   worker: {}

--- a/apgms/pnpm-workspace.yaml
+++ b/apgms/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - webapp
   - shared
   - worker
+  - tests
 
 ignoredBuiltDependencies:
   - '@prisma/client'

--- a/apgms/scripts/test-setup.ts
+++ b/apgms/scripts/test-setup.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+function commandExists(command: string): boolean {
+  try {
+    const probe = spawnSync(command, ["--version"], { stdio: "ignore" });
+    return probe.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function startContainers(): void {
+  const composeFile = path.resolve(process.cwd(), "docker-compose.yml");
+  if (!existsSync(composeFile)) {
+    return;
+  }
+
+  if (!commandExists("docker")) {
+    console.warn("docker not available; skipping container startup");
+    return;
+  }
+
+  const result = spawnSync(
+    "docker",
+    [
+      "compose",
+      "-f",
+      composeFile,
+      "up",
+      "-d",
+      "postgres",
+      "redis"
+    ],
+    {
+      stdio: "inherit",
+    }
+  );
+
+  if (result.status !== 0) {
+    console.warn("docker compose failed to start test services");
+  }
+}
+
+export default async function globalSetup(): Promise<void> {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "test";
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5432/apgms_test?schema=public";
+  process.env.SHADOW_DATABASE_URL =
+    process.env.SHADOW_DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5432/apgms_test_shadow?schema=public";
+  process.env.REDIS_URL =
+    process.env.REDIS_URL ?? "redis://localhost:6379/0";
+
+  if (process.env.START_TEST_SERVICES !== "false") {
+    startContainers();
+  }
+}

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,126 @@
+import type { FastifyInstance, FastifyServerOptions } from "fastify";
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import type { PrismaClient } from "@prisma/client";
+import { registerAuthGuard } from "./auth/auth.guard";
+
+export interface BuildAppOptions {
+  logger?: FastifyServerOptions["logger"];
+}
+
+export interface PrismaAdapter {
+  user: {
+    findMany: PrismaClient["user"]["findMany"];
+  };
+  bankLine: {
+    findMany: PrismaClient["bankLine"]["findMany"];
+    findFirst: PrismaClient["bankLine"]["findFirst"];
+    create: PrismaClient["bankLine"]["create"];
+  };
+}
+
+export interface RouteDescriptor {
+  method: string;
+  url: string;
+  requiresAuth: boolean;
+}
+
+export interface InstrumentedFastifyInstance extends FastifyInstance {
+  routeRegistry: RouteDescriptor[];
+}
+
+export async function buildApp(
+  prisma: PrismaAdapter,
+  options: BuildAppOptions = {}
+): Promise<InstrumentedFastifyInstance> {
+  const app = Fastify({ logger: options.logger ?? true }) as InstrumentedFastifyInstance;
+  const registry: RouteDescriptor[] = [];
+  app.routeRegistry = registry;
+
+  app.addHook("onRoute", (route) => {
+    const methods = Array.isArray(route.method) ? route.method : [route.method];
+    for (const method of methods) {
+      registry.push({
+        method,
+        url: route.url,
+        requiresAuth: route.config?.auth !== false,
+      });
+    }
+  });
+
+  await app.register(cors, { origin: true });
+  await registerAuthGuard(app);
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get(
+    "/health",
+    {
+      config: { auth: false },
+    },
+    async () => ({ ok: true, service: "api-gateway" })
+  );
+
+  app.get("/users", async (req) => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+      where: { orgId: req.authContext?.orgId },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+      where: { orgId: req.authContext?.orgId },
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      if (!req.authContext) {
+        return rep.code(401).send({ error: "unauthorized" });
+      }
+      const body = req.body as {
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+
+      const existing = await prisma.bankLine.findFirst({
+        where: {
+          orgId: req.authContext.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+
+      if (existing) {
+        return rep.code(200).send(existing);
+      }
+
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: req.authContext.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/auth/auth.guard.ts
+++ b/apgms/services/api-gateway/src/auth/auth.guard.ts
@@ -1,0 +1,62 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+export interface AuthContext {
+  orgId: string;
+  userId: string;
+}
+
+export class AuthGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthGuardError";
+  }
+}
+
+export function parseAuthContext(request: FastifyRequest): AuthContext {
+  const orgHeader = request.headers["x-org-id"];
+  const userHeader = request.headers["x-user-id"];
+  if (!orgHeader || !userHeader) {
+    throw new AuthGuardError("Missing authentication headers");
+  }
+
+  const orgId = Array.isArray(orgHeader) ? orgHeader[0] : orgHeader;
+  const userId = Array.isArray(userHeader) ? userHeader[0] : userHeader;
+
+  if (!orgId || !userId) {
+    throw new AuthGuardError("Malformed authentication headers");
+  }
+
+  return { orgId, userId };
+}
+
+export async function registerAuthGuard(app: FastifyInstance): Promise<void> {
+  app.decorateRequest("authContext", null);
+
+  app.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
+    const config =
+      (request.routeOptions as any)?.config ??
+      (request as any).context?.config ??
+      request.routeConfig;
+    const requiresAuth = config?.auth !== false;
+    if (!requiresAuth) {
+      return;
+    }
+
+    try {
+      request.authContext = parseAuthContext(request);
+    } catch (error) {
+      request.log.warn({ err: error }, "auth guard rejected request");
+      reply.code(401).send({ error: "unauthorized" });
+      return reply;
+    }
+  });
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    authContext: AuthContext | null;
+  }
+  interface RouteConfig {
+    auth?: boolean;
+  }
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -7,65 +7,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { buildApp } from "./app";
 
-const app = Fastify({ logger: true });
+const app = await buildApp(prisma, { logger: true });
 
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
 app.ready(() => {
   app.log.info(app.printRoutes());
 });
@@ -77,4 +23,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/tests/contract/openapi.drift.spec.ts
+++ b/apgms/tests/contract/openapi.drift.spec.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { buildApp } from "../../services/api-gateway/src/app.ts";
+import type { InstrumentedFastifyInstance, PrismaAdapter } from "../../services/api-gateway/src/app.ts";
+
+const setupModule = await import("../../scripts/test-setup.ts");
+const setupFn =
+  typeof setupModule.default === "function"
+    ? setupModule.default
+    : setupModule.default.default;
+
+await setupFn();
+
+function loadSpec() {
+  const specPath = fileURLToPath(new URL("../../docs/openapi.json", import.meta.url));
+  return JSON.parse(readFileSync(specPath, "utf-8"));
+}
+
+test("OpenAPI spec matches runtime routes", async () => {
+  const prisma = {
+    user: { findMany: async () => [] },
+    bankLine: {
+      findMany: async () => [],
+      findFirst: async () => null,
+      create: async () => ({}),
+    },
+  } as unknown as PrismaAdapter;
+
+  const app = (await buildApp(prisma, { logger: false })) as InstrumentedFastifyInstance;
+  await app.ready();
+
+  const spec = loadSpec();
+
+  const specPaths = new Map<string, Set<string>>();
+  for (const [url, methods] of Object.entries(spec.paths ?? {})) {
+    const methodSet = new Set<string>();
+    for (const method of Object.keys(methods)) {
+      methodSet.add(method.toUpperCase());
+    }
+    specPaths.set(url, methodSet);
+  }
+
+  const runtimePaths = new Map<string, Map<string, boolean>>();
+  for (const route of app.routeRegistry) {
+    const method = route.method.toUpperCase();
+    if (method === "HEAD" || method === "OPTIONS" || route.url === "*") {
+      continue;
+    }
+    if (!runtimePaths.has(route.url)) {
+      runtimePaths.set(route.url, new Map());
+    }
+    runtimePaths.get(route.url)!.set(method, route.requiresAuth);
+  }
+
+  for (const [url, methods] of runtimePaths) {
+    assert.equal(specPaths.has(url), true, `Spec missing path ${url}`);
+    const specMethods = specPaths.get(url)!;
+    for (const [method, requiresAuth] of methods) {
+      assert.equal(specMethods.has(method), true, `Spec missing method ${method} for ${url}`);
+      const specMethod = spec.paths[url][method.toLowerCase()];
+      if (requiresAuth) {
+        assert.ok(specMethod.security, `${method} ${url} should declare security`);
+        const requirement = JSON.stringify(specMethod.security);
+        assert.ok(requirement.includes("orgAuth"));
+      } else if (specMethod.security) {
+        const hasOrgAuth = specMethod.security.some((entry: Record<string, unknown>) =>
+          Object.prototype.hasOwnProperty.call(entry, "orgAuth")
+        );
+        assert.equal(hasOrgAuth, false, `${method} ${url} should not require orgAuth`);
+      }
+    }
+  }
+
+  for (const [url, methods] of specPaths) {
+    assert.equal(runtimePaths.has(url), true, `Runtime missing path ${url}`);
+    const runtimeMethods = runtimePaths.get(url)!;
+    for (const method of methods) {
+      if (method === "HEAD") {
+        continue;
+      }
+      assert.equal(runtimeMethods.has(method), true, `Runtime missing method ${method} for ${url}`);
+    }
+  }
+
+  await app.close();
+});

--- a/apgms/tests/e2e/bank-lines.idempotency.spec.ts
+++ b/apgms/tests/e2e/bank-lines.idempotency.spec.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildApp } from "../../services/api-gateway/src/app.ts";
+import type { PrismaAdapter } from "../../services/api-gateway/src/app.ts";
+
+const setupModule = await import("../../scripts/test-setup.ts");
+const setupFn =
+  typeof setupModule.default === "function"
+    ? setupModule.default
+    : setupModule.default.default;
+
+await setupFn();
+
+interface BankLineRecord {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}
+
+test("posting the same bank line twice is idempotent", async () => {
+  let bankLines: BankLineRecord[] = [];
+
+  const prisma = {
+    user: { findMany: async () => [] },
+    bankLine: {
+      findMany: async () => bankLines,
+      findFirst: async ({ where }) =>
+        bankLines.find(
+          (line) =>
+            line.orgId === where?.orgId &&
+            line.date.getTime() === (where?.date as Date).getTime() &&
+            line.amount === Number(where?.amount) &&
+            line.payee === where?.payee &&
+            line.desc === where?.desc
+        ) ?? null,
+      create: async ({ data }) => {
+        const created: BankLineRecord = {
+          id: `line-${bankLines.length + 1}`,
+          orgId: data.orgId as string,
+          date: data.date as Date,
+          amount: Number(data.amount),
+          payee: data.payee as string,
+          desc: data.desc as string,
+          createdAt: new Date(),
+        };
+        bankLines = [...bankLines, created];
+        return created;
+      },
+    },
+  } as unknown as PrismaAdapter;
+
+  const app = await buildApp(prisma, { logger: false });
+
+  const payload = {
+    date: "2024-01-01T00:00:00.000Z",
+    amount: 100,
+    payee: "Vendor",
+    desc: "Retainer",
+  };
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { "x-org-id": "org-123", "x-user-id": "user-123" },
+    payload,
+  });
+
+  assert.equal(first.statusCode, 201);
+  const created = first.json() as BankLineRecord;
+  assert.ok(created.id);
+  assert.equal(bankLines.length, 1);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    headers: { "x-org-id": "org-123", "x-user-id": "user-123" },
+    payload,
+  });
+
+  assert.equal(second.statusCode, 200);
+  const reused = second.json() as BankLineRecord;
+  assert.equal(reused.id, created.id);
+  assert.equal(bankLines.length, 1);
+
+  await app.close();
+});

--- a/apgms/tests/index.ts
+++ b/apgms/tests/index.ts
@@ -1,0 +1,4 @@
+import "./unit/auth.guard.spec";
+import "./integration/org.scope.spec";
+import "./e2e/bank-lines.idempotency.spec";
+import "./contract/openapi.drift.spec";

--- a/apgms/tests/integration/org.scope.spec.ts
+++ b/apgms/tests/integration/org.scope.spec.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildApp } from "../../services/api-gateway/src/app.ts";
+import type { PrismaAdapter } from "../../services/api-gateway/src/app.ts";
+
+const setupModule = await import("../../scripts/test-setup.ts");
+const setupFn =
+  typeof setupModule.default === "function"
+    ? setupModule.default
+    : setupModule.default.default;
+
+await setupFn();
+
+interface BankLineRecord {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+}
+
+const baseBankLines: BankLineRecord[] = [
+  {
+    id: "line-1",
+    orgId: "org-1",
+    date: new Date("2023-01-01T00:00:00.000Z"),
+    amount: 100,
+    payee: "Vendor A",
+    desc: "Subscription",
+    createdAt: new Date("2023-01-02T00:00:00.000Z"),
+  },
+  {
+    id: "line-2",
+    orgId: "org-2",
+    date: new Date("2023-01-03T00:00:00.000Z"),
+    amount: 200,
+    payee: "Vendor B",
+    desc: "Consulting",
+    createdAt: new Date("2023-01-04T00:00:00.000Z"),
+  },
+];
+
+const baseUsers = [
+  { id: "user-1", email: "alpha@example.com", orgId: "org-1", createdAt: new Date("2023-01-05") },
+  { id: "user-2", email: "beta@example.com", orgId: "org-2", createdAt: new Date("2023-01-06") },
+];
+
+function createPrisma(): PrismaAdapter {
+  let bankLines = baseBankLines.map((line) => ({ ...line }));
+  const users = baseUsers.map((user) => ({ ...user }));
+
+  return {
+    user: {
+      findMany: async (args) => {
+        const orgId = args?.where?.orgId ?? undefined;
+        return users
+          .filter((user) => !orgId || user.orgId === orgId)
+          .map(({ email, orgId: userOrgId, createdAt }) => ({ email, orgId: userOrgId, createdAt }));
+      },
+    },
+    bankLine: {
+      findMany: async (args) => {
+        const orgId = args?.where?.orgId ?? undefined;
+        return bankLines
+          .filter((line) => !orgId || line.orgId === orgId)
+          .sort((a, b) => b.date.getTime() - a.date.getTime());
+      },
+      findFirst: async (args) => {
+        const predicate = args?.where;
+        if (!predicate) {
+          return null;
+        }
+        return (
+          bankLines.find((line) => {
+            const sameOrg = !predicate.orgId || line.orgId === predicate.orgId;
+            const sameDate =
+              !predicate.date ||
+              (predicate.date instanceof Date
+                ? line.date.getTime() === predicate.date.getTime()
+                : line.date.getTime() === new Date(predicate.date as Date).getTime());
+            const sameAmount =
+              !predicate.amount ||
+              line.amount === Number((predicate.amount as unknown as { equals?: unknown })?.equals ?? predicate.amount);
+            const samePayee = !predicate.payee || line.payee === predicate.payee;
+            const sameDesc = !predicate.desc || line.desc === predicate.desc;
+            return sameOrg && sameDate && sameAmount && samePayee && sameDesc;
+          }) ?? null
+        );
+      },
+      create: async ({ data }) => {
+        const created: BankLineRecord = {
+          id: `line-${bankLines.length + 1}`,
+          orgId: data.orgId as string,
+          date: data.date as Date,
+          amount: Number(data.amount),
+          payee: data.payee as string,
+          desc: data.desc as string,
+          createdAt: new Date(),
+        };
+        bankLines = [...bankLines, created];
+        return created;
+      },
+    },
+  };
+}
+
+test("bank lines are scoped to the caller's org", async () => {
+  const prisma = createPrisma();
+  const app = await buildApp(prisma, { logger: false });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/bank-lines",
+    headers: { "x-org-id": "org-1", "x-user-id": "user-1" },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { lines: BankLineRecord[] };
+  assert.equal(payload.lines.length, 1);
+  assert.equal(payload.lines[0].orgId, "org-1");
+
+  await app.close();
+});
+
+test("user listings are scoped to the caller's org", async () => {
+  const prisma = createPrisma();
+  const app = await buildApp(prisma, { logger: false });
+
+  const response = await app.inject({
+    method: "GET",
+    url: "/users",
+    headers: { "x-org-id": "org-2", "x-user-id": "user-2" },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const payload = response.json() as { users: Array<{ orgId: string }> };
+  assert.equal(payload.users.length, 1);
+  assert.equal(payload.users[0].orgId, "org-2");
+
+  await app.close();
+});

--- a/apgms/tests/package.json
+++ b/apgms/tests/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@apgms/tests",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "tsx run-tests-with-coverage.ts"
+  }
+}

--- a/apgms/tests/run-tests-with-coverage.ts
+++ b/apgms/tests/run-tests-with-coverage.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)));
+const cmd = spawnSync(
+  "pnpm",
+  [
+    "exec",
+    "tsx",
+    "--test",
+    "--test-concurrency=1",
+    "--experimental-test-coverage",
+    "index.ts"
+  ],
+  {
+    cwd: projectRoot,
+    env: process.env,
+    encoding: "utf-8",
+  }
+);
+
+if (cmd.stdout) {
+  process.stdout.write(cmd.stdout);
+}
+if (cmd.stderr) {
+  process.stderr.write(cmd.stderr);
+}
+
+if (cmd.status !== 0) {
+  process.exit(cmd.status ?? 1);
+}
+
+const coverageLine = cmd.stdout
+  .split(/\r?\n/)
+  .find((line) => line.includes("all files"));
+
+if (!coverageLine) {
+  console.error("Unable to determine coverage totals");
+  process.exit(1);
+}
+
+const parts = coverageLine.split("|").map((part) => part.trim()).filter(Boolean);
+const linesPercent = Number(parts[1]);
+
+if (Number.isNaN(linesPercent)) {
+  console.error(`Failed to parse coverage from line: ${coverageLine}`);
+  process.exit(1);
+}
+
+if (linesPercent < 80) {
+  console.error(`Coverage ${linesPercent}% is below required threshold of 80%`);
+  process.exit(1);
+}

--- a/apgms/tests/tsconfig.json
+++ b/apgms/tests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./dist",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apgms/tests/unit/auth.guard.spec.ts
+++ b/apgms/tests/unit/auth.guard.spec.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Fastify from "fastify";
+import type { FastifyRequest } from "fastify";
+import {
+  AuthGuardError,
+  parseAuthContext,
+  registerAuthGuard,
+} from "../../services/api-gateway/src/auth/auth.guard.ts";
+
+const setupModule = await import("../../scripts/test-setup.ts");
+const setupFn =
+  typeof setupModule.default === "function"
+    ? setupModule.default
+    : setupModule.default.default;
+await setupFn();
+
+test("auth guard parses authentication headers", () => {
+  const request = {
+    headers: { "x-org-id": "org-123", "x-user-id": "user-456" },
+  } as FastifyRequest;
+
+  assert.deepStrictEqual(parseAuthContext(request), {
+    orgId: "org-123",
+    userId: "user-456",
+  });
+});
+
+test("auth guard throws when required headers are missing", () => {
+  const request = { headers: {} } as FastifyRequest;
+  assert.throws(() => parseAuthContext(request), AuthGuardError);
+});
+
+test("auth guard decorates requests and enforces authentication", async () => {
+  const app = Fastify({ logger: false });
+  await registerAuthGuard(app);
+
+  app.get("/secure", async (request) => request.authContext);
+  app.get(
+    "/public",
+    { config: { auth: false } },
+    async (request) => request.authContext
+  );
+
+  await app.ready();
+
+  const secureResponse = await app.inject({
+    method: "GET",
+    url: "/secure",
+    headers: {
+      "x-org-id": "org-1",
+      "x-user-id": "user-1",
+    },
+  });
+
+  assert.equal(secureResponse.statusCode, 200, secureResponse.payload);
+  assert.deepStrictEqual(secureResponse.json(), { orgId: "org-1", userId: "user-1" });
+
+  const unauthorized = await app.inject({ method: "GET", url: "/secure" });
+  assert.equal(unauthorized.statusCode, 401);
+
+  const publicRoute = await app.inject({ method: "GET", url: "/public" });
+  assert.equal(publicRoute.statusCode, 200);
+  assert.equal(publicRoute.payload, "null");
+
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- introduce a reusable Fastify app builder with authenticated scoping, idempotent bank-line handling, and route instrumentation
- add database/redis-aware test setup plus unit, integration, e2e, and contract tests with OpenAPI drift detection and coverage enforcement
- wire the tests into a dedicated workspace, OpenAPI spec, and CI workflow that also checks Prisma migration status

## Testing
- pnpm -r test


------
https://chatgpt.com/codex/tasks/task_e_68f4d3e55c488327b7de8c301e4210ff