### PR TITLE
feat: add observability plugins to api gateway

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -16,6 +16,8 @@
   "devDependencies": {
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "prom-client": "^15.1.3",
+    "@opentelemetry/api": "^1.9.0"
   }
 }

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -10,15 +10,20 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
+import metricsPlugin from "./plugins/metrics";
+import healthPlugin from "./plugins/health";
+import tracingPlugin from "./plugins/tracing";
 
 const app = Fastify({ logger: true });
 
+app.decorate("prisma", prisma);
+await app.register(tracingPlugin);
+await app.register(metricsPlugin);
+await app.register(healthPlugin);
 await app.register(cors, { origin: true });
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
-
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
 app.get("/users", async () => {

--- a/apgms/services/api-gateway/src/plugins/health.ts
+++ b/apgms/services/api-gateway/src/plugins/health.ts
@@ -1,0 +1,41 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+
+type CheckResult = { status: 'UP'|'DOWN'|'SKIPPED'; details?: string };
+
+async function checkRedis(app: any): Promise<CheckResult> {
+  if (!app.redis || typeof app.redis.ping !== 'function') return { status: 'SKIPPED' };
+  try {
+    const pong = await app.redis.ping();
+    return (pong && String(pong).toUpperCase().includes('PONG')) ? { status: 'UP' } : { status: 'DOWN', details: String(pong) };
+  } catch (e: any) { return { status: 'DOWN', details: e?.message || 'redis error' }; }
+}
+
+async function checkDatabase(app: any): Promise<CheckResult> {
+  if (!app.prisma) return { status: 'SKIPPED' };
+  try {
+    if (typeof app.prisma.$queryRaw === 'function') {
+      await app.prisma.$queryRaw`SELECT 1`;
+      return { status: 'UP' };
+    }
+    if (typeof app.prisma.$connect === 'function') {
+      await app.prisma.$connect();
+      if (typeof app.prisma.$disconnect === 'function') await app.prisma.$disconnect();
+      return { status: 'UP' };
+    }
+    return { status: 'SKIPPED' };
+  } catch (e: any) { return { status: 'DOWN', details: e?.message || 'db error' }; }
+}
+
+export const healthPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.get('/health', async (_req, reply) => { reply.send({ status: 'UP' }); });
+  app.get('/ready', async (_req, reply) => {
+    const redis = await checkRedis(app);
+    const db = await checkDatabase(app);
+    const components: Record<string, CheckResult> = { redis, database: db };
+    const discovered = Object.values(components).filter(c => c.status !== 'SKIPPED');
+    const allUp = discovered.length === 0 ? true : discovered.every(c => c.status === 'UP');
+    reply.code(allUp ? 200 : 503).send({ status: allUp ? 'UP' : 'DOWN', checks: components, timestamp: new Date().toISOString() });
+  });
+});
+export default healthPlugin;

--- a/apgms/services/api-gateway/src/plugins/metrics.ts
+++ b/apgms/services/api-gateway/src/plugins/metrics.ts
@@ -1,0 +1,41 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import client from 'prom-client';
+
+const DEFAULT_BUCKETS = [0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10];
+
+export const metricsPlugin: FastifyPluginAsync = fp(async (app) => {
+  if (!(client as any).__apgms_registered) {
+    client.collectDefaultMetrics();
+    (client as any).__apgms_registered = true;
+  }
+  const httpHistogram = new client.Histogram({
+    name: 'http_request_duration_seconds',
+    help: 'HTTP request duration in seconds',
+    labelNames: ['method','route','status_code','trace_id'],
+    buckets: DEFAULT_BUCKETS,
+  });
+  const httpCounter = new client.Counter({
+    name: 'http_requests_total',
+    help: 'Total number of HTTP requests',
+    labelNames: ['method','route','status_code','trace_id'],
+  });
+  app.addHook('onRequest', async (req) => { (req as any).__metricsStart = process.hrtime.bigint(); });
+  app.addHook('onResponse', async (req, reply) => {
+    const start = (req as any).__metricsStart as bigint | undefined;
+    const end = process.hrtime.bigint();
+    const seconds = start ? Number(end - start) / 1e9 : 0;
+    const method = (req.method || 'GET').toUpperCase();
+    // @ts-ignore
+    const route = (reply.context?.config?.url) || (req as any).routerPath || req.url || 'unknown';
+    const status = String(reply.statusCode || 200);
+    const traceId = (req as any).traceId || 'none';
+    httpHistogram.observe({ method, route, status_code: status, trace_id: traceId }, seconds);
+    httpCounter.inc({ method, route, status_code: status, trace_id: traceId });
+  });
+  app.get('/metrics', async (_req, reply) => {
+    reply.header('Content-Type', client.register.contentType);
+    return client.register.metrics();
+  });
+});
+export default metricsPlugin;

