### PR TITLE
gateway: Zod validation for request/response

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx src/index.ts"
+    "dev": "tsx src/index.ts",
+    "test": "tsx test/validation.test.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -1,4 +1,4 @@
-﻿import path from "node:path";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
@@ -9,72 +9,146 @@ dotenv.config({ path: path.resolve(__dirname, "../../../.env") });
 
 import Fastify from "fastify";
 import cors from "@fastify/cors";
-import { prisma } from "../../../shared/src/db";
+import {
+  bankLineCreateSchema,
+  bankLineEntitySchema,
+  bankLineListResponseSchema,
+  bankLineQuerySchema,
+  serializeBankLine,
+} from "./validation";
 
-const app = Fastify({ logger: true });
+type PrismaClientLike = {
+  user: {
+    findMany: (args: any) => Promise<any>;
+  };
+  bankLine: {
+    findMany: (args: any) => Promise<any>;
+    create: (args: any) => Promise<any>;
+  };
+};
 
-await app.register(cors, { origin: true });
+const loadPrisma = async (): Promise<PrismaClientLike> => {
+  const module = await import("../../../shared/src/db");
+  return module.prisma as PrismaClientLike;
+};
 
-// sanity log: confirm env is loaded
-app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
+export const createApp = async (deps?: { prisma?: PrismaClientLike }) => {
+  const db = deps?.prisma ?? (await loadPrisma());
+  const app = Fastify({ logger: true });
 
-app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
+  await app.register(cors, { origin: true });
 
-// List users (email + org)
-app.get("/users", async () => {
-  const users = await prisma.user.findMany({
-    select: { email: true, orgId: true, createdAt: true },
-    orderBy: { createdAt: "desc" },
-  });
-  return { users };
-});
+  // sanity log: confirm env is loaded
+  app.log.info({ DATABASE_URL: process.env.DATABASE_URL }, "loaded env");
 
-// List bank lines (latest first)
-app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
-  const lines = await prisma.bankLine.findMany({
-    orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
-  });
-  return { lines };
-});
+  app.get("/health", async () => ({ ok: true, service: "api-gateway" }));
 
