### PR TITLE
e2e: install Playwright browsers and add smoke

### DIFF
--- a/apgms/.github/workflows/e2e.yml
+++ b/apgms/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-﻿name: E2E
+name: E2E
 on: [workflow_dispatch]
 jobs:
   e2e:
@@ -13,5 +13,10 @@ jobs:
           node-version: '18'
           cache: 'pnpm'
       - run: pnpm i
+        working-directory: apgms
+      - run: npx playwright install --with-deps
+        working-directory: apgms
       - run: docker compose up -d
+        working-directory: apgms
       - run: pnpm -w exec playwright test
+        working-directory: apgms

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.1",
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/playwright.config.ts
+++ b/apgms/playwright.config.ts
@@ -1,1 +1,41 @@
-﻿export default {};
+import { defineConfig } from "@playwright/test";
+
+const baseURL = process.env.APGMS_E2E_BASE_URL ?? "http://127.0.0.1:3000";
+
+const defaultHeaders: Record<string, string> = {
+  accept: "application/json",
+  "x-apgms-e2e": "playwright-smoke",
+};
+
+function loadRequiredHeaders(): Record<string, string> {
+  const raw = process.env.APGMS_E2E_REQUIRED_HEADERS;
+  if (!raw) {
+    return defaultHeaders;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const normalized = Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => [key, String(value)])
+    );
+    return { ...defaultHeaders, ...normalized };
+  } catch (error) {
+    console.warn(
+      "Failed to parse APGMS_E2E_REQUIRED_HEADERS; falling back to defaults",
+      error
+    );
+    return defaultHeaders;
+  }
+}
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  use: {
+    baseURL,
+    extraHTTPHeaders: loadRequiredHeaders(),
+  },
+});

--- a/apgms/tests/e2e/health.spec.ts
+++ b/apgms/tests/e2e/health.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+const includeReadyEndpoint = (() => {
+  const flag = process.env.APGMS_E2E_CHECK_READY ?? "";
+  return ["1", "true", "yes"].includes(flag.toLowerCase());
+})();
+
+const endpoints = ["/health"] as const;
+
+test.describe("service health", () => {
+  for (const endpoint of endpoints) {
+    test(`GET ${endpoint} returns ok`, async ({ request }) => {
+      const response = await request.get(endpoint);
+      expect(response.ok(), `${endpoint} should return 2xx`).toBeTruthy();
+      const body = await response.json();
+      expect(body).toMatchObject({ ok: true });
+    });
+  }
+
+  const readinessTest = includeReadyEndpoint ? test : test.fixme;
+
+  readinessTest("GET /ready returns ok", async ({ request }) => {
+    const response = await request.get("/ready");
+    expect(response.ok(), "/ready should return 2xx").toBeTruthy();
+    const body = await response.json();
+    expect(body).toMatchObject({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the E2E workflow installs Playwright browsers and runs commands from the workspace
- configure Playwright with workspace headers/base URL defaults and register it as a dev dependency
- add a smoke spec that exercises the /health endpoint (and a gated /ready check) for API availability

## Testing
- pnpm -w exec playwright test *(fails locally: registry access for @playwright/test is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f606a92abc83278c5089f3d495604e