### PR TITLE
Harden API gateway security surface

### DIFF
--- a/apgms/.github/workflows/security.yml
+++ b/apgms/.github/workflows/security.yml
@@ -1,8 +1,29 @@
-﻿name: Security
-on: [push]
+name: security
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
-  scan:
+  supply-chain:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo scanning
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+      - run: corepack enable && pnpm i --frozen-lockfile
+      - name: SBOM (CycloneDX)
+        run: npx @cyclonedx/cyclonedx-npm --output-file sbom.json
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+      - name: SCA (npm audit)
+        run: pnpm audit --audit-level=high
+      - name: Docker scan (Trivy)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          scan-type: fs
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^12.0.1",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"


### PR DESCRIPTION
## Summary
- enforce strict Helmet CSP, frameguard, and allow-listed CORS origins in the API gateway
- wire new environment-driven configuration helpers to parse CSP and CORS lists
- add comprehensive supply-chain security workflow running SBOM, secret scan, audit, and Trivy

## Testing
- not run (registry access prevented dependency installation for lockfile update)

------
https://chatgpt.com/codex/tasks/task_e_68f62aa04ddc832783a0d8368f60940a