### PR TITLE
Add env validation and JWT key rotation utility

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+ALLOWED_ORIGINS=
+RATE_LIMIT_MAX=300
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=replace-with-generated-secret
+JWT_ISSUER=apgms
+JWT_AUDIENCE=apgms-clients

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/scripts/key-rotate.mjs
+++ b/apgms/scripts/key-rotate.mjs
@@ -1,0 +1,6 @@
+import crypto from "node:crypto";
+
+const secret = crypto.randomBytes(48).toString("hex");
+
+console.log(`JWT_SECRET=${secret}`);
+console.log("Copy the value above into your environment configuration and redeploy the service.");

--- a/apgms/scripts/key-rotate.ts
+++ b/apgms/scripts/key-rotate.ts
@@ -1,0 +1,1 @@
+key-rotate.mjs

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/config.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+const Env = z.object({
+  PORT: z.coerce.number().default(3000),
+  ALLOWED_ORIGINS: z.string().default(""),
+  RATE_LIMIT_MAX: z.coerce.number().default(300),
+  REDIS_URL: z.string().url().default("redis://localhost:6379"),
+  JWT_SECRET: z.string().min(16),
+  JWT_ISSUER: z.string().min(1),
+  JWT_AUDIENCE: z.string().min(1),
+});
+
+export const config = Env.parse(process.env);

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,22 +1,24 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+
+import Fastify from "fastify";
+import cors from "@fastify/cors";
+import { prisma } from "../../../shared/src/db";
 
 // Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+const { config } = await import("./config.js");
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
 
 // sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.log.info({ port: config.PORT }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -70,11 +72,9 @@ app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
+app.listen({ port: config.PORT, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/test/config.spec.ts
+++ b/apgms/services/api-gateway/test/config.spec.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const configPath = join(__dirname, "../src/config.ts");
+
+const validEnv = {
+  PORT: "4000",
+  ALLOWED_ORIGINS: "http://localhost:3000",
+  RATE_LIMIT_MAX: "250",
+  REDIS_URL: "redis://localhost:6379/0",
+  JWT_SECRET: "1234567890abcdef1234567890",
+  JWT_ISSUER: "apgms-test-issuer",
+  JWT_AUDIENCE: "apgms-test-audience",
+};
+
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = { ...process.env };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+const importFreshConfig = async () => {
+  const url = pathToFileURL(configPath);
+  url.searchParams.set("t", `${Date.now()}`);
+  return import(url.href);
+};
+
+describe("config", () => {
+  it("fails fast when required env vars are missing", async () => {
+    const invalidEnv: NodeJS.ProcessEnv = { ...validEnv };
+    delete invalidEnv.JWT_SECRET;
+    process.env = invalidEnv;
+
+    await assert.rejects(importFreshConfig, (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /JWT_SECRET/);
+      return true;
+    });
+  });
+
+  it("parses environment variables when present", async () => {
+    process.env = { ...validEnv };
+
+    const { config } = await importFreshConfig();
+
+    assert.equal(config.PORT, 4000);
+    assert.equal(config.ALLOWED_ORIGINS, validEnv.ALLOWED_ORIGINS);
+    assert.equal(config.RATE_LIMIT_MAX, 250);
+    assert.equal(config.REDIS_URL, validEnv.REDIS_URL);
+    assert.equal(config.JWT_SECRET, validEnv.JWT_SECRET);
+    assert.equal(config.JWT_ISSUER, validEnv.JWT_ISSUER);
+    assert.equal(config.JWT_AUDIENCE, validEnv.JWT_AUDIENCE);
+  });
+});

--- a/apgms/services/api-gateway/tsconfig.json
+++ b/apgms/services/api-gateway/tsconfig.json
@@ -12,5 +12,5 @@
       "@apgms/shared/*": ["shared/src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
## Summary
- add a Zod-backed runtime config module for the API gateway and wire it into the server bootstrap
- add smoke tests around env validation behaviour and document required variables in `.env.example`
- add a JWT secret rotation script for operators

## Testing
- node scripts/key-rotate.ts
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4ed256a248327a0603aa7c18e5991