### PR TITLE
feat(api-gateway): add JWT auth and org scope enforcement

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json --noEmit",
+    "test": "tsx test/run-tests.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+type AuthConfig =
+  | {
+      type: "secret";
+      verifyKey: string;
+    }
+  | {
+      type: "public";
+      verifyKey: string;
+      privateKey?: string;
+    };
+
+const envSchema = z.object({
+  JWT_SECRET: z.string().min(1, "JWT_SECRET cannot be empty").optional(),
+  JWT_PUBLIC_KEY: z.string().min(1, "JWT_PUBLIC_KEY cannot be empty").optional(),
+  JWT_PRIVATE_KEY: z.string().min(1, "JWT_PRIVATE_KEY cannot be empty").optional(),
+});
+
+let cachedConfig: AuthConfig | null = null;
+
+const normalizeKey = (value: string) => value.replace(/\\n/g, "\n");
+
+export const getAuthConfig = (): AuthConfig => {
+  if (cachedConfig) {
+    return cachedConfig;
+  }
+
+  const env = envSchema.parse(process.env);
+
+  if (env.JWT_PUBLIC_KEY) {
+    cachedConfig = {
+      type: "public",
+      verifyKey: normalizeKey(env.JWT_PUBLIC_KEY),
+      privateKey: env.JWT_PRIVATE_KEY ? normalizeKey(env.JWT_PRIVATE_KEY) : undefined,
+    };
+    return cachedConfig;
+  }
+
+  if (env.JWT_SECRET) {
+    cachedConfig = { type: "secret", verifyKey: env.JWT_SECRET };
+    return cachedConfig;
+  }
+
+  throw new Error("Missing JWT configuration: set JWT_SECRET or JWT_PUBLIC_KEY");
+};
+
+export type { AuthConfig };

--- a/apgms/services/api-gateway/src/hooks/org-scope.ts
+++ b/apgms/services/api-gateway/src/hooks/org-scope.ts
@@ -1,0 +1,20 @@
+import type { preHandlerHookHandler } from "fastify";
+
+export const orgScopeHook: preHandlerHookHandler = async (request, reply) => {
+  const user = (request as any).user as { orgId?: string } | undefined;
+
+  if (!user || !user.orgId) {
+    await reply.code(401).send({ code: "UNAUTHENTICATED" });
+    return reply;
+  }
+
+  (request as any).orgId = user.orgId;
+
+  const params = (request.params ?? {}) as Record<string, unknown>;
+  const paramOrgId = typeof params.orgId === "string" ? params.orgId : undefined;
+
+  if (paramOrgId && paramOrgId !== user.orgId) {
+    await reply.code(403).send({ code: "FORBIDDEN" });
+    return reply;
+  }
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -10,71 +10,99 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import { authPlugin } from "./plugins/auth";
+import { orgScopeHook } from "./hooks/org-scope";
 
-const app = Fastify({ logger: true });
+export const buildApp = async () => {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+  await app.register(
+    async (v1App) => {
+      await authPlugin(v1App);
+      v1App.addHook("preHandler", orgScopeHook);
+
+      v1App.get("/ping", async (request) => ({
+        ok: true,
+        user: (request as any).user,
+        orgId: (request as any).orgId,
+      }));
+
+      v1App.get("/orgs/:orgId/ping", async (request) => ({
+        ok: true,
+        orgId: (request as any).orgId,
+      }));
+
+      // List users (email + org)
+      v1App.get("/users", async () => {
+        const users = await prisma.user.findMany({
+          select: { email: true, orgId: true, createdAt: true },
+          orderBy: { createdAt: "desc" },
+        });
+        return { users };
+      });
+
+      // List bank lines (latest first)
+      v1App.get("/bank-lines", async (req) => {
+        const take = Number((req.query as any).take ?? 20);
+        const lines = await prisma.bankLine.findMany({
+          orderBy: { date: "desc" },
+          take: Math.min(Math.max(take, 1), 200),
+        });
+        return { lines };
+      });
+
+      // Create a bank line
+      v1App.post("/bank-lines", async (req, rep) => {
+        try {
+          const body = req.body as {
+            orgId: string;
+            date: string;
+            amount: number | string;
+            payee: string;
+            desc: string;
+          };
+          const created = await prisma.bankLine.create({
+            data: {
+              orgId: body.orgId,
+              date: new Date(body.date),
+              amount: body.amount as any,
+              payee: body.payee,
+              desc: body.desc,
+            },
+          });
+          return rep.code(201).send(created);
+        } catch (e) {
+          req.log.error(e);
+          return rep.code(400).send({ error: "bad_request" });
+        }
+      });
+    },
+    { prefix: "/v1" },
+  );
+
+  return app;
+};
+
+if (process.env.NODE_ENV !== "test") {
+  const app = await buildApp();
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
   });
