### PR TITLE
Fix admin data routes and schemas

### DIFF
--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "tsx --test test/privacy.spec.ts"
+    "test": "vitest run",
+    "test:unit": "vitest run src/**/*.test.ts",
+    "test:api": "vitest run test/**/*.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",
@@ -17,6 +19,7 @@
   "devDependencies": {
     "@types/node": "^24.7.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/apgms/services/api-gateway/src/routes/admin.data.ts
+++ b/apgms/services/api-gateway/src/routes/admin.data.ts
@@ -1,11 +1,15 @@
-<<<<<<< HEAD
 import { createHash } from "node:crypto";
-import type { FastifyInstance, FastifyRequest } from "fastify";
+import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from "fastify";
+import { z } from "zod";
 import {
   adminDataDeleteRequestSchema,
   adminDataDeleteResponseSchema,
+  subjectDataExportRequestSchema,
+  subjectDataExportResponseSchema,
   type AdminDataDeleteRequest,
   type AdminDataDeleteResponse,
+  type SubjectDataExportRequest,
+  type SubjectDataExportResponse,
 } from "../schemas/admin.data";
 
 interface Principal {
@@ -15,6 +19,15 @@ interface Principal {
   token: string;
 }
 
+const exportPrincipalSchema = z.object({
+  id: z.string(),
+  orgId: z.string(),
+  role: z.enum(["admin", "user"]),
+  email: z.string().email(),
+});
+
+type ExportPrincipal = z.infer<typeof exportPrincipalSchema>;
+
 export interface SecurityLogPayload {
   event: "data_delete";
   orgId: string;
@@ -23,45 +36,17 @@ export interface SecurityLogPayload {
   mode: "anonymized" | "deleted";
 }
 
+interface ExportSecurityLogPayload {
+  event: "data_export";
+  orgId: string;
+  principal: string;
+  subjectEmail: string;
+}
+
 const PASSWORD_PLACEHOLDER = "__deleted__";
 
 type SharedDbModule = typeof import("../../../../shared/src/db.js");
 type PrismaClientLike = Pick<SharedDbModule["prisma"], "user" | "bankLine">;
-
-interface AdminDataRouteDeps {
-  prisma?: PrismaClientLike;
-  secLog?: (payload: SecurityLogPayload) => Promise<void> | void;
-}
-
-export async function registerAdminDataRoutes(
-  app: FastifyInstance,
-  deps: AdminDataRouteDeps = {}
-) {
-  const prisma = deps.prisma ?? (await getDefaultPrisma());
-  const securityLogger =
-    deps.secLog ??
-    (async (payload: SecurityLogPayload) => {
-      app.log.info({ security: payload }, "security_event");
-    });
-
-  app.post("/admin/data/delete", async (request, reply) => {
-    const principal = parseAuthorization(request);
-=======
-import { FastifyPluginAsync, FastifyRequest } from "fastify";
-import { z } from "zod";
-import {
-  subjectDataExportRequestSchema,
-  subjectDataExportResponseSchema,
-} from "../schemas/admin.data";
-
-const principalSchema = z.object({
-  id: z.string(),
-  orgId: z.string(),
-  role: z.enum(["admin", "user"]),
-  email: z.string().email(),
-});
-
-type Principal = z.infer<typeof principalSchema>;
 
 type DbClient = {
   user: {
@@ -98,49 +83,26 @@ type DbClient = {
   };
 };
 
-type SecLogFn = (payload: {
-  event: string;
-  orgId: string;
-  principal: string;
-  subjectEmail: string;
-}) => void;
+interface AdminDataRouteDeps {
+  prisma?: PrismaClientLike;
+  secLog?: (payload: SecurityLogPayload) => Promise<void> | void;
+  db?: DbClient;
+  exportLog?: (payload: ExportSecurityLogPayload) => Promise<void> | void;
+}
 
-const parsePrincipal = (req: FastifyRequest): Principal | null => {
-  const header = req.headers.authorization;
-  if (!header) return null;
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  if (!match) return null;
-  try {
-    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
-    const parsed = JSON.parse(decoded);
-    return principalSchema.parse(parsed);
-  } catch {
-    return null;
-  }
-};
-
-const adminDataRoutes: FastifyPluginAsync = async (app) => {
-  const db: DbClient | undefined = (app as any).db;
-  if (!db) {
-    throw new Error("database client not registered");
-  }
-
-  const log: SecLogFn =
-    (app as any).secLog ??
-    ((entry) => {
-      app.log.info({ event: entry.event, ...entry }, "security_event");
+export async function registerAdminDataRoutes(
+  app: FastifyInstance,
+  deps: AdminDataRouteDeps = {}
+) {
+  const prisma = deps.prisma ?? (await getDefaultPrisma());
+  const securityLogger =
+    deps.secLog ??
+    (async (payload: SecurityLogPayload) => {
+      app.log.info({ security: payload }, "security_event");
     });
 
-  app.post("/admin/data/export", async (req, reply) => {
-    const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
-    if (!bodyResult.success) {
-      return reply.code(400).send({ error: "invalid_request" });
-    }
-
-    const body = bodyResult.data;
-
-    const principal = parsePrincipal(req);
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+  app.post("/admin/data/delete", async (request, reply) => {
+    const principal = parseAuthorization(request);
     if (!principal) {
       return reply.code(401).send({ error: "unauthorized" });
     }
@@ -149,7 +111,6 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
       return reply.code(403).send({ error: "forbidden" });
     }
 
-<<<<<<< HEAD
     const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: "invalid_request" });
@@ -157,13 +118,6 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
 
     const body = parsed.data;
 
-=======
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-    if (principal.orgId !== body.orgId) {
-      return reply.code(403).send({ error: "forbidden" });
-    }
-
-<<<<<<< HEAD
     const subject = await prisma.user.findFirst({
       where: { orgId: body.orgId, email: body.email },
     });
@@ -216,10 +170,104 @@ const adminDataRoutes: FastifyPluginAsync = async (app) => {
 
     return reply.code(202).send(response);
   });
+
+  const db = deps.db ?? ((app as any).db as DbClient | undefined);
+  if (db) {
+    const exportLogger: ((payload: ExportSecurityLogPayload) => Promise<void> | void) =
+      deps.exportLog ??
+      ((app as any).secLog && typeof (app as any).secLog === "function"
+        ? (app as any).secLog.bind(app)
+        : (entry: ExportSecurityLogPayload) => {
+            app.log.info({ event: entry.event, ...entry }, "security_event");
+          });
+
+    app.post("/admin/data/export", async (req, reply) => {
+      const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
+      if (!bodyResult.success) {
+        return reply.code(400).send({ error: "invalid_request" });
+      }
+
+      const body = bodyResult.data;
+
+      const principal = parseExportPrincipal(req);
+      if (!principal) {
+        return reply.code(401).send({ error: "unauthorized" });
+      }
+
+      if (principal.role !== "admin") {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+
+      if (principal.orgId !== body.orgId) {
+        return reply.code(403).send({ error: "forbidden" });
+      }
+
+      const userRecord = await db.user.findFirst({
+        where: { email: body.email, orgId: body.orgId },
+        select: {
+          id: true,
+          email: true,
+          createdAt: true,
+          org: { select: { id: true, name: true } },
+        },
+      });
+
+      if (!userRecord) {
+        return reply.code(404).send({ error: "not_found" });
+      }
+
+      const bankLinesCount = await db.bankLine.count({
+        where: { orgId: body.orgId },
+      });
+
+      const exportedAt = new Date().toISOString();
+
+      if (db.accessLog?.create) {
+        await db.accessLog.create({
+          data: {
+            event: "data_export",
+            orgId: body.orgId,
+            principalId: principal.id,
+            subjectEmail: body.email,
+          },
+        });
+      }
+
+      await Promise.resolve(
+        exportLogger({
+          event: "data_export",
+          orgId: body.orgId,
+          principal: principal.id,
+          subjectEmail: body.email,
+        })
+      );
+
+      const responsePayload: SubjectDataExportResponse = {
+        org: {
+          id: userRecord.org.id,
+          name: userRecord.org.name,
+        },
+        user: {
+          id: userRecord.id,
+          email: userRecord.email,
+          createdAt: userRecord.createdAt.toISOString(),
+        },
+        relationships: {
+          bankLinesCount,
+        },
+        exportedAt,
+      };
+
+      const validated = subjectDataExportResponseSchema.parse(responsePayload);
+      return reply.send(validated);
+    });
+  }
 }
 
 function parseAuthorization(request: FastifyRequest): Principal | null {
-  const header = request.headers["authorization"] ?? request.headers["Authorization" as keyof typeof request.headers];
+  const header =
+    request.headers["authorization"] ??
+    request.headers["Authorization" as keyof typeof request.headers];
   if (!header || typeof header !== "string") {
     return null;
   }
@@ -241,6 +289,20 @@ function parseAuthorization(request: FastifyRequest): Principal | null {
     orgId,
     token,
   };
+}
+
+function parseExportPrincipal(req: FastifyRequest): ExportPrincipal | null {
+  const header = req.headers.authorization;
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) return null;
+  try {
+    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded);
+    return exportPrincipalSchema.parse(parsed);
+  } catch {
+    return null;
+  }
 }
 
 async function detectForeignKeyRisk(
@@ -287,67 +349,28 @@ async function getDefaultPrisma(): Promise<PrismaClientLike> {
   return cachedDefaultPrisma;
 }
 
-export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
-=======
-    const userRecord = await db.user.findFirst({
-      where: { email: body.email, orgId: body.orgId },
-      select: {
-        id: true,
-        email: true,
-        createdAt: true,
-        org: { select: { id: true, name: true } },
-      },
-    });
+export type {
+  AdminDataDeleteRequest,
+  AdminDataDeleteResponse,
+  SubjectDataExportRequest,
+  SubjectDataExportResponse,
+};
 
-    if (!userRecord) {
-      return reply.code(404).send({ error: "not_found" });
-    }
+const adminDataRoutesPlugin: FastifyPluginAsync = async (app) => {
+  const db = (app as any).db as DbClient | undefined;
+  if (!db) {
+    throw new Error("database client not registered");
+  }
 
-    const bankLinesCount = await db.bankLine.count({
-      where: { orgId: body.orgId },
-    });
+  const exportLogger =
+    typeof (app as any).secLog === "function"
+      ? (app as any).secLog.bind(app)
+      : undefined;
 
-    const exportedAt = new Date().toISOString();
-
-    if (db.accessLog?.create) {
-      await db.accessLog.create({
-        data: {
-          event: "data_export",
-          orgId: body.orgId,
-          principalId: principal.id,
-          subjectEmail: body.email,
-        },
-      });
-    }
-
-    log({
-      event: "data_export",
-      orgId: body.orgId,
-      principal: principal.id,
-      subjectEmail: body.email,
-    });
-
-    const responsePayload = {
-      org: {
-        id: userRecord.org.id,
-        name: userRecord.org.name,
-      },
-      user: {
-        id: userRecord.id,
-        email: userRecord.email,
-        createdAt: userRecord.createdAt.toISOString(),
-      },
-      relationships: {
-        bankLinesCount,
-      },
-      exportedAt,
-    };
-
-    const validated = subjectDataExportResponseSchema.parse(responsePayload);
-
-    return reply.send(validated);
+  await registerAdminDataRoutes(app, {
+    db,
+    exportLog: exportLogger,
   });
 };
 
-export default adminDataRoutes;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+export default adminDataRoutesPlugin;

--- a/apgms/services/api-gateway/src/schemas/admin.data.ts
+++ b/apgms/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
 
-<<<<<<< HEAD
+export const adminExportQuery = z.object({
+  subjectId: z.string().cuid(),
+});
+
+export const adminDeleteBody = z.object({
+  subjectId: z.string().cuid(),
+  reason: z.string().min(5),
+});
+
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -19,7 +27,7 @@ export const adminDataDeleteResponseSchema = z.object({
 
 export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
 export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
+
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -54,4 +62,3 @@ export type SubjectDataExportRequest = z.infer<
 export type SubjectDataExportResponse = z.infer<
   typeof subjectDataExportResponseSchema
 >;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint


### PR DESCRIPTION
## Summary
- merge the admin data delete and export logic behind a single route module and default Fastify plugin
- extend the admin data schema module with the shared query/body helpers while keeping the existing request/response contracts
- switch the API gateway test scripts back to vitest and add the missing dev dependency

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: vitest binary missing because registry access for pnpm install is denied in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f62a93087883278843e6d0fd234d51