### PR TITLE
Handle invalid bank line take parameter

### DIFF
--- a/apgms/services/api-gateway/src/index.ts
+++ b/apgms/services/api-gateway/src/index.ts
@@ -31,10 +31,13 @@ app.get("/users", async () => {
 
 // List bank lines (latest first)
 app.get("/bank-lines", async (req) => {
-  const take = Number((req.query as any).take ?? 20);
+  const takeRaw = (req.query as any).take;
+  const parsedTake = takeRaw === undefined ? 20 : Number(takeRaw);
+  const take = Number.isFinite(parsedTake) ? parsedTake : 20;
+  const normalizedTake = Math.min(Math.max(Math.floor(take), 1), 200);
   const lines = await prisma.bankLine.findMany({
     orderBy: { date: "desc" },
-    take: Math.min(Math.max(take, 1), 200),
+    take: normalizedTake,
   });
   return { lines };
 });


### PR DESCRIPTION
## Summary
- default the bank line listing page size when the take query parameter is missing or invalid
- clamp the final take value to an integer within the supported range before querying Prisma

## Testing
- pnpm -r run test

------
https://chatgpt.com/codex/tasks/task_e_68f60d0b4c6c8327bfd35212fd36c56d