### PR TITLE
Harden API gateway CORS and audit logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+PORT=3000
+ALLOWED_ORIGINS=http://localhost:5173
+RATE_LIMIT_MAX=300
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=dev-secret
+JWT_ISSUER=apgms
+JWT_AUDIENCE=apgms-clients

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,5 @@
-﻿import path from "node:path";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -11,70 +12,127 @@ import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
-const app = Fastify({ logger: true });
+const buildApp = async () => {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  const allowedOriginSet = new Set(allowedOrigins);
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
+  await app.register(cors, {
+    origin: (origin, cb) => {
+      if (!origin) {
+        cb(null, true);
+        return;
+      }
+      if (allowedOriginSet.has(origin)) {
+        cb(null, true);
+        return;
+      }
+      const error = new Error("Origin not allowed");
+      cb(error, false);
+    },
   });
-  return { users };
-});
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+  app.addHook("onRequest", (req, reply, done) => {
+    const headerValue = req.headers["x-request-id"];
+    const headerId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    const reqId = headerId && headerId.length > 0 ? headerId : randomUUID();
+    (req as any).reqId = reqId;
+    reply.header("x-request-id", reqId);
+    done();
   });
-  return { lines };
-});
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  const auditMethods = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+  app.addHook("onSend", async (req, reply, payload) => {
+    if (auditMethods.has(req.method)) {
+      const reqId = (req as any).reqId;
+      app.log.info({
+        audit: true,
+        method: req.method,
+        url: req.url,
+        statusCode: reply.statusCode,
+        reqId,
+        userId: (req as any).user?.id,
+        orgId: (req as any).orgId,
+      });
+    }
+    return payload;
+  });
+
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+};
+
+const app = await buildApp();
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+if (process.env.NODE_ENV !== "test") {
+  app
+    .listen({ port, host })
+    .catch((err) => {
+      app.log.error(err);
+      process.exit(1);
+    });
+}
+
+export { app, buildApp };
 

--- a/apgms/services/api-gateway/test/security.spec.ts
+++ b/apgms/services/api-gateway/test/security.spec.ts
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NODE_ENV = "test";
+process.env.ALLOWED_ORIGINS = "http://allowed.test";
+
+const { buildApp } = await import("../src/index.ts");
+
+const disallowedOrigin = "http://evil.test";
+
+test("disallowed origins are blocked by CORS", async (t) => {
+  const app = await buildApp();
+  t.after(async () => {
+    await app.close();
+  });
+  await app.ready();
+
+  const response = await app.inject({
+    method: "OPTIONS",
+    url: "/health",
+    headers: {
+      origin: disallowedOrigin,
+      "access-control-request-method": "GET",
+    },
+  });
+
+  assert.equal(response.headers["access-control-allow-origin"], undefined);
+  assert.notEqual(response.statusCode, 200);
+});
+
+test("mutation requests emit audit log entries with request ids", async (t) => {
+  const app = await buildApp();
+  const originalInfo = app.log.info;
+  t.after(async () => {
+    (app.log as any).info = originalInfo;
+    await app.close();
+  });
+
+  const infoCalls: any[][] = [];
+  (app.log as any).info = function (...args: any[]) {
+    infoCalls.push(args);
+    return originalInfo.apply(this, args);
+  };
+
+  await app.register(async (instance) => {
+    instance.post("/__test__", async (_req, reply) => {
+      return reply.send({ ok: true });
+    });
+  });
+
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/__test__",
+    headers: {
+      "x-request-id": "test-req-id",
+    },
+    payload: { ok: true },
+  });
+
+  assert.equal(response.statusCode, 200);
+  const auditCall = infoCalls.find(([entry]) => entry?.audit === true);
+  assert.ok(auditCall, "expected an audit log entry");
+  const [logEntry] = auditCall!;
+  assert.equal(logEntry.reqId, "test-req-id");
+  assert.equal(logEntry.method, "POST");
+  assert.equal(logEntry.url, "/__test__");
+  assert.equal(logEntry.statusCode, 200);
+});


### PR DESCRIPTION
## Summary
- add strict origin allowlist handling, request id propagation, and mutation audit logging to the API gateway
- provide an example environment file documenting required variables
- add security regression tests that cover CORS blocking and audit logging behaviour

## Testing
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4ed1c709c83279df3de4676ecf0ae