### PR TITLE
feat: add reports openapi contract and tooling

### DIFF
--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,34 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test",
+    "emit:openapi": "tsx scripts/emit-openapi.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3",
+    "@fastify/swagger": "^8.15.0",
+    "@fastify/swagger-ui": "^5.2.0",
+    "zod-to-json-schema": "^3.23.3",
+    "zod-validation-error": "^3.3.1",
+    "@fastify/helmet": "^12.0.1",
+    "@fastify/rate-limit": "^9.0.1"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/packages/shared/src/schemas/report.ts
+++ b/apgms/packages/shared/src/schemas/report.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+export const reportTypeEnum = z.enum([
+  'COMPLIANCE_SUMMARY',
+  'PAYMENT_HISTORY',
+  'TAX_OBLIGATIONS',
+  'DISCREPANCY_LOG',
+]);
+
+export const ReportRequestSchema = z.object({
+  reportType: reportTypeEnum,
+  startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date (YYYY-MM-DD)'),
+  endDate:   z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date (YYYY-MM-DD)'),
+})
+.refine(d => {
+  const s = new Date(d.startDate + 'T00:00:00Z').getTime();
+  const e = new Date(d.endDate   + 'T23:59:59Z').getTime();
+  return e >= s;
+}, { message: 'End date must be after or equal to start date', path: ['endDate'] })
+.refine(d => {
+  const s = new Date(d.startDate + 'T00:00:00Z').getTime();
+  const e = new Date(d.endDate   + 'T23:59:59Z').getTime();
+  return (e - s) / 86400000 <= 366;
+}, { message: 'Date range cannot exceed 12 months', path: ['endDate'] });
+
+export type ReportRequest = z.infer<typeof ReportRequestSchema>;
+
+export const ReportOutSchema = z.object({
+  reportId: z.string(),
+});
+export type ReportOut = z.infer<typeof ReportOutSchema>;

--- a/apgms/scripts/emit-openapi.ts
+++ b/apgms/scripts/emit-openapi.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fastify from 'fastify';
+import openapiPlugin from '../services/api-gateway/src/plugins/openapi';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import { reportsRoutes } from '../services/api-gateway/src/routes/v1/reports';
+
+async function main() {
+  const app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 300, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+
+  await app.ready();
+  const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+  if (res.statusCode !== 200) throw new Error('Failed to get openapi.json');
+  const spec = res.json();
+  const out = path.resolve(process.cwd(), 'openapi.json');
+  fs.writeFileSync(out, JSON.stringify(spec, null, 2), 'utf8');
+  await app.close();
+  console.log('OpenAPI written to', out);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,18 +4,27 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
-    "zod": "^4.1.12"
+    "zod": "^4.1.12",
+    "@fastify/helmet": "^12.0.1",
+    "@fastify/rate-limit": "^9.0.1",
+    "@fastify/swagger": "^8.15.0",
+    "@fastify/swagger-ui": "^5.2.0",
+    "fastify-plugin": "^5.0.1",
+    "zod-to-json-schema": "^3.23.3",
+    "zod-validation-error": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.1"
   }
 }

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,10 +10,12 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import openapiPlugin from "./plugins/openapi";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(openapiPlugin);
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");

--- a/apgms/services/api-gateway/src/plugins/openapi.ts
+++ b/apgms/services/api-gateway/src/plugins/openapi.ts
@@ -1,0 +1,33 @@
+import fp from 'fastify-plugin';
+import swagger from '@fastify/swagger';
+import swaggerUI from '@fastify/swagger-ui';
+import { FastifyPluginAsync } from 'fastify';
+
+export const openapiPlugin: FastifyPluginAsync = fp(async (app) => {
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: 'APGMS Gateway',
+        description: 'API Gateway OpenAPI specification',
+        version: '1.0.0',
+      },
+      servers: [{ url: '/' }],
+      components: { securitySchemes: {
+        bearerAuth: { type: 'http', scheme: 'bearer', bearerFormat: 'JWT' }
+      }},
+      security: [{ bearerAuth: [] }],
+    },
+  });
+
+  await app.register(swaggerUI, {
+    routePrefix: '/docs',
+    staticCSP: true,
+  });
+
+  app.get('/openapi.json', async (_req, reply) => {
+    const spec = await app.swagger();
+    reply.type('application/json').send(spec);
+  });
+});
+
+export default openapiPlugin;

