### PR TITLE
feat(ci): enforce coverage and migration checks

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,7 +1,11 @@
-﻿name: CI
-on: [push, pull_request]
+name: CI
+
+on:
+  push:
+  pull_request:
+
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -10,8 +14,97 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+          node-version: "18"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            **/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+
+  quality:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            **/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            **/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-gateway-coverage
+          path: services/api-gateway/coverage
+          if-no-files-found: warn
+
+  migrations:
+    runs-on: ubuntu-latest
+    needs: setup
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pnpm-store
+            **/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+      - name: Check Prisma migrations
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/app
+          SHADOW_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/app?schema=shadow
+        run: pnpm check:migrations

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,25 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "webapp", "shared", "worker"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "typecheck": "pnpm exec tsc --noEmit -p services/api-gateway/tsconfig.json",
+    "lint": "pnpm exec tsx scripts/lint.ts",
+    "check:migrations": "pnpm exec tsx scripts/check-migrations.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/check-migrations.ts
+++ b/apgms/scripts/check-migrations.ts
@@ -1,0 +1,53 @@
+import { spawn } from "node:child_process";
+
+function runMigrateStatus(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", ["-w", "exec", "prisma", "migrate", "status"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (error) => {
+      reject(error);
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else {
+        const message = [stdout, stderr].filter(Boolean).join("\n");
+        reject(new Error(message || `Command exited with status ${code}`));
+      }
+    });
+  });
+}
+
+try {
+  const output = await runMigrateStatus();
+  if (!/up to date/i.test(output)) {
+    console.error("❌ Prisma schema drift detected.");
+    console.error(output.trim());
+    process.exit(1);
+  }
+  console.log("✅ Prisma migrations are up to date.");
+  console.log(output.trim());
+} catch (error) {
+  console.error("❌ Failed to verify Prisma migrations.");
+  if (error instanceof Error) {
+    console.error(error.message);
+  } else {
+    console.error(error);
+  }
+  process.exit(1);
+}

