### PR TITLE
Add API gateway auth, observability, and tooling

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,12 @@
+NODE_ENV=development
+PORT=8080
+LOG_LEVEL=info
+JWT_SECRET=REPLACE_ME_with_256bit_hex
+JWT_ISSUER=apgms
+JWT_AUDIENCE=apgms-clients
+CORS_ALLOWLIST=http://localhost:3000,https://app.example.com
+RATE_LIMIT_MAX=300
+RATE_LIMIT_WINDOW=1 minute
+REDIS_URL=redis://localhost:6379
+DATABASE_URL=postgresql://user:pass@localhost:5432/apgms
+REQUEST_ID_HEADER=x-request-id

--- a/apgms/.github/workflows/release.yml
+++ b/apgms/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+on:
+  push:
+    branches: [ main, master ]
+  workflow_dispatch:
+jobs:
+  build-scan-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (gateway)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}-api-gateway
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+      - name: Build (gateway)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apgms/services/api-gateway/Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Trivy scan (gateway)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+        continue-on-error: true
+      - name: Build & Push (gateway)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apgms/services/api-gateway/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/apgms/docs/slo.md
+++ b/apgms/docs/slo.md
@@ -1,0 +1,24 @@
+# APGMS SLI/SLOs
+
+## Services in scope
+- API Gateway (`services/api-gateway`)
+
+## SLIs
+- Availability: proportion of 2xx/3xx responses.
+- Latency (p95): GET TTFB; POST total duration.
+- Error Rate: proportion of 5xx responses.
+- Readiness: /ready returns UP (200) when dependencies are reachable.
+
+## SLOs (quarterly)
+- Availability: ≥ 99.9%
+- Latency p95: GET ≤ 300ms, POST ≤ 700ms
+- Error Rate: < 0.5%
+- Readiness: ≥ 99.9%
+
+## Alert policy
+- Page if Availability < 99.0% for 5 minutes or Error Rate ≥ 1% for 5 minutes.
+- Ticket if Latency p95 breached for 30 minutes.
+
+## Load-testing regimen
+- Smoke: `k6 run k6/smoke.js -e BASE_URL=https://api.example.com`
+- Load:  `k6 run k6/load.js -e BASE_URL=https://staging-api.example.com`

--- a/apgms/k6/load.js
+++ b/apgms/k6/load.js
@@ -1,0 +1,23 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  stages: [
+    { duration: '1m', target: 10 },
+    { duration: '3m', target: 50 },
+    { duration: '1m', target: 0 },
+  ],
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    http_req_duration: ['p(95)<700', 'p(99)<1500'],
+  }
+};
+
+export default function () {
+  const base = __ENV.BASE_URL || 'http://localhost:8080';
+  const r1 = http.get(`${base}/health`);
+  const r2 = http.get(`${base}/ready`);
+  check(r1, { 'health 200': (r) => r.status === 200 });
+  check(r2, { 'ready 200/503': (r) => [200,503].includes(r.status) });
+  sleep(0.3);
+}

--- a/apgms/k6/smoke.js
+++ b/apgms/k6/smoke.js
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 1,
+  duration: '30s',
+  thresholds: { http_req_failed: ['rate<0.01'], http_req_duration: ['p(95)<500'] }
+};
+
+export default function () {
+  const base = __ENV.BASE_URL || 'http://localhost:8080';
+  ['/health','/ready','/metrics'].forEach((p) => {
+    const res = http.get(`${base}${p}`);
+    check(res, { 'ok': (r) => [200,503].includes(r.status) });
+  });
+  sleep(1);
+}

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,47 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "vitest run",
+    "emit:openapi": "tsx scripts/emit-openapi.ts",
+    "key:rotate": "tsx scripts/key-rotate.ts",
+    "perf:smoke": "k6 run k6/smoke.js",
+    "perf:load": "k6 run k6/load.js",
+    "perf:smoke:docker": "docker run --rm -i -e BASE_URL=$BASE_URL -v $PWD:/work -w /work grafana/k6 run k6/smoke.js",
+    "perf:load:docker": "docker run --rm -i -e BASE_URL=$BASE_URL -v $PWD:/work -w /work grafana/k6 run k6/load.js"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.19.0",
+    "typescript": "^5.9.3",
+    "@fastify/swagger": "^9.4.0",
+    "@fastify/swagger-ui": "^3.0.0",
+    "@fastify/helmet": "^12.5.0",
+    "@fastify/rate-limit": "^10.1.0",
+    "@fastify/cors": "^10.0.0",
+    "@opentelemetry/api": "^1.9.0",
+    "prom-client": "^15.1.3",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.0",
+    "zod-validation-error": "^2.1.0",
+    "vitest": "^2.0.0",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^2.0.12",
+    "@fastify/jwt": "^7.0.1"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/packages/shared/src/schemas/report.ts
+++ b/apgms/packages/shared/src/schemas/report.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const reportTypeEnum = z.enum([
+  'COMPLIANCE_SUMMARY',
+  'PAYMENT_HISTORY',
+  'TAX_OBLIGATIONS',
+  'DISCREPANCY_LOG',
+]);
+
+export const ReportRequestSchema = z.object({
+  reportType: reportTypeEnum,
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date (YYYY-MM-DD)'),
+  endDate:   z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date (YYYY-MM-DD)'),
+})
+.refine(d => {
+  const s = new Date(d.startDate + 'T00:00:00Z').getTime();
+  const e = new Date(d.endDate   + 'T23:59:59Z').getTime();
+  return e >= s;
+}, { message: 'End date must be after or equal to start date', path: ['endDate'] })
+.refine(d => {
+  const s = new Date(d.startDate + 'T00:00:00Z').getTime();
+  const e = new Date(d.endDate   + 'T23:59:59Z').getTime();
+  return (e - s) / 86400000 <= 366;
+}, { message: 'Date range cannot exceed 12 months', path: ['endDate'] });
+
+export type ReportRequest = z.infer<typeof ReportRequestSchema>;
+
+export const ReportOutSchema = z.object({
+  reportId: z.string(),
+});
+export type ReportOut = z.infer<typeof ReportOutSchema>;