-  return { users };
-});
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
+
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
   });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
-
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
-
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+}

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,79 @@
+import type { FastifyInstance } from "fastify";
+
+import { getAuthConfig } from "../config";
+import { verifyJwt } from "../utils/jwt";
+
+type TokenPayload = {
+  sub?: string;
+  id?: string;
+  orgId?: string;
+  roles?: string[] | string;
+};
+
+type UserPayload = {
+  id: string;
+  orgId: string;
+  roles: string[];
+};
+
+const parseRoles = (roles: TokenPayload["roles"]): string[] => {
+  if (!roles) {
+    return [];
+  }
+
+  if (Array.isArray(roles)) {
+    return roles.map((role) => String(role));
+  }
+
+  if (typeof roles === "string") {
+    return roles
+      .split(",")
+      .map((role) => role.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+};
+
+const authPlugin = (fastify: FastifyInstance): void => {
+  fastify.addHook("onRequest", async (request, reply) => {
+    const header = request.headers.authorization;
+    if (!header || !header.startsWith("Bearer ")) {
+      await reply.code(401).send({ code: "UNAUTHENTICATED" });
+      return reply;
+    }
+
+    const token = header.slice("Bearer ".length).trim();
+    if (!token) {
+      await reply.code(401).send({ code: "UNAUTHENTICATED" });
+      return reply;
+    }
+
+    try {
+      const config = getAuthConfig();
+      const decoded = verifyJwt(token, config) as TokenPayload;
+
+      const userId = decoded.sub ?? decoded.id;
+      const orgId = decoded.orgId;
+
+      if (!userId || !orgId) {
+        await reply.code(401).send({ code: "UNAUTHENTICATED" });
+        return reply;
+      }
+
+      const user: UserPayload = {
+        id: userId,
+        orgId,
+        roles: parseRoles(decoded.roles),
+      };
+
+      (request as any).user = user;
+    } catch (error) {
+      request.log.warn({ error }, "JWT verification failed");
+      await reply.code(401).send({ code: "UNAUTHENTICATED" });
+      return reply;
+    }
+  });
+};
+
+export { authPlugin };

--- a/apgms/services/api-gateway/src/utils/jwt.ts
+++ b/apgms/services/api-gateway/src/utils/jwt.ts
@@ -1,0 +1,95 @@
+import { createHmac, createVerify, timingSafeEqual } from "node:crypto";
+
+import type { AuthConfig } from "../config";
+
+const base64UrlEncode = (input: Buffer | string): string => {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  return buffer
+    .toString("base64")
+    .replace(/=+$/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+};
+
+const base64UrlDecode = (input: string): Buffer => {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4;
+  const padded = padding === 0 ? normalized : normalized + "=".repeat(4 - padding);
+  return Buffer.from(padded, "base64");
+};
+
+type JwtHeader = {
+  alg: string;
+  typ?: string;
+};
+
+type JwtPayload = Record<string, unknown>;
+
+const parseSegment = <T>(segment: string): T => {
+  const buffer = base64UrlDecode(segment);
+  return JSON.parse(buffer.toString("utf8")) as T;
+};
+
+const createSignature = (data: string, secret: string): Buffer =>
+  createHmac("sha256", secret).update(data).digest();
+
+const verifySignature = (data: string, signature: Buffer, config: AuthConfig, algorithm: string): boolean => {
+  if (algorithm === "HS256" && config.type === "secret") {
+    const expected = createSignature(data, config.verifyKey);
+    if (expected.length !== signature.length) {
+      return false;
+    }
+    return timingSafeEqual(signature, expected);
+  }
+
+  if (algorithm === "RS256" && config.type === "public") {
+    const verifier = createVerify("RSA-SHA256");
+    verifier.update(data);
+    verifier.end();
+    return verifier.verify(config.verifyKey, signature);
+  }
+
+  throw new Error(`Unsupported JWT configuration for algorithm ${algorithm}`);
+};
+
+export const verifyJwt = (token: string, config: AuthConfig): JwtPayload => {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Invalid token structure");
+  }
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = parseSegment<JwtHeader>(encodedHeader);
+  const payload = parseSegment<JwtPayload>(encodedPayload);
+  const signature = base64UrlDecode(encodedSignature);
+
+  if (!header.alg) {
+    throw new Error("Missing JWT algorithm");
+  }
+
+  const data = `${encodedHeader}.${encodedPayload}`;
+  if (!verifySignature(data, signature, config, header.alg)) {
+    throw new Error("Invalid signature");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (typeof payload.exp === "number" && payload.exp < now) {
+    throw new Error("Token expired");
+  }
+
+  if (typeof payload.nbf === "number" && payload.nbf > now) {
+    throw new Error("Token not active");
+  }
+
+  return payload;
+};
+
+export const signJwt = (payload: JwtPayload, secret: string): string => {
+  const header: JwtHeader = { alg: "HS256", typ: "JWT" };
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = createSignature(data, secret);
+  const encodedSignature = base64UrlEncode(signature);
+  return `${encodedHeader}.${encodedPayload}.${encodedSignature}`;
+};

--- a/apgms/services/api-gateway/test/auth.spec.ts
+++ b/apgms/services/api-gateway/test/auth.spec.ts
@@ -1,0 +1,92 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import request from "supertest";
+
+import { authPlugin } from "../src/plugins/auth";
+import { orgScopeHook } from "../src/hooks/org-scope";
+import { signJwt } from "../src/utils/jwt";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const TEST_SECRET = "test-secret";
+
+const buildTestApp = async (
+  registerRoutes: (app: FastifyInstance) => void,
+): Promise<FastifyInstance> => {
+  const app = Fastify();
+  await app.register(async (instance) => {
+    await authPlugin(instance);
+    instance.addHook("preHandler", orgScopeHook);
+    registerRoutes(instance);
+  });
+  await app.ready();
+  return app;
+};
+
+describe("auth plugin", () => {
+  const apps: FastifyInstance[] = [];
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  afterEach(async () => {
+    await Promise.all(apps.map((app) => app.close()));
+    apps.length = 0;
+  });
+
+  it("returns 401 when authorization header is missing", async () => {
+    const app = await buildTestApp((instance) => {
+      instance.get("/v1/ping", async () => ({ ok: true }));
+    });
+    apps.push(app);
+
+    const response = await request(app).get("/v1/ping");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: "UNAUTHENTICATED" });
+  });
+
+  it("returns 401 for an invalid token", async () => {
+    const app = await buildTestApp((instance) => {
+      instance.get("/v1/ping", async () => ({ ok: true }));
+    });
+    apps.push(app);
+
+    const response = await request(app)
+      .get("/v1/ping")
+      .set("Authorization", "Bearer invalid.token.value");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: "UNAUTHENTICATED" });
+  });
+
+  it("allows access with a valid token", async () => {
+    const app = await buildTestApp((instance) => {
+      instance.get("/v1/ping", async (req) => ({
+        ok: true,
+        user: (req as any).user,
+        orgId: (req as any).orgId,
+      }));
+    });
+    apps.push(app);
+
+    const token = signJwt(
+      {
+        sub: "user-123",
+        orgId: "org-abc",
+        roles: ["admin"],
+      },
+      TEST_SECRET,
+    );
+
+    const response = await request(app)
+      .get("/v1/ping")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      orgId: "org-abc",
+      user: { id: "user-123", orgId: "org-abc", roles: ["admin"] },
+    });
+  });
+});

