### PR TITLE
feat: validate bank line ingestion

### DIFF
--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -17,9 +17,27 @@ async function main() {
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      {
+        orgId: org.id,
+        externalId: "demo-line-1",
+        amountCents: 125075,
+        occurredAt: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2),
+        description: "Office fit-out",
+      },
+      {
+        orgId: org.id,
+        externalId: "demo-line-2",
+        amountCents: -29999,
+        occurredAt: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1),
+        description: "Monthly sub",
+      },
+      {
+        orgId: org.id,
+        externalId: "demo-line-3",
+        amountCents: 500000,
+        occurredAt: today,
+        description: "Investment received",
+      },
     ],
     skipDuplicates: true,
   });

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/index.ts",
-    "test": "tsx --test test/privacy.spec.ts"
+    "test": "tsx --test test/privacy.spec.ts test/bank-lines.spec.ts"
   },
   "dependencies": {
     "@apgms/shared": "workspace:*",

--- a/apgms/services/api-gateway/src/routes/admin.data.ts
+++ b/apgms/services/api-gateway/src/routes/admin.data.ts
@@ -249,27 +249,29 @@ async function detectForeignKeyRisk(
   email: string,
   orgId: string
 ): Promise<boolean> {
-  const relatedLines = await prisma.bankLine.count({
+  const referencesByEmail = await prisma.bankLine.count({
     where: {
       orgId,
-      payee: email,
+      description: {
+        contains: email,
+      },
     },
   });
 
-  if (relatedLines > 0) {
+  if (referencesByEmail > 0) {
     return true;
   }
 
-  const otherRefs = await prisma.bankLine.count({
+  const referencesById = await prisma.bankLine.count({
     where: {
       orgId,
-      desc: {
+      description: {
         contains: userId,
       },
     },
   });
 
-  return otherRefs > 0;
+  return referencesById > 0;
 }
 
 function anonymizeEmail(email: string, userId: string): string {

--- a/apgms/services/api-gateway/src/schemas/bankLine.ts
+++ b/apgms/services/api-gateway/src/schemas/bankLine.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const bankLineInput = z.object({
+  externalId: z.string().min(1),
+  amountCents: z.number().int(),
+  description: z.string().optional(),
+  occurredAt: z.string().datetime(),
+});

--- a/apgms/services/api-gateway/test/admin.data.delete.spec.ts
+++ b/apgms/services/api-gateway/test/admin.data.delete.spec.ts
@@ -180,7 +180,10 @@ describe("POST /admin/data/delete", () => {
 
     assert.equal(findCalls, 1);
     assert.equal(countCalls.length, 1);
-    assert.equal(countCalls[0].where.payee, user.email);
+    assert.deepEqual(countCalls[0].where, {
+      orgId: defaultPayload.orgId,
+      description: { contains: user.email },
+    });
     assert.equal(deleteCalled, false);
     assert.equal(updateCalls.length, 1);
     const updateArgs = updateCalls[0];

--- a/apgms/services/api-gateway/test/bank-lines.spec.ts
+++ b/apgms/services/api-gateway/test/bank-lines.spec.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { randomUUID } from "node:crypto";
+
+import type { BankLine, PrismaClient } from "@prisma/client";
+
+import { createApp } from "../src/app";
+
+type PrismaLike = Pick<
+  PrismaClient,
+  "bankLine" | "user" | "org" | "orgTombstone" | "$transaction"
+>;
+
+type BankLineState = Omit<BankLine, "occurredAt" | "createdAt"> & {
+  occurredAt: Date;
+  createdAt: Date;
+};
+
+type StubState = {
+  bankLines: BankLineState[];
+};
+
+function createPrismaStub(initial?: Partial<StubState>): { client: PrismaLike; state: StubState } {
+  const state: StubState = {
+    bankLines: initial?.bankLines ?? [],
+  };
+
+  const client: PrismaLike = {
+    bankLine: {
+      findMany: async ({ orderBy, take }) => {
+        let lines = [...state.bankLines];
+        if (orderBy?.occurredAt === "desc") {
+          lines.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
+        }
+        if (typeof take === "number") {
+          lines = lines.slice(0, take);
+        }
+        return lines;
+      },
+      upsert: async ({ where, create }) => {
+        const { orgId, externalId } = where.orgId_externalId;
+        const existing = state.bankLines.find(
+          (line) => line.orgId === orgId && line.externalId === externalId
+        );
+        if (existing) {
+          return existing as unknown as BankLine;
+        }
+        const record: BankLineState = {
+          id: create.id ?? randomUUID(),
+          orgId: create.orgId!,
+          externalId: create.externalId!,
+          amountCents: create.amountCents!,
+          occurredAt: create.occurredAt as Date,
+          description: create.description ?? null,
+          createdAt: create.createdAt ?? new Date(),
+        };
+        state.bankLines.push(record);
+        return record as unknown as BankLine;
+      },
+    },
+    user: {
+      findMany: async () => [],
+    },
+    org: {
+      findUnique: async () => null,
+    },
+    orgTombstone: {
+      create: async () => ({}) as any,
+    },
+    $transaction: async (cb) => cb(client as any),
+  } as unknown as PrismaLike;
+
+  return { client, state };
+}
+
+test("POST /bank-lines requires authentication", async () => {
+  const { client } = createPrismaStub();
+  const app = await createApp({ prisma: client as unknown as PrismaClient });
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      externalId: "ext-1",
+      amountCents: 1000,
+      occurredAt: new Date().toISOString(),
+    },
+  });
+
+  assert.equal(response.statusCode, 401);
+
+  await app.close();
+});
+
+test("POST /bank-lines requires an idempotency key", async () => {
+  const { client } = createPrismaStub();
+  const app = await createApp({ prisma: client as unknown as PrismaClient });
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      externalId: "ext-1",
+      amountCents: 1000,
+      occurredAt: new Date().toISOString(),
+    },
+    headers: {
+      authorization: "Bearer member:user-1:org-1",
+    },
+  });
+
+  assert.equal(response.statusCode, 400);
+  const body = response.json() as { error: string };
+  assert.equal(body.error, "idempotency_key_required");
+
+  await app.close();
+});
+
+test("POST /bank-lines validates the payload", async () => {
+  const { client } = createPrismaStub();
+  const app = await createApp({ prisma: client as unknown as PrismaClient });
+  await app.ready();
+
+  const response = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload: {
+      externalId: "",
+      amountCents: "not-a-number",
+      occurredAt: "yesterday",
+    },
+    headers: {
+      authorization: "Bearer member:user-1:org-1",
+      "idempotency-key": "idem-1",
+    },
+  });
+
+  assert.equal(response.statusCode, 400);
+
+  await app.close();
+});
+
+test("POST /bank-lines upserts by external id", async () => {
+  const { client, state } = createPrismaStub();
+  const app = await createApp({ prisma: client as unknown as PrismaClient });
+  await app.ready();
+
+  const payload = {
+    externalId: "ext-1",
+    amountCents: 4200,
+    occurredAt: new Date("2024-03-01T00:00:00Z").toISOString(),
+    description: "Membership fee",
+  };
+
+  const first = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload,
+    headers: {
+      authorization: "Bearer member:user-1:org-1",
+      "idempotency-key": "idem-1",
+    },
+  });
+
+  assert.equal(first.statusCode, 200);
+  const firstBody = first.json() as { id: string };
+  assert.equal(state.bankLines.length, 1);
+
+  const second = await app.inject({
+    method: "POST",
+    url: "/bank-lines",
+    payload,
+    headers: {
+      authorization: "Bearer member:user-1:org-1",
+      "idempotency-key": "idem-1",
+    },
+  });
+
+  assert.equal(second.statusCode, 200);
+  const secondBody = second.json() as { id: string };
+  assert.equal(secondBody.id, firstBody.id);
+  assert.equal(state.bankLines.length, 1);
+
+  await app.close();
+});

