### PR TITLE
feat: add OpenAPI schema emission for reports

### DIFF
--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -1,7 +1,8 @@
-﻿node_modules/
+node_modules/
 dist/
 coverage/
 .env*
 .DS_Store
 .vscode/
 **/__pycache__/
+!openapi.json

--- a/apgms/openapi.json
+++ b/apgms/openapi.json
@@ -1,0 +1,239 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "APGMS API Gateway",
+    "version": "1.0.0",
+    "description": "API Gateway OpenAPI specification"
+  },
+  "paths": {
+    "/docs": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/bank-lines": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/dashboard/generate-report": {
+      "post": {
+        "summary": "Generate a dashboard report",
+        "tags": [
+          "Reports"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "title": "ReportRequest",
+                "type": "object",
+                "properties": {
+                  "reportType": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                  }
+                },
+                "required": [
+                  "reportType",
+                  "startDate",
+                  "endDate"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "title": "ReportOut",
+                  "type": "object",
+                  "properties": {
+                    "reportId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "reportId"
+                  ]
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "issues": {
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "issues"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboard/report/{id}/download": {
+      "get": {
+        "summary": "Download a generated dashboard report",
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF document",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Download a generated dashboard report",
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "PDF document",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,23 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["services/*", "webapp", "shared", "worker"],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "emit:openapi": "tsx scripts/emit-openapi.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/emit-openapi.ts
+++ b/apgms/scripts/emit-openapi.ts
@@ -1,0 +1,46 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { writeFile } from "node:fs/promises";
+import { AddressInfo } from "node:net";
+import dotenv from "dotenv";
+import { buildApp } from "../services/api-gateway/src/app";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+async function main() {
+  process.env.PRISMA_DISABLED = process.env.PRISMA_DISABLED ?? "true";
+
+  const app = await buildApp({ logger: false });
+  await app.ready();
+
+  const address = await app.listen({ port: 0, host: "127.0.0.1" });
+
+  let baseUrl: string;
+  if (typeof address === "string") {
+    baseUrl = address;
+  } else {
+    const info = address as AddressInfo;
+    baseUrl = `http://${info.address}:${info.port}`;
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/openapi.json`);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OpenAPI document: ${response.status}`);
+    }
+    const spec = await response.json();
+    const outputPath = path.resolve(__dirname, "../openapi.json");
+    await writeFile(outputPath, JSON.stringify(spec, null, 2));
+    console.log(`OpenAPI spec written to ${outputPath}`);
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/app.ts
+++ b/apgms/services/api-gateway/src/app.ts
@@ -1,0 +1,75 @@
+import Fastify, { type FastifyServerOptions } from "fastify";
+import cors from "@fastify/cors";
+import { getPrismaClient } from "@apgms/shared/src/db";
+import openApiPlugin from "./plugins/openapi";
+import reportsRoutes from "./routes/v1/reports";
+
+export async function buildApp(options: FastifyServerOptions = {}) {
+  const app = Fastify({ logger: true, ...options });
+
+  await app.register(cors, { origin: true });
+  await openApiPlugin(app);
+
+  app.log.info(
+    { DATABASE_URL: process.env.DATABASE_URL },
+    "loaded env",
+  );
+
+  const prisma = await getPrismaClient();
+
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+  app.get("/users", async () => {
+    const users = await prisma.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+    return { users };
+  });
+
+  app.get("/bank-lines", async (req) => {
+    const take = Number((req.query as any).take ?? 20);
+    const lines = await prisma.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take: Math.min(Math.max(take, 1), 200),
+    });
+    return { lines };
+  });
+
+  app.post("/bank-lines", async (req, rep) => {
+    try {
+      const body = req.body as {
+        orgId: string;
+        date: string;
+        amount: number | string;
+        payee: string;
+        desc: string;
+      };
+      const created = await prisma.bankLine.create({
+        data: {
+          orgId: body.orgId,
+          date: new Date(body.date),
+          amount: body.amount as any,
+          payee: body.payee,
+          desc: body.desc,
+        },
+      });
+      return rep.code(201).send(created);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(400).send({ error: "bad_request" });
+    }
+  });
+
+  await app.register(reportsRoutes);
+
+  app.ready(() => {
+    app.log.info(app.printRoutes());
+  });
+
+  return app;
+}
+
+export default async function createApp(options?: FastifyServerOptions) {
+  return buildApp(options);
+}

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,80 +1,21 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
+import { buildApp } from "./app";
 
-// Load repo-root .env from src/
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
-
-import Fastify from "fastify";
-import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
-
-const app = Fastify({ logger: true });
-
-await app.register(cors, { origin: true });
-
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
-
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
-
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
-    });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
-  }
-});
-
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
 
 const port = Number(process.env.PORT ?? 3000);
 const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+const app = await buildApp();
 
