### PR TITLE
feat: add idempotent bank line routes

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -15,7 +16,9 @@
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
+    "supertest": "^7.0.0",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.3"
   }
 }

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,14 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import idempotencyPlugin from "./plugins/idempotency";
+import { bankLinesRoutes } from "./routes/v1/bank-lines";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(idempotencyPlugin, { ttlSeconds: 3600 });
+await app.register(bankLinesRoutes);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,122 @@
+import fp from 'fastify-plugin';
+import { FastifyReply, FastifyRequest, FastifyPluginAsync } from 'fastify';
+import { createHash } from 'crypto';
+
+type CachedEntry = {
+  statusCode: number;
+  headers: Record<string, string>;
+  payload: string; // JSON stringified
+};
+
+type Store = {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ttlSeconds: number): Promise<void>;
+};
+
+const inMemory = new Map<string, { value: string; expiresAt: number }>();
+
+async function getInMemory(key: string): Promise<string | null> {
+  const rec = inMemory.get(key);
+  if (!rec) return null;
+  if (Date.now() > rec.expiresAt) { inMemory.delete(key); return null; }
+  return rec.value;
+}
+async function setInMemory(key: string, value: string, ttlSeconds: number): Promise<void> {
+  inMemory.set(key, { value, expiresAt: Date.now() + ttlSeconds * 1000 });
+}
+
+function normalizeHeaders(h: Record<string, any>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(h || {})) {
+    if (v == null) continue;
+    out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v);
+  }
+  return out;
+}
+
+function computeDeterministicKey(req: FastifyRequest, orgId: string | undefined): string {
+  const method = (req.method || 'GET').toUpperCase();
+  const url = req.url || '';
+  const body = typeof req.body === 'object' ? JSON.stringify(req.body) : String(req.body ?? '');
+  const idemHeader = (req.headers['idempotency-key'] as string | undefined) || '';
+  const base = JSON.stringify({ method, url, body, orgId, idemHeader });
+  return createHash('sha256').update(base).digest('hex');
+}
+
+export interface IdempotencyOptions {
+  ttlSeconds?: number;         // cache TTL, default 3600
+  headerName?: string;         // request header to respect, default 'idempotency-key'
+  methods?: Array<'POST' | 'PUT' | 'PATCH' | 'DELETE'>; // which methods are idempotent
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    idempotency: IdempotencyOptions;
+  }
+}
+
+const idempotencyPlugin: FastifyPluginAsync<IdempotencyOptions> = fp(async (app, opts) => {
+  const ttl = opts.ttlSeconds ?? 3600;
+  const headerName = (opts.headerName || 'idempotency-key').toLowerCase();
+  const methods = new Set((opts.methods ?? ['POST', 'PUT', 'PATCH', 'DELETE']).map(m => m.toUpperCase()));
+
+  // Prefer Redis if available as app.redis, else fallback to in-memory
+  const store: Store = (app as any).redis && typeof (app as any).redis.get === 'function'
+    ? {
+        get: async (k) => (app as any).redis.get(k),
+        set: async (k, v, t) => { await (app as any).redis.set(k, v, 'EX', t); }
+      }
+    : {
+        get: getInMemory,
+        set: setInMemory
+      };
+
+  app.decorate('idempotency', { ttlSeconds: ttl, headerName, methods });
+
+  app.addHook('preHandler', async (req, reply) => {
+    if (!methods.has((req.method || '').toUpperCase())) return;
+
+    // @ts-ignore populated by auth/org-scope if present
+    const orgId: string | undefined = (req as any).orgId;
+    const key = computeDeterministicKey(req, orgId);
+
+    const cached = await store.get(`idem:${key}`);
+    if (cached) {
+      try {
+        const entry: CachedEntry = JSON.parse(cached);
+        reply.header('Idempotent-Replay', 'true');
+        for (const [hk, hv] of Object.entries(entry.headers || {})) {
+          if (hk === 'content-length') continue;
+          reply.header(hk, hv);
+        }
+        reply.code(entry.statusCode).send(entry.payload ? JSON.parse(entry.payload) : null);
+        return;
+      } catch {
+        // if corrupt, ignore and let request continue
+      }
+    }
+
+    // wrap reply.send to capture result
+    const originalSend = reply.send.bind(reply);
+    reply.send = (payload?: any) => {
+      // only cache JSON responses
+      let bodyStr = '';
+      try {
+        bodyStr = typeof payload === 'string' ? payload : JSON.stringify(payload ?? null);
+      } catch {
+        bodyStr = '';
+      }
+
+      const statusCode = reply.statusCode || 200;
+      const headers = normalizeHeaders(reply.getHeaders() as any);
+
+      const entry: CachedEntry = { statusCode, headers, payload: bodyStr };
+      // no await; fire-and-forget
+      store.set(`idem:${key}`, JSON.stringify(entry), ttl).catch(() => {});
+
+      return originalSend(payload);
+    };
+  });
+});
+
+export default idempotencyPlugin;

