### PR TITLE
Add k6 performance tests and SLO documentation

### DIFF
--- a/apgms/docs/slo.md
+++ b/apgms/docs/slo.md
@@ -1,0 +1,28 @@
+# APGMS SLI/SLOs
+
+## Services in scope
+- API Gateway (`services/api-gateway`)
+
+## SLIs
+- **Availability** (Gateway): proportion of successful requests (HTTP 2xx/3xx).
+- **Latency (p95)**: time to first byte for GETs; total duration for POSTs.
+- **Error Rate**: proportion of 5xx responses.
+- **Readiness**: /ready returns UP (200) when dependencies are reachable.
+
+## SLOs (quarterly targets)
+- Availability: **≥ 99.9%**
+- Latency (p95): **GET ≤ 300ms**, **POST ≤ 700ms**
+- Error Rate: **< 0.5%**
+- Readiness: **≥ 99.9%**
+
+## Alert policy (suggested)
+- Page when: Availability < 99.0% for 5 min, or Error Rate ≥ 1% for 5 min.
+- Ticket when: Latency p95 breached for 30 min.
+
+## Measurement & dashboards
+- Prometheus metrics from `/metrics` (see http_request_duration_seconds, http_requests_total).
+- Grafana dashboards aggregating by route, method, status_code, trace_id.
+
+## Load-testing regimen
+- **Smoke** before every deploy: `k6 run k6/smoke.js -e BASE_URL=https://api.example.com`
+- **Load** weekly on staging: `k6 run k6/load.js -e BASE_URL=https://staging-api.example.com`

--- a/apgms/k6/smoke.js
+++ b/apgms/k6/smoke.js
@@ -1,0 +1,22 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 1,
+  duration: '30s',
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<500']
+  }
+};
+
+export default function () {
+  const endpoints = ['/health','/ready','/metrics'];
+  endpoints.forEach((p) => {
+    const res = http.get(`${__ENV.BASE_URL || 'http://localhost:8080'}${p}`);
+    check(res, {
+      'status is 200 or 503 (ready may be 503)': (r) => [200,503].includes(r.status),
+    });
+  });
+  sleep(1);
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,31 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "perf:smoke": "k6 run k6/smoke.js",
+    "perf:load": "k6 run k6/load.js",
+    "perf:smoke:docker": "docker run --rm -i -e BASE_URL=$BASE_URL -v $PWD:/work -w /work grafana/k6 run k6/smoke.js",
+    "perf:load:docker": "docker run --rm -i -e BASE_URL=$BASE_URL -v $PWD:/work -w /work grafana/k6 run k6/load.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}


### PR DESCRIPTION
## Summary
- add k6 smoke and load scripts with defined thresholds
- document service SLOs and recommended alerting triggers
- expose npm scripts for running the new k6 scenarios locally or via Docker

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f500c7b61883279ef30538dda01005