--- a/apgms/scripts/emit-openapi.ts
+++ b/apgms/scripts/emit-openapi.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fastify from 'fastify';
+import openapiPlugin from '../services/api-gateway/src/plugins/openapi';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import { reportsRoutes } from '../services/api-gateway/src/routes/v1/reports';
+
+async function main() {
+  const app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 300, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+
+  await app.ready();
+  const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+  if (res.statusCode !== 200) throw new Error('Failed to fetch /openapi.json: ' + res.statusCode);
+  const spec = res.json();
+  const out = path.resolve(process.cwd(), 'apgms/openapi.json');
+  fs.writeFileSync(out, JSON.stringify(spec, null, 2), 'utf8');
+  await app.close();
+  console.log('OpenAPI written to', out);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/apgms/scripts/key-rotate.ts
+++ b/apgms/scripts/key-rotate.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+function generateHex(bytes = 32) { return crypto.randomBytes(bytes).toString('hex'); }
+
+function rotateInEnvFile(envPath: string) {
+  if (!fs.existsSync(envPath)) {
+    console.log(`[key-rotate] No .env found at ${envPath}. Printing new secret to stdout.`);
+    console.log(`JWT_SECRET=${generateHex(32)}`);
+    return;
+  }
+  const backupPath = envPath + '.bak.' + Date.now();
+  fs.copyFileSync(envPath, backupPath);
+  const raw = fs.readFileSync(envPath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+  let found = false;
+  const next = lines.map((line) => {
+    if (/^\s*JWT_SECRET\s*=/.test(line)) { found = true; return `JWT_SECRET=${generateHex(32)}`; }
+    return line;
+  });
+  if (!found) next.push(`JWT_SECRET=${generateHex(32)}`);
+  fs.writeFileSync(envPath, next.join('\n'), 'utf8');
+  console.log(`[key-rotate] Rotated JWT_SECRET in ${envPath}`);
+  console.log(`[key-rotate] Backup created at ${backupPath}`);
+}
+
+(function main(){
+  const repoRoot = process.cwd();
+  const envPath = path.join(repoRoot, 'apgms/.env');
+  rotateInEnvFile(envPath);
+})();

--- a/apgms/services/api-gateway/.dockerignore
+++ b/apgms/services/api-gateway/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+pnpm-debug.log
+.DS_Store
+.git
+.gitignore
+coverage
+dist
+.env
+.env.*

--- a/apgms/services/api-gateway/Dockerfile
+++ b/apgms/services/api-gateway/Dockerfile
@@ -1,0 +1,27 @@
+# ---- Build stage ----
+FROM node:20-alpine AS builder
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+WORKDIR /app
+
+COPY pnpm-lock.yaml ./
+COPY package.json ./
+COPY packages ./packages
+COPY services/api-gateway/package.json ./services/api-gateway/package.json
+COPY services/api-gateway/tsconfig.json ./services/api-gateway/tsconfig.json
+COPY services/api-gateway ./services/api-gateway
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm -r build
+RUN pnpm -r prune --prod
+
+# ---- Runtime stage ----
+FROM node:20-alpine AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=builder /app/services/api-gateway/dist ./services/api-gateway/dist
+COPY --from=builder /app/services/api-gateway/package.json ./services/api-gateway/package.json
+COPY --from=builder /app/node_modules ./node_modules
+EXPOSE 8080
+CMD ["node", "services/api-gateway/dist/index.js"]

--- a/apgms/services/api-gateway/src/config.ts
+++ b/apgms/services/api-gateway/src/config.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+const EnvSchema = z.object({
+  NODE_ENV: z.enum(['production','development','test']).default('development'),
+  PORT: z.coerce.number().int().positive().default(8080),
+  LOG_LEVEL: z.enum(['fatal','error','warn','info','debug','trace','silent']).default('info'),
+  JWT_SECRET: z.string().min(32, 'JWT_SECRET must be at least 32 chars (use 256-bit hex)'),
+  JWT_ISSUER: z.string().default('apgms'),
+  JWT_AUDIENCE: z.string().default('apgms-clients'),
+  CORS_ALLOWLIST: z.string().default('http://localhost:3000'),
+  RATE_LIMIT_MAX: z.coerce.number().int().positive().default(300),
+  RATE_LIMIT_WINDOW: z.string().default('1 minute'),
+  REDIS_URL: z.string().optional(),
+  DATABASE_URL: z.string().optional(),
+  REQUEST_ID_HEADER: z.string().default('x-request-id'),
+});
+
+export type AppConfig = z.infer<typeof EnvSchema>;
+let cached: AppConfig | null = null;
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  if (cached) return cached;
+  const parsed = EnvSchema.safeParse(env);
+  if (!parsed.success) {
+    const errs = parsed.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ');
+    throw new Error(`Invalid environment configuration: ${errs}`);
+  }
+  cached = parsed.data;
+  return cached!;
+}
+
+const config = loadConfig();
+export default config;

--- a/apgms/services/api-gateway/src/hooks/org-scope.ts
+++ b/apgms/services/api-gateway/src/hooks/org-scope.ts
@@ -1,0 +1,13 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+export async function orgScopeHook(req: FastifyRequest, reply: FastifyReply) {
+  const user = (req as any).user;
+  if (!user?.orgId) {
+    return reply.code(401).send({ code: 'UNAUTHENTICATED' });
+  }
+  const params = (req.params ?? {}) as Record<string, string>;
+  if (params.orgId && params.orgId !== user.orgId) {
+    return reply.code(403).send({ code: 'FORBIDDEN' });
+  }
+  (req as any).orgId = user.orgId;
+}

--- a/apgms/services/api-gateway/src/plugins/audit.ts
+++ b/apgms/services/api-gateway/src/plugins/audit.ts
@@ -1,0 +1,32 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+type AuditRecord = {
+  ts: string; method: string; url: string; status: number;
+  requestId?: string; userId?: string; orgId?: string;
+};
+
+declare module 'fastify' {
+  interface FastifyInstance { auditSink: AuditRecord[]; }
+}
+
+export const auditPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.decorate('auditSink', [] as AuditRecord[]);
+  app.addHook('onResponse', async (req, reply) => {
+    const m = (req.method || '').toUpperCase();
+    if (!['POST','PUT','PATCH','DELETE'].includes(m)) return;
+    const rec: AuditRecord = {
+      ts: new Date().toISOString(),
+      method: m,
+      url: req.url,
+      status: reply.statusCode,
+      requestId: (req as any).requestId,
+      userId: (req as any).user?.id,
+      orgId: (req as any).orgId,
+    };
+    app.auditSink.push(rec);
+    if (process.env.NODE_ENV !== 'test') app.log.info({ audit: rec }, 'mutation_audit');
+  });
+});
+
+export default auditPlugin;