--- a/apgms/services/api-gateway/test/org-scope.spec.ts
+++ b/apgms/services/api-gateway/test/org-scope.spec.ts
@@ -1,0 +1,57 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import request from "supertest";
+
+import { authPlugin } from "../src/plugins/auth";
+import { orgScopeHook } from "../src/hooks/org-scope";
+import { signJwt } from "../src/utils/jwt";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const TEST_SECRET = "test-secret";
+
+const buildTestApp = async (
+  registerRoutes: (app: FastifyInstance) => void,
+): Promise<FastifyInstance> => {
+  const app = Fastify();
+  await app.register(async (instance) => {
+    await authPlugin(instance);
+    instance.addHook("preHandler", orgScopeHook);
+    registerRoutes(instance);
+  });
+  await app.ready();
+  return app;
+};
+
+describe("org scope hook", () => {
+  const apps: FastifyInstance[] = [];
+
+  beforeAll(() => {
+    process.env.JWT_SECRET = TEST_SECRET;
+  });
+
+  afterEach(async () => {
+    await Promise.all(apps.map((app) => app.close()));
+    apps.length = 0;
+  });
+
+  it("rejects cross-organisation access", async () => {
+    const app = await buildTestApp((instance) => {
+      instance.get("/v1/orgs/:orgId/resource", async () => ({ ok: true }));
+    });
+    apps.push(app);
+
+    const token = signJwt(
+      {
+        sub: "user-123",
+        orgId: "org-abc",
+      },
+      TEST_SECRET,
+    );
+
+    const response = await request(app)
+      .get("/v1/orgs/org-def/resource")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ code: "FORBIDDEN" });
+  });
+});