+app
+  .listen({ port, host })
+  .catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });

--- a/apgms/services/api-gateway/src/plugins/openapi.ts
+++ b/apgms/services/api-gateway/src/plugins/openapi.ts
@@ -1,0 +1,270 @@
+import type { FastifyInstance } from "fastify";
+import type { ZodTypeAny } from "zod";
+
+declare module "fastify" {
+  interface FastifyInstance {
+    jsonSchemaFromZod<T extends ZodTypeAny>(
+      schema: T,
+      name?: string,
+    ): Record<string, unknown>;
+  }
+}
+
+type RouteSchema = {
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  body?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  response?: Record<string, any>;
+};
+
+const jsonSchemaFromZodInternal = (
+  schema: ZodTypeAny,
+  name?: string,
+): Record<string, unknown> => {
+  const buildSchema = (current: ZodTypeAny): Record<string, unknown> => {
+    const def = (current as any)?.def;
+    if (!def) {
+      return {};
+    }
+
+    if (def.type === "optional") {
+      return buildSchema(def.innerType);
+    }
+
+    switch (def.type) {
+      case "object": {
+        const rawShape = typeof def.shape === "function" ? def.shape() : def.shape;
+        const properties: Record<string, unknown> = {};
+        const required: string[] = [];
+        for (const key of Object.keys(rawShape)) {
+          const child = rawShape[key];
+          const unwrapped = unwrap(child);
+          properties[key] = buildSchema(unwrapped.schema);
+          if (!unwrapped.optional) {
+            required.push(key);
+          }
+        }
+        const objectSchema: Record<string, unknown> = {
+          type: "object",
+          properties,
+        };
+        if (required.length > 0) {
+          objectSchema.required = required;
+        }
+        return objectSchema;
+      }
+      case "string": {
+        const json: Record<string, unknown> = { type: "string" };
+        const checks = def.checks ?? [];
+        for (const check of checks) {
+          const pattern = check?._zod?.def?.pattern;
+          if (pattern instanceof RegExp) {
+            json.pattern = pattern.source;
+          }
+        }
+        return json;
+      }
+      case "enum": {
+        return {
+          type: "string",
+          enum: def.values,
+        };
+      }
+      default:
+        return {};
+    }
+  };
+
+  const unwrap = (
+    current: ZodTypeAny,
+  ): { schema: ZodTypeAny; optional: boolean } => {
+    let node = current;
+    let optional = false;
+    while (true) {
+      const def = (node as any)?.def;
+      if (!def) {
+        break;
+      }
+      if (def.type === "optional") {
+        optional = true;
+        node = def.innerType;
+        continue;
+      }
+      break;
+    }
+    return { schema: node, optional };
+  };
+
+  const schemaJson = buildSchema(schema);
+  if (name) {
+    return {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      title: name,
+      ...schemaJson,
+    };
+  }
+  return schemaJson;
+};
+
+const swaggerPlugin = async (
+  app: FastifyInstance,
+  opts: { info?: Record<string, any> },
+) => {
+  const collectedRoutes: Array<{
+    url: string;
+    method: string;
+    schema?: RouteSchema;
+  }> = [];
+
+  app.addHook("onRoute", (routeOptions) => {
+    const method = Array.isArray(routeOptions.method)
+      ? routeOptions.method[0]
+      : routeOptions.method;
+    if (!method) return;
+    collectedRoutes.push({
+      url: routeOptions.url,
+      method: method.toLowerCase(),
+      schema: routeOptions.schema as RouteSchema | undefined,
+    });
+  });
+
+  app.decorate("swagger", () => {
+    const info = opts.info ?? {
+      title: "API Gateway",
+      version: "1.0.0",
+    };
+    const paths: Record<string, any> = {};
+
+    for (const route of collectedRoutes) {
+      const pathKey = route.url.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+      if (!paths[pathKey]) {
+        paths[pathKey] = {};
+      }
+      const schema = route.schema ?? {};
+      const responses: Record<string, any> = {};
+      if (schema.response) {
+        for (const [status, responseSchema] of Object.entries(schema.response)) {
+          if (responseSchema && typeof responseSchema === "object") {
+            if ((responseSchema as any).content) {
+              responses[status] = {
+                description: (responseSchema as any).description ?? "",
+                content: (responseSchema as any).content,
+              };
+            } else {
+              responses[status] = {
+                description: "",
+                content: {
+                  "application/json": {
+                    schema: responseSchema,
+                  },
+                },
+              };
+            }
+          }
+        }
+      } else {
+        responses["200"] = { description: "" };
+      }
+
+      const parameters = buildParameters(schema.params as any);
+      const requestBody = schema.body
+        ? {
+            required: true,
+            content: {
+              "application/json": { schema: schema.body },
+            },
+          }
+        : undefined;
+
+      paths[pathKey][route.method] = {
+        summary: schema.summary,
+        description: schema.description,
+        tags: schema.tags,
+        parameters: parameters.length > 0 ? parameters : undefined,
+        requestBody,
+        responses,
+      };
+    }
+
+    return {
+      openapi: "3.0.3",
+      info,
+      paths,
+    };
+  });
+};
+
+const swaggerUiPlugin = async (
+  app: FastifyInstance,
+  opts: { routePrefix?: string },
+) => {
+  const routePrefix = opts.routePrefix ?? "/docs";
+  const specUrl = `/openapi.json`;
+
+  app.get(routePrefix, { schema: { hide: true } }, async (_req, reply) => {
+    const html = `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>API Gateway Docs</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 2rem; }
+      pre { background: #f6f8fa; padding: 1rem; border-radius: 8px; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>API Gateway OpenAPI</h1>
+    <p>The canonical OpenAPI document is available at <a href="${specUrl}">${specUrl}</a>.</p>
+    <pre id="spec">Loading OpenAPI document…</pre>
+    <script>
+      fetch('${specUrl}').then(function(res){ return res.json(); }).then(function(spec){
+        document.getElementById('spec').textContent = JSON.stringify(spec, null, 2);
+      }).catch(function(err){
+        document.getElementById('spec').textContent = 'Failed to load OpenAPI document: ' + err;
+      });
+    </script>
+  </body>
+</html>`;
+    reply.header("Content-Type", "text/html; charset=utf-8");
+    return reply.send(html);
+  });
+};
+
+const openApiPlugin = async (app: FastifyInstance) => {
+  app.decorate("jsonSchemaFromZod", (schema: ZodTypeAny, name?: string) =>
+    jsonSchemaFromZodInternal(schema, name),
+  );
+
+  await swaggerPlugin(app, {
+    info: {
+      title: "APGMS API Gateway",
+      version: "1.0.0",
+      description: "API Gateway OpenAPI specification",
+    },
+  });
+
+  await swaggerUiPlugin(app, {
+    routePrefix: "/docs",
+  });
+
+  app.get("/openapi.json", { schema: { hide: true } }, async () => app.swagger());
+};
+
+function buildParameters(schema?: Record<string, unknown>) {
+  if (!schema || schema.type !== "object") {
+    return [];
+  }
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  const properties = schema.properties ?? {};
+  return Object.keys(properties).map((key) => ({
+    name: key,
+    in: "path",
+    required: required.includes(key),
+    schema: properties[key],
+  }));
+}
+
+export default openApiPlugin;
+export { jsonSchemaFromZodInternal };

