### PR TITLE
Sanitize bank line pagination query parameter

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -31,10 +31,15 @@ app.get("/users", async () => {
 
 // List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+  const rawTake = (req.query as Record<string, unknown>).take;
+  const takeValue = Number(rawTake ?? 20);
+  const take = Number.isFinite(takeValue)
+    ? Math.min(Math.max(Math.trunc(takeValue), 1), 200)
+    : 20;
+
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+    take,
   });
   return { lines };
 });


### PR DESCRIPTION
## Summary
- validate the `/bank-lines` take query parameter before passing it to Prisma
- retain the existing clamp to 1..200 while defaulting to 20 on invalid input

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f5f3e9b9f08327898206497fd17960