### PR TITLE
feat(api-gateway): add operational endpoints

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,15 +10,17 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { metricsPlugin } from "./plugins/metrics";
+import { healthRoutes } from "./routes/ops/health";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(metricsPlugin);
+await app.register(healthRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
 app.get("/users", async () => {

--- a/apgms/services/api-gateway/src/plugins/metrics.ts
+++ b/apgms/services/api-gateway/src/plugins/metrics.ts
@@ -1,0 +1,25 @@
+import { FastifyPluginAsync } from "fastify";
+
+let counters: Record<string, number> = {};
+
+export const metricsPlugin: FastifyPluginAsync = async (app) => {
+  app.get("/metrics", async (_req, reply) => {
+    // Minimal Prometheus exposition
+    const lines = Object.entries(counters).map(([name, value]) => `${name} ${value}`);
+    reply.type("text/plain").send(lines.join("\n"));
+  });
+
+  app.decorate("metrics", {
+    inc: (name: string, by = 1) => {
+      counters[name] = (counters[name] ?? 0) + by;
+    },
+  });
+};
+
+declare module "fastify" {
+  interface FastifyInstance {
+    metrics: {
+      inc: (name: string, by?: number) => void;
+    };
+  }
+}

--- a/apgms/services/api-gateway/src/routes/ops/health.ts
+++ b/apgms/services/api-gateway/src/routes/ops/health.ts
@@ -1,0 +1,15 @@
+import { FastifyInstance } from "fastify";
+
+export async function healthRoutes(app: FastifyInstance) {
+  app.get("/health", async (_req, reply) => reply.send({ ok: true }));
+
+  app.get("/ready", async (_req, reply) => {
+    const redisOk = app.hasDecorator("redis") ? "ok" : "na";
+    // TODO: also check DB if present
+    if (redisOk === "ok") {
+      return reply.send({ ready: true });
+    }
+
+    return reply.code(503).send({ ready: false });
+  });
+}


### PR DESCRIPTION
## Summary
- add a lightweight metrics plugin exposing a Prometheus-compatible counter surface
- add health and readiness routes that reflect redis availability
- register the operational plugins on the api-gateway server

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4da7cd0cc832795afc950f9587fdf