### PR TITLE
Secure API gateway edge

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,17 +4,24 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^12.0.0",
+    "bcryptjs": "^2.4.3",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^24.7.1",
+    "vitest": "^2.1.4",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,16 +9,66 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import helmet from "@fastify/helmet";
+import bcrypt from "bcryptjs";
+import { z } from "zod";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+await app.register(helmet, { contentSecurityPolicy: false });
+await app.register(cors, {
+  origin: allowedOrigins.length > 0 ? allowedOrigins : true,
+});
 
 // sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+app.log.info("environment loaded");
+
+const PUBLIC_ROUTES = new Set(["/health", "/ready"]);
+
+app.addHook("preHandler", async (req, rep) => {
+  const routeUrl = req.routeOptions?.url;
+  if (routeUrl && PUBLIC_ROUTES.has(routeUrl)) {
+    return;
+  }
+
+  const providedKey = req.headers["x-api-key"];
+  const expectedKey = process.env.API_GATEWAY_KEY;
+  const expectedHash = process.env.API_GATEWAY_KEY_HASH;
+
+  if (typeof providedKey !== "string") {
+    return rep.code(401).send({ error: "unauthorized" });
+  }
+
+  if (expectedHash) {
+    const ok = await bcrypt.compare(providedKey, expectedHash);
+    if (!ok) {
+      return rep.code(401).send({ error: "unauthorized" });
+    }
+    return;
+  }
+
+  if (!expectedKey || providedKey !== expectedKey) {
+    return rep.code(401).send({ error: "unauthorized" });
+  }
+});
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+app.get("/ready", async (_req, rep) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return rep.code(200).send({ ok: true });
+  } catch (error) {
+    rep.log.error(error, "readiness check failed");
+    return rep.code(503).send({ ok: false });
+  }
+});
 
 // List users (email + org)
 app.get("/users", async () => {
@@ -42,17 +92,19 @@ app.get("/bank-lines", async (req) => {
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
   try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
+    const createLineSchema = z.object({
+      orgId: z.string().min(1),
+      date: z.coerce.date(),
+      amount: z.coerce.number(),
+      payee: z.string().min(1),
+      desc: z.string().min(1),
+    });
+
+    const body = createLineSchema.parse(req.body);
     const created = await prisma.bankLine.create({
       data: {
         orgId: body.orgId,
-        date: new Date(body.date),
+        date: body.date,
         amount: body.amount as any,
         payee: body.payee,
         desc: body.desc,


### PR DESCRIPTION
## Summary
- add helmet, tighten CORS configuration, and avoid logging sensitive environment variables
- enforce API key authentication, supporting hashed keys, and add a readiness probe against the database
- validate create bank line payloads with Zod and expand package scripts and dependencies for build/test tooling

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: `vitest` binary unavailable because dependencies cannot be installed in this environment)*
- pnpm --filter @apgms/api-gateway build *(fails: missing packages such as `@fastify/helmet` because registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68f5309eaea0832797c85fd136c47512