### PR TITLE
Fix Prisma generate script path

### DIFF
--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prisma:generate": "prisma generate --schema=shared/prisma/schema.prisma",
+    "prisma:generate": "prisma generate --schema=prisma/schema.prisma",
     "build": "echo building shared"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- fix the shared package Prisma generate script to point at the local schema path

## Testing
- pnpm test
- pnpm --filter @apgms/shared prisma:generate *(fails: Prisma engines download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f6058b7d78832790dd59f77610b1c4