### PR TITLE
gateway: auth + CORS allowlist + helmet + zod + remove secret logs

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,2 @@
+API_GATEWAY_KEY=changeme
+ALLOWED_ORIGINS=https://app.example.com,http://localhost:5173

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- secure non-GET routes behind an x-api-key check sourced from API_GATEWAY_KEY
- tighten gateway middleware by registering helmet and restricting CORS origins via ALLOWED_ORIGINS
- validate /bank-lines payloads with zod and provide environment variable examples

## Testing
- pnpm -r build

------
https://chatgpt.com/codex/tasks/task_e_68f5e8149490832783eb6b4cccc4b519