--- a/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
@@ -1,0 +1,50 @@
+import { FastifyInstance } from 'fastify';
+import { randomUUID } from 'crypto';
+
+type BankLine = {
+  id: string;
+  orgId: string;
+  accountId: string;
+  amount: number;
+  currency: string;
+  occurredAt: string;
+  description?: string;
+};
+
+const memory: Record<string, BankLine> = {};
+
+export async function bankLinesRoutes(app: FastifyInstance) {
+  // Create (idempotent via idempotency plugin)
+  app.post('/v1/bank-lines', async (req, reply) => {
+    // @ts-ignore
+    const orgId: string = (req as any).orgId || 'demo-org';
+    const body = (req.body || {}) as Partial<BankLine>;
+    const line: BankLine = {
+      id: randomUUID(),
+      orgId,
+      accountId: String(body.accountId ?? 'acct-unknown'),
+      amount: Number(body.amount ?? 0),
+      currency: String(body.currency ?? 'AUD'),
+      occurredAt: String(body.occurredAt ?? new Date().toISOString()),
+      description: body.description
+    };
+    memory[line.id] = line;
+    reply.code(201).send(line);
+  });
+
+  // Read
+  app.get('/v1/bank-lines/:id', async (req, reply) => {
+    const { id } = (req.params as any);
+    const found = memory[id];
+    if (!found) return reply.code(404).send({ code: 'NOT_FOUND' });
+    // @ts-ignore
+    const orgId: string = (req as any).orgId || 'demo-org';
+    if (found.orgId !== orgId) return reply.code(403).send({ code: 'FORBIDDEN' });
+    reply.send(found);
+  });
+
+  // List (basic)
+  app.get('/v1/bank-lines', async (_req, reply) => {
+    reply.send(Object.values(memory));
+  });
+}

--- a/apgms/services/api-gateway/test/idempotency.spec.ts
+++ b/apgms/services/api-gateway/test/idempotency.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import request from 'supertest';
+import idempotencyPlugin from '../src/plugins/idempotency';
+import { bankLinesRoutes } from '../src/routes/v1/bank-lines';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(idempotencyPlugin, { ttlSeconds: 60 });
+  await app.register(bankLinesRoutes);
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('idempotency', () => {
+  it('replays the same response on duplicate POST with the same Idempotency-Key', async () => {
+    const key = 'test-key-123';
+    const body = { accountId: 'acct-1', amount: 100, currency: 'AUD' };
+
+    const r1 = await request(app.server)
+      .post('/v1/bank-lines')
+      .set('Idempotency-Key', key)
+      .send(body);
+
+    expect([200,201]).toContain(r1.status);
+    const first = r1.body;
+    expect(first).toHaveProperty('id');
+
+    const r2 = await request(app.server)
+      .post('/v1/bank-lines')
+      .set('Idempotency-Key', key)
+      .send(body);
+
+    expect(r2.status).toBe(200);                      // replayed
+    expect(r2.headers['idempotent-replay']).toBe('true');
+    expect(r2.body).toEqual(first);                   // same payload
+  });
+
+  it('creates a new resource with a different Idempotency-Key', async () => {
+    const body = { accountId: 'acct-1', amount: 100, currency: 'AUD' };
+
+    const r1 = await request(app.server)
+      .post('/v1/bank-lines')
+      .set('Idempotency-Key', 'key-A')
+      .send(body);
+
+    const r2 = await request(app.server)
+      .post('/v1/bank-lines')
+      .set('Idempotency-Key', 'key-B')
+      .send(body);
+
+    expect(r1.body.id).not.toBe(r2.body.id);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Redis-aware idempotency plugin with in-memory fallback for the API gateway
- register the plugin and expose new versioned /v1/bank-lines routes
- add a vitest suite verifying idempotent POST behaviour and wire supporting scripts/dependencies

## Testing
- Not run (pnpm install blocked by registry 403 in workspace)

------
https://chatgpt.com/codex/tasks/task_e_68f4fcad17e08327be68b8f99d812bf0