--- a/apgms/services/api-gateway/src/routes/v1/reports.ts
+++ b/apgms/services/api-gateway/src/routes/v1/reports.ts
@@ -1,0 +1,73 @@
+import { FastifyInstance } from 'fastify';
+import { ReportRequestSchema, ReportOutSchema } from '../../../../packages/shared/src/schemas/report';
+import { fromZodError } from 'zod-validation-error';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { createHash } from 'crypto';
+
+const ReportRequestJSON = zodToJsonSchema(ReportRequestSchema, 'ReportRequest');
+const ReportOutJSON     = zodToJsonSchema(ReportOutSchema, 'ReportOut');
+
+export async function reportsRoutes(app: FastifyInstance) {
+  app.post('/dashboard/generate-report', {
+    schema: {
+      description: 'Generate a report for the given period',
+      tags: ['reports'],
+      body: ReportRequestJSON as any,
+      response: {
+        200: ReportOutJSON as any,
+        401: { type: 'object', properties: { code: { type: 'string' } } },
+        422: { type: 'object', properties: { code: { type: 'string' }, errors: { type: 'object' } } },
+      },
+      security: [{ bearerAuth: [] }],
+    }
+  }, async (req, reply) => {
+    const parsed = ReportRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.code(422).send({ code: 'INVALID_BODY', errors: fromZodError(parsed.error) });
+    }
+
+    // @ts-ignore
+    const orgId = (req as any).orgId || 'demo-org';
+    const idemKey = (req.headers['idempotency-key'] as string | undefined);
+    const bodyHash = createHash('sha256').update(JSON.stringify(parsed.data)).digest('hex');
+    const cacheKey = `report:${orgId}:${idemKey ?? bodyHash}`;
+
+    if ((app as any).redis) {
+      const existing = await (app as any).redis.get(cacheKey);
+      if (existing) return reply.send({ reportId: existing });
+    }
+
+    const reportId = `${orgId}-${Date.now()}`;
+    if ((app as any).redis) await (app as any).redis.set(cacheKey, reportId, 'EX', 3600);
+
+    reply.send({ reportId });
+  });
+
+  app.get('/dashboard/report/:id/download', {
+    schema: {
+      description: 'Download a generated report PDF by id',
+      tags: ['reports'],
+      params: {
+        type: 'object',
+        properties: { id: { type: 'string' } },
+        required: ['id'],
+      },
+      response: {
+        200: { description: 'PDF file', content: { 'application/pdf': { schema: { type: 'string', format: 'binary' } } } },
+        401: { type: 'object', properties: { code: { type: 'string' } } },
+        403: { type: 'object', properties: { code: { type: 'string' } } },
+      },
+      security: [{ bearerAuth: [] }],
+    }
+  }, async (req, reply) => {
+    const { id } = (req.params as any);
+    // @ts-ignore
+    const orgId = (req as any).orgId || 'demo-org';
+
+    const pdf = Buffer.from('%PDF-1.4\n%...replace with actual pdf...\n', 'utf8');
+    reply
+      .type('application/pdf')
+      .header('Content-Disposition', `attachment; filename="apgms-report-${id}.pdf"`)
+      .send(pdf);
+  });
+}

--- a/apgms/services/api-gateway/test/contract.spec.ts
+++ b/apgms/services/api-gateway/test/contract.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import openapiPlugin from '../src/plugins/openapi';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+import { reportsRoutes } from '../src/routes/v1/reports';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('openapi contract', () => {
+  it('exposes /openapi.json with report routes', async () => {
+    const res = await app.inject({ method: 'GET', url: '/openapi.json' });
+    expect(res.statusCode).toBe(200);
+    const spec = res.json();
+    const paths = Object.keys(spec.paths || {});
+    expect(paths).toContain('/dashboard/generate-report');
+    expect(paths).toContain('/dashboard/report/{id}/download');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared report schemas for validating request and response payloads
- register an OpenAPI plugin with report routes and provide a script to emit the specification
- cover the OpenAPI exposure with a Fastify contract test

## Testing
- `pnpm -r build`
- `pnpm emit:openapi` *(fails: Cannot find module '@fastify/swagger' because registry access requires authentication)*
- `pnpm -r test` *(fails: vitest executable missing because registry access requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68f50ab0ed8083278bc547dc612c364a