### PR TITLE
Add API gateway health test and webapp smoke test

### DIFF
--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,1 @@
-﻿export default {};
+export default {};

--- a/apgms/pnpm-lock.yaml
+++ b/apgms/pnpm-lock.yaml
@@ -75,7 +75,14 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  webapp: {}
+  webapp:
+    devDependencies:
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   worker: {}
 

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/**/*.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,74 +7,94 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
 
-const app = Fastify({ logger: true });
+export async function build(app?: FastifyInstance) {
+  const server = app ?? Fastify({ logger: true });
 
-await app.register(cors, { origin: true });
+  await server.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+  // sanity log: confirm env is loaded
+  server.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  server.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
+  if (process.env.API_GATEWAY_DISABLE_DB === "true") {
+    server.log.warn("database-backed routes are disabled");
+  } else {
+    const { prisma } = await import("../../../shared/src/db");
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
-
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+    // List users (email + org)
+    server.get("/users", async () => {
+      const users = await prisma.user.findMany({
+        select: { email: true, orgId: true, createdAt: true },
+        orderBy: { createdAt: "desc" },
+      });
+      return { users };
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+
+    // List bank lines (latest first)
+    server.get("/bank-lines", async (req) => {
+      const take = Number((req.query as any).take ?? 20);
+      const lines = await prisma.bankLine.findMany({
+        orderBy: { date: "desc" },
+        take: Math.min(Math.max(take, 1), 200),
+      });
+      return { lines };
+    });
+
+    // Create a bank line
+    server.post("/bank-lines", async (req, rep) => {
+      try {
+        const body = req.body as {
+          orgId: string;
+          date: string;
+          amount: number | string;
+          payee: string;
+          desc: string;
+        };
+        const created = await prisma.bankLine.create({
+          data: {
+            orgId: body.orgId,
+            date: new Date(body.date),
+            amount: body.amount as any,
+            payee: body.payee,
+            desc: body.desc,
+          },
+        });
+        return rep.code(201).send(created);
+      } catch (e) {
+        req.log.error(e);
+        return rep.code(400).send({ error: "bad_request" });
+      }
+    });
   }
-});
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
+  return server;
+}
+
+export async function start() {
+  const app = await build();
+
+  await app.ready();
+  // Print routes so we can SEE POST /bank-lines is registered
   app.log.info(app.printRoutes());
-});
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  try {
+    await app.listen({ port, host });
+  } catch (err) {
+    app.log.error(err);
+    process.exit(1);
+  }
+}
+
+const entrypoint = fileURLToPath(import.meta.url);
+
+if (process.argv[1] === entrypoint) {
+  start();
+}
 

--- a/apgms/services/api-gateway/test/health.spec.ts
+++ b/apgms/services/api-gateway/test/health.spec.ts
@@ -1,0 +1,30 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import Fastify from "fastify";
+import { build } from "../src/index";
+
+describe("health/ready", () => {
+  const app = Fastify({ logger: false });
+  const apiKey = "test-api-key";
+
+  before(async () => {
+    process.env.API_GATEWAY_KEY = apiKey;
+    process.env.API_GATEWAY_DISABLE_DB = "true";
+    await build(app);
+  });
+
+  after(async () => {
+    await app.close();
+  });
+
+  it("exposes /health", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/health",
+      headers: { "x-api-key": apiKey },
+    });
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.json(), { ok: true, service: "api-gateway" });
+  });
+});

--- a/apgms/webapp/dev-server.mjs
+++ b/apgms/webapp/dev-server.mjs
@@ -1,0 +1,41 @@
+import http from "node:http";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = __dirname;
+
+const port = Number(process.env.WEBAPP_PORT ?? 4173);
+const host = process.env.WEBAPP_HOST ?? "127.0.0.1";
+
+const indexHtml = await readFile(path.join(webRoot, "index.html"), "utf8");
+
+const server = http.createServer((req, res) => {
+  if (req.method !== "GET" || req.url === undefined) {
+    res.writeHead(405);
+    res.end();
+    return;
+  }
+
+  if (req.url === "/" || req.url === "/index.html") {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end(indexHtml);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not Found");
+});
+
+function shutdown() {
+  server.close(() => process.exit(0));
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+server.listen(port, host, () => {
+  console.log(`webapp dev server listening on http://${host}:${port}`);
+});

--- a/apgms/webapp/index.html
+++ b/apgms/webapp/index.html
@@ -1,1 +1,11 @@
-﻿<!doctype html><html><head><meta charset='utf-8'><title>APGMS</title></head><body><div id='root'></div></body></html>
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>APGMS</title>
+  </head>
+  <body>
+    <h1>APGMS Webapp</h1>
+    <div id="root"></div>
+  </body>
+</html>

--- a/apgms/webapp/package.json
+++ b/apgms/webapp/package.json
@@ -1,1 +1,14 @@
-{"name":"@apgms/webapp","version":"0.1.0","private":true,"scripts":{"build":"echo build webapp","test":"echo test webapp"}}
+{
+  "name": "@apgms/webapp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "echo build webapp",
+    "dev": "node dev-server.mjs",
+    "test": "tsx --test tests/**/*.spec.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/apgms/webapp/tests/smoke.spec.ts
+++ b/apgms/webapp/tests/smoke.spec.ts
@@ -1,0 +1,55 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, "..");
+
+let server: ReturnType<typeof createServer>;
+let baseUrl: string;
+
+describe("webapp smoke", () => {
+  before(async () => {
+    const indexHtml = await readFile(path.join(webRoot, "index.html"), "utf8");
+    server = createServer((req, res) => {
+      if (req.method === "GET" && (req.url === "/" || req.url === "/index.html")) {
+        res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        res.end(indexHtml);
+        return;
+      }
+
+      res.writeHead(404);
+      res.end("Not Found");
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        if (address && typeof address !== "string") {
+          baseUrl = `http://${address.address}:${address.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  after(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it("serves the home page", async () => {
+    const res = await fetch(`${baseUrl}/`);
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /APGMS Webapp/);
+  });
+});


### PR DESCRIPTION
## Summary
- refactor the API gateway entrypoint to expose a reusable builder and allow disabling database-backed routes for tests
- add a node:test-based health check along with workspace test scripts and lockfile updates
- serve a static homepage via a lightweight dev server and cover it with a smoke test

## Testing
- `../../node_modules/.bin/tsx --test test/health.spec.ts`
- `../node_modules/.bin/tsx --test tests/smoke.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68f530eb394083279a7a061ac1af7fd0