### PR TITLE
Add Prometheus metrics and readiness endpoints

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,7 +1,15 @@
-﻿node_modules/
+node_modules/
 dist/
 coverage/
 .env*
 .DS_Store
 .vscode/
 **/__pycache__/
+!services/
+!services/api-gateway/
+!services/api-gateway/node_modules/
+services/api-gateway/node_modules/*
+!services/api-gateway/node_modules/fastify-plugin/
+!services/api-gateway/node_modules/fastify-plugin/**
+!services/api-gateway/node_modules/prom-client/
+!services/api-gateway/node_modules/prom-client/**

--- a/apgms/services/api-gateway/node_modules/fastify-plugin/index.d.ts
+++ b/apgms/services/api-gateway/node_modules/fastify-plugin/index.d.ts
@@ -1,0 +1,7 @@
+import type { FastifyPluginAsync } from "fastify";
+
+declare function fastifyPlugin<T extends FastifyPluginAsync>(plugin: T): T;
+
+declare namespace fastifyPlugin {}
+
+export = fastifyPlugin;

--- a/apgms/services/api-gateway/node_modules/fastify-plugin/index.js
+++ b/apgms/services/api-gateway/node_modules/fastify-plugin/index.js
@@ -1,0 +1,8 @@
+function fastifyPlugin(plugin) {
+  return plugin;
+}
+
+fastifyPlugin.default = fastifyPlugin;
+
+module.exports = fastifyPlugin;
+module.exports.default = fastifyPlugin;

--- a/apgms/services/api-gateway/node_modules/prom-client/index.d.ts
+++ b/apgms/services/api-gateway/node_modules/prom-client/index.d.ts
@@ -1,0 +1,47 @@
+export type LabelValues = Record<string, string>;
+
+export interface CounterConfiguration<T extends string> {
+  name: string;
+  help: string;
+  labelNames?: T[];
+}
+
+export interface HistogramConfiguration<T extends string> {
+  name: string;
+  help: string;
+  labelNames?: T[];
+  buckets?: number[];
+}
+
+export class Counter<T extends string = string> {
+  constructor(configuration: CounterConfiguration<T>);
+  inc(labels: LabelValues, value?: number): void;
+  inc(value?: number): void;
+}
+
+export class Histogram<T extends string = string> {
+  constructor(configuration: HistogramConfiguration<T>);
+  observe(labels: LabelValues, value: number): void;
+  observe(value: number): void;
+}
+
+export interface MetricRecord {
+  name: string;
+  help: string;
+  type: string;
+  get(): string;
+  reset(): void;
+}
+
+export interface Register {
+  contentType: string;
+  registerMetric<T extends MetricRecord>(metric: T): T;
+  getSingleMetric<T extends MetricRecord>(name: string): T | undefined;
+  metrics(): string;
+  resetMetrics(): void;
+  clear(): void;
+}
+
+export const register: Register;
+
+export function collectDefaultMetrics(): void;

--- a/apgms/services/api-gateway/node_modules/prom-client/index.js
+++ b/apgms/services/api-gateway/node_modules/prom-client/index.js
@@ -1,0 +1,200 @@
+const DEFAULT_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+class MetricRegistry {
+  constructor() {
+    this._metrics = new Map();
+  }
+
+  registerMetric(metric) {
+    if (this._metrics.has(metric.name)) {
+      throw new Error(`Metric with name ${metric.name} already exists`);
+    }
+    this._metrics.set(metric.name, metric);
+    return metric;
+  }
+
+  getSingleMetric(name) {
+    return this._metrics.get(name);
+  }
+
+  metrics() {
+    return Array.from(this._metrics.values())
+      .map((metric) => metric.get())
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  resetMetrics() {
+    for (const metric of this._metrics.values()) {
+      if (typeof metric.reset === "function") {
+        metric.reset();
+      }
+    }
+  }
+
+  clear() {
+    this._metrics.clear();
+  }
+}
+
+function formatLabels(labels) {
+  const entries = Object.entries(labels || {});
+  if (entries.length === 0) {
+    return "";
+  }
+  return `{${entries.map(([key, value]) => `${key}="${value}"`).join(",")}}`;
+}
+
+class Counter {
+  constructor(config) {
+    this.name = config.name;
+    this.help = config.help;
+    this.labelNames = config.labelNames || [];
+    this.type = "counter";
+    this._values = new Map();
+    register.registerMetric(this);
+  }
+
+  inc(labelsOrValue, value) {
+    let labels = {};
+    let incValue = 1;
+    if (typeof labelsOrValue === "number") {
+      incValue = labelsOrValue;
+    } else if (labelsOrValue && typeof labelsOrValue === "object") {
+      labels = labelsOrValue;
+    }
+    if (typeof value === "number") {
+      incValue = value;
+    }
+    const key = JSON.stringify(labels);
+    const current = this._values.get(key) || 0;
+    this._values.set(key, current + incValue);
+  }
+
+  reset() {
+    this._values.clear();
+  }
+
+  get() {
+    const header = `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} counter`;
+    const body = Array.from(this._values.entries())
+      .map(([labels, value]) => {
+        const parsedLabels = JSON.parse(labels);
+        const labelSuffix = formatLabels(parsedLabels);
+        return `${this.name}${labelSuffix} ${value}`;
+      })
+      .join("\n");
+    return body ? `${header}\n${body}` : header;
+  }
+}
+
+class Histogram {
+  constructor(config) {
+    this.name = config.name;
+    this.help = config.help;
+    this.labelNames = config.labelNames || [];
+    this.buckets = Array.isArray(config.buckets)
+      ? config.buckets.slice().sort((a, b) => a - b)
+      : [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10];
+    this.type = "histogram";
+    this._values = new Map();
+    register.registerMetric(this);
+  }
+
+  observe(labels, value) {
+    if (typeof labels === "number") {
+      value = labels;
+      labels = {};
+    }
+    labels = labels || {};
+    const key = JSON.stringify(labels);
+    let buckets = this._values.get(key);
+    if (!buckets) {
+      buckets = {
+        bucketCounts: new Array(this.buckets.length).fill(0),
+        sum: 0,
+        count: 0,
+      };
+      this._values.set(key, buckets);
+    }
+    for (let i = 0; i < this.buckets.length; i++) {
+      if (value <= this.buckets[i]) {
+        buckets.bucketCounts[i] += 1;
+      }
+    }
+    buckets.sum += value;
+    buckets.count += 1;
+  }
+
+  reset() {
+    this._values.clear();
+  }
+
+  get() {
+    const header = `# HELP ${this.name} ${this.help}\n# TYPE ${this.name} histogram`;
+    const lines = [];
+    for (const [labelsString, buckets] of this._values.entries()) {
+      const labels = JSON.parse(labelsString);
+      for (let i = 0; i < this.buckets.length; i++) {
+        const bound = this.buckets[i];
+        const leLabels = { ...labels, le: String(bound) };
+        const labelSuffix = formatLabels(leLabels);
+        lines.push(`${this.name}_bucket${labelSuffix} ${buckets.bucketCounts[i]}`);
+      }
+      const infLabels = { ...labels, le: "+Inf" };
+      lines.push(`${this.name}_bucket${formatLabels(infLabels)} ${buckets.count}`);
+      const labelSuffix = formatLabels(labels);
+      lines.push(`${this.name}_sum${labelSuffix} ${buckets.sum}`);
+      lines.push(`${this.name}_count${labelSuffix} ${buckets.count}`);
+    }
+    return lines.length > 0 ? `${header}\n${lines.join("\n")}` : header;
+  }
+}
+
+const register = new MetricRegistry();
+register.contentType = DEFAULT_CONTENT_TYPE;
+
+let defaultsRegistered = false;
+
+function collectDefaultMetrics() {
+  if (defaultsRegistered) {
+    return;
+  }
+  defaultsRegistered = true;
+  const processStart = Date.now() / 1000;
+  register.registerMetric({
+    name: "process_cpu_user_seconds_total",
+    help: "Total user CPU time spent in seconds.",
+    type: "counter",
+    get() {
+      const usage = process.cpuUsage();
+      const seconds = usage.user / 1e6;
+      return (
+        `# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.\n` +
+        `# TYPE process_cpu_user_seconds_total counter\n` +
+        `process_cpu_user_seconds_total ${seconds}`
+      );
+    },
+    reset() {},
+  });
+  register.registerMetric({
+    name: "process_start_time_seconds",
+    help: "Start time of the process since unix epoch in seconds.",
+    type: "gauge",
+    get() {
+      return (
+        `# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.\n` +
+        `# TYPE process_start_time_seconds gauge\n` +
+        `process_start_time_seconds ${processStart}`
+      );
+    },
+    reset() {},
+  });
+}
+
+module.exports = {
+  Counter,
+  Histogram,
+  collectDefaultMetrics,
+  register,
+};

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,13 +4,16 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/ops.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "fastify-plugin": "^5.0.1",
+    "prom-client": "^15.1.2",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -10,15 +10,19 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import metricsPlugin from "./plugins/metrics";
+import healthRoutes from "./routes/ops/health";
 
 const app = Fastify({ logger: true });
 
+app.decorate("prisma", prisma);
+
 await app.register(cors, { origin: true });
+await app.register(metricsPlugin);
+await app.register(healthRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
 app.get("/users", async () => {
@@ -77,4 +81,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/metrics.ts
+++ b/apgms/services/api-gateway/src/plugins/metrics.ts
@@ -1,0 +1,95 @@
+import fp from "fastify-plugin";
+import promClient from "prom-client";
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+const requestStartKey = Symbol("requestStartTime");
+
+let defaultMetricsRegistered = false;
+
+const httpRequestCounter = (() => {
+  const existing = promClient.register.getSingleMetric(
+    "http_requests_total",
+  ) as promClient.Counter<string> | undefined;
+  if (existing) {
+    return existing;
+  }
+  return new promClient.Counter({
+    name: "http_requests_total",
+    help: "Total number of HTTP requests",
+    labelNames: ["method", "route", "status_code"],
+  });
+})();
+
+const httpRequestDuration = (() => {
+  const existing = promClient.register.getSingleMetric(
+    "http_request_duration_seconds",
+  ) as promClient.Histogram<string> | undefined;
+  if (existing) {
+    return existing;
+  }
+  return new promClient.Histogram({
+    name: "http_request_duration_seconds",
+    help: "HTTP request duration in seconds",
+    labelNames: ["method", "route", "status_code"],
+    buckets: [
+      0.005,
+      0.01,
+      0.025,
+      0.05,
+      0.1,
+      0.25,
+      0.5,
+      1,
+      2.5,
+      5,
+      10,
+    ],
+  });
+})();
+
+function recordRequestMetrics(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  durationSeconds?: number,
+) {
+  const route = request.routeOptions?.url ?? request.routerPath ?? request.url;
+  const labels = {
+    method: request.method,
+    route,
+    status_code: String(reply.statusCode),
+  };
+  httpRequestCounter.inc(labels);
+  if (typeof durationSeconds === "number") {
+    httpRequestDuration.observe(labels, durationSeconds);
+  }
+}
+
+const metricsPlugin = fp(async (app: FastifyInstance) => {
+  if (!defaultMetricsRegistered) {
+    promClient.collectDefaultMetrics();
+    defaultMetricsRegistered = true;
+  }
+
+  app.addHook("onRequest", (request: FastifyRequest, _reply, done) => {
+    (request as any)[requestStartKey] = process.hrtime.bigint();
+    done();
+  });
+
+  app.addHook("onResponse", (request: FastifyRequest, reply, done) => {
+    const start = (request as any)[requestStartKey] as bigint | undefined;
+    let durationSeconds: number | undefined;
+    if (typeof start === "bigint") {
+      const diff = process.hrtime.bigint() - start;
+      durationSeconds = Number(diff) / 1e9;
+    }
+    recordRequestMetrics(request, reply, durationSeconds);
+    done();
+  });
+
+  app.get("/metrics", async (_request, reply) => {
+    reply.header("Content-Type", promClient.register.contentType);
+    return promClient.register.metrics();
+  });
+});
+
+export default metricsPlugin;

--- a/apgms/services/api-gateway/src/routes/ops/health.ts
+++ b/apgms/services/api-gateway/src/routes/ops/health.ts
@@ -1,0 +1,66 @@
+import fp from "fastify-plugin";
+import type { FastifyInstance } from "fastify";
+import type { PrismaClient } from "@prisma/client";
+
+type RedisClient = {
+  ping: () => Promise<unknown> | unknown;
+};
+
+declare module "fastify" {
+  interface FastifyInstance {
+    prisma?: PrismaClient;
+    redis?: RedisClient;
+  }
+}
+
+async function checkRedis(app: FastifyInstance): Promise<string | null> {
+  if (!app.redis) {
+    return null;
+  }
+
+  try {
+    await app.redis.ping();
+    return null;
+  } catch (error) {
+    app.log.error({ err: error }, "Redis readiness check failed");
+    return "redis";
+  }
+}
+
+async function checkDatabase(app: FastifyInstance): Promise<string | null> {
+  const prisma = app.prisma;
+  if (!prisma) {
+    return null;
+  }
+
+  try {
+    if (typeof prisma.$queryRawUnsafe === "function") {
+      await prisma.$queryRawUnsafe("SELECT 1");
+    } else {
+      await prisma.$queryRaw`SELECT 1`;
+    }
+    return null;
+  } catch (error) {
+    app.log.error({ err: error }, "Database readiness check failed");
+    return "database";
+  }
+}
+
+const healthRoutes = fp(async (app: FastifyInstance) => {
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/ready", async (request, reply) => {
+    const failures = (
+      await Promise.all([checkRedis(app), checkDatabase(app)])
+    ).filter((value): value is string => value !== null);
+
+    if (failures.length > 0) {
+      request.log.error({ failures }, "readiness check failed");
+      return reply.code(503).send({ ok: false, failures });
+    }
+
+    return { ok: true };
+  });
+});
+
+export default healthRoutes;

--- a/apgms/services/api-gateway/test/ops.spec.ts
+++ b/apgms/services/api-gateway/test/ops.spec.ts
@@ -1,0 +1,96 @@
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import promClient from "prom-client";
+import metricsPlugin from "../src/plugins/metrics";
+import healthRoutes from "../src/routes/ops/health";
+
+class PrismaMock {
+  constructor(private readonly shouldFail = false) {}
+
+  async $queryRawUnsafe(_query: string) {
+    if (this.shouldFail) {
+      throw new Error("db down");
+    }
+    return [{ ok: 1 }];
+  }
+}
+
+type RedisMockOptions = { shouldFail?: boolean };
+
+function createRedisMock(options: RedisMockOptions = {}) {
+  return {
+    async ping() {
+      if (options.shouldFail) {
+        throw new Error("redis down");
+      }
+      return "PONG";
+    },
+  };
+}
+
+async function buildTestApp(options: {
+  redis?: ReturnType<typeof createRedisMock>;
+  prisma?: PrismaMock;
+} = {}) {
+  const app = Fastify({ logger: false });
+  if (!app.hasDecorator("prisma")) {
+    app.decorate("prisma", options.prisma ?? new PrismaMock());
+  }
+  if (options.redis) {
+    app.decorate("redis", options.redis);
+  }
+  await app.register(metricsPlugin);
+  await app.register(healthRoutes);
+  await app.ready();
+  return app;
+}
+
+beforeEach(() => {
+  promClient.register.resetMetrics();
+});
+
+test("GET /health returns service ok", async () => {
+  const app = await buildTestApp();
+  const response = await app.inject({ method: "GET", url: "/health" });
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.ok, true);
+  await app.close();
+});
+
+test("GET /ready returns 503 when redis is down", async () => {
+  const app = await buildTestApp({
+    redis: createRedisMock({ shouldFail: true }),
+    prisma: new PrismaMock(false),
+  });
+  const response = await app.inject({ method: "GET", url: "/ready" });
+  assert.equal(response.statusCode, 503);
+  const payload = response.json();
+  assert.equal(payload.ok, false);
+  assert.ok(Array.isArray(payload.failures));
+  assert.ok(payload.failures.includes("redis"));
+  await app.close();
+});
+
+test("GET /ready returns 200 when dependencies are healthy", async () => {
+  const app = await buildTestApp({
+    redis: createRedisMock(),
+    prisma: new PrismaMock(false),
+  });
+  const response = await app.inject({ method: "GET", url: "/ready" });
+  assert.equal(response.statusCode, 200);
+  const payload = response.json();
+  assert.equal(payload.ok, true);
+  await app.close();
+});
+
+test("GET /metrics exposes Prometheus format", async () => {
+  const app = await buildTestApp();
+  const response = await app.inject({ method: "GET", url: "/metrics" });
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers["content-type"], promClient.register.contentType);
+  const body = response.body;
+  assert.match(body, /process_cpu_user_seconds_total/);
+  await app.close();
+});


### PR DESCRIPTION
## Summary
- add a Fastify metrics plugin backed by prom-client that exposes /metrics with request counters and latency histograms
- expose /health and /ready routes that verify Redis and Prisma availability for readiness
- add node:test coverage around health, readiness, and metrics plus vendor minimal prom-client/fastify-plugin shims for the offline workspace

## Testing
- pnpm --filter @apgms/api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4deda456483279b03710d1b1d15fb