--- a/apgms/services/api-gateway/test/run-tests.ts
+++ b/apgms/services/api-gateway/test/run-tests.ts
@@ -1,0 +1,10 @@
+import { runSuites } from "./vitest-mock";
+
+await import("./auth.spec");
+await import("./org-scope.spec");
+
+const success = await runSuites();
+
+if (!success) {
+  process.exitCode = 1;
+}

--- a/apgms/services/api-gateway/test/supertest-mock.ts
+++ b/apgms/services/api-gateway/test/supertest-mock.ts
@@ -1,0 +1,113 @@
+import type { FastifyInstance, InjectOptions } from "fastify";
+
+type SupertestResponse = {
+  status: number;
+  body: unknown;
+  headers: Record<string, string>;
+};
+
+type SupertestRequest = {
+  set: (name: string, value: string) => SupertestRequest;
+  send: (body: InjectOptions["payload"]) => SupertestRequest;
+  then: <TResult1 = SupertestResponse, TResult2 = never>(
+    onFulfilled?: (value: SupertestResponse) => TResult1 | PromiseLike<TResult1>,
+    onRejected?: (reason: unknown) => TResult2 | PromiseLike<TResult2>,
+  ) => Promise<TResult1 | TResult2>;
+  catch: <TResult = never>(
+    onRejected?: (reason: unknown) => TResult | PromiseLike<TResult>,
+  ) => Promise<SupertestResponse | TResult>;
+  finally: (onFinally?: () => void) => Promise<SupertestResponse>;
+};
+
+const parseBody = (raw: unknown): unknown => {
+  if (raw === null || raw === undefined) {
+    return undefined;
+  }
+
+  if (Buffer.isBuffer(raw)) {
+    return parseBody(raw.toString("utf8"));
+  }
+
+  if (typeof raw !== "string") {
+    return raw;
+  }
+
+  if (raw === "") {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+};
+
+const normalizeHeaders = (input: unknown): Record<string, string> => {
+  const result: Record<string, string> = {};
+  if (!input || typeof input !== "object") {
+    return result;
+  }
+
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (Array.isArray(value)) {
+      result[key] = value.map((item) => String(item)).join(", ");
+    } else if (value !== undefined) {
+      result[key] = String(value);
+    }
+  }
+
+  return result;
+};
+
+const createRequest = (
+  app: FastifyInstance,
+  options: Pick<InjectOptions, "method" | "url">,
+): SupertestRequest => {
+  const headers: Record<string, string> = {};
+  let payload: InjectOptions["payload"];
+
+  const execute = async (): Promise<SupertestResponse> => {
+    const response: any = await app.inject({
+      ...options,
+      headers,
+      payload,
+    });
+
+    return {
+      status: response.statusCode as number,
+      body: parseBody(response.body),
+      headers: normalizeHeaders(response.headers),
+    };
+  };
+
+  const request: SupertestRequest = {
+    set(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return request;
+    },
+    send(body: InjectOptions["payload"]) {
+      payload = body;
+      return request;
+    },
+    then(onFulfilled, onRejected) {
+      return execute().then(onFulfilled, onRejected);
+    },
+    catch(onRejected) {
+      return execute().catch(onRejected);
+    },
+    finally(onFinally) {
+      return execute().finally(onFinally);
+    },
+  };
+
+  return request;
+};
+
+const request = (app: FastifyInstance) => ({
+  get: (url: string) => createRequest(app, { method: "GET", url }),
+  post: (url: string) => createRequest(app, { method: "POST", url }),
+});
+
+export default request;
+export type { SupertestResponse, SupertestRequest };