--- a/apgms/services/api-gateway/src/plugins/auth.ts
+++ b/apgms/services/api-gateway/src/plugins/auth.ts
@@ -1,0 +1,39 @@
+/// <reference types="fastify/types/logger" />
+import fp from 'fastify-plugin';
+import fjwt from '@fastify/jwt';
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
+
+type JwtUser = { id: string; orgId: string; roles?: string[] };
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    authenticate: (req: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  }
+  interface FastifyRequest {
+    user?: JwtUser;
+  }
+}
+
+export const authPlugin: FastifyPluginAsync = fp(async (app) => {
+  const secret = process.env.JWT_SECRET || 'dev-secret';
+  const issuer = process.env.JWT_ISSUER || 'apgms';
+  const audience = process.env.JWT_AUDIENCE || 'apgms-clients';
+
+  await app.register(fjwt, {
+    secret,
+    sign: { issuer, audience, algorithm: 'HS256' },
+    verify: { issuer, audience, algorithms: ['HS256'] },
+  });
+
+  app.decorate('authenticate', async (req, reply) => {
+    try {
+      const tok = await req.jwtVerify<{ id: string; orgId: string; roles?: string[] }>();
+      if (!tok?.id || !tok?.orgId) throw new Error('missing-claims');
+      req.user = { id: tok.id, orgId: tok.orgId, roles: tok.roles ?? [] };
+    } catch {
+      reply.code(401).send({ code: 'UNAUTHENTICATED' });
+    }
+  });
+});
+
+export default authPlugin;

