### PR TITLE
Add report UI validation and authenticated API client

### DIFF
--- a/apgms/webapp/src/components/ReportsPage.tsx
+++ b/apgms/webapp/src/components/ReportsPage.tsx
@@ -1,0 +1,280 @@
+import React, { ChangeEvent, FormEvent, useMemo, useState } from 'react';
+import { AxiosError } from 'axios';
+
+import StatusBadge from './StatusBadge';
+import { dashboardAPI } from '../services/api';
+import { ReportRequest, reportRequestSchema, reportTypeEnum } from '../schemas/reportSchema';
+
+type FormErrors = Partial<Record<keyof ReportRequest, string>>;
+
+type GeneratedReport = {
+  id: string;
+  status?: string;
+  requestedAt?: string;
+};
+
+const formatReportType = (value: string) =>
+  value
+    .toLowerCase()
+    .split('_')
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const ensurePdfExtension = (filename: string) =>
+  filename.toLowerCase().endsWith('.pdf') ? filename : `${filename}.pdf`;
+
+const extractFilename = (dispositionHeader?: string | null, fallback = 'report.pdf') => {
+  if (!dispositionHeader) return fallback;
+
+  const filenameStarMatch = dispositionHeader.match(/filename\*\s*=\s*([^;]+)/i);
+  if (filenameStarMatch) {
+    const value = filenameStarMatch[1].trim();
+    const parts = value.split("''");
+    if (parts.length === 2) {
+      try {
+        const decoded = decodeURIComponent(parts[1].replace(/"/g, ''));
+        if (decoded) return ensurePdfExtension(decoded);
+      } catch (err) {
+        console.warn('Failed to decode RFC5987 filename', err);
+      }
+    }
+  }
+
+  const filenameMatch = dispositionHeader.match(/filename\s*=\s*"?([^";]+)"?/i);
+  if (filenameMatch && filenameMatch[1]) {
+    return ensurePdfExtension(filenameMatch[1].trim());
+  }
+
+  return fallback;
+};
+
+const deriveReportId = (payload: any) => {
+  const candidate =
+    payload?.reportId ??
+    payload?.id ??
+    payload?.data?.reportId ??
+    payload?.data?.id ??
+    payload?.reference ??
+    payload?.uuid ??
+    payload?.jobId;
+  return (candidate ? String(candidate) : `report-${Date.now()}`) as string;
+};
+
+export default function ReportsPage() {
+  const reportTypeOptions = useMemo(() => reportTypeEnum.options, []);
+
+  const [formData, setFormData] = useState<ReportRequest>({
+    reportType: reportTypeOptions[0],
+    startDate: '',
+    endDate: '',
+  });
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [report, setReport] = useState<GeneratedReport | null>(null);
+
+  const handleInputChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    setFormErrors((prev) => ({ ...prev, [name]: undefined }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitError(null);
+    setDownloadError(null);
+
+    const result = reportRequestSchema.safeParse(formData);
+    if (!result.success) {
+      const fieldErrors: FormErrors = {};
+      const flattened = result.error.flatten();
+      (Object.keys(flattened.fieldErrors) as Array<keyof ReportRequest>).forEach((key) => {
+        const messages = flattened.fieldErrors[key];
+        if (messages?.length) {
+          fieldErrors[key] = messages[0];
+        }
+      });
+      setFormErrors(fieldErrors);
+      return;
+    }
+
+    setFormErrors({});
+    setIsSubmitting(true);
+
+    try {
+      const { data } = await dashboardAPI.generateReport(result.data);
+      const id = deriveReportId(data);
+      const status = data?.status ?? data?.state ?? 'READY';
+      const requestedAt = data?.requestedAt ?? data?.createdAt ?? new Date().toISOString();
+
+      setReport({ id, status, requestedAt });
+    } catch (error) {
+      const err = error as AxiosError<any>;
+      const message =
+        (err.response?.data &&
+          (err.response.data.message || err.response.data.error || err.response.data.detail)) ||
+        err.message ||
+        'Failed to generate report. Please try again later.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDownload = async () => {
+    if (!report?.id) return;
+    setDownloadError(null);
+    setIsDownloading(true);
+
+    try {
+      const response = await dashboardAPI.downloadReport(report.id);
+      const blob = new Blob([response.data], {
+        type: response.headers['content-type'] || 'application/pdf',
+      });
+      const filename = ensurePdfExtension(
+        extractFilename(response.headers['content-disposition'], `report-${report.id}.pdf`)
+      );
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      const err = error as AxiosError<any>;
+      const message =
+        (err.response?.data &&
+          (err.response.data.message || err.response.data.error || err.response.data.detail)) ||
+        err.message ||
+        'Failed to download report. Please try again later.';
+      setDownloadError(message);
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6 p-6">
+      <div className="rounded-xl bg-white p-6 shadow">
+        <h1 className="text-2xl font-semibold text-gray-900">Generate Compliance Report</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Choose a report type and date range. Reports are limited to a 12-month window and dates
+          must be in YYYY-MM-DD format.
+        </p>
+
+        <form className="mt-6 space-y-5" onSubmit={handleSubmit} noValidate>
+          <div>
+            <label htmlFor="reportType" className="block text-sm font-medium text-gray-700">
+              Report Type
+            </label>
+            <select
+              id="reportType"
+              name="reportType"
+              className="mt-1 block w-full rounded-md border border-gray-300 bg-white py-2 px-3 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              value={formData.reportType}
+              onChange={handleInputChange}
+            >
+              {reportTypeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {formatReportType(option)}
+                </option>
+              ))}
+            </select>
+            {formErrors.reportType && (
+              <p className="mt-1 text-sm text-red-600">{formErrors.reportType}</p>
+            )}
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label htmlFor="startDate" className="block text-sm font-medium text-gray-700">
+                Start Date
+              </label>
+              <input
+                id="startDate"
+                name="startDate"
+                type="date"
+                value={formData.startDate}
+                onChange={handleInputChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                placeholder="YYYY-MM-DD"
+              />
+              {formErrors.startDate && (
+                <p className="mt-1 text-sm text-red-600">{formErrors.startDate}</p>
+              )}
+            </div>
+            <div>
+              <label htmlFor="endDate" className="block text-sm font-medium text-gray-700">
+                End Date
+              </label>
+              <input
+                id="endDate"
+                name="endDate"
+                type="date"
+                value={formData.endDate}
+                onChange={handleInputChange}
+                className="mt-1 block w-full rounded-md border border-gray-300 py-2 px-3 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                placeholder="YYYY-MM-DD"
+              />
+              {formErrors.endDate && (
+                <p className="mt-1 text-sm text-red-600">{formErrors.endDate}</p>
+              )}
+            </div>
+          </div>
+
+          {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-indigo-300"
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? 'Generating…' : 'Generate Report'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {report && (
+        <div className="rounded-xl border border-green-200 bg-white p-6 shadow">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900">Report Ready</h2>
+            <StatusBadge status={report.status ?? 'READY'} />
+          </div>
+          <dl className="mt-4 space-y-2 text-sm text-gray-700">
+            <div>
+              <dt className="font-medium text-gray-600">Report ID</dt>
+              <dd className="font-mono text-gray-900">{report.id}</dd>
+            </div>
+            {report.requestedAt && (
+              <div>
+                <dt className="font-medium text-gray-600">Requested At</dt>
+                <dd>{new Date(report.requestedAt).toLocaleString()}</dd>
+              </div>
+            )}
+          </dl>
+
+          {downloadError && <p className="mt-3 text-sm text-red-600">{downloadError}</p>}
+
+          <div className="mt-4">
+            <button
+              type="button"
+              onClick={handleDownload}
+              className="inline-flex items-center rounded-md border border-transparent bg-emerald-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-emerald-300"
+              disabled={isDownloading}
+            >
+              {isDownloading ? 'Downloading…' : 'Download PDF'}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apgms/webapp/src/components/StatusBadge.tsx
+++ b/apgms/webapp/src/components/StatusBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type Status = 'COMPLETED' | 'PENDING' | 'FAILED' | 'RETRYING' | 'PROCESSING' | string;
+
+const statusStyles: Record<string, string> = {
+  COMPLETED:  'bg-green-100 text-green-800',
+  PENDING:    'bg-yellow-100 text-yellow-800',
+  FAILED:     'bg-red-100 text-red-800',
+  RETRYING:   'bg-orange-100 text-orange-800',
+  PROCESSING: 'bg-blue-100 text-blue-800',
+};
+
+export default function StatusBadge({ status }: { status: Status }) {
+  const cls = statusStyles[status] ?? 'bg-gray-100 text-gray-800';
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${cls}`}>
+      {status}
+    </span>
+  );
+}

--- a/apgms/webapp/src/schemas/reportSchema.ts
+++ b/apgms/webapp/src/schemas/reportSchema.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+export const reportTypeEnum = z.enum([
+  'COMPLIANCE_SUMMARY',
+  'PAYMENT_HISTORY',
+  'TAX_OBLIGATIONS',
+  'DISCREPANCY_LOG',
+]);
+
+export const reportRequestSchema = z
+  .object({
+    reportType: reportTypeEnum,
+    startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date'),
+    endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date'),
+  })
+  .refine(
+    (d) =>
+      new Date(`${d.endDate}T23:59:59Z`).getTime() >=
+      new Date(`${d.startDate}T00:00:00Z`).getTime(),
+    {
+      message: 'End date must be after or equal to start date',
+      path: ['endDate'],
+    }
+  )
+  .refine((d) => {
+    const ms =
+      new Date(`${d.endDate}T23:59:59Z`).getTime() -
+      new Date(`${d.startDate}T00:00:00Z`).getTime();
+    return ms / 86_400_000 <= 366;
+  },
+  {
+    message: 'Date range cannot exceed 12 months',
+    path: ['endDate'],
+  });
+
+export type ReportRequest = z.infer<typeof reportRequestSchema>;

--- a/apgms/webapp/src/services/api.ts
+++ b/apgms/webapp/src/services/api.ts
@@ -1,0 +1,79 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+
+const API_BASE_URL =
+  (typeof import.meta !== 'undefined' ? (import.meta as any).env?.VITE_API_BASE_URL : undefined) ||
+  process.env.REACT_APP_API_BASE_URL ||
+  'http://localhost:8080/api';
+
+let isRefreshing = false;
+let failedQueue: Array<{ resolve: (v?: unknown) => void; reject: (e?: any) => void }> = [];
+
+const processQueue = (error: Error | null) => {
+  failedQueue.forEach((p) => (error ? p.reject(error) : p.resolve()));
+  failedQueue = [];
+};
+
+const api = axios.create({
+  baseURL: API_BASE_URL,
+  headers: { 'Content-Type': 'application/json' },
+  timeout: 30000,
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('authToken');
+  if (token) {
+    (config.headers as any).Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  async (error: AxiosError) => {
+    const original = error.config as AxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !original?._retry) {
+      original._retry = true;
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => failedQueue.push({ resolve, reject }))
+          .then(() => api(original))
+          .catch((e) => Promise.reject(e));
+      }
+
+      isRefreshing = true;
+
+      try {
+        const refreshToken = localStorage.getItem('refreshToken');
+        if (!refreshToken) {
+          throw new Error('no-refresh-token');
+        }
+
+        const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, { refreshToken });
+        localStorage.setItem('authToken', data.accessToken);
+        localStorage.setItem('refreshToken', data.refreshToken);
+        processQueue(null);
+        return api(original);
+      } catch (e) {
+        processQueue(e as Error);
+        localStorage.removeItem('authToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(e);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export const dashboardAPI = {
+  generateReport: (req: { reportType: string; startDate: string; endDate: string }) =>
+    api.post('/dashboard/generate-report', req),
+  downloadReport: (reportId: string, extra?: any) =>
+    api.get(`/dashboard/report/${reportId}/download`, { responseType: 'blob', ...(extra || {}) }),
+};
+
+export default api;


### PR DESCRIPTION
## Summary
- add a reusable status badge component for report status display
- implement an authenticated axios client with token refresh and dashboard helpers
- define zod schemas for report requests and build a validated reports page with download handling

## Testing
- pnpm dev *(fails: Command "dev" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f4da5cd574832780cb7dab5c2da6bc