--- a/apgms/services/api-gateway/src/routes/v1/reports.ts
+++ b/apgms/services/api-gateway/src/routes/v1/reports.ts
@@ -1,0 +1,107 @@
+import type { FastifyPluginAsync } from "fastify";
+import { z } from "zod";
+import {
+  ReportOutSchema,
+  ReportRequestSchema,
+} from "@apgms/shared/src/schemas/report";
+
+const ReportDownloadParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+const reportsRoutes: FastifyPluginAsync = async (app) => {
+  const reportRequestJson = app.jsonSchemaFromZod(
+    ReportRequestSchema,
+    "ReportRequest",
+  );
+  const reportOutJson = app.jsonSchemaFromZod(ReportOutSchema, "ReportOut");
+  const reportDownloadParamsJson = app.jsonSchemaFromZod(
+    ReportDownloadParamsSchema,
+    "ReportDownloadParams",
+  );
+
+  app.post(
+    "/dashboard/generate-report",
+    {
+      schema: {
+        tags: ["Reports"],
+        summary: "Generate a dashboard report",
+        body: reportRequestJson,
+        response: {
+          200: reportOutJson,
+          422: {
+            type: "object",
+            properties: {
+              error: { type: "string" },
+              issues: { type: "array" },
+            },
+            required: ["error", "issues"],
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const parsed = ReportRequestSchema.safeParse(request.body);
+      if (!parsed.success) {
+        return reply.status(422).send({
+          error: "validation_error",
+          issues: parsed.error.issues,
+        });
+      }
+
+      const reportId = `report_${Date.now()}`;
+      return reply.send({ reportId });
+    },
+  );
+
+  app.get(
+    "/dashboard/report/:id/download",
+    {
+      schema: {
+        tags: ["Reports"],
+        summary: "Download a generated dashboard report",
+        params: reportDownloadParamsJson,
+        response: {
+          200: {
+            description: "PDF document",
+            content: {
+              "application/pdf": {
+                schema: {
+                  type: "string",
+                  format: "binary",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (request, reply) => {
+      const parsed = ReportDownloadParamsSchema.safeParse(request.params);
+      if (!parsed.success) {
+        return reply.status(400).send({ error: "invalid_report_id" });
+      }
+
+      const pdfContent = [
+        "%PDF-1.4",
+        "%âãÏÓ",
+        "1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj",
+        "2 0 obj<< /Type /Pages /Count 1 /Kids [3 0 R] >>endobj",
+        "3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>endobj",
+        "4 0 obj<< /Length 44 >>stream",
+        "BT /F1 24 Tf 50 150 Td (Report Ready) Tj ET",
+        "endstream endobj",
+        "xref\n0 5\n0000000000 65535 f \n0000000010 00000 n \n0000000079 00000 n \n0000000177 00000 n \n0000000331 00000 n \ntrailer<< /Root 1 0 R /Size 5 >>\nstartxref\n447\n%%EOF",
+      ].join("\n");
+
+      reply.header("Content-Type", "application/pdf");
+      reply.header(
+        "Content-Disposition",
+        `attachment; filename="${parsed.data.id}.pdf"`,
+      );
+      return reply.send(Buffer.from(pdfContent));
+    },
+  );
+};
+
+export default reportsRoutes;

--- a/apgms/services/api-gateway/test/contract.spec.ts
+++ b/apgms/services/api-gateway/test/contract.spec.ts
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildApp } from "../src/app";
+
+test("OpenAPI exposes report routes", async (t) => {
+  process.env.PRISMA_DISABLED = "true";
+  const app = await buildApp({ logger: false });
+
+  t.after(async () => {
+    await app.close();
+  });
+
+  await app.ready();
+  const response = await app.inject({ method: "GET", url: "/openapi.json" });
+
+  assert.equal(response.statusCode, 200);
+
+  const spec = JSON.parse(response.body);
+
+  assert.ok(spec.paths?.["/dashboard/generate-report"], "missing generate-report path");
+  assert.ok(
+    spec.paths?.["/dashboard/report/{id}/download"],
+    "missing report download path",
+  );
+});

--- a/apgms/shared/src/db.ts
+++ b/apgms/shared/src/db.ts
@@ -1,2 +1,31 @@
-﻿import { PrismaClient } from "@prisma/client";
-export const prisma = new PrismaClient();
+import type { PrismaClient } from "@prisma/client";
+
+let prismaPromise: Promise<PrismaClient> | null = null;
+
+const createMockClient = (): PrismaClient => {
+  const mock = {
+    user: {
+      findMany: async () => [],
+    },
+    bankLine: {
+      findMany: async () => [],
+      create: async () => {
+        throw new Error("Prisma client is disabled");
+      },
+    },
+    $disconnect: async () => {},
+  } as unknown as PrismaClient;
+  return mock;
+};
+
+export const getPrismaClient = async (): Promise<PrismaClient> => {
+  if (process.env.PRISMA_DISABLED === "true") {
+    return createMockClient();
+  }
+  if (!prismaPromise) {
+    prismaPromise = import("@prisma/client").then(({ PrismaClient }) => {
+      return new PrismaClient();
+    });
+  }
+  return prismaPromise;
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
-﻿// shared
+export * from "./db";
+export * from "./schemas/report";

--- a/apgms/shared/src/schemas/report.ts
+++ b/apgms/shared/src/schemas/report.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const ReportRequestSchema = z
+  .object({
+    reportType: z.enum([
+      "COMPLIANCE_SUMMARY",
+      "PAYMENT_HISTORY",
+      "TAX_OBLIGATIONS",
+      "DISCREPANCY_LOG",
+    ]),
+    startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  })
+  .refine(
+    (data) =>
+      new Date(`${data.endDate}T23:59:59Z`) >=
+      new Date(`${data.startDate}T00:00:00Z`),
+    {
+      message: "end >= start",
+      path: ["endDate"],
+    },
+  )
+  .refine(
+    (data) =>
+      (new Date(data.endDate).getTime() -
+        new Date(data.startDate).getTime()) /
+        86_400_000 <=
+      366,
+    {
+      message: "range <= 12 months",
+      path: ["endDate"],
+    },
+  );
+
+export const ReportOutSchema = z.object({
+  reportId: z.string(),
+});


### PR DESCRIPTION
## Summary
- add shared Zod schemas for dashboard report requests and responses
- wire API gateway through a shared app builder with custom OpenAPI emission and report routes
- provide a script, generated spec, and contract test to verify the documented endpoints

## Testing
- pnpm -r build
- pnpm emit:openapi
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f4ed107628832795c52de4c9953408