### PR TITLE
Enforce coverage and migration checks in CI

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-﻿name: CI
+name: CI
 on: [push, pull_request]
 jobs:
   build:
@@ -10,8 +10,14 @@ jobs:
           version: 9
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: 'pnpm'
-      - run: pnpm i
+      - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
-      - run: pnpm -r test
+      - run: pnpm -r test -- --coverage
+      - run: pnpm exec tsx scripts/check-migrations.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: '**/coverage/**'

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,38 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  },
+  "vitest": {
+    "coverage": {
+      "provider": "v8",
+      "all": true,
+      "reportsDirectory": "coverage",
+      "functions": 80,
+      "branches": 80,
+      "lines": 80,
+      "statements": 80
+    }
+  }
+}

--- a/apgms/scripts/check-migrations.ts
+++ b/apgms/scripts/check-migrations.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process';
+
+const command = 'pnpm';
+const args = ['-w', 'exec', 'prisma', 'migrate', 'status'];
+
+const result = spawnSync(command, args, { stdio: 'pipe' });
+
+if (result.error) {
+  console.error('Failed to run prisma migrate status:', result.error);
+  process.exit(1);
+}
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+if (typeof result.status === 'number' && result.status !== 0) {
+  process.exit(result.status);
+}
+
+const output = (result.stdout ?? Buffer.from('')).toString();
+
+if (!output.toLowerCase().includes('up to date')) {
+  console.error('\nPrisma migrations are not up to date.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- configure Vitest to require minimum 80% coverage and write reports to the coverage directory
- update the CI workflow to install dependencies with frozen lockfile, run tests with coverage on Node 20, check Prisma migrations, and upload the coverage artifact
- add a helper script that fails the pipeline when Prisma migrate status is not up to date

## Testing
- pnpm -r test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68f4ed5616cc8327a8c7a7fd8053963f