--- a/apgms/services/api-gateway/test/privacy.spec.ts
+++ b/apgms/services/api-gateway/test/privacy.spec.ts
@@ -80,8 +80,11 @@ test("admin export returns organisation data without secrets", async (t) => {
     createdAt: stub.state.users[0].createdAt.toISOString(),
   });
   assert.equal(body.export.bankLines.length, 1);
-  assert.equal(body.export.bankLines[0].amount, 1200);
-  assert.equal(body.export.bankLines[0].date, stub.state.bankLines[0].date.toISOString());
+  assert.equal(body.export.bankLines[0].amountCents, 1200);
+  assert.equal(
+    body.export.bankLines[0].occurredAt,
+    stub.state.bankLines[0].occurredAt.toISOString()
+  );
   assert.equal(body.export.org.deletedAt, null);
 });
 
@@ -166,8 +169,8 @@ function createPrismaStub(initial?: Partial<State>): Stub {
     bankLine: {
       findMany: async ({ orderBy, take }) => {
         let lines = [...state.bankLines];
-        if (orderBy?.date === "desc") {
-          lines.sort((a, b) => b.date.getTime() - a.date.getTime());
+        if (orderBy?.occurredAt === "desc") {
+          lines.sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime());
         }
         if (typeof take === "number") {
           lines = lines.slice(0, take);
@@ -178,10 +181,10 @@ function createPrismaStub(initial?: Partial<State>): Stub {
         const created = {
           id: data.id ?? randomUUID(),
           orgId: data.orgId!,
-          date: data.date as Date,
-          amount: data.amount as any,
-          payee: data.payee!,
-          desc: data.desc!,
+          externalId: data.externalId!,
+          amountCents: data.amountCents!,
+          occurredAt: data.occurredAt as Date,
+          description: data.description ?? null,
           createdAt: data.createdAt ?? new Date(),
         } as unknown as BankLine;
         state.bankLines.push(created);
@@ -231,10 +234,10 @@ function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lin
   state.bankLines.push({
     id: ids.lineId,
     orgId: ids.orgId,
-    date: new Date("2024-02-02T00:00:00Z"),
-    amount: 1200 as any,
-    payee: "Vendor",
-    desc: "Invoice",
+    externalId: "ext-1",
+    amountCents: 1200,
+    occurredAt: new Date("2024-02-02T00:00:00Z"),
+    description: "Invoice",
     createdAt,
   } as BankLine);
 }

--- a/apgms/shared/prisma/migrations/20251010133921_init/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010133921_init/migration.sql
@@ -22,10 +22,10 @@ CREATE TABLE "User" (
 CREATE TABLE "BankLine" (
     "id" TEXT NOT NULL,
     "orgId" TEXT NOT NULL,
-    "date" TIMESTAMP(3) NOT NULL,
-    "amount" DECIMAL(65,30) NOT NULL,
-    "payee" TEXT NOT NULL,
-    "desc" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "description" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "BankLine_pkey" PRIMARY KEY ("id")
@@ -33,6 +33,7 @@ CREATE TABLE "BankLine" (
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "BankLine_orgId_externalId_key" ON "BankLine"("orgId", "externalId");
 
 -- AddForeignKey
 ALTER TABLE "User" ADD CONSTRAINT "User_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -27,14 +27,16 @@ model User {
 }
 
 model BankLine {
-  id        String   @id @default(cuid())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
-  date      DateTime
-  amount    Decimal
-  payee     String
-  desc      String
-  createdAt DateTime @default(now())
+  id          String   @id @default(cuid())
+  org         Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId       String
+  externalId  String
+  amountCents Int
+  occurredAt  DateTime
+  description String?
+  createdAt   DateTime @default(now())
+
+  @@unique([orgId, externalId])
 }
 
 model OrgTombstone {


### PR DESCRIPTION
## Summary
- validate `/bank-lines` payloads with a dedicated Zod schema and enforce auth plus idempotency when inserting
- reshape the Prisma bank line model, seed data, and exports to use external IDs, occurredAt timestamps, and amount cents
- add coverage for the new endpoint behavior and adjust existing tests to the updated bank line structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f62a8694f88327967fc7d276d3bbf3