### PR TITLE
Add API gateway container and release workflow

### DIFF
--- a/apgms/.github/workflows/release.yml
+++ b/apgms/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+on:
+  push:
+    tags: ['v*.*.*']
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm -r build
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: docker build -t ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }} services/api-gateway
+      - name: Scan (trivy)
+        uses: aquasecurity/trivy-action@0.22.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }}
+          format: 'table'
+          exit-code: '0'
+      - name: Push image (sha + semver)
+        run: |
+          docker push ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }} ghcr.io/${{ github.repository }}/api-gateway:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}/api-gateway:${{ github.ref_name }}

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm fetch
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules /app/node_modules
+COPY . .
+RUN corepack enable && pnpm -r build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/services/api-gateway/dist ./dist
+COPY package.json pnpm-lock.yaml ./
+RUN addgroup -S nodejs && adduser -S nodejs -G nodejs
+USER nodejs
+EXPOSE 3000
+CMD ["node","dist/index.js"]


### PR DESCRIPTION
## Summary
- add a Dockerfile to containerize the API gateway service
- add a release workflow to build, scan, and push the API gateway image with immutable tags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4deed41348327ada468e6de01d1c3