--- a/apgms/scripts/lint.ts
+++ b/apgms/scripts/lint.ts
@@ -1,0 +1,68 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+const projectRoot = path.resolve(new URL("..", import.meta.url).pathname);
+const globs = [
+  "services/api-gateway/src",
+  "services/api-gateway/test",
+  "scripts",
+];
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(fullPath)));
+    } else if (entry.isFile() && fullPath.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function main() {
+  const offenders: Array<{ file: string; line: number; snippet: string }> = [];
+
+  for (const pattern of globs) {
+    const absolute = path.join(projectRoot, pattern);
+    try {
+      const stats = await stat(absolute);
+      if (!stats.isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    const files = await collectFiles(absolute);
+    for (const file of files) {
+      const content = await readFile(file, "utf8");
+      const lines = content.split(/\r?\n/);
+      lines.forEach((line, index) => {
+        if (/\b(?:describe|test|it)\.only\s*\(/.test(line)) {
+          offenders.push({ file, line: index + 1, snippet: line.trim() });
+        }
+      });
+    }
+  }
+
+  if (offenders.length > 0) {
+    console.error("❌ Found focused tests. Remove .only before committing.");
+    for (const offender of offenders) {
+      console.error(` - ${path.relative(projectRoot, offender.file)}:${offender.line} ${offender.snippet}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("✅ Lint checks passed (no focused tests detected).");
+}
+
+main().catch((error) => {
+  console.error("❌ Lint script failed.");
+  console.error(error);
+  process.exit(1);
+});

--- a/apgms/scripts/ts-loader.mjs
+++ b/apgms/scripts/ts-loader.mjs
@@ -1,0 +1,44 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const extensions = new Set([".ts", ".tsx"]);
+
+export async function resolve(specifier, context, defaultResolve) {
+  const ext = path.extname(specifier);
+  if (extensions.has(ext)) {
+    const url = new URL(specifier, context.parentURL ?? pathToFileURL(process.cwd() + "/"));
+    return { url: url.href, shortCircuit: true };
+  }
+  if (!ext && (specifier.startsWith("./") || specifier.startsWith("../"))) {
+    const withTs = new URL(`${specifier}.ts`, context.parentURL ?? pathToFileURL(process.cwd() + "/"));
+    return { url: withTs.href, shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+
+export async function load(url, context, defaultLoad) {
+  if (extensions.has(path.extname(url))) {
+    const filename = fileURLToPath(url);
+    const source = await readFile(filename, "utf8");
+    const transpiled = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        target: ts.ScriptTarget.ES2022,
+        esModuleInterop: true,
+        sourceMap: true,
+        inlineSourceMap: true,
+        inlineSources: true,
+      },
+      fileName: filename,
+    });
+    return {
+      format: "module",
+      source: transpiled.outputText,
+      shortCircuit: true,
+    };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "node --loader ../../scripts/ts-loader.mjs ./test/run-with-coverage.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,74 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import cors from "@fastify/cors";
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from "fastify";
+import dotenv from "dotenv";
+
+import { prisma } from "./deps.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
+
+export async function createApp(options: FastifyServerOptions = {}): Promise<FastifyInstance> {
+  const app = Fastify({ logger: true, ...options });
+
+  await app.register(cors, { origin: true });
+
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const takeParam = Number((req.query as Record<string, unknown>).take ?? 20);
+    const take = Math.min(Math.max(takeParam, 1), 200);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (error) {
+      req.log.error(error);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  await app.ready();
+
+  return app;
+}

--- a/apgms/services/api-gateway/src/deps.ts
+++ b/apgms/services/api-gateway/src/deps.ts
@@ -1,0 +1,1 @@
+export { prisma } from "../../../shared/src/db";

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,13 @@
-﻿import path from "node:path";
-import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
+import { createApp } from "./app.ts";
 
-// Load repo-root .env from src/
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+const app = await createApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/test/app.test.ts
+++ b/apgms/services/api-gateway/test/app.test.ts
@@ -1,0 +1,184 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { prisma } from "../src/deps.ts";
+
+type UserRecord = { email: string; orgId: string; createdAt: Date };
+type BankLineRecord = {
+  id: string;
+  orgId: string;
+  date: Date;
+  amount: number;
+  payee: string;
+  desc: string;
+  createdAt: Date;
+};
+
+const userFindMany = test.mock.method(prisma.user, "findMany", async () => defaultUsers);
+const bankLineFindMany = test.mock.method(prisma.bankLine, "findMany", async () => defaultLines);
+const bankLineCreate = test.mock.method(
+  prisma.bankLine,
+  "create",
+  async (input: { data: BankLineRecord }) => ({ ...input.data, id: "line-1" }),
+);
+
+let defaultUsers: UserRecord[] = [];
+let defaultLines: BankLineRecord[] = [];
+
+test.beforeEach(() => {
+  defaultUsers = [{ email: "a@example.com", orgId: "org-1", createdAt: new Date("2024-01-01") }];
+  defaultLines = [
+    {
+      id: "line-1",
+      orgId: "org-1",
+      date: new Date("2024-01-01"),
+      amount: 100,
+      payee: "Vendor",
+      desc: "Payment",
+      createdAt: new Date("2024-01-02"),
+    },
+  ];
+  userFindMany.mock.resetCalls();
+  bankLineFindMany.mock.resetCalls();
+  bankLineCreate.mock.resetCalls();
+  userFindMany.mock.mockImplementation(async () => defaultUsers);
+  bankLineFindMany.mock.mockImplementation(async () => defaultLines);
+  bankLineCreate.mock.mockImplementation(async ({ data }: { data: BankLineRecord }) => ({ ...data, id: "line-2" }));
+});
+
+test.after(() => {
+  test.mock.restoreAll();
+});
+
+async function buildApp() {
+  const { createApp } = (await import("../src/app.ts")) as typeof import("../src/app.ts");
+  return createApp({ logger: false });
+}
+
+test("exposes health endpoint", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), { ok: true, service: "api-gateway" });
+});
+
+test("returns users ordered by createdAt", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const response = await app.inject({ method: "GET", url: "/users" });
+
+  assert.equal(userFindMany.mock.callCount(), 1);
+  assert.deepEqual(userFindMany.mock.calls[0].arguments[0], {
+    select: { email: true, orgId: true, createdAt: true },
+    orderBy: { createdAt: "desc" },
+  });
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.json(), {
+    users: defaultUsers.map((user) => ({
+      ...user,
+      createdAt: user.createdAt.toISOString(),
+    })),
+  });
+});
+
+test("limits bank line listings and enforces bounds", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  await app.inject({ method: "GET", url: "/bank-lines?take=500" });
+  const firstCall = bankLineFindMany.mock.calls[0].arguments[0] as { take: number };
+  assert.equal(firstCall.take, 200);
+
+  await app.inject({ method: "GET", url: "/bank-lines?take=-5" });
+  const secondCall = bankLineFindMany.mock.calls[1].arguments[0] as { take: number };
+  assert.equal(secondCall.take, 1);
+
+  const response = await app.inject({ method: "GET", url: "/bank-lines" });
+  const thirdCall = bankLineFindMany.mock.calls[2].arguments[0] as { take: number };
+  assert.equal(thirdCall.take, 20);
+  const lines = (await bankLineFindMany.mock.calls[2].result) as BankLineRecord[];
+  assert.deepEqual(response.json(), {
+    lines: lines.map((line: BankLineRecord) => ({
+      ...line,
+      date: new Date(line.date).toISOString(),
+      createdAt: new Date(line.createdAt).toISOString(),
+    })),
+  });
+});
+
+test("creates bank lines and returns the persisted record", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const payload = {
+    orgId: "org-1",
+    date: "2024-02-01",
+    amount: 200,
+    payee: "Supplier",
+    desc: "Invoice",
+  };
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload,
+    headers: { "content-type": "application/json" },
+  });
+
+  assert.equal(bankLineCreate.mock.callCount(), 1);
+  assert.deepEqual(bankLineCreate.mock.calls[0].arguments[0], {
+    data: {
+      orgId: "org-1",
+      date: new Date("2024-02-01"),
+      amount: 200,
+      payee: "Supplier",
+      desc: "Invoice",
+    },
+  });
+  assert.equal(response.statusCode, 201);
+  assert.equal(response.json().payee, "Supplier");
+});
+
+test("reports bad requests when persistence fails", async (t) => {
+  bankLineCreate.mock.mockImplementationOnce(async () => {
+    throw new Error("boom");
+  });
+
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      orgId: "org-1",
+      date: "2024-02-01",
+      amount: 200,
+      payee: "Supplier",
+      desc: "Invoice",
+    },
+    headers: { "content-type": "application/json" },
+  });
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.json(), { error: "bad_request" });
+});
+
+test("enables CORS for browser clients", async (t) => {
+  const app = await buildApp();
+  t.after(() => app.close());
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/bank-lines",
+    headers: {
+      origin: "https://example.com",
+      "access-control-request-method": "POST",
+    },
+  });
+
+  assert.equal(response.headers["access-control-allow-origin"], "https://example.com");
+});

--- a/apgms/services/api-gateway/test/run-with-coverage.ts
+++ b/apgms/services/api-gateway/test/run-with-coverage.ts
@@ -1,0 +1,266 @@
+import { spawn } from "node:child_process";
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const serviceRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const coverageDir = path.join(serviceRoot, "coverage");
+const v8Dir = path.join(coverageDir, "v8");
+const loaderPath = path.resolve(serviceRoot, "../../scripts/ts-loader.mjs");
+
+await rm(coverageDir, { recursive: true, force: true });
+await mkdir(v8Dir, { recursive: true });
+
+const testFiles = await collectTestFiles(path.join(serviceRoot, "test"));
+
+if (testFiles.length === 0) {
+  console.error("No test files found under services/api-gateway/test");
+  process.exit(1);
+}
+
+const testArgs = [
+  "--test",
+  "--experimental-test-coverage",
+  "--loader",
+  loaderPath,
+  ...testFiles.map((file) => path.relative(serviceRoot, file)),
+];
+
+const child = spawn(process.execPath, testArgs, {
+  cwd: serviceRoot,
+  stdio: "inherit",
+  env: { ...process.env, NODE_V8_COVERAGE: v8Dir },
+});
+
+const exitCode: number | null = await new Promise((resolve) => {
+  child.on("exit", (code) => resolve(code));
+});
+
+if (exitCode !== 0) {
+  process.exit(exitCode ?? 1);
+}
+
+await ensureCoverageThresholds(v8Dir, serviceRoot, coverageDir);
+
+async function ensureCoverageThresholds(v8Directory: string, projectRoot: string, outputDir: string) {
+  const coverageByFile = new Map<
+    string,
+    {
+      lineRanges: Array<{ start: number; end: number; count: number }>;
+      branchRanges: Map<string, number>;
+    }
+  >();
+
+  const files = await readdir(v8Directory);
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const raw = await readFile(path.join(v8Directory, file), "utf8");
+    const json = JSON.parse(raw) as {
+      result: Array<{
+        url: string;
+        functions: Array<{
+          functionName: string;
+          isBlockCoverage: boolean;
+          ranges: Array<{ startOffset: number; endOffset: number; count: number }>;
+        }>;
+      }>;
+    };
+    for (const entry of json.result) {
+      if (!entry.url.startsWith("file:")) {
+        continue;
+      }
+      const filePath = fileURLToPath(entry.url);
+      if (!filePath.includes(`${path.sep}services${path.sep}api-gateway${path.sep}src${path.sep}`)) {
+        continue;
+      }
+      let fileCoverage = coverageByFile.get(filePath);
+      if (!fileCoverage) {
+        fileCoverage = { lineRanges: [], branchRanges: new Map() };
+        coverageByFile.set(filePath, fileCoverage);
+      }
+      for (const fn of entry.functions) {
+        for (const range of fn.ranges) {
+          fileCoverage.lineRanges.push({
+            start: range.startOffset,
+            end: range.endOffset,
+            count: range.count ?? 0,
+          });
+          if (fn.isBlockCoverage) {
+            const key = `${range.startOffset}:${range.endOffset}`;
+            const existing = fileCoverage.branchRanges.get(key) ?? 0;
+            fileCoverage.branchRanges.set(key, Math.max(existing, range.count ?? 0));
+          }
+        }
+      }
+    }
+  }
+
+  const summary: Record<
+    string,
+    {
+      lines: { covered: number; total: number; pct: number; uncovered: number[] };
+      branches: { covered: number; total: number; pct: number };
+    }
+  > = {};
+
+  let totalLines = 0;
+  let coveredLines = 0;
+  let totalBranches = 0;
+  let coveredBranches = 0;
+
+  for (const [filePath, coverage] of coverageByFile) {
+    const metrics = await computeFileCoverage(filePath, coverage.lineRanges, coverage.branchRanges);
+    const relativePath = path.relative(projectRoot, filePath);
+    summary[relativePath] = metrics;
+    totalLines += metrics.lines.total;
+    coveredLines += metrics.lines.covered;
+    totalBranches += metrics.branches.total;
+    coveredBranches += metrics.branches.covered;
+  }
+
+  const totalLinePct = totalLines === 0 ? 100 : (coveredLines / totalLines) * 100;
+  const totalBranchPct = totalBranches === 0 ? 100 : (coveredBranches / totalBranches) * 100;
+
+  await writeFile(
+    path.join(outputDir, "summary.json"),
+    JSON.stringify(
+      {
+        totals: {
+          lines: { covered: coveredLines, total: totalLines, pct: totalLinePct },
+          branches: { covered: coveredBranches, total: totalBranches, pct: totalBranchPct },
+        },
+        files: summary,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  const failingFiles = Object.entries(summary).filter(
+    ([, metrics]) => metrics.lines.pct < 80 || metrics.branches.pct < 80,
+  );
+
+  if (totalLinePct < 80 || totalBranchPct < 80 || failingFiles.length > 0) {
+    console.error("❌ Coverage thresholds not met.");
+    for (const [file, metrics] of failingFiles) {
+      console.error(
+        ` - ${file}: lines ${metrics.lines.pct.toFixed(2)}%, branches ${metrics.branches.pct.toFixed(2)}% (min 80%)`,
+      );
+    }
+    console.error(
+      `Totals: lines ${totalLinePct.toFixed(2)}% (${coveredLines}/${totalLines}), branches ${totalBranchPct.toFixed(2)}% (${coveredBranches}/${totalBranches}).`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ Coverage thresholds satisfied. Lines ${totalLinePct.toFixed(2)}%, Branches ${totalBranchPct.toFixed(2)}%.`,
+  );
+}
+
+async function collectTestFiles(dir: string): Promise<string[]> {
+  let entries: string[] = [];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+  const results: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    const info = await stat(fullPath);
+    if (info.isDirectory()) {
+      results.push(...(await collectTestFiles(fullPath)));
+    } else if (info.isFile() && entry.endsWith(".test.ts")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+async function computeFileCoverage(
+  filePath: string,
+  ranges: Array<{ start: number; end: number; count: number }>,
+  branchRanges: Map<string, number>,
+) {
+  const source = await readFile(filePath, "utf8");
+  const lines = source.split("\n");
+  const lineInfo: Array<{ start: number; end: number; text: string }> = [];
+  let offset = 0;
+  for (const text of lines) {
+    const start = offset;
+    const end = start + text.length;
+    lineInfo.push({ start, end, text });
+    offset = end + 1;
+  }
+
+  const coverageState = lineInfo.map((info) => ({
+    hasCode: info.text.trim().length > 0,
+    covered: false,
+  }));
+
+  const offsets = lineInfo.map((info) => info.end);
+
+  function offsetToLine(offset: number) {
+    let low = 0;
+    let high = offsets.length - 1;
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      if (offsets[mid] > offset) {
+        high = mid - 1;
+      } else {
+        low = mid + 1;
+      }
+    }
+    return Math.max(0, Math.min(offsets.length - 1, low));
+  }
+
+  for (const range of ranges) {
+    const startIndex = offsetToLine(range.start);
+    const endIndex = offsetToLine(Math.max(range.end - 1, range.start));
+    for (let i = startIndex; i <= endIndex; i++) {
+      if (coverageState[i]) {
+        coverageState[i].covered ||= range.count > 0;
+      }
+    }
+  }
+
+  const uncoveredLines: number[] = [];
+  let covered = 0;
+  let total = 0;
+  coverageState.forEach((state, index) => {
+    if (!state.hasCode) {
+      return;
+    }
+    total += 1;
+    if (state.covered) {
+      covered += 1;
+    } else {
+      uncoveredLines.push(index + 1);
+    }
+  });
+
+  let branchTotal = 0;
+  let branchCovered = 0;
+  for (const [, count] of branchRanges) {
+    branchTotal += 1;
+    if (count > 0) {
+      branchCovered += 1;
+    }
+  }
+
+  return {
+    lines: {
+      covered,
+      total,
+      pct: total === 0 ? 100 : (covered / total) * 100,
+      uncovered: uncoveredLines,
+    },
+    branches: {
+      covered: branchCovered,
+      total: branchTotal,
+      pct: branchTotal === 0 ? 100 : (branchCovered / branchTotal) * 100,
+    },
+  };
+}

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -6,11 +6,12 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,43 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+type PrismaClientStub = {
+  user: { findMany: (...args: unknown[]) => Promise<unknown> };
+  bankLine: {
+    findMany: (...args: unknown[]) => Promise<unknown>;
+    create: (...args: unknown[]) => Promise<unknown>;
+  };
+};
+
+let prisma: PrismaClientStub;
+
+try {
+  const prismaPackage = await import("@prisma/client");
+  const { PrismaClient } = prismaPackage as unknown as { PrismaClient: new () => PrismaClientStub };
+  prisma = new PrismaClient();
+} catch (error) {
+  const stubError =
+    error instanceof Error
+      ? error
+      : (() => {
+          const fallback = new Error("Unknown error loading @prisma/client");
+          (fallback as any).cause = error;
+          return fallback;
+        })();
+  console.warn("Using Prisma client stub because the real client could not be loaded.", stubError.message);
+  const stub: PrismaClientStub = {
+    user: {
+      findMany: async () => {
+        throw stubError;
+      },
+    },
+    bankLine: {
+      findMany: async () => {
+        throw stubError;
+      },
+      create: async () => {
+        throw stubError;
+      },
+    },
+  };
+  prisma = stub;
+}
+
+export { prisma };


### PR DESCRIPTION
## Summary
- split the CI workflow into setup, quality, test, and migration jobs with pnpm caching and drift detection
- add TypeScript loader, lint, and migration helper scripts along with a coverage runner that enforces ≥80% line/branch coverage for the API gateway
- refactor the API gateway into a testable Fastify app with a Prisma stub and comprehensive node:test suite for key routes

## Testing
- pnpm test
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f4dee481988327ab6316b66caac596