--- a/apgms/services/api-gateway/src/plugins/cors-allowlist.ts
+++ b/apgms/services/api-gateway/src/plugins/cors-allowlist.ts
@@ -1,0 +1,29 @@
+import fp from 'fastify-plugin';
+import cors from '@fastify/cors';
+import { FastifyPluginAsync } from 'fastify';
+
+function parseAllowlist(v?: string): string[] {
+  if (!v || !v.trim()) return ['http://localhost:3000'];
+  return v.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+export const corsAllowlistPlugin: FastifyPluginAsync = fp(async (app) => {
+  const allowlist = parseAllowlist(process.env.CORS_ALLOWLIST);
+  const wildcard = allowlist.includes('*');
+
+  await app.register(cors, {
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true);
+      if (wildcard) return cb(null, true);
+      const ok = allowlist.includes(origin);
+      cb(ok ? null : new Error('CORS_ORIGIN_NOT_ALLOWED'), ok);
+    },
+    credentials: true,
+    methods: ['GET','HEAD','POST','PUT','PATCH','DELETE','OPTIONS'],
+    allowedHeaders: ['Content-Type','Authorization','Idempotency-Key','X-Request-Id'],
+    exposedHeaders: ['X-Request-Id','Idempotent-Replay'],
+    maxAge: 86400
+  });
+});
+
+export default corsAllowlistPlugin;

--- a/apgms/services/api-gateway/src/plugins/health.ts
+++ b/apgms/services/api-gateway/src/plugins/health.ts
@@ -1,0 +1,51 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+type CheckResult = { status: 'UP'|'DOWN'|'SKIPPED'; details?: string };
+
+async function checkRedis(app: any): Promise<CheckResult> {
+  if (!app.redis || typeof app.redis.ping !== 'function') return { status: 'SKIPPED' };
+  try {
+    const pong = await app.redis.ping();
+    return (pong && String(pong).toUpperCase().includes('PONG')) ? { status: 'UP' } : { status: 'DOWN', details: String(pong) };
+  } catch (e: any) {
+    return { status: 'DOWN', details: e?.message || 'redis error' };
+  }
+}
+
+async function checkDatabase(app: any): Promise<CheckResult> {
+  if (!app.prisma) return { status: 'SKIPPED' };
+  try {
+    if (typeof app.prisma.$queryRaw === 'function') {
+      await app.prisma.$queryRaw`SELECT 1`;
+      return { status: 'UP' };
+    }
+    if (typeof app.prisma.$connect === 'function') {
+      await app.prisma.$connect();
+      if (typeof app.prisma.$disconnect === 'function') await app.prisma.$disconnect();
+      return { status: 'UP' };
+    }
+    return { status: 'SKIPPED' };
+  } catch (e: any) {
+    return { status: 'DOWN', details: e?.message || 'db error' };
+  }
+}
+
+export const healthPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.get('/health', async (_req, reply) => {
+    reply.send({ status: 'UP' });
+  });
+
+  app.get('/ready', async (_req, reply) => {
+    const redis = await checkRedis(app);
+    const db = await checkDatabase(app);
+    const components: Record<string, CheckResult> = { redis, database: db };
+    const discovered = Object.values(components).filter(c => c.status !== 'SKIPPED');
+    const allUp = discovered.length === 0 ? true : discovered.every(c => c.status === 'UP');
+    const status = allUp ? 'UP' : 'DOWN';
+    const code = allUp ? 200 : 503;
+    reply.code(code).send({ status, checks: components, timestamp: new Date().toISOString() });
+  });
+});
+
+export default healthPlugin;

--- a/apgms/services/api-gateway/src/plugins/idempotency.ts
+++ b/apgms/services/api-gateway/src/plugins/idempotency.ts
@@ -1,0 +1,40 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import { createHash } from 'crypto';
+
+export const idempotencyPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.addHook('preHandler', async (req, reply) => {
+    const method = (req.method || 'GET').toUpperCase();
+    if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return;
+
+    const key = (req.headers['idempotency-key'] as string | undefined)?.trim();
+    const bodyHash = createHash('sha256').update(JSON.stringify(req.body ?? {})).digest('hex');
+    // @ts-ignore
+    const orgId = (req as any).orgId || 'anon';
+    const idem = key || bodyHash;
+    (req as any).__idemKey = idem;
+    (req as any).__idemCacheKey = `idem:${orgId}:${req.routerPath || req.url}:${idem}`;
+
+    if (app.redis) {
+      const cached = await app.redis.get((req as any).__idemCacheKey);
+      if (cached) {
+        reply.header('Idempotent-Replay', 'true');
+        return reply.code(200).send(JSON.parse(cached));
+      }
+    }
+  });
+
+  app.addHook('onSend', async (req, reply, payload) => {
+    const method = (req.method || 'GET').toUpperCase();
+    if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return payload;
+    if (reply.statusCode >= 200 && reply.statusCode < 300 && (req as any).__idemCacheKey && app.redis) {
+      try {
+        const value = typeof payload === 'string' ? payload : JSON.stringify(payload);
+        await app.redis!.set((req as any).__idemCacheKey, value, 'EX', 3600);
+      } catch {}
+    }
+    return payload;
+  });
+});
+
+export default idempotencyPlugin;

