### PR TITLE
feat: add api gateway config validation

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,27 @@
+# ---- Runtime ---
+NODE_ENV=development
+PORT=8080
+LOG_LEVEL=info
+
+# ---- Auth / JWT ----
+JWT_SECRET=REPLACE_ME_with_256bit_hex
+JWT_ISSUER=apgms
+JWT_AUDIENCE=apgms-clients
+
+# ---- CORS ----
+# Comma-separated list of allowed origins. Example below allows local dev + production UI.
+CORS_ALLOWLIST=http://localhost:3000,https://app.example.com
+
+# ---- Rate Limit ----
+RATE_LIMIT_MAX=300
+RATE_LIMIT_WINDOW=1 minute
+
+# ---- Data Stores ----
+REDIS_URL=redis://localhost:6379
+DATABASE_URL=postgresql://user:pass@localhost:5432/apgms
+
+# ---- Misc ----
+REQUEST_ID_HEADER=x-request-id
+
+# Copy this file to .env and customize values for local dev.
+# In CI/Prod, prefer managed secret stores and environment injection, not .env files.

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,29 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "key:rotate": "tsx scripts/key-rotate.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "zod": "^4.1.12"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/key-rotate.ts
+++ b/apgms/scripts/key-rotate.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+function generateHex(bytes = 32) {
+  return crypto.randomBytes(bytes).toString('hex'); // 256-bit default
+}
+
+function rotateInEnvFile(envPath: string) {
+  if (!fs.existsSync(envPath)) {
+    console.log(`[key-rotate] No .env found at ${envPath}. Printing new secret to stdout.`);
+    console.log(`JWT_SECRET=${generateHex(32)}`);
+    return;
+  }
+
+  const backupPath = envPath + '.bak.' + Date.now();
+  fs.copyFileSync(envPath, backupPath);
+
+  const raw = fs.readFileSync(envPath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+  let found = false;
+  const next = lines.map((line) => {
+    if (/^\s*JWT_SECRET\s*=/.test(line)) {
+      found = true;
+      return `JWT_SECRET=${generateHex(32)}`;
+    }
+    return line;
+  });
+
+  if (!found) {
+    next.push(`JWT_SECRET=${generateHex(32)}`);
+  }
+
+  fs.writeFileSync(envPath, next.join('\n'), 'utf8');
+
+  console.log(`[key-rotate] Rotated JWT_SECRET in ${envPath}`);
+  console.log(`[key-rotate] Backup created at ${backupPath}`);
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const envPath = path.join(repoRoot, '.env');
+  rotateInEnvFile(envPath);
+
+  // For infra-managed secrets (e.g., GitHub/AWS/GCP), just copy the printed value to your secret store.
+}
+
+main();

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  NODE_ENV: z.enum(['production','development','test']).default('development'),
+  PORT: z.coerce.number().int().positive().default(8080),
+  LOG_LEVEL: z.enum(['fatal','error','warn','info','debug','trace','silent']).default('info'),
+
+  JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 chars (use 256-bit hex)'),
+  JWT_ISSUER: z.string().default('apgms'),
+  JWT_AUDIENCE: z.string().default('apgms-clients'),
+
+  CORS_ALLOWLIST: z.string().default('http://localhost:3000'),
+
+  RATE_LIMIT_MAX: z.coerce.number().int().positive().default(300),
+  RATE_LIMIT_WINDOW: z.string().default('1 minute'),
+
+  REDIS_URL: z.string().optional(),
+  DATABASE_URL: z.string().optional(),
+
+  REQUEST_ID_HEADER: z.string().default('x-request-id'),
+});
+
+export type AppConfig = z.infer<typeof EnvSchema>;
+
+let cached: AppConfig | null = null;
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  if (cached) return cached;
+  const parsed = EnvSchema.safeParse(env);
+  if (!parsed.success) {
+    const errs = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new Error(`Invalid environment configuration: ${errs}`);
+  }
+  cached = parsed.data;
+  return cached!;
+}
+
+const config = loadConfig();
+export default config;

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,6 +9,7 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import config from "./config";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
@@ -17,6 +18,7 @@ await app.register(cors, { origin: true });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.log.info({ env: config.NODE_ENV, port: config.PORT }, "config_loaded");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
@@ -70,7 +72,7 @@ app.ready(() => {
   app.log.info(app.printRoutes());
 });
 
-const port = Number(process.env.PORT ?? 3000);
+const port = config.PORT;
 const host = "0.0.0.0";
 
 app.listen({ port, host }).catch((err) => {

--- a/apgms/services/api-gateway/test/config.spec.ts
+++ b/apgms/services/api-gateway/test/config.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { loadConfig } from '../src/config';
+
+describe('config validation', () => {
+  it('accepts valid env', () => {
+    const cfg = loadConfig({
+      NODE_ENV: 'test',
+      PORT: '8080',
+      LOG_LEVEL: 'info',
+      JWT_SECRET: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      JWT_ISSUER: 'apgms',
+      JWT_AUDIENCE: 'apgms-clients',
+      CORS_ALLOWLIST: 'http://localhost:3000',
+      RATE_LIMIT_MAX: '100',
+      RATE_LIMIT_WINDOW: '1 minute',
+      REQUEST_ID_HEADER: 'x-request-id',
+    } as any);
+    expect(cfg.PORT).toBe(8080);
+    expect(cfg.JWT_SECRET.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('rejects missing/weak JWT_SECRET', () => {
+    expect(() => loadConfig({
+      NODE_ENV: 'test',
+      PORT: '8080',
+      LOG_LEVEL: 'info',
+      JWT_ISSUER: 'apgms',
+      JWT_AUDIENCE: 'apgms-clients',
+      CORS_ALLOWLIST: 'http://localhost:3000',
+      RATE_LIMIT_MAX: '100',
+      RATE_LIMIT_WINDOW: '1 minute',
+    } as any)).toThrow(/JWT_SECRET/);
+  });
+});


### PR DESCRIPTION
## Summary
- add a repository-wide .env example and jwt rotation script
- validate api-gateway environment with zod and reuse config in the server entrypoint
- add vitest coverage for config validation

## Testing
- pnpm --filter api-gateway test

------
https://chatgpt.com/codex/tasks/task_e_68f4fe1aebdc8327a121c703760026f1