--- a/apgms/services/api-gateway/test/vitest-mock.ts
+++ b/apgms/services/api-gateway/test/vitest-mock.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+
+type Hook = () => void | Promise<void>;
+
+type TestCase = {
+  name: string;
+  fn: () => void | Promise<void>;
+  suite: Suite;
+};
+
+type Suite = {
+  name: string;
+  tests: TestCase[];
+  suites: Suite[];
+  beforeAll: Hook[];
+  afterEach: Hook[];
+  parent?: Suite;
+};
+
+const createSuite = (name: string, parent?: Suite): Suite => ({
+  name,
+  tests: [],
+  suites: [],
+  beforeAll: [],
+  afterEach: [],
+  parent,
+});
+
+const rootSuite = createSuite("");
+const suiteStack: Suite[] = [rootSuite];
+
+const currentSuite = (): Suite => suiteStack[suiteStack.length - 1];
+
+export const describe = (name: string, fn: () => void) => {
+  const parent = currentSuite();
+  const suite = createSuite(name, parent);
+  parent.suites.push(suite);
+  suiteStack.push(suite);
+  try {
+    fn();
+  } finally {
+    suiteStack.pop();
+  }
+};
+
+export const it = (name: string, fn: () => void | Promise<void>) => {
+  const suite = currentSuite();
+  suite.tests.push({ name, fn, suite });
+};
+
+export const beforeAll = (fn: Hook) => {
+  currentSuite().beforeAll.push(fn);
+};
+
+export const afterEach = (fn: Hook) => {
+  currentSuite().afterEach.push(fn);
+};
+
+class Expectation<T> {
+  constructor(private readonly actual: T) {}
+
+  toBe(expected: T) {
+    assert.strictEqual(this.actual, expected);
+  }
+
+  toEqual(expected: unknown) {
+    assert.deepStrictEqual(this.actual, expected);
+  }
+
+  toMatchObject(expected: unknown) {
+    matchObject(this.actual, expected);
+  }
+}
+
+const matchObject = (actual: unknown, expected: unknown) => {
+  if (Array.isArray(expected)) {
+    assert.ok(Array.isArray(actual), "Expected an array");
+    assert.strictEqual(actual.length, expected.length);
+    expected.forEach((item, index) => matchObject((actual as unknown[])[index], item));
+    return;
+  }
+
+  if (expected === null || typeof expected !== "object") {
+    assert.strictEqual(actual, expected);
+    return;
+  }
+
+  assert.ok(actual !== null && typeof actual === "object", "Expected an object");
+  for (const [key, value] of Object.entries(expected as Record<string, unknown>)) {
+    matchObject((actual as Record<string, unknown>)[key], value);
+  }
+};
+
+export const expect = <T>(actual: T) => new Expectation(actual);
+
+const runSuite = async (suite: Suite, ancestors: string[], inheritedAfterEach: Hook[]): Promise<boolean> => {
+  let success = true;
+  const path = suite.name ? [...ancestors, suite.name] : ancestors;
+
+  for (const hook of suite.beforeAll) {
+    await hook();
+  }
+
+  const allAfterEach = [...suite.afterEach, ...inheritedAfterEach];
+
+  for (const test of suite.tests) {
+    const fullName = [...path, test.name].join(" ");
+    try {
+      await test.fn();
+      console.log(`✓ ${fullName}`);
+    } catch (error) {
+      success = false;
+      console.error(`✗ ${fullName}`);
+      console.error(error);
+    } finally {
+      for (const hook of allAfterEach) {
+        try {
+          await hook();
+        } catch (error) {
+          success = false;
+          console.error(`✗ afterEach hook failed for ${fullName}`);
+          console.error(error);
+        }
+      }
+    }
+  }
+
+  for (const child of suite.suites) {
+    const childSuccess = await runSuite(child, path, allAfterEach);
+    success = success && childSuccess;
+  }
+
+  return success;
+};
+
+export const runSuites = async (): Promise<boolean> => {
+  return runSuite(rootSuite, [], []);
+};

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -9,8 +9,10 @@
     "types": ["node"],
     "baseUrl": "../../",
     "paths": {
-      "@apgms/shared/*": ["shared/src/*"]
+      "@apgms/shared/*": ["shared/src/*"],
+      "vitest": ["services/api-gateway/test/vitest-mock"],
+      "supertest": ["services/api-gateway/test/supertest-mock"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test", "types"]
 }

--- a/apgms/services/api-gateway/types/prisma-client.d.ts
+++ b/apgms/services/api-gateway/types/prisma-client.d.ts
@@ -1,0 +1,7 @@
+declare module "@prisma/client" {
+  class PrismaClient {
+    [key: string]: any;
+  }
+
+  export { PrismaClient };
+}


### PR DESCRIPTION
## Summary
- add a lightweight auth plugin that loads JWT configuration, verifies bearer tokens, and decorates requests with user context
- introduce an organisation scope pre-handler to propagate org identifiers and forbid cross-organisation access on parameterised routes
- restructure the API gateway v1 registration to apply the new auth and scope hooks, expose ping/org routes for validation, and add supporting utilities, stubs, and tests

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4dea61d9483279e43c3e725eb5dc1