### PR TITLE
gateway: /ready probe and Prometheus /metrics

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/metrics": "^11.1.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -9,16 +9,30 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import metricsPlugin from "@fastify/metrics";
 import { prisma } from "../../../shared/src/db";
 
 const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
+await app.register(metricsPlugin, {
+  endpoint: "/metrics",
+});
 
 // sanity log: confirm env is loaded
 app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+
+app.get("/ready", async (req, rep) => {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    return { ready: true };
+  } catch (error) {
+    req.log.error({ err: error }, "readiness check failed");
+    return rep.code(503).send({ ready: false });
+  }
+});
 
 // List users (email + org)
 app.get("/users", async () => {


### PR DESCRIPTION
## Summary
- add a /ready route that exercises Prisma connectivity before reporting readiness
- register @fastify/metrics to expose Prometheus-compatible metrics on /metrics

## Testing
- ⚠️ `pnpm install` *(fails: GET https://registry.npmjs.org/@fastify%2Fmetrics returned 403 in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f5e82bd454832787f5c6b1b000862d