--- a/apgms/services/api-gateway/src/plugins/tracing.ts
+++ b/apgms/services/api-gateway/src/plugins/tracing.ts
@@ -1,0 +1,35 @@
+import fp from 'fastify-plugin';
+import { FastifyPluginAsync } from 'fastify';
+import { ROOT_CONTEXT, trace } from '@opentelemetry/api';
+import { randomBytes } from 'crypto';
+
+function genTraceId() { return randomBytes(16).toString('hex'); }
+function genSpanId() { return randomBytes(8).toString('hex'); }
+
+function parseOrCreate(inbound?: string) {
+  try {
+    if (inbound?.startsWith('00-')) {
+      const [ , traceId, spanId, flags ] = inbound.split('-');
+      if (traceId?.length === 32 && spanId?.length === 16) return { traceId, spanId, sampled: flags || '01' };
+    }
+  } catch {}
+  return { traceId: genTraceId(), spanId: genSpanId(), sampled: '01' };
+}
+
+export const tracingPlugin: FastifyPluginAsync = fp(async (app) => {
+  app.addHook('onRequest', async (req, reply) => {
+    const parsed = parseOrCreate(req.headers['traceparent'] as string | undefined);
+    (req as any).traceId = parsed.traceId;
+    (req as any).spanId = parsed.spanId;
+    reply.header('traceparent', `00-${parsed.traceId}-${parsed.spanId}-${parsed.sampled}`);
+    reply.header('x-trace-id', parsed.traceId);
+    const tracer = trace.getTracer('apgms-gateway');
+    const span = tracer.startSpan('http_request', undefined, ROOT_CONTEXT);
+    (req as any).__span = span;
+  });
+  app.addHook('onResponse', async (req) => {
+    const span = (req as any).__span;
+    if (span && typeof span.end === 'function') span.end();
+  });
+});
+export default tracingPlugin;

--- a/apgms/services/api-gateway/test/observability.spec.ts
+++ b/apgms/services/api-gateway/test/observability.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import metricsPlugin from '../src/plugins/metrics';
+import healthPlugin from '../src/plugins/health';
+import tracingPlugin from '../src/plugins/tracing';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  (app as any).redis = { ping: async () => 'PONG' };
+  await app.register(tracingPlugin);
+  await app.register(metricsPlugin);
+  await app.register(healthPlugin);
+  app.get('/demo', async (_req, reply) => reply.send({ ok: true }));
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('health & readiness', () => {
+  it('health returns UP', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('UP');
+  });
+});
+
+describe('metrics', () => {
+  it('exposes prometheus metrics', async () => {
+    await app.inject({ method: 'GET', url: '/demo' });
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/plain/);
+    expect(res.body).toContain('http_requests_total');
+  });
+});
+
+describe('tracing', () => {
+  it('emits trace headers', async () => {
+    const res = await app.inject({ method: 'GET', url: '/demo' });
+    expect(res.headers['traceparent']).toBeTruthy();
+    expect(res.headers['x-trace-id']).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add tracing, metrics, and health Fastify plugins to the API gateway
- expose metrics and readiness endpoints with automated coverage

## Testing
- pnpm -r build
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68f50b994fe88327b0cbf95fd42c7f28