--- a/apgms/services/api-gateway/src/plugins/metrics.ts
+++ b/apgms/services/api-gateway/src/plugins/metrics.ts
@@ -1,0 +1,50 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import client from 'prom-client';
+
+const DEFAULT_BUCKETS = [0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10];
+
+export const metricsPlugin: FastifyPluginAsync = fp(async (app) => {
+  if (!(client as any).__apgms_registered) {
+    client.collectDefaultMetrics();
+    (client as any).__apgms_registered = true;
+  }
+
+  const httpHistogram = new client.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method','route','status_code','trace_id'],
+    buckets: DEFAULT_BUCKETS,
+  });
+
+  const httpCounter = new client.Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method','route','status_code','trace_id'],
+  });
+
+  app.addHook('onRequest', async (req) => {
+    (req as any).__metricsStart = process.hrtime.bigint();
+  });
+
+  app.addHook('onResponse', async (req, reply) => {
+    const start = (req as any).__metricsStart as bigint | undefined;
+    const end = process.hrtime.bigint();
+    const seconds = start ? Number(end - start) / 1e9 : 0;
+    const method = (req.method || 'GET').toUpperCase();
+    // @ts-ignore
+    const route = (reply.context?.config?.url) || (req as any).routerPath || req.url || 'unknown';
+    const status = String(reply.statusCode || 200);
+    const traceId = (req as any).traceId || 'none';
+
+    httpHistogram.observe({ method, route, status_code: status, trace_id: traceId }, seconds);
+    httpCounter.inc({ method, route, status_code: status, trace_id: traceId });
+  });
+
+  app.get('/metrics', async (_req, reply) => {
+    reply.header('Content-Type', client.register.contentType);
+    return client.register.metrics();
+  });
+});
+
+export default metricsPlugin;

--- a/apgms/services/api-gateway/src/plugins/openapi.ts
+++ b/apgms/services/api-gateway/src/plugins/openapi.ts
@@ -1,0 +1,33 @@
+import fp from 'fastify-plugin';
+import swagger from '@fastify/swagger';
+import swaggerUI from '@fastify/swagger-ui';
+import { FastifyPluginAsync } from 'fastify';
+
+export const openapiPlugin: FastifyPluginAsync = fp(async (app) => {
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: 'APGMS Gateway',
+        description: 'API Gateway OpenAPI specification',
+        version: '1.0.0',
+      },
+      servers: [{ url: '/' }],
+      components: { securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }
+      }},
+      security: [{ bearerAuth: [] }],
+    },
+  });
+
+  await app.register(swaggerUI, {
+    routePrefix: '/docs',
+    staticCSP: true,
+  });
+
+  app.get('/openapi.json', async (_req, reply) => {
+    const spec = await app.swagger();
+    reply.type('application/json').send(spec);
+  });
+});
+
+export default openapiPlugin;

--- a/apgms/services/api-gateway/src/plugins/redis.ts
+++ b/apgms/services/api-gateway/src/plugins/redis.ts
@@ -1,0 +1,25 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+type RedisLike = {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, mode?: string, ttl?: number): Promise<any>;
+  ping(): Promise<string>;
+};
+
+declare module 'fastify' {
+  interface FastifyInstance { redis?: RedisLike; }
+}
+
+export const redisPlugin: FastifyPluginAsync = fp(async (app) => {
+  const url = process.env.REDIS_URL;
+  if (!url) return; // optional
+  const { createClient } = require('redis');
+  const client = createClient({ url });
+  client.on('error', (e: any) => app.log.error({ err: e }, 'redis_error'));
+  await client.connect();
+  app.decorate('redis', client);
+  app.addHook('onClose', async () => { try { await client.quit(); } catch {} });
+});
+
+export default redisPlugin;

--- a/apgms/services/api-gateway/src/plugins/request-id.ts
+++ b/apgms/services/api-gateway/src/plugins/request-id.ts
@@ -1,0 +1,15 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import { randomUUID } from 'crypto';
+
+export const requestIdPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.addHook('onRequest', async (req, reply) => {
+    let rid = (req.headers['x-request-id'] as string | undefined)?.trim();
+    const uuidV4Re = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!rid || !uuidV4Re.test(rid)) rid = randomUUID();
+    (req as any).requestId = rid;
+    reply.header('x-request-id', rid);
+  });
+});
+
+export default requestIdPlugin;

