### PR TITLE
Add stub refresh token endpoint

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { authRoutes } from "./routes/v1/auth";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(authRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/routes/v1/auth.ts
+++ b/apgms/services/api-gateway/src/routes/v1/auth.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from "fastify";
+
+export async function authRoutes(app: FastifyInstance) {
+  app.post("/auth/refresh", async (req, reply) => {
+    const { refreshToken } = (req.body || {}) as { refreshToken?: string };
+    if (!refreshToken) {
+      return reply.code(400).send({ code: "BAD_REQUEST" });
+    }
+
+    // TODO: validate refresh token (e.g., against DB/Redis/jwt verify)
+    // Issue new tokens (stub)
+    const accessToken = "stub.access.token." + Date.now();
+    const newRefresh = "stub.refresh.token." + Date.now();
+    return reply.send({ accessToken, refreshToken: newRefresh });
+  });
+}


### PR DESCRIPTION
## Summary
- add an auth refresh route that returns new stub access and refresh tokens
- register the auth routes with the API gateway server

## Testing
- pnpm --filter @apgms/api-gateway dev *(fails: The requested module '@prisma/client' does not provide an export named 'PrismaClient')*

------
https://chatgpt.com/codex/tasks/task_e_68f4da8974b48327833ceb2d16732791