### PR TITLE
identity: bcrypt hashing for users; secure seeds

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,2 @@
+# WARNING: Change before running seeds outside local development.
+SEED_USER_PASSWORD=BirchalSeed#2024!

--- a/apgms/package.json
+++ b/apgms/package.json
@@ -1,1 +1,28 @@
-{"name":"apgms","private":true,"version":"0.1.0","workspaces":["services/*","webapp","shared","worker"],"scripts":{"build":"pnpm -r run build","test":"pnpm -r run test"},"devDependencies":{"@types/node":"^24.7.1","prisma":"6.17.1","tsx":"^4.20.6","typescript":"^5.9.3"},"dependencies":{"@fastify/cors":"^11.1.0","@prisma/client":"6.17.1","fastify":"^5.6.1","zod":"^4.1.12"}}
+{
+  "name": "apgms",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "services/*",
+    "webapp",
+    "shared",
+    "worker"
+  ],
+  "scripts": {
+    "build": "pnpm -r run build",
+    "test": "pnpm -r run test"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.1",
+    "prisma": "6.17.1",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@fastify/cors": "^11.1.0",
+    "@prisma/client": "6.17.1",
+    "bcryptjs": "^2.4.3",
+    "fastify": "^5.6.1",
+    "zod": "^4.1.12"
+  }
+}

--- a/apgms/scripts/seed.ts
+++ b/apgms/scripts/seed.ts
@@ -1,7 +1,13 @@
-﻿import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
 const prisma = new PrismaClient();
+const DEFAULT_SEED_PASSWORD = "BirchalSeed#2024!";
 
 async function main() {
+  const seedPassword = process.env.SEED_USER_PASSWORD ?? DEFAULT_SEED_PASSWORD;
+  const passwordHash = await bcrypt.hash(seedPassword, 12);
+
   const org = await prisma.org.upsert({
     where: { id: "demo-org" },
     update: {},
@@ -11,15 +17,37 @@ async function main() {
   await prisma.user.upsert({
     where: { email: "founder@example.com" },
     update: {},
-    create: { email: "founder@example.com", password: "password123", orgId: org.id },
+    create: {
+      email: "founder@example.com",
+      password: passwordHash,
+      orgId: org.id,
+    },
   });
 
   const today = new Date();
   await prisma.bankLine.createMany({
     data: [
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-2), amount: 1250.75, payee: "Acme", desc: "Office fit-out" },
-      { orgId: org.id, date: new Date(today.getFullYear(), today.getMonth(), today.getDate()-1), amount: -299.99, payee: "CloudCo", desc: "Monthly sub" },
-      { orgId: org.id, date: today, amount: 5000.00, payee: "Birchal", desc: "Investment received" },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2),
+        amount: 1250.75,
+        payee: "Acme",
+        desc: "Office fit-out",
+      },
+      {
+        orgId: org.id,
+        date: new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1),
+        amount: -299.99,
+        payee: "CloudCo",
+        desc: "Monthly sub",
+      },
+      {
+        orgId: org.id,
+        date: today,
+        amount: 5000.0,
+        payee: "Birchal",
+        desc: "Investment received",
+      },
     ],
     skipDuplicates: true,
   });
@@ -27,5 +55,11 @@ async function main() {
   console.log("Seed OK");
 }
 
-main().catch(e => { console.error(e); process.exit(1); })
-  .finally(async () => { await prisma.$disconnect(); });
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apgms/shared/prisma/schema.prisma
+++ b/apgms/shared/prisma/schema.prisma
@@ -18,6 +18,7 @@ model Org {
 model User {
   id        String   @id @default(cuid())
   email     String   @unique
+  /// BCrypt hash of the user's password.
   password  String
   createdAt DateTime @default(now())
   org       Org      @relation(fields: [orgId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary
- document that user passwords are stored as bcrypt hashes in the shared Prisma schema
- hash the seeded user password with bcryptjs using a configurable environment variable and stronger default
- add a `.env.example` entry warning about the seed password configuration

## Testing
- `pnpm exec tsx scripts/seed.ts` *(fails: Prisma client generation requires downloading engines, which is blocked by 403 responses in this environment)*
- `pnpm exec prisma generate` *(fails: engine downloads blocked by 403 responses in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f60dd17e1c8327a5c1ccc195631a27