### PR TITLE
feat: harden api gateway http surface

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,4 @@
+PORT=3000
+ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3001
+RATE_LIMIT_MAX=300
+REDIS_URL=redis://localhost:6379

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- attach deterministic request ids while enforcing an in-memory rate limit for burst control
- replace permissive CORS with an allowlist and add security headers plus mutation auditing
- document gateway environment variables including allowed origins and rate limit configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4da7442dc8327989823b065007e07