--- a/apgms/services/api-gateway/src/plugins/tracing.ts
+++ b/apgms/services/api-gateway/src/plugins/tracing.ts
@@ -1,0 +1,34 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import { randomBytes } from 'crypto';
+
+function generateTraceId(): string { return randomBytes(16).toString('hex'); }
+function generateSpanId(): string { return randomBytes(8).toString('hex'); }
+
+function parseOrCreateTraceparent(inbound?: string): { traceId: string; spanId: string; sampled: string } {
+  try {
+    if (inbound && inbound.startsWith('00-')) {
+      const parts = inbound.split('-');
+      if (parts.length >= 4) {
+        const [ , traceId, spanId, flags ] = parts;
+        if (traceId?.length === 32 && spanId?.length === 16) {
+          return { traceId, spanId, sampled: flags || '01' };
+        }
+      }
+    }
+  } catch {}
+  return { traceId: generateTraceId(), spanId: generateSpanId(), sampled: '01' };
+}
+
+export const tracingPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.addHook('onRequest', async (req, reply) => {
+    const inbound = (req.headers['traceparent'] as string | undefined);
+    const parsed = parseOrCreateTraceparent(inbound);
+    (req as any).traceId = parsed.traceId;
+    (req as any).spanId = parsed.spanId;
+    reply.header('traceparent', `00-${parsed.traceId}-${parsed.spanId}-${parsed.sampled}`);
+    reply.header('x-trace-id', parsed.traceId);
+  });
+});
+
+export default tracingPlugin;

--- a/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
+++ b/apgms/services/api-gateway/src/routes/v1/bank-lines.ts
@@ -1,0 +1,11 @@
+import { FastifyInstance } from 'fastify';
+import { randomUUID } from 'crypto';
+
+export async function bankLinesRoutes(app: FastifyInstance) {
+  app.post('/v1/orgs/:orgId/bank-lines', async (req, reply) => {
+    // @ts-ignore
+    const orgId = (req as any).orgId;
+    const id = randomUUID();
+    reply.code(201).send({ id, orgId });
+  });
+}

--- a/apgms/services/api-gateway/src/routes/v1/reports.ts
+++ b/apgms/services/api-gateway/src/routes/v1/reports.ts
@@ -1,0 +1,73 @@
+import { FastifyInstance } from 'fastify';
+import { ReportRequestSchema, ReportOutSchema } from '../../../../packages/shared/src/schemas/report';
+import { fromZodError } from 'zod-validation-error';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { createHash } from 'crypto';
+
+const ReportRequestJSON = zodToJsonSchema(ReportRequestSchema, 'ReportRequest');
+const ReportOutJSON     = zodToJsonSchema(ReportOutSchema, 'ReportOut');
+
+export async function reportsRoutes(app: FastifyInstance) {
+  app.post('/dashboard/generate-report', {
+    schema: {
+      description: 'Generate a report for the given period',
+      tags: ['reports'],
+      body: ReportRequestJSON as any,
+      response: {
+        200: ReportOutJSON as any,
+        401: { type: 'object', properties: { code: { type: 'string' } } },
+        422: { type: 'object', properties: { code: { type: 'string' }, errors: { type: 'object' } } },
+      },
+      security: [{ bearerAuth: [] }],
+    }
+  }, async (req, reply) => {
+    const parsed = ReportRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(422).send({ code: 'INVALID_BODY', errors: fromZodError(parsed.error) });
+    }
+
+    // @ts-ignore
+    const orgId = (req as any).orgId || 'demo-org';
+    const idemKey = (req.headers['idempotency-key'] as string | undefined);
+    const bodyHash = createHash('sha256').update(JSON.stringify(parsed.data)).digest('hex');
+    const cacheKey = `report:${orgId}:${idemKey ?? bodyHash}`;
+
+    if ((app as any).redis) {
+      const existing = await (app as any).redis.get(cacheKey);
+      if (existing) return reply.send({ reportId: existing });
+    }
+
+    const reportId = `${orgId}-${Date.now()}`;
+    if ((app as any).redis) await (app as any).redis.set(cacheKey, reportId, 'EX', 3600);
+
+    reply.send({ reportId });
+  });
+
+  app.get('/dashboard/report/:id/download', {
+    schema: {
+      description: 'Download a generated report PDF by id',
+      tags: ['reports'],
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+      },
+      response: {
+        200: { description: 'PDF file', content: { 'application/pdf': { schema: { type: 'string', format: 'binary' } } } },
+        401: { type: 'object', properties: { code: { type: 'string' } } },
+        403: { type: 'object', properties: { code: { type: 'string' } } },
+      },
+      security: [{ bearerAuth: [] }],
+    }
+  }, async (req, reply) => {
+    const { id } = (req.params as any);
+    // @ts-ignore
+    const orgId = (req as any).orgId || 'demo-org';
+
+    const pdf = Buffer.from('%PDF-1.4\n%...replace with actual pdf...\n', 'utf8');
+    reply
+      .type('application/pdf')
+      .header('Content-Disposition', `attachment; filename="apgms-report-${id}.pdf"`)
+      .send(pdf);
+  });
+}

