### PR TITLE
gateway: auth middleware, basic RBAC, and PII minimization

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for local development.
+# services/api-gateway reads this key to authenticate write operations.
+API_GATEWAY_KEY=replace-with-shared-secret

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
-import Fastify from "fastify";
+import Fastify, { type FastifyReply, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
 import { prisma } from "../../../shared/src/db";
 
@@ -15,24 +15,72 @@ const app = Fastify({ logger: true });
 
 await app.register(cors, { origin: true });
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+const API_GATEWAY_KEY = process.env.API_GATEWAY_KEY;
+const ORG_HEADER = "x-org-id";
+
+app.addHook("onRequest", async (req, rep) => {
+  if (req.method === "GET") {
+    return;
+  }
+
+  if (!API_GATEWAY_KEY) {
+    req.log.error("API gateway key missing; rejecting non-GET request");
+    return rep.code(500).send({ error: "server_misconfigured" });
+  }
+
+  const providedKey = req.headers["x-api-key"];
+  if (providedKey !== API_GATEWAY_KEY) {
+    return rep.code(401).send({ error: "unauthorized" });
+  }
+});
+
+const requireOrgContext = (
+  req: FastifyRequest,
+  rep: FastifyReply,
+): string | undefined => {
+  const header = req.headers[ORG_HEADER];
+  if (typeof header !== "string" || header.trim().length === 0) {
+    rep.code(400).send({ error: "org_header_required" });
+    return;
+  }
+  return header;
+};
 
 app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
 // List users (email + org)
-app.get("/users", async () => {
+app.get("/users", async (req, rep) => {
+  const orgId = requireOrgContext(req, rep);
+  if (!orgId) {
+    return;
+  }
+
   const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
+    where: { orgId },
+    select: { id: true, email: true, createdAt: true },
     orderBy: { createdAt: "desc" },
   });
   return { users };
 });
 
 // List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
+app.get("/bank-lines", async (req, rep) => {
+  const orgId = requireOrgContext(req, rep);
+  if (!orgId) {
+    return;
+  }
+
   const take = Number((req.query as any).take ?? 20);
   const lines = await prisma.bankLine.findMany({
+    where: { orgId },
+    select: {
+      id: true,
+      date: true,
+      amount: true,
+      payee: true,
+      desc: true,
+      createdAt: true,
+    },
     orderBy: { date: "desc" },
     take: Math.min(Math.max(take, 1), 200),
   });
@@ -41,6 +89,11 @@ app.get("/bank-lines", async (req) => {
 
 // Create a bank line
 app.post("/bank-lines", async (req, rep) => {
+  const orgId = requireOrgContext(req, rep);
+  if (!orgId) {
+    return;
+  }
+
   try {
     const body = req.body as {
       orgId: string;
@@ -49,6 +102,15 @@ app.post("/bank-lines", async (req, rep) => {
       payee: string;
       desc: string;
     };
+
+    if (!body || typeof body.orgId !== "string" || body.orgId.trim().length === 0) {
+      return rep.code(400).send({ error: "invalid_org" });
+    }
+
+    if (body.orgId !== orgId) {
+      return rep.code(403).send({ error: "forbidden_org" });
+    }
+
     const created = await prisma.bankLine.create({
       data: {
         orgId: body.orgId,
@@ -56,6 +118,14 @@ app.post("/bank-lines", async (req, rep) => {
         amount: body.amount as any,
         payee: body.payee,
         desc: body.desc,
+      },
+      select: {
+        id: true,
+        date: true,
+        amount: true,
+        payee: true,
+        desc: true,
+        createdAt: true,
       },
     });
     return rep.code(201).send(created);


### PR DESCRIPTION
## Summary
- enforce API key authentication for write routes and add org-scoped guardrails
- limit /users and /bank-lines payloads to non-sensitive fields
- expose API_GATEWAY_KEY example configuration and allow committing it

## Testing
- pnpm -r build

------
https://chatgpt.com/codex/tasks/task_e_68f5f4c48a888327aafa38863dbe7b7d