### PR TITLE
gateway: @fastify/helmet + CSP and CORS allowlist

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for local development
+DATABASE_URL="postgresql://apgms:apgms@localhost:5432/apgms"
+PORT=3000
+ALLOWED_ORIGINS=http://localhost:3000,https://app.apgms.com

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^12.2.0",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"


### PR DESCRIPTION
## Summary
- register @fastify/helmet on the API gateway with a CSP to send standard security headers
- drive CORS origin checking from an ALLOWED_ORIGINS environment variable and block disallowed origins
- document ALLOWED_ORIGINS in the shared .env example and allow the file to be versioned

## Testing
- pnpm add @fastify/helmet --filter @apgms/api-gateway *(fails: registry returns 403 in sandbox, dependency added manually)*

------
https://chatgpt.com/codex/tasks/task_e_68f5f5018158832786249ae26fbb5ce6