### PR TITLE
feat: secure api gateway user and bank routes with jwt

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -5,3 +5,5 @@ PORT=3000
 TAX_ENGINE_URL=http://tax-engine:8000
 WEBAPP_PORT=5173
 REDIS_URL=redis://redis:6379
+CORS_ALLOWLIST=https://app.example.com
+JWT_DEV_SECRET=REPLACE_ME_IN_DEV

--- a/apgms/services/api-gateway/package.json
+++ b/apgms/services/api-gateway/package.json
@@ -10,6 +10,8 @@
   "dependencies": {
     "@apgms/shared": "workspace:*",
     "@fastify/cors": "^11.1.0",
+    "@fastify/helmet": "^11.2.1",
+    "@fastify/jwt": "^9.4.2",
     "dotenv": "^16.6.1",
     "fastify": "^5.6.1",
     "zod": "^4.1.12"


### PR DESCRIPTION
## Summary
- add helmet, cors allowlist, and JWT guard wiring to the API gateway bootstrap
- require authenticated org-scoped access for the /users and /bank-lines endpoints with trimmed response payloads
- document the new environment variables and include the new security dependencies

## Testing
- pnpm --filter @apgms/api-gateway test *(fails: missing @fastify/helmet because registry installs are blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f62a66488c8327bb39883ec9eb6076