### PR TITLE
feat(api-gateway): add jwt auth and org scope enforcement

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,18 +4,25 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "build": "node -e \"console.log('skip build for api-gateway')\"",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/jwt": "^8.0.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
+    "fastify-plugin": "^5.0.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
+    "@types/supertest": "^2.0.16",
+    "supertest": "^6.3.4",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.1"
   }
 }

--- a/apgms/services/api-gateway/src/hooks/org-scope.ts
+++ b/apgms/services/api-gateway/src/hooks/org-scope.ts
@@ -1,0 +1,16 @@
+import type { preHandlerHookHandler } from "fastify";
+
+export const orgScopeHook: preHandlerHookHandler = async (request, reply) => {
+  const user = request.user;
+
+  if (!user) {
+    return reply.code(401).send({ code: "UNAUTHENTICATED" });
+  }
+
+  request.orgId = user.orgId;
+
+  const params = request.params as { orgId?: string };
+  if (params?.orgId && params.orgId !== user.orgId) {
+    return reply.code(403).send({ code: "FORBIDDEN" });
+  }
+};

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -10,71 +10,98 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import authPlugin from "./plugins/auth";
+import { orgScopeHook } from "./hooks/org-scope";
 
-const app = Fastify({ logger: true });
+export async function createApp() {
+  const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  await app.register(cors, { origin: true });
+  await app.register(authPlugin);
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
+    return { users };
+  });
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  await app.register(
+    async (v1) => {
+      const authenticateHook = (app as any).authenticate;
+      v1.addHook("preHandler", authenticateHook);
+      v1.addHook("preHandler", orgScopeHook);
+
+      v1.get("/ping", async (req) => ({
+        pong: true,
+        user: req.user,
+      }));
+
+      v1.get("/orgs/:orgId/resource", async (req) => ({
+        orgId: req.orgId,
+      }));
+    },
+    { prefix: "/v1" }
+  );
+
+  // Print routes so we can SEE POST /bank-lines is registered
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
-
+if (process.argv[1] === __filename) {
+  const app = await createApp();
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });
+}

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,86 @@
+export interface AuthenticatedUser {
+  id: string;
+  orgId: string;
+  roles?: string[];
+}
+
+interface TokenPayload {
+  sub?: string;
+  id?: string;
+  orgId?: string;
+  roles?: string[];
+}
+
+declare module "fastify" {
+  interface FastifyRequest {
+    user: AuthenticatedUser | null;
+    orgId?: string;
+  }
+
+  interface FastifyInstance {
+    authenticate: (request: any, reply: any) => Promise<any>;
+  }
+}
+
+const fp = (await import("fastify-plugin")).default;
+
+const authPlugin = fp(async (app: any) => {
+  const secret = process.env.JWT_SECRET;
+  const issuer = process.env.JWT_ISSUER;
+  const audience = process.env.JWT_AUDIENCE;
+
+  if (!secret) {
+    throw new Error("JWT_SECRET is required");
+  }
+
+  if (!issuer) {
+    throw new Error("JWT_ISSUER is required");
+  }
+
+  if (!audience) {
+    throw new Error("JWT_AUDIENCE is required");
+  }
+
+  const jwtPlugin = (await import("@fastify/jwt")).default;
+  await app.register(jwtPlugin, {
+    secret,
+    sign: {
+      issuer,
+      audience,
+    },
+    verify: {
+      issuer,
+      audience,
+    },
+  });
+
+  app.decorateRequest("user", null);
+
+  const authenticate = async (request: any, reply: any) => {
+    try {
+      const payload = (await request.jwtVerify()) as TokenPayload;
+      const id = payload.sub ?? payload.id;
+      const orgId = payload.orgId;
+
+      if (!id || !orgId) {
+        throw new Error("Invalid token payload");
+      }
+
+      request.user = {
+        id,
+        orgId,
+        roles: payload.roles,
+      } satisfies AuthenticatedUser;
+    } catch (err) {
+      request.user = null;
+      if (request.log && request.log.warn) {
+        request.log.warn({ err }, "authentication failed");
+      }
+      return reply.code(401).send({ code: "UNAUTHENTICATED" });
+    }
+  };
+
+  app.decorate("authenticate", authenticate);
+});
+
+export default authPlugin;

--- a/apgms/services/api-gateway/test/auth.spec.mjs
+++ b/apgms/services/api-gateway/test/auth.spec.mjs
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import supertest from "supertest";
+import { createApp } from "../src/index";
+
+describe("authentication", () => {
+  let app;
+
+  beforeEach(async () => {
+    process.env.JWT_SECRET = "dev-secret";
+    process.env.JWT_ISSUER = "apgms";
+    process.env.JWT_AUDIENCE = "apgms-clients";
+
+    app = await createApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("rejects missing Authorization header", async () => {
+    const response = await supertest(app).get("/v1/ping");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: "UNAUTHENTICATED" });
+  });
+
+  it("rejects invalid token", async () => {
+    const response = await supertest(app)
+      .get("/v1/ping")
+      .set("Authorization", "Bearer bad-token");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: "UNAUTHENTICATED" });
+  });
+
+  it("accepts a valid token", async () => {
+    const token = await app.jwt.sign({
+      sub: "user-1",
+      orgId: "orgA",
+      roles: ["admin"],
+    });
+
+    const response = await supertest(app)
+      .get("/v1/ping")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      pong: true,
+      user: {
+        id: "user-1",
+        orgId: "orgA",
+        roles: ["admin"],
+      },
+    });
+  });
+});

--- a/apgms/services/api-gateway/test/org-scope.spec.mjs
+++ b/apgms/services/api-gateway/test/org-scope.spec.mjs
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import supertest from "supertest";
+import { createApp } from "../src/index";
+
+describe("org scope hook", () => {
+  let app;
+
+  beforeEach(async () => {
+    process.env.JWT_SECRET = "dev-secret";
+    process.env.JWT_ISSUER = "apgms";
+    process.env.JWT_AUDIENCE = "apgms-clients";
+
+    app = await createApp();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("rejects cross-org access", async () => {
+    const token = await app.jwt.sign({ sub: "user-1", orgId: "orgA" });
+
+    const response = await supertest(app)
+      .get("/v1/orgs/otherOrg/resource")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ code: "FORBIDDEN" });
+  });
+
+  it("allows matching org access", async () => {
+    const token = await app.jwt.sign({ sub: "user-1", orgId: "orgA" });
+
+    const response = await supertest(app)
+      .get("/v1/orgs/orgA/resource")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ orgId: "orgA" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Fastify auth plugin that verifies JWTs and decorates requests with user/org metadata
- introduce an org scope pre-handler to enforce organisation-based access control on /v1 routes
- refactor the gateway bootstrap to expose createApp(), apply the new guards, and cover them with vitest/supertest tests

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4ed08cf248327a1aadf24629daffd