### PR TITLE
Add security plugins to API gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -14,6 +14,9 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^12.5.1",
+    "@fastify/rate-limit": "^10.1.1",
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -8,12 +8,23 @@ const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
-import cors from "@fastify/cors";
+import helmet from "@fastify/helmet";
+import rateLimit from "@fastify/rate-limit";
 import { prisma } from "../../../shared/src/db";
+import corsAllowlistPlugin from "./plugins/cors-allowlist";
+import requestIdPlugin from "./plugins/request-id";
+import auditPlugin from "./plugins/audit";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+await app.register(helmet);
+await app.register(requestIdPlugin);
+await app.register(corsAllowlistPlugin);
+await app.register(rateLimit, {
+  max: Number(process.env.RATE_LIMIT_MAX ?? 300),
+  timeWindow: process.env.RATE_LIMIT_WINDOW ?? "1 minute",
+});
+await app.register(auditPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
@@ -77,4 +88,3 @@ app.listen({ port, host }).catch((err) => {
   app.log.error(err);
   process.exit(1);
 });
-

--- a/apgms/services/api-gateway/src/plugins/audit.ts
+++ b/apgms/services/api-gateway/src/plugins/audit.ts
@@ -1,0 +1,27 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+type AuditRecord = {
+  ts: string; method: string; url: string; status: number;
+  requestId?: string; userId?: string; orgId?: string;
+};
+
+declare module 'fastify' {
+  interface FastifyInstance { auditSink: AuditRecord[]; }
+}
+
+export const auditPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.decorate('auditSink', [] as AuditRecord[]);
+  app.addHook('onResponse', async (req, reply) => {
+    const method = (req.method || '').toUpperCase();
+    if (!['POST','PUT','PATCH','DELETE'].includes(method)) return;
+    const rec: AuditRecord = {
+      ts: new Date().toISOString(),
+      method, url: req.url, status: reply.statusCode,
+      requestId: (req as any).requestId, userId: (req as any).user?.id, orgId: (req as any).orgId,
+    };
+    app.auditSink.push(rec);
+    if (process.env.NODE_ENV !== 'test') app.log.info({ audit: rec }, 'mutation_audit');
+  });
+});
+export default auditPlugin;

--- a/apgms/services/api-gateway/src/plugins/cors-allowlist.ts
+++ b/apgms/services/api-gateway/src/plugins/cors-allowlist.ts
@@ -1,0 +1,27 @@
+import fp from 'fastify-plugin';
+import cors from '@fastify/cors';
+import { FastifyPluginAsync } from 'fastify';
+
+function parseAllowlist(v?: string): string[] {
+  if (!v || !v.trim()) return ['http://localhost:3000'];
+  return v.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+export const corsAllowlistPlugin: FastifyPluginAsync = fp(async (app) => {
+  const allowlist = parseAllowlist(process.env.CORS_ALLOWLIST);
+  const wildcard = allowlist.includes('*');
+  await app.register(cors, {
+    origin: (origin, cb) => {
+      if (!origin) return cb(null, true);
+      if (wildcard) return cb(null, true);
+      const ok = allowlist.includes(origin);
+      cb(ok ? null : new Error('CORS_ORIGIN_NOT_ALLOWED'), ok);
+    },
+    credentials: true,
+    methods: ['GET','HEAD','POST','PUT','PATCH','DELETE','OPTIONS'],
+    allowedHeaders: ['Content-Type','Authorization','Idempotency-Key','X-Request-Id'],
+    exposedHeaders: ['X-Request-Id','Idempotent-Replay'],
+    maxAge: 86400
+  });
+});
+export default corsAllowlistPlugin;

--- a/apgms/services/api-gateway/src/plugins/request-id.ts
+++ b/apgms/services/api-gateway/src/plugins/request-id.ts
@@ -1,0 +1,14 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import { randomUUID } from 'crypto';
+
+export const requestIdPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.addHook('onRequest', async (req, reply) => {
+    let rid = (req.headers['x-request-id'] as string | undefined)?.trim();
+    const uuidV4Re = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    if (!rid || !uuidV4Re.test(rid)) rid = randomUUID();
+    (req as any).requestId = rid;
+    reply.header('x-request-id', rid);
+  });
+});
+export default requestIdPlugin;

--- a/apgms/services/api-gateway/test/http-security.spec.ts
+++ b/apgms/services/api-gateway/test/http-security.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import corsAllowlistPlugin from '../src/plugins/cors-allowlist';
+import requestIdPlugin from '../src/plugins/request-id';
+import auditPlugin from '../src/plugins/audit';
+
+let app: any;
+
+beforeAll(async () => {
+  process.env.CORS_ALLOWLIST = 'https://allowed.example.com,http://localhost:3000';
+  app = fastify({ logger: false });
+  await app.register(helmet);
+  await app.register(requestIdPlugin);
+  await app.register(corsAllowlistPlugin);
+  await app.register(rateLimit, { max: 50, timeWindow: '1 minute' });
+  await app.register(auditPlugin);
+  app.get('/ping', async (_req, reply) => reply.send({ ok: true }));
+  app.post('/mutate', async (_req, reply) => reply.code(201).send({ ok: true }));
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('CORS allowlist', () => {
+  it('allows allowed origin', async () => {
+    const res = await app.inject({ method: 'GET', url: '/ping', headers: { origin: 'https://allowed.example.com' } });
+    expect(res.headers['access-control-allow-origin']).toBe('https://allowed.example.com');
+  });
+});
+
+describe('request-id & audit', () => {
+  it('adds x-request-id and logs mutation', async () => {
+    const res = await app.inject({ method: 'POST', url: '/mutate' });
+    expect(res.headers['x-request-id']).toBeTruthy();
+    expect(app.auditSink.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Fastify plugins for request IDs, audit logging, and CORS allowlisting
- register helmet, rate limiting, and security plugins in the API gateway
- add vitest coverage for HTTP surface security behaviours

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f50b00f1dc832794a02daa0c738355