### PR TITLE
gateway: add API-key auth and minimize PII

### DIFF
--- a/apgms/.env.example
+++ b/apgms/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and adjust values for local development.
+# API_GATEWAY_KEY secures non-GET gateway endpoints; keep it secret.
+API_GATEWAY_KEY=change-me

--- a/apgms/.gitignore
+++ b/apgms/.gitignore
@@ -2,6 +2,7 @@
 dist/
 coverage/
 .env*
+!.env.example
 .DS_Store
 .vscode/
 **/__pycache__/


### PR DESCRIPTION
## Summary
- add an API key guard to non-GET api-gateway routes and reduce returned fields for list endpoints
- remove logging of sensitive environment values
- document the API_GATEWAY_KEY in the shared environment example and ensure it is tracked

## Testing
- pnpm -r build

Labels: P0, security

------
https://chatgpt.com/codex/tasks/task_e_68f60dcb59dc832790f747711deb5021