### PR TITLE
Add Vitest configuration and CI coverage workflow

### DIFF
--- a/apgms/.github/workflows/ci.yml
+++ b/apgms/.github/workflows/ci.yml
@@ -1,17 +1,35 @@
-﻿name: CI
-on: [push, pull_request]
+name: CI
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
       - uses: pnpm/action-setup@v4
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm -r build
+      - name: Prisma migrate status gate (all workspaces)
+        run: pnpm -r exec -- prisma migrate status --no-color
+      - name: Tests with coverage (fail under thresholds)
+        run: pnpm -r test -- --coverage
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          node-version: '18'
-          cache: 'pnpm'
-      - run: pnpm i
-      - run: pnpm -r build
-      - run: pnpm -r test
+          name: coverage
+          path: |
+            coverage
+            **/coverage

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "vitest run",
+    "test:workspaces": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/services/api-gateway/test/reports.e2e.spec.ts
+++ b/apgms/services/api-gateway/test/reports.e2e.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fastify from 'fastify';
+import openapiPlugin from '../src/plugins/openapi';
+import { reportsRoutes } from '../src/routes/v1/reports';
+import cors from '@fastify/cors';
+import helmet from '@fastify/helmet';
+import rateLimit from '@fastify/rate-limit';
+
+let app: any;
+
+beforeAll(async () => {
+  app = fastify({ logger: false });
+  await app.register(cors, { origin: true });
+  await app.register(helmet);
+  await app.register(rateLimit, { max: 100, timeWindow: '1 minute' });
+  await app.register(openapiPlugin);
+  await app.register(reportsRoutes);
+  await app.ready();
+});
+
+afterAll(async () => { await app.close(); });
+
+describe('reports e2e', () => {
+  it('rejects invalid body with 422', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dashboard/generate-report',
+      payload: { reportType: 'PAYMENT_HISTORY', startDate: 'bad', endDate: 'also-bad' }
+    });
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('accepts valid body and returns reportId', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/dashboard/generate-report',
+      payload: { reportType: 'PAYMENT_HISTORY', startDate: '2024-07-01', endDate: '2024-07-31' }
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toHaveProperty('reportId');
+  });
+});

--- a/apgms/vitest.config.ts
+++ b/apgms/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+    watch: false,
+    reporters: ['default'],
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json', 'lcov'],
+      lines: 80,
+      statements: 80,
+      functions: 80,
+      branches: 75
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add Vitest configuration at the repo root to enforce coverage thresholds
- add an API Gateway reports E2E test covering invalid/valid payload scenarios
- update the CI workflow to install dependencies, build, check Prisma migrations, and run tests with coverage artifacts
- expose a workspace-level Vitest test script

## Testing
- pnpm -r build
- pnpm -r test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68f50bc5a05083278dcd0ac0aba65d90