### PR TITLE
Add API gateway container image build and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+on:
+  push:
+    tags: ['v*.*.*']
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm -r build
+      - name: Login GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build image
+        run: docker build -t ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }} services/api-gateway
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.22.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }}
+          format: 'table'
+          exit-code: '0'
+      - name: Push (sha + semver)
+        run: |
+          docker push ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }}
+          docker tag ghcr.io/${{ github.repository }}/api-gateway:${{ github.sha }} ghcr.io/${{ github.repository }}/api-gateway:${{ github.ref_name }}
+          docker push ghcr.io/${{ github.repository }}/api-gateway:${{ github.ref_name }}

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm fetch
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY . .
+RUN corepack enable && pnpm -r build
+
+FROM node:20-alpine AS run
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/services/api-gateway/dist ./dist
+COPY package.json pnpm-lock.yaml ./
+RUN addgroup -S nodejs && adduser -S nodejs -G nodejs
+USER nodejs
+EXPOSE 3000
+CMD ["node","dist/index.js"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the API gateway service
- introduce a release workflow that builds, scans, and pushes immutable images to GHCR

## Testing
- docker build -t test services/api-gateway *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f4ed602eb083279c47a9674e366dc2