--- a/apgms/services/api-gateway/test/auth.spec.ts
+++ b/apgms/services/api-gateway/test/auth.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import request from 'supertest';
+import authPlugin from '../src/plugins/auth';
+import { orgScopeHook } from '../src/hooks/org-scope';
+
+const JWT_SECRET = process.env.TEST_JWT_SECRET || 'dev-secret';
+
+function signHS256(payload: object) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const data = `${header}.${body}`;
+  const crypto = require('crypto');
+  const sig = crypto.createHmac('sha256', JWT_SECRET).update(data).digest('base64url');
+  return `${data}.${sig}`;
+}
+
+let app: any;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = JWT_SECRET;
+  process.env.JWT_ISSUER = 'apgms';
+  process.env.JWT_AUDIENCE = 'apgms-clients';
+
+  app = fastify();
+  await app.register(authPlugin);
+  app.register(async (i, _o, d) => {
+    i.addHook('preHandler', i.authenticate);
+    i.addHook('preHandler', orgScopeHook);
+    i.get('/v1/ping', async (_req, reply) => reply.send({ ok: true }));
+    i.get('/v1/orgs/:orgId/resource', async (_req, reply) => reply.send({ ok: true }));
+    d();
+  });
+  await app.listen({ port: 0 });
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('auth', () => {
+  it('rejects missing token', async () => {
+    const res = await request(app.server).get('/v1/ping');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHENTICATED');
+  });
+
+  it('rejects bad token', async () => {
+    const res = await request(app.server).get('/v1/ping').set('Authorization','Bearer bad.token.here');
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts good token', async () => {
+    const token = signHS256({ id: 'u1', orgId: 'orgA', iss: 'apgms', aud: 'apgms-clients' });
+    const res = await request(app.server).get('/v1/ping').set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});
+
+describe('org-scope', () => {
+  it('forbids cross-org access', async () => {
+    const token = signHS256({ id: 'u1', orgId: 'orgA', iss: 'apgms', aud: 'apgms-clients' });
+    const res = await request(app.server)
+      .get('/v1/orgs/orgB/resource')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('FORBIDDEN');
+  });
+
+  it('allows same-org access', async () => {
+    const token = signHS256({ id: 'u1', orgId: 'orgA', iss: 'apgms', aud: 'apgms-clients' });
+    const res = await request(app.server)
+      .get('/v1/orgs/orgA/resource')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apgms/services/api-gateway/test/config.spec.ts
+++ b/apgms/services/api-gateway/test/config.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { loadConfig } from '../src/config';
+
+describe('config validation', () => {
+  it('accepts valid env', () => {
+    const cfg = loadConfig({
+      NODE_ENV: 'test',
+      PORT: '8080',
+      LOG_LEVEL: 'info',
+      JWT_SECRET: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      JWT_ISSUER: 'apgms',
+      JWT_AUDIENCE: 'apgms-clients',
+      CORS_ALLOWLIST: 'http://localhost:3000',
+      RATE_LIMIT_MAX: '100',
+      RATE_LIMIT_WINDOW: '1 minute',
+      REQUEST_ID_HEADER: 'x-request-id',
+    } as any);
+    expect(cfg.PORT).toBe(8080);
+    expect(cfg.JWT_SECRET.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('rejects missing/weak JWT_SECRET', () => {
+    expect(() => loadConfig({
+      NODE_ENV: 'test',
+      PORT: '8080',
+      LOG_LEVEL: 'info',
+      JWT_ISSUER: 'apgms',
+      JWT_AUDIENCE: 'apgms-clients',
+      CORS_ALLOWLIST: 'http://localhost:3000',
+      RATE_LIMIT_MAX: '100',
+      RATE_LIMIT_WINDOW: '1 minute',
+    } as any)).toThrow(/JWT_SECRET/);
+  });
+});

--- a/apgms/services/api-gateway/test/contract.spec.ts
+++ b/apgms/services/api-gateway/test/contract.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import openapiPlugin from '../src/plugins/openapi';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import { reportsRoutes } from '../src/routes/v1/reports';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('openapi contract', () => {
+  it('exposes /openapi.json with report routes', async () => {
+    const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+    expect(res.statusCode).toBe(200);
+    const spec = res.json();
+    const paths = Object.keys(spec.paths || {});
+    expect(paths).toContain('/dashboard/generate-report');
+    expect(paths).toContain('/dashboard/report/{id}/download');
+  });
+});

--- a/apgms/services/api-gateway/test/http-security.spec.ts
+++ b/apgms/services/api-gateway/test/http-security.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import corsAllowlistPlugin from '../src/plugins/cors-allowlist';
+import requestIdPlugin from '../src/plugins/request-id';
+import auditPlugin from '../src/plugins/audit';
+
+let app: any;
+
+beforeAll(async () => {
+  process.env.CORS_ALLOWLIST = 'https://allowed.example.com,http://localhost:3000';
+  app = fastify({ logger: false });
+  await app.register(helmet);
+  await app.register(requestIdPlugin);
+  await app.register(corsAllowlistPlugin);
+  await app.register(rateLimit, { max: 50, timeWindow: '1 minute' });
+  await app.register(auditPlugin);
+  app.get('/ping', async (_req, reply) => reply.send({ ok: true }));
+  app.post('/mutate', async (_req, reply) => reply.code(201).send({ ok: true }));
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+it('allows allowed origin', async () => {
+  const res = await app.inject({ method: 'GET', url: '/ping', headers: { origin: 'https://allowed.example.com' } });
+  expect(res.statusCode).toBe(200);
+  expect(res.headers['access-control-allow-origin']).toBe('https://allowed.example.com');
+});
+
+it('adds x-request-id', async () => {
+  const res = await app.inject({ method: 'GET', url: '/ping' });
+  expect(res.headers['x-request-id']).toBeTruthy();
+});
+
+it('audits mutation', async () => {
+  const res = await app.inject({ method: 'POST', url: '/mutate' });
+  expect(res.statusCode).toBe(201);
+  expect(app.auditSink.length).toBeGreaterThan(0);
+});

--- a/apgms/services/api-gateway/test/idempotency.spec.ts
+++ b/apgms/services/api-gateway/test/idempotency.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import idempotencyPlugin from '../src/plugins/idempotency';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  // mock redis
+  const store = new Map<string, string>();
+  (app as any).redis = {
+    async get(k: string) { return store.get(k) ?? null; },
+    async set(k: string, v: string) { store.set(k, v); return 'OK'; },
+  };
+  await app.register(idempotencyPlugin);
+  app.post('/test', async (_req, reply) => reply.send({ ok: true, ts: 1 }));
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+it('replays same idempotency-key with Idempotent-Replay', async () => {
+  const key = 'abc123';
+  const first = await app.inject({ method: 'POST', url: '/test', headers: { 'idempotency-key': key }, payload: { x: 1 } });
+  expect(first.statusCode).toBe(200);
+  const second = await app.inject({ method: 'POST', url: '/test', headers: { 'idempotency-key': key }, payload: { x: 1 } });
+  expect(second.statusCode).toBe(200);
+  expect(second.headers['idempotent-replay']).toBe('true');
+  expect(second.json()).toEqual(first.json());
+});

--- a/apgms/services/api-gateway/test/observability.spec.ts
+++ b/apgms/services/api-gateway/test/observability.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import metricsPlugin from '../src/plugins/metrics';
+import healthPlugin from '../src/plugins/health';
+import tracingPlugin from '../src/plugins/tracing';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  (app as any).redis = { ping: async () => 'PONG' };
+  await app.register(tracingPlugin);
+  await app.register(metricsPlugin);
+  await app.register(healthPlugin);
+  app.get('/demo', async (_req, reply) => reply.send({ ok: true }));
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+it('health returns UP', async () => {
+  const res = await app.inject({ method: 'GET', url: '/health' });
+  expect(res.statusCode).toBe(200);
+  expect(res.json().status).toBe('UP');
+});
+
+it('ready checks redis', async () => {
+  const res = await app.inject({ method: 'GET', url: '/ready' });
+  const body = res.json();
+  expect(body.checks.redis.status).toBe('UP');
+});
+
+it('exposes Prometheus metrics', async () => {
+  await app.inject({ method: 'GET', url: '/demo' });
+  const res = await app.inject({ method: 'GET', url: '/metrics' });
+  expect(res.statusCode).toBe(200);
+  expect(res.headers['content-type']).toMatch(/text\/plain/);
+  expect(res.body).toContain('http_requests_total');
+});
+
+it('emits trace headers', async () => {
+  const res = await app.inject({ method: 'GET', url: '/demo' });
+  expect(res.headers['traceparent']).toBeTruthy();
+  expect(res.headers['x-trace-id']).toBeTruthy();
+});

--- a/apgms/services/api-gateway/test/reports.e2e.spec.ts
+++ b/apgms/services/api-gateway/test/reports.e2e.spec.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import openapiPlugin from '../src/plugins/openapi';
+import { reportsRoutes } from '../src/routes/v1/reports';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+it('rejects invalid body with 422', async () => {
+  const res = await app.inject({
+    method: 'POST', url: '/dashboard/generate-report',
+    payload: { reportType: 'PAYMENT_HISTORY', startDate: 'bad', endDate: 'also-bad' }
+  });
+  expect(res.statusCode).toBe(422);
+});
+
+it('accepts valid body', async () => {
+  const res = await app.inject({
+    method: 'POST', url: '/dashboard/generate-report',
+    payload: { reportType: 'PAYMENT_HISTORY', startDate: '2024-07-01', endDate: '2024-07-31' }
+  });
+  expect(res.statusCode).toBe(200);
+  expect(res.json()).toHaveProperty('reportId');
+});

--- a/apgms/vitest.config.ts
+++ b/apgms/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    watch: false,
+    reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json', 'lcov'],
+      lines: 80, statements: 80, functions: 80, branches: 75
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add authentication/org scoping, redis-backed idempotency, and HTTP hardening plugins to the API gateway
- expose report schemas with OpenAPI support, tracing/metrics/health endpoints, and supporting scripts/tests
- introduce k6 performance scenarios, SLO documentation, container build assets, and release automation

## Testing
- not run (pnpm dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68f503ae91788327ad78c18439aec581