### PR TITLE
Add Vitest config, reports e2e test, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm -r build
+
+      - name: Prisma migrate status gate (all workspaces)
+        run: pnpm -r exec -- prisma migrate status --no-color
+
+      - name: Tests with coverage (fail under thresholds)
+        run: pnpm -r test -- --coverage
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage
+            **/coverage

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.1"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/api-gateway/test/reports.e2e.spec.ts
+++ b/apgms/services/api-gateway/test/reports.e2e.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import openapiPlugin from '../src/plugins/openapi';
+import { reportsRoutes } from '../src/routes/v1/reports';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('reports e2e', () => {
+  it('rejects invalid body with 422', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dashboard/generate-report',
+      payload: { reportType: 'PAYMENT_HISTORY', startDate: 'bad', endDate: 'also-bad' }
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('accepts valid body and returns reportId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dashboard/generate-report',
+      payload: { reportType: 'PAYMENT_HISTORY', startDate: '2024-07-01', endDate: '2024-07-31' }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty('reportId');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    watch: false,
+    reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json', 'lcov'],
+      lines: 80,
+      statements: 80,
+      functions: 80,
+      branches: 75
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add a root vitest configuration with coverage thresholds to align the monorepo
- create a reports endpoint e2e test for the API gateway service
- define a CI workflow that builds, checks Prisma migrations, and runs tests with coverage

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f500bc44e08327a1cf0b89068dcccd