### PR TITLE
Hash user passwords and remove plaintext storage

### DIFF
--- a/apgms/scripts/migrate-plaintext-passwords.ts
+++ b/apgms/scripts/migrate-plaintext-passwords.ts
@@ -1,0 +1,91 @@
+import { randomBytes } from "node:crypto";
+
+import { prisma } from "@apgms/shared/src/db";
+import { hash } from "@apgms/shared/src/crypto";
+
+async function hasLegacyPasswordColumn(): Promise<boolean> {
+  const result = await prisma.$queryRaw<{ exists: boolean }[]>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name = 'User'
+        AND column_name = 'password'
+    ) AS "exists";
+  `;
+
+  return result[0]?.exists ?? false;
+}
+
+async function loadLegacyPasswords(): Promise<Map<string, string>> {
+  const rows = await prisma.$queryRaw<{ id: string; password: string | null }[]>`
+    SELECT "id", "password"
+    FROM "User";
+  `;
+
+  const entries = rows
+    .filter((row) => typeof row.password === "string" && row.password.trim().length > 0)
+    .map((row) => [row.id, row.password!.trim()] as const);
+
+  return new Map(entries);
+}
+
+async function main(): Promise<void> {
+  const legacyColumnPresent = await hasLegacyPasswordColumn();
+  const legacyPasswords = legacyColumnPresent ? await loadLegacyPasswords() : new Map();
+
+  const usersNeedingHash = await prisma.user.findMany({
+    where: { passwordHash: "" },
+    select: { id: true, email: true },
+  });
+
+  if (usersNeedingHash.length === 0) {
+    console.log("No plaintext passwords detected; nothing to migrate.");
+    return;
+  }
+
+  let migratedCount = 0;
+  let resetCount = 0;
+
+  for (const user of usersNeedingHash) {
+    const legacyPassword = legacyPasswords.get(user.id);
+    let passwordHash: string;
+
+    if (legacyPassword) {
+      passwordHash = await hash(legacyPassword);
+      migratedCount += 1;
+    } else {
+      const temporaryPassword = randomBytes(24).toString("base64url");
+      passwordHash = await hash(temporaryPassword);
+      resetCount += 1;
+      console.warn(
+        `User ${user.email} (${user.id}) is missing a legacy password; generated a temporary hash and requires reset.`,
+      );
+    }
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash },
+    });
+  }
+
+  if (legacyColumnPresent) {
+    try {
+      await prisma.$executeRawUnsafe('ALTER TABLE "User" DROP COLUMN "password"');
+      console.log("Dropped legacy plaintext password column.");
+    } catch (error) {
+      console.warn("Failed to drop legacy password column; please remove manually.", error);
+    }
+  }
+
+  console.log(`Migrated ${migratedCount} accounts; flagged ${resetCount} for forced reset.`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed to migrate plaintext passwords", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,4 +1,6 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import { hash } from "@apgms/shared/src/crypto";
+
 const prisma = new PrismaClient();
 
 async function main() {
@@ -8,18 +10,38 @@ async function main() {
     create: { id: "demo-org", name: "Demo Org" },
   });
 
+  const passwordHash = await hash(process.env.SEED_ADMIN_PASSWORD ?? "ChangeMe!123");
+
   await prisma.user.upsert({
     where: { email: "founder@example.com" },
-    update: {},
-    create: { email: "founder@example.com", password: "password123", orgId: org.id },
+    update: { passwordHash },
+    create: { email: "founder@example.com", passwordHash, orgId: org.id },
   });
 
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2),
+        amount: 1250.75,
+        payee: "Acme",
+        desc: "Office fit-out",
+      },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1),
+        amount: -299.99,
+        payee: "CloudCo",
+        desc: "Monthly sub",
+      },
+      {
+        orgId: org.id,
+        date: today,
+        amount: 5000.0,
+        payee: "Birchal",
+        desc: "Investment received",
+      },
     ],
     skipDuplicates: true,
   });
@@ -27,5 +49,11 @@ async function main() {
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/services/api-gateway/src/routes/admin.data.ts
+++ b/apgms/services/api-gateway/src/routes/admin.data.ts
@@ -1,18 +1,31 @@
-<<<<<<< HEAD
 import { createHash } from "node:crypto";
-import type { FastifyInstance, FastifyRequest } from "fastify";
+
+import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from "fastify";
+import { z } from "zod";
+
+import { hash } from "@apgms/shared/src/crypto";
+
 import {
   adminDataDeleteRequestSchema,
   adminDataDeleteResponseSchema,
+  subjectDataExportRequestSchema,
+  subjectDataExportResponseSchema,
   type AdminDataDeleteRequest,
   type AdminDataDeleteResponse,
 } from "../schemas/admin.data";
 
-interface Principal {
+interface DeletePrincipal {
   id: string;
   role: string;
   orgId: string;
   token: string;
+}
+
+interface ExportPrincipal {
+  id: string;
+  orgId: string;
+  role: "admin" | "user";
+  email: string;
 }
 
 export interface SecurityLogPayload {
@@ -33,9 +46,12 @@ interface AdminDataRouteDeps {
   secLog?: (payload: SecurityLogPayload) => Promise<void> | void;
 }
 
+let cachedDefaultPrisma: PrismaClientLike | null = null;
+let cachedDeletedHash: string | null = null;
+
 export async function registerAdminDataRoutes(
   app: FastifyInstance,
-  deps: AdminDataRouteDeps = {}
+  deps: AdminDataRouteDeps = {},
 ) {
   const prisma = deps.prisma ?? (await getDefaultPrisma());
   const securityLogger =
@@ -45,14 +61,80 @@ export async function registerAdminDataRoutes(
     });
 
   app.post("/admin/data/delete", async (request, reply) => {
-    const principal = parseAuthorization(request);
-=======
-import { FastifyPluginAsync, FastifyRequest } from "fastify";
-import { z } from "zod";
-import {
-  subjectDataExportRequestSchema,
-  subjectDataExportResponseSchema,
-} from "../schemas/admin.data";
+    const principal = parseDeleteAuthorization(request);
+    if (!principal) {
+      return reply.code(401).send({ error: "unauthorized" });
+    }
+
+    if (principal.role !== "admin") {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.code(400).send({ error: "invalid_request" });
+    }
+
+    const body = parsed.data;
+
+    if (principal.orgId !== body.orgId) {
+      return reply.code(403).send({ error: "forbidden" });
+    }
+
+    const subject = await prisma.user.findFirst({
+      where: { orgId: body.orgId, email: body.email },
+    });
+
+    if (!subject) {
+      return reply.code(404).send({ error: "not_found" });
+    }
+
+    const hasConstraintRisk = await detectForeignKeyRisk(
+      prisma,
+      subject.id,
+      subject.email,
+      subject.orgId,
+    );
+
+    const occurredAt = new Date().toISOString();
+    let response: AdminDataDeleteResponse;
+
+    if (hasConstraintRisk) {
+      const anonymizedEmail = anonymizeEmail(subject.email, subject.id);
+      const placeholderHash = await getDeletedPasswordHash();
+      await prisma.user.update({
+        where: { id: subject.id },
+        data: {
+          email: anonymizedEmail,
+          passwordHash: placeholderHash,
+        },
+      });
+
+      response = adminDataDeleteResponseSchema.parse({
+        action: "anonymized",
+        userId: subject.id,
+        occurredAt,
+      });
+    } else {
+      await prisma.user.delete({ where: { id: subject.id } });
+      response = adminDataDeleteResponseSchema.parse({
+        action: "deleted",
+        userId: subject.id,
+        occurredAt,
+      });
+    }
+
+    await securityLogger({
+      event: "data_delete",
+      orgId: body.orgId,
+      principal: principal.id,
+      subjectUserId: subject.id,
+      mode: response.action,
+    });
+
+    return reply.code(202).send(response);
+  });
+}
 
 const principalSchema = z.object({
   id: z.string(),
@@ -60,8 +142,6 @@ const principalSchema = z.object({
   role: z.enum(["admin", "user"]),
   email: z.string().email(),
 });
-
-type Principal = z.infer<typeof principalSchema>;
 
 type DbClient = {
   user: {
@@ -105,190 +185,36 @@ type SecLogFn = (payload: {
   subjectEmail: string;
 }) => void;
 
-const parsePrincipal = (req: FastifyRequest): Principal | null => {
-  const header = req.headers.authorization;
-  if (!header) return null;
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  if (!match) return null;
-  try {
-    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
-    const parsed = JSON.parse(decoded);
-    return principalSchema.parse(parsed);
-  } catch {
-    return null;
-  }
-};
-
 const adminDataRoutes: FastifyPluginAsync = async (app) => {
   const db: DbClient | undefined = (app as any).db;
   if (!db) {
-    throw new Error("database client not registered");
+    throw new Error("Database client must be provided via app.decorate('db', client)");
   }
 
-  const log: SecLogFn =
-    (app as any).secLog ??
-    ((entry) => {
-      app.log.info({ event: entry.event, ...entry }, "security_event");
-    });
+  const securityLog: SecLogFn =
+    typeof (app as any).secLog === "function"
+      ? (app as any).secLog
+      : (entry) => {
+          app.log.info({ event: entry.event, ...entry }, "security_event");
+        };
 
-  app.post("/admin/data/export", async (req, reply) => {
-    const bodyResult = subjectDataExportRequestSchema.safeParse(req.body);
-    if (!bodyResult.success) {
-      return reply.code(400).send({ error: "invalid_request" });
-    }
-
-    const body = bodyResult.data;
-
-    const principal = parsePrincipal(req);
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+  app.post("/admin/data/export", async (request, reply) => {
+    const principal = parseExportPrincipal(request);
     if (!principal) {
       return reply.code(401).send({ error: "unauthorized" });
     }
 
-    if (principal.role !== "admin") {
-      return reply.code(403).send({ error: "forbidden" });
-    }
-
-<<<<<<< HEAD
-    const parsed = adminDataDeleteRequestSchema.safeParse(request.body);
+    const parsed = subjectDataExportRequestSchema.safeParse(request.body);
     if (!parsed.success) {
       return reply.code(400).send({ error: "invalid_request" });
     }
 
     const body = parsed.data;
 
-=======
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
-    if (principal.orgId !== body.orgId) {
+    if (principal.role !== "admin" || principal.orgId !== body.orgId) {
       return reply.code(403).send({ error: "forbidden" });
     }
 
-<<<<<<< HEAD
-    const subject = await prisma.user.findFirst({
-      where: { orgId: body.orgId, email: body.email },
-    });
-
-    if (!subject) {
-      return reply.code(404).send({ error: "not_found" });
-    }
-
-    const hasConstraintRisk = await detectForeignKeyRisk(
-      prisma,
-      subject.id,
-      subject.email,
-      subject.orgId
-    );
-
-    const occurredAt = new Date().toISOString();
-    let response: AdminDataDeleteResponse;
-
-    if (hasConstraintRisk) {
-      const anonymizedEmail = anonymizeEmail(subject.email, subject.id);
-      await prisma.user.update({
-        where: { id: subject.id },
-        data: {
-          email: anonymizedEmail,
-          password: PASSWORD_PLACEHOLDER,
-        },
-      });
-
-      response = adminDataDeleteResponseSchema.parse({
-        action: "anonymized",
-        userId: subject.id,
-        occurredAt,
-      });
-    } else {
-      await prisma.user.delete({ where: { id: subject.id } });
-      response = adminDataDeleteResponseSchema.parse({
-        action: "deleted",
-        userId: subject.id,
-        occurredAt,
-      });
-    }
-
-    await securityLogger({
-      event: "data_delete",
-      orgId: body.orgId,
-      principal: principal.id,
-      subjectUserId: subject.id,
-      mode: response.action,
-    });
-
-    return reply.code(202).send(response);
-  });
-}
-
-function parseAuthorization(request: FastifyRequest): Principal | null {
-  const header = request.headers["authorization"] ?? request.headers["Authorization" as keyof typeof request.headers];
-  if (!header || typeof header !== "string") {
-    return null;
-  }
-
-  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
-  if (!match) {
-    return null;
-  }
-
-  const token = match[1];
-  const [role, principalId, orgId] = token.split(":");
-  if (!role || !principalId || !orgId) {
-    return null;
-  }
-
-  return {
-    id: principalId,
-    role,
-    orgId,
-    token,
-  };
-}
-
-async function detectForeignKeyRisk(
-  prisma: PrismaClientLike,
-  userId: string,
-  email: string,
-  orgId: string
-): Promise<boolean> {
-  const relatedLines = await prisma.bankLine.count({
-    where: {
-      orgId,
-      payee: email,
-    },
-  });
-
-  if (relatedLines > 0) {
-    return true;
-  }
-
-  const otherRefs = await prisma.bankLine.count({
-    where: {
-      orgId,
-      desc: {
-        contains: userId,
-      },
-    },
-  });
-
-  return otherRefs > 0;
-}
-
-function anonymizeEmail(email: string, userId: string): string {
-  const hash = createHash("sha256").update(`${email}:${userId}`).digest("hex");
-  return `deleted+${hash.slice(0, 12)}@example.com`;
-}
-
-let cachedDefaultPrisma: PrismaClientLike | null = null;
-
-async function getDefaultPrisma(): Promise<PrismaClientLike> {
-  if (!cachedDefaultPrisma) {
-    const module = (await import("../../../../shared/src/db.js")) as SharedDbModule;
-    cachedDefaultPrisma = module.prisma;
-  }
-  return cachedDefaultPrisma;
-}
-
-export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
-=======
     const userRecord = await db.user.findFirst({
       where: { email: body.email, orgId: body.orgId },
       select: {
@@ -320,14 +246,14 @@ export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
       });
     }
 
-    log({
+    securityLog({
       event: "data_export",
       orgId: body.orgId,
       principal: principal.id,
       subjectEmail: body.email,
     });
 
-    const responsePayload = {
+    const responsePayload = subjectDataExportResponseSchema.parse({
       org: {
         id: userRecord.org.id,
         name: userRecord.org.name,
@@ -341,13 +267,107 @@ export type { AdminDataDeleteRequest, AdminDataDeleteResponse };
         bankLinesCount,
       },
       exportedAt,
-    };
+    });
 
-    const validated = subjectDataExportResponseSchema.parse(responsePayload);
-
-    return reply.send(validated);
+    return reply.send(responsePayload);
   });
 };
 
+function parseDeleteAuthorization(request: FastifyRequest): DeletePrincipal | null {
+  const header =
+    request.headers["authorization"] ??
+    request.headers["Authorization" as keyof typeof request.headers];
+
+  if (!header || typeof header !== "string") {
+    return null;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1];
+  const [role, principalId, orgId] = token.split(":");
+  if (!role || !principalId || !orgId) {
+    return null;
+  }
+
+  return {
+    id: principalId,
+    role,
+    orgId,
+    token,
+  };
+}
+
+function parseExportPrincipal(request: FastifyRequest): ExportPrincipal | null {
+  const header = request.headers.authorization;
+  if (!header || typeof header !== "string") {
+    return null;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(match[1], "base64url").toString("utf8");
+    return principalSchema.parse(JSON.parse(decoded));
+  } catch {
+    return null;
+  }
+}
+
+async function detectForeignKeyRisk(
+  prisma: PrismaClientLike,
+  userId: string,
+  email: string,
+  orgId: string,
+): Promise<boolean> {
+  const relatedLines = await prisma.bankLine.count({
+    where: {
+      orgId,
+      payee: email,
+    },
+  });
+
+  if (relatedLines > 0) {
+    return true;
+  }
+
+  const otherRefs = await prisma.bankLine.count({
+    where: {
+      orgId,
+      desc: {
+        contains: userId,
+      },
+    },
+  });
+
+  return otherRefs > 0;
+}
+
+function anonymizeEmail(email: string, userId: string): string {
+  const digest = createHash("sha256").update(`${email}:${userId}`).digest("hex");
+  return `deleted+${digest.slice(0, 12)}@example.com`;
+}
+
+async function getDefaultPrisma(): Promise<PrismaClientLike> {
+  if (!cachedDefaultPrisma) {
+    const module = (await import("../../../../shared/src/db.js")) as SharedDbModule;
+    cachedDefaultPrisma = module.prisma;
+  }
+  return cachedDefaultPrisma;
+}
+
+async function getDeletedPasswordHash(): Promise<string> {
+  if (!cachedDeletedHash) {
+    cachedDeletedHash = await hash(PASSWORD_PLACEHOLDER);
+  }
+  return cachedDeletedHash;
+}
+
 export default adminDataRoutes;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+export type { AdminDataDeleteRequest, AdminDataDeleteResponse };

--- a/apgms/services/api-gateway/src/schemas/admin.data.ts
+++ b/apgms/services/api-gateway/src/schemas/admin.data.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-<<<<<<< HEAD
 export const adminDataDeleteRequestSchema = z.object({
   orgId: z.string().min(1, "orgId is required"),
   email: z.string().email("email must be valid"),
@@ -19,7 +18,7 @@ export const adminDataDeleteResponseSchema = z.object({
 
 export type AdminDataDeleteRequest = z.infer<typeof adminDataDeleteRequestSchema>;
 export type AdminDataDeleteResponse = z.infer<typeof adminDataDeleteResponseSchema>;
-=======
+
 export const subjectDataExportRequestSchema = z.object({
   orgId: z.string().min(1),
   email: z.string().email(),
@@ -47,11 +46,5 @@ export const subjectDataExportResponseSchema = z.object({
   exportedAt: z.string(),
 });
 
-export type SubjectDataExportRequest = z.infer<
-  typeof subjectDataExportRequestSchema
->;
-
-export type SubjectDataExportResponse = z.infer<
-  typeof subjectDataExportResponseSchema
->;
->>>>>>> origin/codex/add-admin-gated-subject-data-export-endpoint
+export type SubjectDataExportRequest = z.infer<typeof subjectDataExportRequestSchema>;
+export type SubjectDataExportResponse = z.infer<typeof subjectDataExportResponseSchema>;

--- a/apgms/services/api-gateway/test/privacy.spec.ts
+++ b/apgms/services/api-gateway/test/privacy.spec.ts
@@ -224,7 +224,7 @@ function seedOrgWithData(state: State, ids: { orgId: string; userId: string; lin
   state.users.push({
     id: ids.userId,
     email: "someone@example.com",
-    password: "hashed-password",
+    passwordHash: "hashed-password",
     orgId: ids.orgId,
     createdAt,
   } as User);

--- a/apgms/shared/package.json
+++ b/apgms/shared/package.json
@@ -14,7 +14,8 @@
     "build": "echo building shared"
   },
   "dependencies": {
-    "@prisma/client": "6.17.1"
+    "@prisma/client": "6.17.1",
+    "bcryptjs": "^2.4.3"
   },
   "devDependencies": {
     "prisma": "6.17.1",

--- a/apgms/shared/prisma/migrations/20251010133921_init/migration.sql
+++ b/apgms/shared/prisma/migrations/20251010133921_init/migration.sql
@@ -11,7 +11,7 @@ CREATE TABLE "Org" (
 CREATE TABLE "User" (
     "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
-    "password" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "orgId" TEXT NOT NULL,
 

--- a/apgms/shared/prisma/migrations/20251014120000_add_password_hash/migration.sql
+++ b/apgms/shared/prisma/migrations/20251014120000_add_password_hash/migration.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "passwordHash" TEXT;
+
+UPDATE "User"
+SET "passwordHash" = COALESCE("passwordHash", '')
+WHERE "passwordHash" IS NULL;
+
+ALTER TABLE "User"
+  ALTER COLUMN "passwordHash" SET DEFAULT '';
+
+ALTER TABLE "User"
+  ALTER COLUMN "passwordHash" SET NOT NULL;
+
+ALTER TABLE "User"
+  ALTER COLUMN "passwordHash" DROP DEFAULT;

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -18,12 +18,12 @@ model Org {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  password  String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
-  orgId     String
+  id           String   @id @default(cuid())
+  email        String   @unique
+  passwordHash String
+  createdAt    DateTime @default(now())
+  org          Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId        String
 }
 
 model BankLine {

--- a/apgms/shared/src/crypto.ts
+++ b/apgms/shared/src/crypto.ts
@@ -1,0 +1,15 @@
+import bcrypt from "bcryptjs";
+
+const DEFAULT_ROUNDS = 12;
+
+export function hash(value: string, rounds = DEFAULT_ROUNDS): Promise<string> {
+  return bcrypt.hash(value, rounds);
+}
+
+export function verify(value: string, hashed: string): Promise<boolean> {
+  return bcrypt.compare(value, hashed);
+}
+
+export const cryptoConfig = {
+  rounds: DEFAULT_ROUNDS,
+};

--- a/apgms/shared/src/index.ts
+++ b/apgms/shared/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./masking";
+export * from "./crypto";

--- a/apgms/shared/src/masking.ts
+++ b/apgms/shared/src/masking.ts
@@ -3,6 +3,7 @@ const SENSITIVE_KEY_PATTERNS = [
   "token",
   "secret",
   "key",
+  "passwordhash",
   "authorization",
   "cookie",
   "session",


### PR DESCRIPTION
## Summary
- add shared bcrypt helpers and ensure password hashes are treated as sensitive data
- update Prisma schema, migrations, and seed/migration scripts to populate passwordHash instead of plaintext passwords
- update admin data routes and tests to work with hashed passwords during anonymisation and verification

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f62a74a41c83278433b1516c629c35