### PR TITLE
gateway: auth middleware, org guard, and PII minimization

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for the monorepo
+
+# Shared secrets
+DATABASE_URL="postgresql://user:password@localhost:5432/db"
+
+# API gateway security
+# API_GATEWAY_KEY is required for all non-GET requests via the `x-api-key` header.
+API_GATEWAY_KEY="replace-with-strong-key"
+
+# Clients must scope gateway traffic to an organisation by including
+# the `x-org-id` header (e.g. X-Org-Id=org_123) on routes such as /users
+# and /bank-lines. Requests missing this header are rejected.

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- enforce API key authentication on all non-GET routes in the gateway
- scope user and bank line access by organisation and minimize returned PII
- add example environment entries for the gateway key and org header guidance

## Testing
- `pnpm -r build`

------
https://chatgpt.com/codex/tasks/task_e_68f6067914008327b7fdf2d1c92545fe