-// Create a bank line
-app.post("/bank-lines", async (req, rep) => {
-  try {
-    const body = req.body as {
-      orgId: string;
-      date: string;
-      amount: number | string;
-      payee: string;
-      desc: string;
-    };
-    const created = await prisma.bankLine.create({
-      data: {
-        orgId: body.orgId,
-        date: new Date(body.date),
-        amount: body.amount as any,
-        payee: body.payee,
-        desc: body.desc,
-      },
+  // List users (email + org)
+  app.get("/users", async () => {
+    const users = await db.user.findMany({
+      select: { email: true, orgId: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
     });
-    return rep.code(201).send(created);
-  } catch (e) {
-    req.log.error(e);
-    return rep.code(400).send({ error: "bad_request" });
+    return { users };
+  });
+
+  // List bank lines (latest first)
+  app.get("/bank-lines", async (req, rep) => {
+    const parsedQuery = bankLineQuerySchema.safeParse(req.query ?? {});
+    if (!parsedQuery.success) {
+      return rep.code(400).send({
+        error: "validation_error",
+        issues: parsedQuery.error.issues,
+      });
+    }
+
+    const take = parsedQuery.data.take ?? 20;
+    const lines = await db.bankLine.findMany({
+      orderBy: { date: "desc" },
+      take,
+    });
+
+    let serializedLines;
+    try {
+      serializedLines = lines.map((line) => serializeBankLine(line));
+    } catch (error) {
+      req.log.error({ err: error }, "failed to serialize bank lines");
+      return rep.code(500).send({ error: "response_serialization_failed" });
+    }
+    const responsePayload = {
+      lines: serializedLines,
+    };
+    const responseValidation = bankLineListResponseSchema.safeParse(responsePayload);
+    if (!responseValidation.success) {
+      req.log.error(
+        { issues: responseValidation.error.issues },
+        "bank line list response validation failed",
+      );
+      return rep.code(500).send({ error: "response_validation_failed" });
+    }
+
+    return responseValidation.data;
+  });
+
+  // Create a bank line
+  app.post("/bank-lines", async (req, rep) => {
+    const parsedBody = bankLineCreateSchema.safeParse(req.body ?? {});
+    if (!parsedBody.success) {
+      return rep.code(400).send({
+        error: "validation_error",
+        issues: parsedBody.error.issues,
+      });
+    }
+
+    try {
+      const created = await db.bankLine.create({
+        data: {
+          orgId: parsedBody.data.orgId,
+          date: parsedBody.data.date,
+          amount: parsedBody.data.amount,
+          payee: parsedBody.data.payee,
+          desc: parsedBody.data.desc,
+        },
+      });
+      let serialized;
+      try {
+        serialized = serializeBankLine(created);
+      } catch (error) {
+        req.log.error({ err: error }, "failed to serialize created bank line");
+        return rep.code(500).send({ error: "response_serialization_failed" });
+      }
+      const responseValidation = bankLineEntitySchema.safeParse(serialized);
+      if (!responseValidation.success) {
+        req.log.error(
+          { issues: responseValidation.error.issues },
+          "bank line create response validation failed",
+        );
+        return rep.code(500).send({ error: "response_validation_failed" });
+      }
+      return rep.code(201).send(responseValidation.data);
+    } catch (e) {
+      req.log.error(e);
+      return rep.code(500).send({ error: "bank_line_create_failed" });
+    }
+  });
+
+  if (process.env.NODE_ENV !== "test") {
+    app.ready(() => {
+      app.log.info(app.printRoutes());
+    });
   }
-});
 
-// Print routes so we can SEE POST /bank-lines is registered
-app.ready(() => {
-  app.log.info(app.printRoutes());
-});
+  return app;
+};
 
-const port = Number(process.env.PORT ?? 3000);
-const host = "0.0.0.0";
+if (process.env.NODE_ENV !== "test") {
+  const app = await createApp();
 
-app.listen({ port, host }).catch((err) => {
-  app.log.error(err);
-  process.exit(1);
-});
+  const port = Number(process.env.PORT ?? 3000);
+  const host = "0.0.0.0";
 
+  app.listen({ port, host }).catch((err) => {
+    app.log.error(err);
+    process.exit(1);
+  });
+}

--- a/apgms/services/api-gateway/src/validation.ts
+++ b/apgms/services/api-gateway/src/validation.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+export const bankLineQuerySchema = z
+  .object({
+    take: z.coerce.number().int().min(1).max(200).optional(),
+  })
+  .strict();
+
+export const bankLineCreateSchema = z
+  .object({
+    orgId: z.string().min(1, "orgId is required"),
+    date: z.coerce.date(),
+    amount: z.coerce.number(),
+    payee: z.string().min(1, "payee is required"),
+    desc: z.string().min(1, "desc is required"),
+  })
+  .strict();
+
+export const bankLineEntitySchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  date: z.string().datetime(),
+  amount: z.number(),
+  payee: z.string(),
+  desc: z.string(),
+  createdAt: z.string().datetime(),
+});
+
+export const bankLineListResponseSchema = z.object({
+  lines: z.array(bankLineEntitySchema),
+});
+
+export type BankLineResponse = z.infer<typeof bankLineEntitySchema>;
+
+export const serializeBankLine = (line: any): BankLineResponse => {
+  const rawAmount = line.amount as unknown;
+  const amount =
+    typeof rawAmount === "number"
+      ? rawAmount
+      : rawAmount && typeof (rawAmount as { toNumber?: () => number }).toNumber === "function"
+        ? (rawAmount as { toNumber: () => number }).toNumber()
+        : Number(rawAmount);
+
+  if (!Number.isFinite(amount)) {
+    throw new Error("Unable to serialize bank line amount");
+  }
+
+  const date = line.date instanceof Date ? line.date : new Date(line.date);
+  const createdAt =
+    line.createdAt instanceof Date ? line.createdAt : new Date(line.createdAt);
+
+  return {
+    id: String(line.id),
+    orgId: String(line.orgId),
+    date: date.toISOString(),
+    amount,
+    payee: String(line.payee),
+    desc: String(line.desc),
+    createdAt: createdAt.toISOString(),
+  } satisfies BankLineResponse;
+};

--- a/apgms/services/api-gateway/test/validation.test.ts
+++ b/apgms/services/api-gateway/test/validation.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi, dynamicImportModule } from "./vitest";
+
+process.env.NODE_ENV = "test";
+
+const bankLineMock = {
+  findMany: vi.fn(),
+  create: vi.fn(),
+};
+
+const userMock = {
+  findMany: vi.fn(),
+};
+
+const prismaMock = {
+  bankLine: bankLineMock,
+  user: userMock,
+};
+
+const { bankLineCreateSchema, bankLineQuerySchema } = await dynamicImportModule(
+  "../src/validation.ts",
+);
+const { createApp } = await dynamicImportModule("../src/index.ts");
+
+describe("bank line validators", () => {
+  beforeEach(() => {
+    bankLineMock.findMany.mockReset();
+    bankLineMock.create.mockReset();
+    userMock.findMany.mockReset();
+
+    bankLineMock.findMany.mockResolvedValue([]);
+    userMock.findMany.mockResolvedValue([]);
+    bankLineMock.create.mockResolvedValue({
+      id: "line_1",
+      orgId: "org_1",
+      date: new Date("2024-01-02T00:00:00.000Z"),
+      amount: 100,
+      payee: "Acme",
+      desc: "Payment",
+      createdAt: new Date("2024-01-03T00:00:00.000Z"),
+    });
+  });
+
+  it("coerces query take and enforces bounds", () => {
+    expect(bankLineQuerySchema.parse({ take: "10" }).take).toBe(10);
+    expect(bankLineQuerySchema.safeParse({ take: 0 }).success).toBe(false);
+    expect(bankLineQuerySchema.safeParse({ take: 500 }).success).toBe(false);
+  });
+
+  it("rejects invalid create payload", () => {
+    const result = bankLineCreateSchema.safeParse({
+      orgId: "",
+      date: "not-a-date",
+      amount: "abc",
+      payee: "",
+      desc: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns 400 with schema issues for invalid POST body", async () => {
+    const app = await createApp({ prisma: prismaMock as any });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/bank-lines",
+      payload: {
+        orgId: "",
+        date: "not-a-date",
+        amount: "abc",
+        payee: "",
+        desc: "",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("validation_error");
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(bankLineMock.create).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+
+  it("returns 400 for invalid take query", async () => {
+    const app = await createApp({ prisma: prismaMock as any });
+    await app.ready();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/bank-lines",
+      query: {
+        take: "500",
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("validation_error");
+    expect(body.issues.length).toBeGreaterThan(0);
+    expect(bankLineMock.findMany).not.toHaveBeenCalled();
+
+    await app.close();
+  });
+});

--- a/apgms/services/api-gateway/test/vitest.ts
+++ b/apgms/services/api-gateway/test/vitest.ts
@@ -1,0 +1,200 @@
+type Hook = () => unknown | Promise<unknown>;
+type TestCase = () => unknown | Promise<unknown>;
+
+type MockFn<T extends (...args: any[]) => any> = T & {
+  mock: {
+    calls: Parameters<T>[];
+  };
+  mockClear: () => void;
+  mockReset: () => void;
+  mockResolvedValue: (value: any) => MockFn<T>;
+};
+
+interface Suite {
+  name: string;
+  tests: { name: string; fn: TestCase }[];
+  beforeEach: Hook[];
+}
+
+const suites: Suite[] = [];
+let currentSuite: Suite | null = null;
+
+const queueRun = () => {
+  if ((queueRun as any).scheduled) {
+    return;
+  }
+  (queueRun as any).scheduled = true;
+  process.nextTick(runSuites);
+};
+
+async function runSuites() {
+  for (const suite of suites) {
+    console.log(`Suite: ${suite.name}`);
+    for (const test of suite.tests) {
+      try {
+        for (const hook of suite.beforeEach) {
+          await hook();
+        }
+        await test.fn();
+        console.log(`  ✓ ${test.name}`);
+      } catch (error) {
+        console.error(`  ✗ ${test.name}`);
+        console.error(error);
+        process.exitCode = 1;
+      }
+    }
+  }
+}
+
+export const describe = (name: string, fn: () => void) => {
+  const parentSuite = currentSuite;
+  const suite: Suite = { name, tests: [], beforeEach: [] };
+  currentSuite = suite;
+  fn();
+  suites.push(suite);
+  currentSuite = parentSuite;
+  queueRun();
+};
+
+export const beforeEach = (hook: Hook) => {
+  if (!currentSuite) {
+    throw new Error("beforeEach must be called within describe");
+  }
+  currentSuite.beforeEach.push(hook);
+};
+
+export const it = (name: string, fn: TestCase) => {
+  if (!currentSuite) {
+    throw new Error("it must be called within describe");
+  }
+  currentSuite.tests.push({ name, fn });
+};
+
+type Expectation<T> = {
+  toBe: (expected: T) => void;
+  toEqual: (expected: unknown) => void;
+  toThrow: (matcher?: RegExp | string) => void;
+  toBeGreaterThan: (value: number) => void;
+  toBeGreaterThanOrEqual: (value: number) => void;
+  not: Expectation<T>;
+  toHaveBeenCalled: () => void;
+};
+
+const isMockFn = (value: unknown): value is { mock?: { calls: unknown[][] } } => {
+  return !!value && typeof value === "function" && "mock" in (value as any);
+};
+
+const createExpectation = <T>(value: T, negate = false): Expectation<T> => {
+  const compare = (condition: boolean, message: string) => {
+    const pass = negate ? !condition : condition;
+    if (!pass) {
+      throw new Error(message);
+    }
+  };
+
+  const expectation: Expectation<T> = {
+    toBe(expected: T) {
+      compare(Object.is(value, expected), `Expected ${value as any} to be ${expected as any}`);
+    },
+    toEqual(expected: unknown) {
+      const actualJson = JSON.stringify(value);
+      const expectedJson = JSON.stringify(expected);
+      compare(actualJson === expectedJson, `Expected ${actualJson} to equal ${expectedJson}`);
+    },
+    toThrow(matcher?: RegExp | string) {
+      if (typeof value !== "function") {
+        throw new Error("toThrow expects a function");
+      }
+      let thrown = null;
+      try {
+        (value as unknown as () => unknown)();
+      } catch (error) {
+        thrown = error;
+      }
+      compare(thrown !== null, "Expected function to throw");
+      if (thrown && matcher) {
+        const message = (thrown as Error).message ?? String(thrown);
+        if (matcher instanceof RegExp) {
+          compare(matcher.test(message), `Expected error message to match ${matcher}`);
+        } else {
+          compare(message.includes(matcher), `Expected error message to include ${matcher}`);
+        }
+      }
+    },
+    toBeGreaterThan(threshold: number) {
+      if (typeof (value as any) !== "number") {
+        throw new Error("toBeGreaterThan expects a number");
+      }
+      compare((value as any) > threshold, `Expected ${value as any} to be greater than ${threshold}`);
+    },
+    toBeGreaterThanOrEqual(threshold: number) {
+      if (typeof (value as any) !== "number") {
+        throw new Error("toBeGreaterThanOrEqual expects a number");
+      }
+      compare((value as any) >= threshold, `Expected ${value as any} to be greater than or equal to ${threshold}`);
+    },
+    toHaveBeenCalled() {
+      if (!isMockFn(value)) {
+        throw new Error("toHaveBeenCalled expects a vi.fn mock");
+      }
+      compare(value.mock?.calls.length ? value.mock.calls.length > 0 : false, "Expected mock to have been called");
+    },
+    get not() {
+      return createExpectation(value, !negate);
+    },
+  };
+
+  return expectation;
+};
+
+export const expect = <T>(value: T): Expectation<T> => createExpectation(value);
+
+type MockImplementation<T extends (...args: any[]) => any> = {
+  impl: T;
+};
+
+const createMock = <T extends (...args: any[]) => any>(implementation?: T): MockFn<T> => {
+  const impl: MockImplementation<T> = {
+    impl: (implementation ?? ((() => undefined) as T)) as T,
+  };
+
+  const mockFn: any = (...args: Parameters<T>) => {
+    mockFn.mock.calls.push(args);
+    return impl.impl(...args);
+  };
+  mockFn.mock = { calls: [] as Parameters<T>[] };
+  mockFn.mockClear = () => {
+    mockFn.mock.calls = [];
+  };
+  mockFn.mockReset = () => {
+    mockFn.mockClear();
+    impl.impl = (implementation ?? ((() => undefined) as T)) as T;
+  };
+  mockFn.mockResolvedValue = (value: any) => {
+    impl.impl = ((..._args: Parameters<T>) => Promise.resolve(value)) as T;
+    return mockFn;
+  };
+  return mockFn as MockFn<T>;
+};
+
+const moduleMocks = new Map<string, () => any>();
+
+export const vi = {
+  fn: createMock,
+  mock(modulePath: string, factory: () => any) {
+    moduleMocks.set(modulePath, factory);
+  },
+  async importActual<T>(modulePath: string): Promise<T> {
+    const module = await import(modulePath);
+    return module as T;
+  },
+};
+
+const dynamicImport = async (specifier: string) => {
+  if (moduleMocks.has(specifier)) {
+    return moduleMocks.get(specifier)!();
+  }
+  return import(specifier);
+};
+
+export const dynamicImportModule = dynamicImport;


### PR DESCRIPTION
## Summary
- add Zod schemas to validate /bank-lines inputs and serialized responses
- guard Fastify handlers with response validation and injectable Prisma client for testing
- add lightweight vitest-style harness plus workspace script exercising validator edge cases

## Testing
- `pnpm -r test`

_Requested labels: P1, quality_


------
https://chatgpt.com/codex/tasks/task_e_68f60688d3ac832789d87749e6f0afcc